### PR TITLE
Store page image for HEAP2_PRUNE with FPI

### DIFF
--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -149,6 +149,7 @@ pub const XLOG_HEAP_DELETE: u8 = 0x10;
 pub const XLOG_HEAP_UPDATE: u8 = 0x20;
 pub const XLOG_HEAP_HOT_UPDATE: u8 = 0x40;
 pub const XLOG_HEAP_INIT_PAGE: u8 = 0x80;
+pub const XLOG_HEAP2_PRUNE: u8 = 0x10;
 pub const XLOG_HEAP2_VISIBLE: u8 = 0x40;
 pub const XLOG_HEAP2_MULTI_INSERT: u8 = 0x50;
 pub const XLH_INSERT_ALL_FROZEN_SET: u8 = (1 << 5) as u8;

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -286,9 +286,11 @@ impl<'a, R: Repository> WalIngest<'a, R> {
         //
         if blk.apply_image
             && blk.has_image
-            && decoded.xl_rmid == pg_constants::RM_XLOG_ID
-            && (decoded.xl_info == pg_constants::XLOG_FPI
-                || decoded.xl_info == pg_constants::XLOG_FPI_FOR_HINT)
+            && ((decoded.xl_rmid == pg_constants::RM_XLOG_ID
+				 && (decoded.xl_info == pg_constants::XLOG_FPI
+					 || decoded.xl_info == pg_constants::XLOG_FPI_FOR_HINT)) ||
+				(decoded.xl_rmid == pg_constants::RM_HEAP2_ID
+				 && (decoded.xl_info & pg_constants::XLOG_HEAP_OPMASK) == pg_constants::XLOG_HEAP2_PRUNE))
         // compression of WAL is not yet supported: fall back to storing the original WAL record
             && (blk.bimg_info & pg_constants::BKPIMAGE_IS_COMPRESSED) == 0
         {

--- a/test_runner/performance/test_update.py
+++ b/test_runner/performance/test_update.py
@@ -8,12 +8,15 @@ from fixtures.benchmark_fixture import MetricReport, ZenithBenchmarker
 from fixtures.compare_fixtures import PgCompare
 import pytest
 
+
 def test_update(zenith_with_baseline: PgCompare):
     env = zenith_with_baseline
 
     with closing(env.pg.connect()) as conn:
         with conn.cursor() as cur:
-            cur.execute("create table t (pk integer, val bigint default 0, t text default repeat(' ', 100))")
+            cur.execute(
+                "create table t (pk integer, val bigint default 0, t text default repeat(' ', 100))"
+            )
             cur.execute('insert into t (pk) values (generate_series(1,10000000))')
             with env.record_duration('update'):
                 cur.execute('update t set val=val+1')

--- a/test_runner/performance/test_update.py
+++ b/test_runner/performance/test_update.py
@@ -9,7 +9,8 @@ from fixtures.compare_fixtures import PgCompare
 import pytest
 
 
-def test_update(zenith_with_baseline: PgCompare):
+@pytest.mark.parametrize('rows', [pytest.param(1000000)])
+def test_update(zenith_with_baseline: PgCompare, rows: int):
     env = zenith_with_baseline
 
     with closing(env.pg.connect()) as conn:
@@ -17,7 +18,7 @@ def test_update(zenith_with_baseline: PgCompare):
             cur.execute(
                 "create table t (pk integer, val bigint default 0, t text default repeat(' ', 100))"
             )
-            cur.execute('insert into t (pk) values (generate_series(1,10000000))')
+            cur.execute(f'insert into t (pk) values (generate_series(1,{rows}))')
             with env.record_duration('update'):
                 cur.execute('update t set val=val+1')
             with env.record_duration('select'):

--- a/test_runner/performance/test_update.py
+++ b/test_runner/performance/test_update.py
@@ -1,0 +1,21 @@
+# Test sequential scan speed
+#
+from contextlib import closing
+from dataclasses import dataclass
+from fixtures.zenith_fixtures import ZenithEnv
+from fixtures.log_helper import log
+from fixtures.benchmark_fixture import MetricReport, ZenithBenchmarker
+from fixtures.compare_fixtures import PgCompare
+import pytest
+
+def test_update(zenith_with_baseline: PgCompare):
+    env = zenith_with_baseline
+
+    with closing(env.pg.connect()) as conn:
+        with conn.cursor() as cur:
+            cur.execute("create table t (pk integer, val bigint default 0, t text default repeat(' ', 100))")
+            cur.execute('insert into t (pk) values (generate_series(1,10000000))')
+            with env.record_duration('update'):
+                cur.execute('update t set val=val+1')
+            with env.record_duration('select'):
+                cur.execute('select sum(val) from t')


### PR DESCRIPTION
I noticed that massive update (i.e. "update t set x=x+1") cause generation of a lot of HEAP2_PRUNE war records with FPI.
And looking at code of `heap_xlog_prune` I noticed that it it does nothing except extracting image when contains FPI.
Well, not exactly true - it also updates FSM. But we in any case ignore this updates.
So HEAP2_PRUNE+FPI can be handled by pageserver itself (as it is done for XLOG_FPI) by storing page image than applying WAL record.