### PR TITLE
Use 1Mb chunk instead of page for loading data from pageserver

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -290,6 +290,7 @@ impl PostgresNode {
         conf.append("max_replication_slots", "10");
         conf.append("hot_standby", "on");
         conf.append("shared_buffers", "1MB");
+        conf.append("zenith.file_cache_size", "4096");
         conf.append("fsync", "off");
         conf.append("max_connections", "100");
         conf.append("wal_level", "replica");


### PR DESCRIPTION
In this PR I have tried to implement yet another bulk loading mechanism based on local file cache. Right now we see that Zenith is 3-10 times slower than Vanilla Postgres  when working set doesn't fit in compute node cache. It is because of expensive get-page request-response roundrip. At the same time we can not use too much memory for shared buffers because we are going to server multiple tenants on the same node. Local file cache somehow address this problem, significantly reducing number of get-page requests and proving performance comparable with larger shared buffers without large memory footprint.  

But there is still problem of cache prewarming, i.e. node restart. Lazy loading of each of still cause very slow execution. The idea is to use larger chunk of communication between pageserver and compute node. Local file cache use 1Mb chunks. So in this PR I changed get_page_at_lsn to return 1Mb chunks instead of 8kb pages. Received chunk is stored in local file cache.

Results: TPC-H Q7 execution with scale=1 (~1GB) data set.

Warm run:

Vanilla shared buffers 1Gb: 0.6 sec 
Zenith shared buffers 1Gb: 0.7 sec
Zenith shared buffers 1Mb: 34 sec
Zenith shared buffers 1Mb + local file cache: 3.2 sec

Cold run (node restart):
Vanilla shared buffers 1Gb: 2.5 sec
Zenith shared buffers 1Mb: 35 sec
Zenith shared buffers 1Mb + local file cache: 12 sec
Zenith shared buffers 1Mb + chunk load: 9 sec

So as you see effect of large chunks is not so large.
Looks like extraction page at pageserver is not so fast.
Also it is important to notice that checkpointer parameters should be adjusted so that
pages are stored in image layers before running this query.
Without it cold query execution time is 13 and 12 seconds correspondingly (so difference is event smaller).

Please notice that chunks are handled only on protocol level: almost nothing is changed in pageserver to support efficient chunk extraction. Chunk at pageserver is constructed by separate get_page_at_lsn request. It may explain small effect of chunk load. 