### PR TITLE
Use disk_consistent_lsn in synchronous standby_status_update

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -855,6 +855,10 @@ impl Timeline for LayeredTimeline {
             .observe_closure_duration(|| self.checkpoint_internal(0, true))
     }
 
+    fn get_disk_consistent_lsn(&self) -> Lsn {
+        self.disk_consistent_lsn.load()
+    }
+
     fn get_last_record_lsn(&self) -> Lsn {
         self.last_record_lsn.load().last
     }

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -132,6 +132,8 @@ pub trait Timeline: Send + Sync {
     fn get_prev_record_lsn(&self) -> Lsn;
     fn get_start_lsn(&self) -> Lsn;
 
+    fn get_disk_consistent_lsn(&self) -> Lsn;
+
     /// Mutate the timeline with a [`TimelineWriter`].
     fn writer<'a>(&'a self) -> Box<dyn TimelineWriter + 'a>;
 


### PR DESCRIPTION
… pageserver can guarantee durability only up to this point, and all later WAL must be requested from safekepers after pageserver restart.