### PR TITLE
Create test_sync_safekeepers_old_term_ahead

### DIFF
--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -505,6 +505,9 @@ def test_sync_safekeepers_old_term_ahead(repo_dir: str, pg_bin: PgBin, wa_factor
     appender.append(2, term=1, lm_message="msg1")
     appender.append(2, term=1, lm_message="msg1")
 
+    new_epoch = appender.flush_lsns[0]
+    appender.epoch_start_lsn = new_epoch
+
     appender.append(0, term=2, lm_message="msg2")
     appender.append(1, term=2, lm_message="msg2")
 

--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -444,7 +444,12 @@ class WalAppender:
     """Helper for appending WAL to safekeepers, keeps track of last inserted lsn."""
 
     # 0/16B9188 is good lsn to start with, it's valid and not in the segment start, nor in zero segment
-    def __init__(self, acceptors, tenant_id, timeline_id, epoch_start_lsn=0x16B9188, begin_lsn=0x16B9188):
+    def __init__(self,
+                 acceptors,
+                 tenant_id,
+                 timeline_id,
+                 epoch_start_lsn=0x16B9188,
+                 begin_lsn=0x16B9188):
         self.acceptors = acceptors
         self.epoch_start_lsn = epoch_start_lsn
         self.begin_lsn = begin_lsn
@@ -452,7 +457,7 @@ class WalAppender:
         self.timeline_id = timeline_id
         self.flush_lsns = dict()
 
-    def append(self, i, term, lm_message = "message", lm_prefix = "", set_commit_lsn = False):
+    def append(self, i, term, lm_message="message", lm_prefix="", set_commit_lsn=False):
         """Append new logical message to i'th safekeeper."""
         lsn = self.flush_lsns.get(i, self.begin_lsn)
         req = {
@@ -481,8 +486,11 @@ class WalAppender:
         for i, lsn in self.flush_lsns.items():
             print(f'end_lsn for acceptors[{i}] = {lsn_to_hex(lsn)}')
 
+
 # one safekeeper with old term and a lot of non-commited wal
-def test_sync_safekeepers_old_term_ahead(repo_dir: str, pg_bin: PgBin, wa_factory: WalAcceptorFactory):
+def test_sync_safekeepers_old_term_ahead(repo_dir: str,
+                                         pg_bin: PgBin,
+                                         wa_factory: WalAcceptorFactory):
     wa_factory.start_n_new(3)
 
     timeline_id = uuid.uuid4().hex


### PR DESCRIPTION
Add test to run `--sync-safekeepers` on WAL that looks like this:

```
S1(2): R1(a),R2(f)
S2(2): R1(a),R2(f)
S3(1): R1(a),R2(b),R3(c),R4(d), R5(e)
```

Currently test produces TimeoutError.