### PR TITLE
circleci: Save the postgres logs as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,11 @@ jobs:
             du -sh /tmp/test_output/*
             for DIR in /tmp/test_output/*; do
               mv $DIR/repo/pageserver.log $DIR/ || true # ignore errors
+              for PGDIR in $DIR/repo/pgdatadirs/pg?; do
+                echo "PGDIR: $PGDIR"
+                NEW_LOG="${PGDIR##*/}_log"
+                mv $PGDIR/log "$DIR/$NEW_LOG" || true # ignore errors
+              done
               echo "rm $DIR/repo"
               rm -rf $DIR/repo
             done


### PR DESCRIPTION
This bit of bash script in the circleci config rescues the log files while deleting everything else. It's pretty bad, but I'm not sure what to replace it with.

This change will save files matching the glob `repo/pgdatadirs/pg?/log`, and rename them `pgX_log`. ([example](https://app.circleci.com/pipelines/github/zenithdb/zenith/68/workflows/9fbdbf2b-d6cc-4922-8f8f-160308e3a7bb/jobs/190/artifacts))

Fixes #109 
