### PR TITLE
Read SLRUs from the page server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1331,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nix",
+ "num_enum",
  "once_cell",
  "postgres 0.19.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=2949d98df52587d562986aad155dd4e889e408b7)",
  "postgres-protocol 0.6.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=2949d98df52587d562986aad155dd4e889e408b7)",
@@ -1555,6 +1577,16 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-hack"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -42,6 +42,7 @@ nix = "0.23"
 once_cell = "1.8.0"
 crossbeam-utils = "0.8.5"
 fail = "0.5.0"
+num_enum = "0.5.7"
 
 rust-s3 = { version = "0.28", default-features = false, features = ["no-verify-ssl", "tokio-rustls-tls"] }
 async-compression = {version = "0.3", features = ["zstd", "tokio"]}

--- a/pageserver/src/relish.rs
+++ b/pageserver/src/relish.rs
@@ -23,6 +23,7 @@
 //! All relishes are versioned by LSN in the repository.
 //!
 
+use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -208,7 +209,20 @@ impl fmt::Display for RelishTag {
 /// These files are divided into segments, which are divided into
 /// pages of the same BLCKSZ as used for relation files.
 ///
-#[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    TryFromPrimitive,
+)]
+#[repr(u8)]
 pub enum SlruKind {
     Clog,
     MultiXactMembers,


### PR DESCRIPTION
As discussed with @hlinnaka, we need this feature for the multi-master project.

This PR adds options for postgres to read SLRU pages (e.g. clog, multixact) from the page server. 

This PR still needs some more testing and it's ok if it is not merged to main. I very much appreciate if someone can take a second look. 

PR in postgres: https://github.com/zenithdb/postgres/pull/142 