### PR TITLE
Change 'zenith tenant list' API to return tenant state added in 0dc7a3fc

### DIFF
--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -20,6 +20,7 @@ use zenith_utils::zid::ZTenantId;
 use crate::local_env::LocalEnv;
 use crate::read_pidfile;
 use pageserver::branches::BranchInfo;
+use pageserver::tenant_mgr::TenantInfo;
 use zenith_utils::connstring::connection_address;
 
 #[derive(Error, Debug)]
@@ -269,7 +270,7 @@ impl PageServerNode {
         Ok(())
     }
 
-    pub fn tenant_list(&self) -> Result<Vec<String>> {
+    pub fn tenant_list(&self) -> Result<Vec<TenantInfo>> {
         Ok(self
             .http_request(Method::GET, format!("{}/{}", self.http_base_url, "tenant"))
             .send()?

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -4,7 +4,7 @@
 // TODO: move all paths construction to conf impl
 //
 
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{bail, Context, Result};
 use postgres_ffi::ControlFileData;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -246,18 +246,6 @@ fn bootstrap_timeline(
     fs::remove_dir_all(pgdata_path)?;
 
     Ok(())
-}
-
-pub(crate) fn get_tenants(conf: &PageServerConf) -> Result<Vec<String>> {
-    let tenants_dir = conf.tenants_path();
-
-    std::fs::read_dir(&tenants_dir)?
-        .map(|dir_entry_res| {
-            let dir_entry = dir_entry_res?;
-            ensure!(dir_entry.file_type()?.is_dir());
-            Ok(dir_entry.file_name().to_str().unwrap().to_owned())
-        })
-        .collect()
 }
 
 pub(crate) fn get_branches(conf: &PageServerConf, tenantid: &ZTenantId) -> Result<Vec<BranchInfo>> {

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -164,13 +164,13 @@ paths:
       description: Get tenants list
       responses:
         "200":
-          description: OK
+          description: TenantInfo
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  type: string
+                  $ref: "#/components/schemas/TenantInfo"
         "401":
           description: Unauthorized Error
           content:
@@ -243,6 +243,16 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
+    TenantInfo:
+      type: object
+      required:
+        - id
+        - state
+      properties:
+        id:
+          type: string
+        state:
+          type: string
     BranchInfo:
       type: object
       required:

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -124,7 +124,7 @@ async fn tenant_list_handler(request: Request<Body>) -> Result<Response<Body>, A
 
     let response_data = tokio::task::spawn_blocking(move || {
         let _enter = info_span!("tenant_list").entered();
-        crate::branches::get_tenants(get_config(&request))
+        crate::tenant_mgr::list_tenants()
     })
     .await
     .map_err(ApiError::from_err)??;

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -637,7 +637,7 @@ impl postgres_backend::Handler for PageServerHandler {
                 .write_message_noflush(&BeMessage::DataRow(&[Some(&branches_buf)]))?
                 .write_message_noflush(&BeMessage::CommandComplete(b"SELECT 1"))?;
         } else if query_string.starts_with("tenant_list") {
-            let tenants = crate::branches::get_tenants(self.conf)?;
+            let tenants = crate::tenant_mgr::list_tenants()?;
             let tenants_buf = serde_json::to_vec(&tenants)?;
 
             pgb.write_message_noflush(&SINGLE_COL_ROWDESC)?

--- a/test_runner/batch_others/test_zenith_cli.py
+++ b/test_runner/batch_others/test_zenith_cli.py
@@ -60,11 +60,11 @@ def test_cli_branch_list(pageserver: ZenithPageserver, zenith_cli):
 
 def helper_compare_tenant_list(page_server_cur, zenith_cli: ZenithCli):
     page_server_cur.execute(f'tenant_list')
-    tenants_api = sorted(json.loads(page_server_cur.fetchone()[0]))
+    tenants_api = sorted(map(lambda t: t['id'], json.loads(page_server_cur.fetchone()[0])))
 
     res = zenith_cli.run(["tenant", "list"])
     assert res.stderr == ''
-    tenants_cli = sorted(res.stdout.splitlines())
+    tenants_cli = sorted(map(lambda t: t.split()[0], res.stdout.splitlines()))
 
     assert tenants_api == tenants_cli
 
@@ -94,7 +94,7 @@ def test_cli_tenant_list(pageserver: ZenithPageserver, zenith_cli: ZenithCli):
 
     res = zenith_cli.run(["tenant", "list"])
     res.check_returncode()
-    tenants = sorted(res.stdout.splitlines())
+    tenants = sorted(map(lambda t: t.split()[0], res.stdout.splitlines()))
 
     assert pageserver.initial_tenant in tenants
     assert tenant1 in tenants

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -269,7 +269,7 @@ class ZenithPageserverHttpClient(requests.Session):
         res.raise_for_status()
         return res.json()
 
-    def tenant_list(self) -> List[str]:
+    def tenant_list(self) -> List[Dict]:
         res = self.get(f"http://localhost:{self.port}/v1/tenant")
         res.raise_for_status()
         return res.json()
@@ -401,7 +401,7 @@ class ZenithPageserver(PgProtocol):
         self.zenith_cli.run(['start'])
         self.running = True
         # get newly created tenant id
-        self.initial_tenant = self.zenith_cli.run(['tenant', 'list']).stdout.strip()
+        self.initial_tenant = self.zenith_cli.run(['tenant', 'list']).stdout.split()[0]
         return self
 
     def stop(self, immediate=False) -> 'ZenithPageserver':

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -384,8 +384,8 @@ fn handle_tenant(tenant_match: &ArgMatches, env: &local_env::LocalEnv) -> Result
     let pageserver = PageServerNode::from_env(env);
     match tenant_match.subcommand() {
         ("list", Some(_)) => {
-            for tenant in pageserver.tenant_list()? {
-                println!("{}", tenant);
+            for t in pageserver.tenant_list()? {
+                println!("{} {}", t.id, t.state);
             }
         }
         ("create", Some(create_match)) => {


### PR DESCRIPTION
current code only uses two tenant states: CloudOnly (short moment while the tenant is bootstrapping) and Active
