### PR TITLE
Disable GC test.

### DIFF
--- a/test_runner/batch_others/test_gc.py
+++ b/test_runner/batch_others/test_gc.py
@@ -1,3 +1,5 @@
+import pytest
+
 from contextlib import closing
 from fixtures.zenith_fixtures import PostgresFactory, ZenithPageserver
 import psycopg2.extras
@@ -10,6 +12,10 @@ pytest_plugins = ("fixtures.zenith_fixtures")
 # This test is pretty tightly coupled with the current implementation of page version storage
 # and garbage collection in object_repository.rs.
 #
+@pytest.mark.skip(reason=""""
+    Current GC test is flaky and overly strict. Since we are migrating to the layered repo format
+    with different GC implementation let's just silence this test for now.
+""")
 def test_gc(zenith_cli, pageserver: ZenithPageserver, postgres: PostgresFactory, pg_bin):
     zenith_cli.run(["branch", "test_gc", "empty"])
     pg = postgres.create_start('test_gc')
@@ -40,7 +46,7 @@ def test_gc(zenith_cli, pageserver: ZenithPageserver, postgres: PostgresFactory,
 
                     # Insert a row. The first insert will also create a metadata entry for the
                     # relation, with size == 1 block. Hence, bump up the expected relation count.
-                    n_relations += 1;
+                    n_relations += 1
                     print("Inserting one row and running GC")
                     cur.execute("INSERT INTO foo VALUES (1)")
                     pscur.execute(f"do_gc {pageserver.initial_tenant} {timeline} 0")


### PR DESCRIPTION
Current GC test is flaky and overly strict. Since we are migrating to the layered repo format
with different GC implementation let's just silence this test for now.