### PR TITLE
Remove unused 'update_meta' argument.

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -766,14 +766,7 @@ impl Timeline for LayeredTimeline {
         Ok(())
     }
 
-    fn put_page_image(
-        &self,
-        rel: RelishTag,
-        blknum: u32,
-        lsn: Lsn,
-        img: Bytes,
-        _update_meta: bool,
-    ) -> Result<()> {
+    fn put_page_image(&self, rel: RelishTag, blknum: u32, lsn: Lsn, img: Bytes) -> Result<()> {
         if !rel.is_blocky() && blknum != 0 {
             bail!(
                 "invalid request for block {} for non-blocky relish {}",

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -228,7 +228,6 @@ fn walreceiver_main(
                             0,
                             lsn,
                             new_checkpoint_bytes,
-                            false,
                         )?;
                     }
                 }


### PR DESCRIPTION
It was used by the object repository code, but now that that's gone, it's
dead.