### PR TITLE
Optimize parse_relfilename() function.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,6 +1359,7 @@ dependencies = [
  "chrono",
  "crc32c",
  "hex",
+ "lazy_static",
  "log",
  "rand",
  "regex",

--- a/postgres_ffi/Cargo.toml
+++ b/postgres_ffi/Cargo.toml
@@ -15,6 +15,7 @@ byteorder = "1.4.3"
 anyhow = "1.0"
 crc32c = "0.6.0"
 hex = "0.4.3"
+lazy_static = "1.4"
 log = "0.4.14"
 thiserror = "1.0"
 workspace_hack = { path = "../workspace_hack" }


### PR DESCRIPTION
Compiling a Regex is very expensive, so let's not do it on every
invocation. This was consuming a big fraction of the time in creating
a new base backup at "zenith pg create". This commits brings down the
time to run "zenith pg create" on a freshly created repository from
about 2 seconds to 1 second.

It's not worth spending much effort on optimizing things at this stage
in general, but might as well pick low-hanging fruit like this.