### PR TITLE
Safekeeper metrics refactor

### DIFF
--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -312,6 +312,13 @@ impl SafeKeeperMetrics {
             commit_lsn: COMMIT_LSN_GAUGE.with_label_values(&[&ztli_str]),
         }
     }
+
+    fn new_noname() -> SafeKeeperMetrics {
+        SafeKeeperMetrics {
+            flush_lsn: FLUSH_LSN_GAUGE.with_label_values(&["n/a"]),
+            commit_lsn: COMMIT_LSN_GAUGE.with_label_values(&["n/a"]),
+        }
+    }
 }
 
 /// SafeKeeper which consumes events (messages from compute) and provides
@@ -322,7 +329,7 @@ pub struct SafeKeeper<ST: Storage> {
     pub flush_lsn: Lsn,
     pub tli: u32,
     // Cached metrics so we don't have to recompute labels on each update.
-    metrics: Option<SafeKeeperMetrics>,
+    metrics: SafeKeeperMetrics,
     /// not-yet-flushed pairs of same named fields in s.*
     pub commit_lsn: Lsn,
     pub truncate_lsn: Lsn,
@@ -341,7 +348,7 @@ where
         SafeKeeper {
             flush_lsn,
             tli,
-            metrics: None,
+            metrics: SafeKeeperMetrics::new_noname(),
             commit_lsn: state.commit_lsn,
             truncate_lsn: state.truncate_lsn,
             storage,
@@ -393,7 +400,7 @@ where
         self.s.server.wal_seg_size = msg.wal_seg_size;
         self.storage.persist(&self.s, true)?;
 
-        self.metrics = Some(SafeKeeperMetrics::new(self.s.server.ztli));
+        self.metrics = SafeKeeperMetrics::new(self.s.server.ztli);
 
         info!(
             "processed greeting from proposer {:?}, sending term {:?}",
@@ -430,8 +437,6 @@ where
     /// Handle request to append WAL.
     #[allow(clippy::comparison_chain)]
     fn handle_append_request(&mut self, msg: &AppendRequest) -> Result<AcceptorProposerMessage> {
-        let metrics = self.metrics.as_ref().unwrap();
-
         // log first AppendRequest from this proposer
         if self.elected_proposer_term < msg.h.term {
             info!(
@@ -520,7 +525,7 @@ where
         }
         if last_rec_lsn > self.flush_lsn {
             self.flush_lsn = last_rec_lsn;
-            metrics.flush_lsn.set(u64::from(self.flush_lsn) as f64);
+            self.metrics.flush_lsn.set(u64::from(self.flush_lsn) as f64);
         }
 
         // Advance commit_lsn taking into account what we have locally. xxx this
@@ -538,7 +543,9 @@ where
             sync_control_file |=
                 commit_lsn >= msg.h.epoch_start_lsn && self.s.commit_lsn < msg.h.epoch_start_lsn;
             self.commit_lsn = commit_lsn;
-            metrics.commit_lsn.set(u64::from(self.commit_lsn) as f64);
+            self.metrics
+                .commit_lsn
+                .set(u64::from(self.commit_lsn) as f64);
         }
 
         self.truncate_lsn = msg.h.truncate_lsn;


### PR DESCRIPTION
As it turns out, there are some tests for Safekeeper protocol which call `handle_append_request` without calling `handle_greeing` before, so it's entirely possible to have a Safekeeper with no `ztli` in tests.

It looks like there were no unit tests which actually updated `flush_lsn`/`commit_lsn` before so the panic was not triggered in tests. Maybe adding a unit test which would trigger a panic is a good idea. However, I think that such happy-path scenarios are covered in bigger tests, so unit-testing would be of little use.

Some minor refactoring and clean-up are also included.