### PR TITLE
[refactor] Safekeeper push replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "bookfile",
  "byteorder",
  "bytes",
@@ -1315,7 +1316,7 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 [[package]]
 name = "postgres"
 version = "0.19.1"
-source = "git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858#9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=f744467a9904ef8258605c20ac0f318efb7659db#f744467a9904ef8258605c20ac0f318efb7659db"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1329,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.1"
-source = "git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858#9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=f744467a9904ef8258605c20ac0f318efb7659db#f744467a9904ef8258605c20ac0f318efb7659db"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -1347,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.1"
-source = "git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858#9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=f744467a9904ef8258605c20ac0f318efb7659db#f744467a9904ef8258605c20ac0f318efb7659db"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2161,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.1"
-source = "git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858#9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=f744467a9904ef8258605c20ac0f318efb7659db#f744467a9904ef8258605c20ac0f318efb7659db"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2341,6 +2342,7 @@ dependencies = [
  "crc32c",
  "daemonize",
  "fs2",
+ "futures",
  "hex",
  "humantime",
  "lazy_static",
@@ -2354,6 +2356,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-postgres",
  "tokio-stream",
  "walkdir",
  "workspace_hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,6 +2595,7 @@ dependencies = [
  "lazy_static",
  "log",
  "postgres",
+ "postgres-types",
  "rand",
  "routerify",
  "rustls",

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 rand = "0.8.3"
 tar = "0.4.33"
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Stas Kelvich <stas@zenith.tech>"]
 edition = "2018"
 
 [dependencies]
+bincode = "1.3"
 bookfile = "^0.3"
 chrono = "0.4.19"
 rand = "0.8.3"
@@ -18,9 +19,9 @@ log = "0.4.14"
 clap = "2.33.0"
 daemonize = "0.4.1"
 tokio = { version = "1.11", features = ["process", "macros", "fs"] }
-postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
-postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
+postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
 routerify = "2"
 anyhow = "1.0"
 crc32c = "0.6.0"

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -18,6 +18,7 @@ pub mod repository;
 pub mod restore_local_repo;
 pub mod tenant_mgr;
 pub mod waldecoder;
+// pub mod walpush_receiver;
 pub mod walreceiver;
 pub mod walredo;
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -541,7 +541,7 @@ impl postgres_backend::Handler for PageServerHandler {
             // START_PUSH_REPLICATION <zenith tenant id> <zenith timelineid> <end of WAL LSN>
             // TODO lazy static
             let re = Regex::new(
-                r"^START_PUSH_REPLICATION ([[:xdigit:]]+) ([[:xdigit:]]+) ([[:xdigit:]]+)$",
+                r"^START_PUSH_REPLICATION ([[:xdigit:]]+) ([[:xdigit:]]+) ([[:xdigit:]]+/[[:xdigit:]]+)$",
             )
             .unwrap();
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -37,7 +37,7 @@ use crate::branches;
 use crate::relish::*;
 use crate::repository::Timeline;
 use crate::tenant_mgr;
-use crate::walreceiver;
+use crate::walreceiver::StandardWalReceiver;
 use crate::PageServerConf;
 
 // Wrapped in libpq CopyData
@@ -554,7 +554,7 @@ impl postgres_backend::Handler for PageServerHandler {
             // Check that the timeline exists
             tenant_mgr::get_timeline_for_tenant(tenantid, timelineid)?;
 
-            walreceiver::launch_wal_receiver(self.conf, timelineid, &connstr, tenantid.to_owned());
+            StandardWalReceiver::launch(self.conf, connstr, timelineid, tenantid.to_owned());
 
             pgb.write_message_noflush(&BeMessage::CommandComplete(b"SELECT 1"))?;
         } else if query_string.starts_with("branch_create ") {

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -12,7 +12,6 @@ use crate::tenant_mgr;
 use crate::waldecoder::{decode_wal_record, WalStreamDecoder};
 use crate::PageServerConf;
 use anyhow::{anyhow, bail, Context, Error, Result};
-use bincode::config::Options;
 use bytes::Bytes;
 use lazy_static::lazy_static;
 use log::*;
@@ -33,7 +32,7 @@ use std::sync::Mutex;
 use std::thread;
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
-use zenith_utils::bin_ser::{be_coder, BeSer};
+use zenith_utils::bin_ser::BeSer;
 use zenith_utils::lsn::Lsn;
 use zenith_utils::postgres_backend::PostgresBackend;
 use zenith_utils::pq_proto::{BeMessage, FeMessage, XLogDataBody};
@@ -452,7 +451,7 @@ impl<'pg> PushWalReceiver<'pg> {
     ///
     /// Any returned error will be from serialization failing.
     fn serialize_with_tag<T: Serialize>(val: T, tag: u8) -> Result<Vec<u8>> {
-        let mut buf = be_coder().serialize(&val)?;
+        let mut buf = BeSer::ser(&val)?;
         buf.insert(0, tag);
         Ok(buf)
     }

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -403,7 +403,7 @@ impl<'pg> PushWalReceiver<'pg> {
         end_of_wal: Lsn,
     ) -> Result<()> {
         // Check that we aren't already receiving for this timeline.
-        if WAL_PUSH_RECEVIERS.lock().unwrap().insert(timelineid) {
+        if !WAL_PUSH_RECEVIERS.lock().unwrap().insert(timelineid) {
             bail!("already receiving WAL for timeline")
         }
 

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -469,6 +469,7 @@ fn get_last_rec_lsn_and_startpoint(timeline: &dyn Timeline) -> (Lsn, Lsn) {
 }
 
 /// Central logic for receiving the WAL, generic over the connection we get it from
+#[allow(clippy::too_many_arguments)]
 fn walreceiver_loop(
     mut conn: impl WalReceiverConnection,
     conf: &PageServerConf,

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4.3"
 serde = "1"
 serde_json = "1"
 tokio = "1.11"
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
 clap = "2.33.0"
 rustls = "0.19.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -20,8 +20,10 @@ daemonize = "0.4.1"
 rust-s3 = { version = "0.27.0-rc4", features = ["no-verify-ssl"] }
 tokio = "1.11"
 tokio-stream = { version = "0.1.4" }
-postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
+futures = "0.3.13"
 anyhow = "1.0"
 crc32c = "0.6.0"
 humantime = "2.1.0"

--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -375,7 +375,7 @@ impl<'pg> StandardReplicationConn<'pg> {
             start_pos,
             stop_pos,
             tli,
-            &timeline,
+            timeline,
             wal_seg_size as usize,
         )
     }

--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -3,10 +3,13 @@
 
 use crate::send_wal::SendWalHandler;
 use crate::timeline::{Timeline, TimelineTools};
+use crate::WalAcceptorConf;
 use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use log::*;
-use postgres_ffi::xlog_utils::{get_current_timestamp, TimestampTz, XLogFileName, MAX_SEND_SIZE};
+use postgres_ffi::xlog_utils::{
+    get_current_timestamp, TimeLineID, TimestampTz, XLogFileName, MAX_SEND_SIZE,
+};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::cmp::min;
@@ -49,17 +52,69 @@ impl HotStandbyFeedback {
     }
 }
 
-/// A network connection that's speaking the replication protocol.
-pub struct ReplicationConn {
-    /// This is an `Option` because we will spawn a background thread that will
-    /// `take` it from us.
-    stream_in: Option<ReadStream>,
+/// A network connection that's speaking the typical postgres replication protocol.
+pub struct StandardReplicationConn<'pg> {
+    /// Postgres connection
+    pgb: &'pg mut PostgresBackend,
+}
+
+struct StandardReplicationReciever(ReadStream);
+
+/// Required functionality to implement the sending half of the replication protocol.
+///
+/// Implemented for [`StandardReplication`] and [`PushReplication`]
+trait ReplicationSender {
+    /// Sends XLogData over the connection
+    fn send_xlogdata(&mut self, data: XLogDataBody) -> Result<()>;
+}
+
+/// Required functionality to implement the receiving half of the replication protcol
+trait ReplicationReceiver {
+    /// Waits for the contents of the next CopyData message, or `None` if the connection
+    /// has closed
+    fn receive_copydata(&mut self) -> Result<Option<Bytes>>;
+}
+
+impl<'pg> ReplicationSender for StandardReplicationConn<'pg> {
+    fn send_xlogdata(&mut self, data: XLogDataBody) -> Result<()> {
+        self.pgb.write_message(&BeMessage::XLogData(data))?;
+        Ok(())
+    }
+}
+
+impl ReplicationReceiver for StandardReplicationReciever {
+    fn receive_copydata(&mut self) -> Result<Option<Bytes>> {
+        // Repeatedly receive until we get a message we can do something with
+        loop {
+            let msg = FeMessage::read(&mut self.0)?
+                .ok_or_else(|| anyhow!("connection ended without CopyDone"))?;
+
+            match msg {
+                FeMessage::CopyData(bytes) => return Ok(Some(bytes)),
+                FeMessage::CopyDone => return Ok(None),
+                FeMessage::CopyFail => return Err(anyhow!("Copy failed")),
+                FeMessage::Sync => (),
+                _ => {
+                    // We only handle the above messages. Anything else is ignored.
+                    info!("unexpected message {:?}", msg);
+                }
+            };
+        }
+    }
 }
 
 // TODO: move this to crate::timeline when there's more users
 // TODO: design a proper Timeline mock api
 trait HsFeedbackSubscriber {
-    fn add_hs_feedback(&self, _feedback: HotStandbyFeedback) {}
+    fn add_hs_feedback(&self, feedback: HotStandbyFeedback);
+}
+
+// Blanket implementation so that by-reference and by-value works for any function
+// expecting `T: HsFeedbackSubscriber`
+impl<'a, S: HsFeedbackSubscriber> HsFeedbackSubscriber for &'a S {
+    fn add_hs_feedback(&self, feedback: HotStandbyFeedback) {
+        (*self).add_hs_feedback(feedback)
+    }
 }
 
 impl HsFeedbackSubscriber for Arc<Timeline> {
@@ -69,49 +124,130 @@ impl HsFeedbackSubscriber for Arc<Timeline> {
     }
 }
 
-impl ReplicationConn {
-    /// Create a new `ReplicationConn`
-    pub fn new(pgb: &mut PostgresBackend) -> Self {
-        Self {
-            stream_in: pgb.take_stream_in(),
+/// Runs the replication data-sending loop over the provided connection
+fn do_send_loop(
+    conn: &mut impl ReplicationSender,
+    conf: &WalAcceptorConf,
+    mut start_pos: Lsn,
+    stop_pos: Lsn,
+    tli: TimeLineID,
+    timeline: &Timeline,
+    wal_seg_size: usize,
+) -> Result<()> {
+    let mut end_pos: Lsn;
+    let mut wal_file: Option<File> = None;
+
+    loop {
+        /* Wait until we have some data to stream */
+        if stop_pos != Lsn(0) {
+            /* recovery mode: stream up to the specified LSN (VCL) */
+            if start_pos >= stop_pos {
+                /* recovery finished */
+                break;
+            }
+            end_pos = stop_pos;
+        } else {
+            /* normal mode */
+            end_pos = timeline.wait_for_lsn(start_pos);
+        }
+        if end_pos == END_REPLICATION_MARKER {
+            break;
+        }
+
+        // Take the `File` from `wal_file`, or open a new file.
+        let mut file = match wal_file.take() {
+            Some(file) => file,
+            None => {
+                // Open a new file.
+                let segno = start_pos.segment_number(wal_seg_size as usize);
+                let wal_file_name = XLogFileName(tli, segno, wal_seg_size);
+                let timeline_id = timeline.timelineid.to_string();
+                let wal_file_path = conf.data_dir.join(timeline_id).join(wal_file_name);
+                open_wal_file(&wal_file_path)?
+            }
+        };
+
+        let xlogoff = start_pos.segment_offset(wal_seg_size as usize);
+
+        // How much to read and send in message? We cannot cross the WAL file
+        // boundary, and we don't want send more than MAX_SEND_SIZE.
+        let send_size = end_pos.checked_sub(start_pos).unwrap().0 as usize;
+        let send_size = min(send_size, wal_seg_size - xlogoff);
+        let send_size = min(send_size, MAX_SEND_SIZE);
+
+        // Read some data from the file.
+        let mut file_buf = vec![0u8; send_size];
+        file.seek(SeekFrom::Start(xlogoff as u64))
+            .and_then(|_| file.read_exact(&mut file_buf))
+            .context("Failed to read data from WAL file")?;
+
+        conn.send_xlogdata(XLogDataBody {
+            wal_start: start_pos.0,
+            wal_end: end_pos.0,
+            timestamp: get_current_timestamp(),
+            data: &file_buf,
+        })
+        .context("Failed to send XLogData")?;
+
+        start_pos += send_size as u64;
+
+        debug!("sent WAL up to {}", end_pos);
+
+        // Decide whether to reuse this file. If we don't set wal_file here
+        // a new file will be opened next time.
+        if start_pos.segment_offset(wal_seg_size) != 0 {
+            wal_file = Some(file);
         }
     }
 
-    /// Handle incoming messages from the network.
-    /// This is spawned into the background by `handle_start_replication`.
-    fn background_thread(
-        mut stream_in: impl Read,
-        subscriber: impl HsFeedbackSubscriber,
-    ) -> Result<()> {
-        // Wait for replica's feedback.
-        while let Some(msg) = FeMessage::read(&mut stream_in)? {
-            match &msg {
-                FeMessage::CopyData(m) => {
-                    // There's two possible data messages that the client is supposed to send here:
-                    // `HotStandbyFeedback` and `StandbyStatusUpdate`. We only handle hot standby
-                    // feedback.
+    Ok(())
+}
 
-                    match m.first().cloned() {
-                        Some(HOT_STANDBY_FEEDBACK_TAG_BYTE) => {
-                            // Note: deserializing is on m[1..] because we skip the tag byte.
-                            let feedback = HotStandbyFeedback::des(&m[1..])
-                                .context("failed to deserialize HotStandbyFeedback")?;
-                            subscriber.add_hs_feedback(feedback);
-                        }
-                        Some(STANDBY_STATUS_UPDATE_TAG_BYTE) => (),
-                        _ => warn!("unexpected message {:?}", msg),
-                    }
-                }
-                FeMessage::Sync => {}
-                FeMessage::CopyFail => return Err(anyhow!("Copy failed")),
-                _ => {
-                    // We only handle `CopyData`, 'Sync', 'CopyFail' messages. Anything else is ignored.
-                    info!("unexpected message {:?}", msg);
-                }
+fn do_receive_loop(
+    conn: &mut impl ReplicationReceiver,
+    subscriber: impl HsFeedbackSubscriber,
+) -> Result<()> {
+    while let Some(msg) = conn.receive_copydata()? {
+        // There's two possible data messages that the client is supposed to send here,
+        // inside of the CopyData: `HotStandbyFeedback` and `StandbyStatusUpdate`. We only
+        // handle hot standby feedback.
+
+        match msg.first().cloned() {
+            Some(HOT_STANDBY_FEEDBACK_TAG_BYTE) => {
+                // Note: deserializing is on m[1..] because we skip the tag byte.
+                let feedback = HotStandbyFeedback::des(&msg[1..])
+                    .context("failed to deserialize HotStandbyFeedback")?;
+                subscriber.add_hs_feedback(feedback);
             }
+            Some(STANDBY_STATUS_UPDATE_TAG_BYTE) => (),
+            _ => warn!("unexpected message {:?}", msg),
         }
+    }
 
-        Ok(())
+    Ok(())
+}
+
+fn open_wal_file(wal_file_path: &Path) -> Result<File> {
+    // First try to open the .partial file.
+    let mut partial_path = wal_file_path.to_owned();
+    partial_path.set_extension("partial");
+    if let Ok(opened_file) = File::open(&partial_path) {
+        return Ok(opened_file);
+    }
+
+    // If that failed, try it without the .partial extension.
+    File::open(&wal_file_path)
+        .with_context(|| format!("Failed to open WAL file {:?}", wal_file_path))
+        .map_err(|e| {
+            error!("{}", e);
+            e
+        })
+}
+
+impl<'pg> StandardReplicationConn<'pg> {
+    /// Create a new `ReplicationConn`
+    pub fn new(pgb: &'pg mut PostgresBackend) -> Self {
+        StandardReplicationConn { pgb }
     }
 
     /// Helper function that parses a pair of LSNs.
@@ -126,48 +262,29 @@ impl ReplicationConn {
         Ok((start_pos, stop_pos))
     }
 
-    /// Helper function for opening a wal file.
-    fn open_wal_file(wal_file_path: &Path) -> Result<File> {
-        // First try to open the .partial file.
-        let mut partial_path = wal_file_path.to_owned();
-        partial_path.set_extension("partial");
-        if let Ok(opened_file) = File::open(&partial_path) {
-            return Ok(opened_file);
-        }
-
-        // If that failed, try it without the .partial extension.
-        File::open(&wal_file_path)
-            .with_context(|| format!("Failed to open WAL file {:?}", wal_file_path))
-            .map_err(|e| {
-                error!("{}", e);
-                e
-            })
-    }
-
     ///
     /// Handle START_REPLICATION replication command
     ///
-    pub fn run(
-        &mut self,
-        swh: &mut SendWalHandler,
-        pgb: &mut PostgresBackend,
-        cmd: &Bytes,
-    ) -> Result<()> {
-        // spawn the background thread which receives HotStandbyFeedback messages.
-        let bg_timeline = Arc::clone(swh.timeline.get());
-        let bg_stream_in = self.stream_in.take().unwrap();
+    pub fn run(&mut self, swh: &mut SendWalHandler, cmd: &Bytes) -> Result<()> {
+        let timeline = swh.timeline.get();
 
-        thread::spawn(move || {
-            if let Err(err) = Self::background_thread(bg_stream_in, bg_timeline) {
+        // spawn the background thread which receives HotStandbyFeedback messages.
+        let bg_timeline = Arc::clone(timeline);
+        let bg_stream_in = self.pgb.take_stream_in().unwrap();
+
+        thread::spawn(|| {
+            let mut recv = StandardReplicationReciever(bg_stream_in);
+
+            if let Err(err) = do_receive_loop(&mut recv, bg_timeline) {
                 error!("Replication background thread failed: {}", err);
             }
         });
 
         let (mut start_pos, mut stop_pos) = Self::parse_start_stop(cmd)?;
 
-        let mut wal_seg_size: usize;
+        let mut wal_seg_size: u32;
         loop {
-            wal_seg_size = swh.timeline.get().get_info().server.wal_seg_size as usize;
+            wal_seg_size = timeline.get_info().server.wal_seg_size;
             if wal_seg_size == 0 {
                 error!("Cannot start replication before connecting to wal_proposer");
                 sleep(Duration::from_secs(1));
@@ -175,7 +292,7 @@ impl ReplicationConn {
                 break;
             }
         }
-        let (wal_end, timeline) = swh.timeline.get().get_end_of_wal();
+        let (wal_end, tli) = timeline.get_end_of_wal();
         if start_pos == Lsn(0) {
             start_pos = wal_end;
         }
@@ -185,76 +302,17 @@ impl ReplicationConn {
         info!("Start replication from {} till {}", start_pos, stop_pos);
 
         // switch to copy
-        pgb.write_message(&BeMessage::CopyBothResponse)?;
+        self.pgb.write_message(&BeMessage::CopyBothResponse)?;
 
-        let mut end_pos: Lsn;
-        let mut wal_file: Option<File> = None;
-
-        loop {
-            /* Wait until we have some data to stream */
-            if stop_pos != Lsn(0) {
-                /* recovery mode: stream up to the specified LSN (VCL) */
-                if start_pos >= stop_pos {
-                    /* recovery finished */
-                    break;
-                }
-                end_pos = stop_pos;
-            } else {
-                /* normal mode */
-                let timeline = swh.timeline.get();
-                end_pos = timeline.wait_for_lsn(start_pos);
-            }
-            if end_pos == END_REPLICATION_MARKER {
-                break;
-            }
-
-            // Take the `File` from `wal_file`, or open a new file.
-            let mut file = match wal_file.take() {
-                Some(file) => file,
-                None => {
-                    // Open a new file.
-                    let segno = start_pos.segment_number(wal_seg_size);
-                    let wal_file_name = XLogFileName(timeline, segno, wal_seg_size);
-                    let timeline_id = swh.timeline.get().timelineid.to_string();
-                    let wal_file_path = swh.conf.data_dir.join(timeline_id).join(wal_file_name);
-                    Self::open_wal_file(&wal_file_path)?
-                }
-            };
-
-            let xlogoff = start_pos.segment_offset(wal_seg_size) as usize;
-
-            // How much to read and send in message? We cannot cross the WAL file
-            // boundary, and we don't want send more than MAX_SEND_SIZE.
-            let send_size = end_pos.checked_sub(start_pos).unwrap().0 as usize;
-            let send_size = min(send_size, wal_seg_size - xlogoff);
-            let send_size = min(send_size, MAX_SEND_SIZE);
-
-            // Read some data from the file.
-            let mut file_buf = vec![0u8; send_size];
-            file.seek(SeekFrom::Start(xlogoff as u64))
-                .and_then(|_| file.read_exact(&mut file_buf))
-                .context("Failed to read data from WAL file")?;
-
-            // Write some data to the network socket.
-            pgb.write_message(&BeMessage::XLogData(XLogDataBody {
-                wal_start: start_pos.0,
-                wal_end: end_pos.0,
-                timestamp: get_current_timestamp(),
-                data: &file_buf,
-            }))
-            .context("Failed to send XLogData")?;
-
-            start_pos += send_size as u64;
-
-            debug!("sent WAL up to {}", end_pos);
-
-            // Decide whether to reuse this file. If we don't set wal_file here
-            // a new file will be opened next time.
-            if start_pos.segment_offset(wal_seg_size) != 0 {
-                wal_file = Some(file);
-            }
-        }
-        Ok(())
+        do_send_loop(
+            self,
+            &swh.conf,
+            start_pos,
+            stop_pos,
+            tli,
+            &timeline,
+            wal_seg_size as usize,
+        )
     }
 }
 
@@ -262,13 +320,23 @@ impl ReplicationConn {
 mod tests {
     use super::*;
 
-    // A no-op impl for tests
-    impl HsFeedbackSubscriber for () {}
+    // No-op impls for tests
+    struct NoOpSubscriber;
+    struct EmptyStream;
+
+    impl HsFeedbackSubscriber for NoOpSubscriber {
+        fn add_hs_feedback(&self, _feedback: HotStandbyFeedback) {}
+    }
+
+    impl ReplicationReceiver for EmptyStream {
+        fn receive_copydata(&mut self) -> Result<Option<Bytes>> {
+            Ok(None)
+        }
+    }
 
     #[test]
     fn test_replication_conn_background_thread_eof() {
         // Test that background_thread recognizes EOF
-        let stream: &[u8] = &[];
-        ReplicationConn::background_thread(stream, ()).unwrap();
+        do_receive_loop(&mut EmptyStream, NoOpSubscriber).unwrap();
     }
 }

--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -65,7 +65,7 @@ struct StandardReplicationReciever(ReadStream);
 /// Implemented for [`StandardReplication`] and [`PushReplication`]
 trait ReplicationSender {
     /// Sends XLogData over the connection
-    fn send_xlogdata(&mut self, data: XLogDataBody) -> Result<()>;
+    fn send_xlogdata(&mut self, data: XLogDataBody<&[u8]>) -> Result<()>;
 }
 
 /// Required functionality to implement the receiving half of the replication protcol
@@ -76,7 +76,7 @@ trait ReplicationReceiver {
 }
 
 impl<'pg> ReplicationSender for StandardReplicationConn<'pg> {
-    fn send_xlogdata(&mut self, data: XLogDataBody) -> Result<()> {
+    fn send_xlogdata(&mut self, data: XLogDataBody<&[u8]>) -> Result<()> {
         self.pgb.write_message(&BeMessage::XLogData(data))?;
         Ok(())
     }

--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -481,7 +481,7 @@ impl PushReplicationConn<'_> {
         loop {
             let connection_result = rt.block_on(tokio_postgres::connect(&ps_connstr, NoTls));
 
-            let (client, _connection) = match connection_result {
+            let (client, connection) = match connection_result {
                 Ok(tuple) => tuple,
                 Err(e) => {
                     error!(
@@ -503,6 +503,8 @@ impl PushReplicationConn<'_> {
                     }
                 }
             };
+            // spawn tokio-postgres task doing the actual IO
+            rt.spawn(connection);
 
             connected_at_least_once = true;
 

--- a/walkeeper/src/send_wal.rs
+++ b/walkeeper/src/send_wal.rs
@@ -4,7 +4,7 @@
 
 use crate::json_ctrl::handle_json_ctrl;
 use crate::receive_wal::ReceiveWalConn;
-use crate::replication::ReplicationConn;
+use crate::replication::StandardReplicationConn;
 use crate::timeline::{Timeline, TimelineTools};
 use crate::WalAcceptorConf;
 use anyhow::{anyhow, bail, Result};
@@ -74,7 +74,7 @@ impl postgres_backend::Handler for SendWalHandler {
             self.handle_identify_system(pgb)?;
             Ok(())
         } else if query_string.starts_with(b"START_REPLICATION") {
-            ReplicationConn::new(pgb).run(self, pgb, &query_string)?;
+            StandardReplicationConn::new(pgb).run(self, &query_string)?;
             Ok(())
         } else if query_string.starts_with(b"START_WAL_PUSH") {
             ReceiveWalConn::new(pgb)?.run(self)?;

--- a/zenith/Cargo.toml
+++ b/zenith/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 clap = "2.33.0"
 anyhow = "1.0"
 serde_json = "1"
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
 
 # FIXME: 'pageserver' is needed for BranchInfo. Refactor
 pageserver = { path = "../pageserver" }

--- a/zenith_utils/Cargo.toml
+++ b/zenith_utils/Cargo.toml
@@ -13,6 +13,7 @@ hyper = { version = "0.14.7", features = ["full"] }
 lazy_static = "1.4.0"
 log = "0.4.14"
 postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 routerify = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/zenith_utils/Cargo.toml
+++ b/zenith_utils/Cargo.toml
@@ -12,8 +12,8 @@ bytes = "1.0.1"
 hyper = { version = "0.14.7", features = ["full"] }
 lazy_static = "1.4.0"
 log = "0.4.14"
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
-postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
+postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="f744467a9904ef8258605c20ac0f318efb7659db" }
 routerify = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/zenith_utils/src/lsn.rs
+++ b/zenith_utils/src/lsn.rs
@@ -118,9 +118,9 @@ impl From<Lsn> for u64 {
     }
 }
 
-impl Into<PgLsn> for Lsn {
-    fn into(self) -> PgLsn {
-        u64::from(self).into()
+impl From<Lsn> for PgLsn {
+    fn from(lsn: Lsn) -> PgLsn {
+        u64::from(lsn).into()
     }
 }
 

--- a/zenith_utils/src/lsn.rs
+++ b/zenith_utils/src/lsn.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 
+use postgres_types::PgLsn;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::{Add, AddAssign};
@@ -114,6 +115,12 @@ impl From<u64> for Lsn {
 impl From<Lsn> for u64 {
     fn from(lsn: Lsn) -> u64 {
         lsn.0
+    }
+}
+
+impl Into<PgLsn> for Lsn {
+    fn into(self) -> PgLsn {
+        u64::from(self).into()
     }
 }
 

--- a/zenith_utils/src/pq_proto.rs
+++ b/zenith_utils/src/pq_proto.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, bail, Result};
 use byteorder::{BigEndian, ByteOrder};
 use byteorder::{ReadBytesExt, BE};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use serde::{Deserialize, Serialize};
 // use postgres_ffi::xlog_utils::TimestampTz;
 use std::collections::HashMap;
 use std::io;
@@ -355,7 +356,7 @@ pub enum BeMessage<'a> {
     ParseComplete,
     ReadyForQuery,
     RowDescription(&'a [RowDescriptor<'a>]),
-    XLogData(XLogDataBody<'a>),
+    XLogData(XLogDataBody<&'a [u8]>),
     NoticeResponse(String),
 }
 
@@ -400,12 +401,12 @@ impl RowDescriptor<'_> {
     }
 }
 
-#[derive(Debug)]
-pub struct XLogDataBody<'a> {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XLogDataBody<D> {
     pub wal_start: u64,
     pub wal_end: u64,
     pub timestamp: i64,
-    pub data: &'a [u8],
+    pub data: D,
 }
 
 pub static HELLO_WORLD_ROW: BeMessage = BeMessage::DataRow(&[Some(b"hello world")]);


### PR DESCRIPTION
Adds a new command to the page server, `START_PUSH_REPLICATION`, which (mostly) imitates the usual replication protocol, as if the page server had connected to the safekeeper itself.

The one primary difference is that immediately after receiving the connection, the page server sends a message back to the safekeeper with the starting LSN to stream from (where that would normally be given as part of the `START_REPLICATION` command).

The bulk of the work is done, just need to iron out the bugs. Pushed here for general review while that's going on.