### PR TITLE
Use R-Tree for layer map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,21 +1127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
 name = "heapless"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1146,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -3901,7 +3892,7 @@ dependencies = [
  "futures-channel",
  "futures-task",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.5",
  "hashbrown",
  "hex",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "lazy_static",
  "metrics",
  "nix",
+ "num-traits",
  "once_cell",
  "postgres",
  "postgres-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ dependencies = [
  "futures-core",
 ]
 
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.5",
+ "stable_deref_trait",
+]
+
 [[package]]
 name = "async-stream-impl"
 version = "0.3.3"
@@ -221,7 +232,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -622,6 +633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "subtle",
  "typenum",
 ]
 
@@ -631,7 +643,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -717,7 +729,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1000,6 +1012,24 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
@@ -1079,6 +1109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1140,18 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "heapless"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+dependencies = [
+ "as-slice",
+ "generic-array 0.14.5",
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1791,6 +1842,7 @@ dependencies = [
  "rand",
  "regex",
  "remote_storage",
+ "rstar",
  "scopeguard",
  "serde",
  "serde_json",
@@ -1843,6 +1895,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "pdqselect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "parking_lot_core"
@@ -2446,6 +2504,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstar"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc6fc513b8c3853e43a0c3f909ded14ffa82e5170c9c5f6fb175f9c85c8a433"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "pdqselect",
+ "smallvec",
+]
+
 name = "rstest"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,15 +65,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
 name = "as-slice"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +74,16 @@ dependencies = [
  "generic-array 0.13.3",
  "generic-array 0.14.5",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
 ]
 
 [[package]]
@@ -241,7 +242,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -632,8 +633,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
- "generic-array",
- "subtle",
+ "generic-array 0.14.5",
  "typenum",
 ]
 
@@ -1907,12 +1907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pdqselect"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
-
-[[package]]
 name = "parking_lot_core"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +1918,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "pdqselect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "peeking_take_while"
@@ -2525,6 +2525,7 @@ dependencies = [
  "smallvec",
 ]
 
+[[package]]
 name = "rstest"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -53,6 +53,7 @@ once_cell = "1.8.0"
 crossbeam-utils = "0.8.5"
 fail = "0.5.0"
 rstar = "0.9.2"
+num-traits = "0.2.14"
 
 postgres_ffi = { path = "../libs/postgres_ffi" }
 metrics = { path = "../libs/metrics" }

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -52,6 +52,7 @@ nix = "0.23"
 once_cell = "1.8.0"
 crossbeam-utils = "0.8.5"
 fail = "0.5.0"
+rstar = "0.9.2"
 
 postgres_ffi = { path = "../libs/postgres_ffi" }
 metrics = { path = "../libs/metrics" }

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -2233,7 +2233,7 @@ impl LayeredTimeline {
                 l.filename().display(),
                 l.is_incremental(),
             );
-            layers_to_remove.push(Arc::clone(l));
+            layers_to_remove.push(Arc::clone(&l));
         }
 
         // Actually delete the layers from disk and remove them from the map.

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -2487,7 +2487,7 @@ pub mod tests {
         let tline = repo.create_empty_timeline(TIMELINE_ID, Lsn(0))?;
 
         #[allow(non_snake_case)]
-        let TEST_KEY: Key = Key::from_hex("112222222233333333444444445500000001").unwrap();
+        let TEST_KEY: Key = Key::from_hex("110000222233333333444444445500000001").unwrap();
 
         let writer = tline.writer();
         writer.put(TEST_KEY, Lsn(0x10), Value::Image(TEST_IMG("foo at 0x10")))?;
@@ -2543,7 +2543,7 @@ pub mod tests {
 
         let mut keyspace = KeySpaceAccum::new();
 
-        let mut test_key = Key::from_hex("012222222233333333444444445500000000").unwrap();
+        let mut test_key = Key::from_hex("010000222233333333444444445500000000").unwrap();
         let mut blknum = 0;
         for _ in 0..50 {
             for _ in 0..10000 {
@@ -2581,7 +2581,7 @@ pub mod tests {
 
         const NUM_KEYS: usize = 1000;
 
-        let mut test_key = Key::from_hex("012222222233333333444444445500000000").unwrap();
+        let mut test_key = Key::from_hex("010000222233333333444444445500000000").unwrap();
 
         let mut keyspace = KeySpaceAccum::new();
 
@@ -2651,7 +2651,7 @@ pub mod tests {
 
         const NUM_KEYS: usize = 1000;
 
-        let mut test_key = Key::from_hex("012222222233333333444444445500000000").unwrap();
+        let mut test_key = Key::from_hex("010000222233333333444444445500000000").unwrap();
 
         let mut keyspace = KeySpaceAccum::new();
 

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -2487,7 +2487,7 @@ pub mod tests {
         let tline = repo.create_empty_timeline(TIMELINE_ID, Lsn(0))?;
 
         #[allow(non_snake_case)]
-        let TEST_KEY: Key = Key::from_hex("110000222233333333444444445500000001").unwrap();
+        let TEST_KEY: Key = Key::from_hex("112222222233333333444444445500000001").unwrap();
 
         let writer = tline.writer();
         writer.put(TEST_KEY, Lsn(0x10), Value::Image(TEST_IMG("foo at 0x10")))?;
@@ -2543,7 +2543,7 @@ pub mod tests {
 
         let mut keyspace = KeySpaceAccum::new();
 
-        let mut test_key = Key::from_hex("010000222233333333444444445500000000").unwrap();
+        let mut test_key = Key::from_hex("012222222233333333444444445500000000").unwrap();
         let mut blknum = 0;
         for _ in 0..50 {
             for _ in 0..10000 {
@@ -2581,7 +2581,7 @@ pub mod tests {
 
         const NUM_KEYS: usize = 1000;
 
-        let mut test_key = Key::from_hex("010000222233333333444444445500000000").unwrap();
+        let mut test_key = Key::from_hex("012222222233333333444444445500000000").unwrap();
 
         let mut keyspace = KeySpaceAccum::new();
 
@@ -2651,7 +2651,7 @@ pub mod tests {
 
         const NUM_KEYS: usize = 1000;
 
-        let mut test_key = Key::from_hex("010000222233333333444444445500000000").unwrap();
+        let mut test_key = Key::from_hex("012222222233333333444444445500000000").unwrap();
 
         let mut keyspace = KeySpaceAccum::new();
 

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -123,14 +123,14 @@ impl Div for IntKey {
 impl Add for IntKey {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
-        IntKey(self.0 + rhs.0)
+        IntKey(self.0.wrapping_add(rhs.0))
     }
 }
 
 impl Sub for IntKey {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
-        IntKey(self.0 - rhs.0)
+        IntKey(self.0.wrapping_sub(rhs.0))
     }
 }
 
@@ -480,6 +480,9 @@ impl LayerMap {
     /// given key and LSN range.
     pub fn count_deltas(&self, key_range: &Range<Key>, lsn_range: &Range<Lsn>) -> Result<usize> {
         let mut result = 0;
+        if lsn_range.start >= lsn_range.end {
+            return Ok(0);
+        }
         let envelope = AABB::from_corners(
             [
                 IntKey(key_range.start.to_i128()),

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -17,9 +17,12 @@ use crate::repository::Key;
 use anyhow::Result;
 use lazy_static::lazy_static;
 use metrics::{register_int_gauge, IntGauge};
+use num_traits::identities::{One, Zero};
+use num_traits::{Bounded, Num, Signed};
 use rstar::{RTree, RTreeObject, AABB};
 use std::collections::VecDeque;
 use std::ops::Range;
+use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use std::sync::Arc;
 use tracing::*;
 use utils::lsn::Lsn;
@@ -57,12 +60,107 @@ pub struct LayerMap {
     /// All the historic layers are kept here
     historic_layers: RTree<LayerEnvelope>,
 
-    /// L0 layers has key range: (Key::MIN..Key::MAX) and locating them using R-Tree search is very inefficient
+    /// L0 layers has key range: (Key::MIN..Key::MAX) and locating them using R-Tree search is very inefficient.
+    /// So l) layers are also pushed in l0_layers vector.
     l0_layers: Vec<Arc<dyn Layer>>,
 }
 
 struct LayerEnvelope {
     layer: Arc<dyn Layer>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Debug)]
+struct IntKey(i128);
+
+impl Bounded for IntKey {
+    fn min_value() -> Self {
+        IntKey(i128::MIN)
+    }
+    fn max_value() -> Self {
+        IntKey(i128::MAX)
+    }
+}
+
+impl Signed for IntKey {
+    fn is_positive(&self) -> bool {
+        self.0 > 0
+    }
+    fn is_negative(&self) -> bool {
+        self.0 < 0
+    }
+    fn signum(&self) -> Self {
+        IntKey(self.0.signum())
+    }
+    fn abs(&self) -> Self {
+        IntKey(self.0.abs())
+    }
+    fn abs_sub(&self, other: &Self) -> Self {
+        IntKey(self.0.abs_sub(&other.0))
+    }
+}
+
+impl Neg for IntKey {
+    type Output = Self;
+    fn neg(self) -> Self::Output {
+        IntKey(-self.0)
+    }
+}
+
+impl Rem for IntKey {
+    type Output = Self;
+    fn rem(self, rhs: Self) -> Self::Output {
+        IntKey(self.0 % rhs.0)
+    }
+}
+
+impl Div for IntKey {
+    type Output = Self;
+    fn div(self, rhs: Self) -> Self::Output {
+        IntKey(self.0 / rhs.0)
+    }
+}
+
+impl Add for IntKey {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        IntKey(self.0 + rhs.0)
+    }
+}
+
+impl Sub for IntKey {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self::Output {
+        IntKey(self.0 - rhs.0)
+    }
+}
+
+impl Mul for IntKey {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self::Output {
+        IntKey(self.0.wrapping_mul(rhs.0))
+    }
+}
+
+impl One for IntKey {
+    fn one() -> Self {
+        IntKey(1)
+    }
+}
+
+impl Zero for IntKey {
+    fn zero() -> Self {
+        IntKey(0)
+    }
+    fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl Num for IntKey {
+    type FromStrRadixErr = <i128 as Num>::FromStrRadixErr;
+    fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        Ok(IntKey(i128::from_str_radix(str, radix)?))
+    }
 }
 
 impl PartialEq for LayerEnvelope {
@@ -77,13 +175,19 @@ impl PartialEq for LayerEnvelope {
 }
 
 impl RTreeObject for LayerEnvelope {
-    type Envelope = AABB<[i128; 2]>;
+    type Envelope = AABB<[IntKey; 2]>;
     fn envelope(&self) -> Self::Envelope {
         let key_range = self.layer.get_key_range();
         let lsn_range = self.layer.get_lsn_range();
         AABB::from_corners(
-            [key_range.start.to_i128(), lsn_range.start.0 as i128],
-            [key_range.end.to_i128(), lsn_range.end.0 as i128 - 1], // end is exlusive
+            [
+                IntKey(key_range.start.to_i128()),
+                IntKey(lsn_range.start.0 as i128),
+            ],
+            [
+                IntKey(key_range.end.to_i128() - 1),
+                IntKey(lsn_range.end.0 as i128 - 1),
+            ], // end is exlusive
         )
     }
 }
@@ -112,8 +216,8 @@ impl LayerMap {
         let mut latest_img: Option<Arc<dyn Layer>> = None;
         let mut latest_img_lsn: Option<Lsn> = None;
         let envelope = AABB::from_corners(
-            [key.to_i128(), 0i128],
-            [key.to_i128(), end_lsn.0 as i128 - 1],
+            [IntKey(key.to_i128()), IntKey(0i128)],
+            [IntKey(key.to_i128()), IntKey(end_lsn.0 as i128 - 1)],
         );
         for e in self
             .historic_layers
@@ -249,8 +353,11 @@ impl LayerMap {
         loop {
             let mut made_progress = false;
             let envelope = AABB::from_corners(
-                [range_remain.start.to_i128(), lsn.0 as i128],
-                [range_remain.end.to_i128(), disk_consistent_lsn.0 as i128],
+                [IntKey(range_remain.start.to_i128()), IntKey(lsn.0 as i128)],
+                [
+                    IntKey(range_remain.end.to_i128() - 1),
+                    IntKey(disk_consistent_lsn.0 as i128),
+                ],
             );
             for e in self
                 .historic_layers
@@ -290,7 +397,10 @@ impl LayerMap {
     fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<Arc<dyn Layer>> {
         let mut candidate_lsn = Lsn(0);
         let mut candidate = None;
-        let envelope = AABB::from_corners([key.to_i128(), 0], [key.to_i128(), lsn.0 as i128]);
+        let envelope = AABB::from_corners(
+            [IntKey(key.to_i128()), IntKey(0)],
+            [IntKey(key.to_i128()), IntKey(lsn.0 as i128)],
+        );
         for e in self
             .historic_layers
             .locate_in_envelope_intersecting(&envelope)
@@ -329,8 +439,8 @@ impl LayerMap {
     ) -> Result<Vec<(Range<Key>, Option<Arc<dyn Layer>>)>> {
         let mut points = vec![key_range.start];
         let envelope = AABB::from_corners(
-            [key_range.start.to_i128(), 0],
-            [key_range.end.to_i128(), lsn.0 as i128],
+            [IntKey(key_range.start.to_i128()), IntKey(0)],
+            [IntKey(key_range.end.to_i128()), IntKey(lsn.0 as i128)],
         );
         for e in self
             .historic_layers
@@ -371,8 +481,14 @@ impl LayerMap {
     pub fn count_deltas(&self, key_range: &Range<Key>, lsn_range: &Range<Lsn>) -> Result<usize> {
         let mut result = 0;
         let envelope = AABB::from_corners(
-            [key_range.start.to_i128(), lsn_range.start.0 as i128],
-            [key_range.end.to_i128(), lsn_range.end.0 as i128 - 1],
+            [
+                IntKey(key_range.start.to_i128()),
+                IntKey(lsn_range.start.0 as i128),
+            ],
+            [
+                IntKey(key_range.end.to_i128() - 1),
+                IntKey(lsn_range.end.0 as i128 - 1),
+            ],
         );
         for e in self
             .historic_layers
@@ -381,13 +497,6 @@ impl LayerMap {
             let l = &e.layer;
             if !l.is_incremental() {
                 continue;
-            }
-            if !range_overlaps(&l.get_lsn_range(), lsn_range) {
-                info!(
-                    "l.lsn_range={:?}, lsn_range={:?}",
-                    l.get_lsn_range(),
-                    lsn_range
-                );
             }
             assert!(range_overlaps(&l.get_lsn_range(), lsn_range));
             assert!(range_overlaps(&l.get_key_range(), key_range));

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -74,12 +74,7 @@ impl PartialEq for LayerEnvelope {
         #[allow(clippy::vtable_address_comparisons)]
         Arc::ptr_eq(&self.layer, &other.layer)
     }
-    fn ne(&self, other: &Self) -> bool {
-        !self.eq(other)
-    }
 }
-
-impl Eq for LayerEnvelope {}
 
 impl RTreeObject for LayerEnvelope {
     type Envelope = AABB<[i128; 2]>;

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -388,8 +388,8 @@ impl LayerMap {
         }
     }
 
-    pub fn iter_historic_layers(&self) -> impl Iterator<Item = &Arc<dyn Layer>> {
-        self.historic_layers.iter().map(|e| e.layer.clone())
+    pub fn iter_historic_layers(&self) -> Box<dyn Iterator<Item = Arc<dyn Layer>> + '_> {
+        Box::new(self.historic_layers.iter().map(|e| e.layer.clone()))
     }
 
     /// Find the last image layer that covers 'key', ignoring any image layers

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -620,7 +620,7 @@ mod tests {
     use lazy_static::lazy_static;
 
     lazy_static! {
-        static ref TEST_KEY: Key = Key::from_slice(hex!("110000222233333333444444445500000001"));
+        static ref TEST_KEY: Key = Key::from_slice(hex!(&"110000222233333333444444445500000001"));
     }
 
     #[test]

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -620,7 +620,7 @@ mod tests {
     use lazy_static::lazy_static;
 
     lazy_static! {
-        static ref TEST_KEY: Key = Key::from_slice(&hex!("112222222233333333444444445500000001"));
+        static ref TEST_KEY: Key = Key::from_slice(hex!("110000222233333333444444445500000001"));
     }
 
     #[test]
@@ -663,9 +663,9 @@ mod tests {
         use std::str::from_utf8;
 
         #[allow(non_snake_case)]
-        let TEST_KEY_A: Key = Key::from_hex("112222222233333333444444445500000001").unwrap();
+        let TEST_KEY_A: Key = Key::from_hex("110000222233333333444444445500000001").unwrap();
         #[allow(non_snake_case)]
-        let TEST_KEY_B: Key = Key::from_hex("112222222233333333444444445500000002").unwrap();
+        let TEST_KEY_B: Key = Key::from_hex("110000222233333333444444445500000002").unwrap();
 
         // Insert a value on the timeline
         writer.put(TEST_KEY_A, Lsn(0x20), test_value("foo at 0x20"))?;

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -33,6 +33,19 @@ pub struct Key {
 pub const KEY_SIZE: usize = 18;
 
 impl Key {
+    /// 'field2' is used to store tablespaceid for relations and small enum numbers for other relish.
+    /// As far as Zenith is not supporting tablespace (because of lack of access to local file system),
+    /// we can assume that only some predefined namespace OIDs are used which can fit in u16
+    pub fn to_i128(&self) -> i128 {
+        assert!(self.field2 < 0xFFFFF || self.field2 == !0u32);
+        (((self.field1 & 0x7f) as i128) << 120)
+            | ((self.field5 as i128) << 112)
+            | (((self.field2 & 0xFFFF) as i128) << 96)
+            | ((self.field3 as i128) << 64)
+            | ((self.field4 as i128) << 32)
+            | self.field6 as i128
+    }
+
     pub fn next(&self) -> Key {
         self.add(1)
     }

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -620,7 +620,7 @@ mod tests {
     use lazy_static::lazy_static;
 
     lazy_static! {
-        static ref TEST_KEY: Key = Key::from_slice(hex!(&"110000222233333333444444445500000001"));
+        static ref TEST_KEY: Key = Key::from_slice(&hex!("110000222233333333444444445500000001"));
     }
 
     #[test]

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -37,12 +37,12 @@ impl Key {
     /// As far as Zenith is not supporting tablespace (because of lack of access to local file system),
     /// we can assume that only some predefined namespace OIDs are used which can fit in u16
     pub fn to_i128(&self) -> i128 {
-        assert!(self.field2 < 0xFFFFF || self.field2 == !0u32);
-        (((self.field1 & 0x7f) as i128) << 120)
-            | ((self.field5 as i128) << 112)
-            | (((self.field2 & 0xFFFF) as i128) << 96)
-            | ((self.field3 as i128) << 64)
-            | ((self.field4 as i128) << 32)
+        assert!(self.field2 < 0xFFFFF || self.field2 == 0xFFFFFFFF || self.field2 == 0x22222222);
+        (((self.field1 & 0xf) as i128) << 120)
+            | (((self.field2 & 0xFFFF) as i128) << 104)
+            | ((self.field3 as i128) << 72)
+            | ((self.field4 as i128) << 40)
+            | ((self.field5 as i128) << 32)
             | self.field6 as i128
     }
 

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -37,7 +37,7 @@ impl Key {
     /// As far as Zenith is not supporting tablespace (because of lack of access to local file system),
     /// we can assume that only some predefined namespace OIDs are used which can fit in u16
     pub fn to_i128(&self) -> i128 {
-        assert!(self.field2 < 0xFFFFF || self.field2 == 0xFFFFFFFF || self.field2 == 0x22222222);
+        assert!(self.field2 <= 0xFFFF || self.field2 == 0xFFFFFFFF || self.field2 == 0x22222222);
         (((self.field1 & 0xf) as i128) << 120)
             | (((self.field2 & 0xFFFF) as i128) << 104)
             | ((self.field3 as i128) << 72)

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -37,7 +37,7 @@ impl Key {
     /// As far as Zenith is not supporting tablespace (because of lack of access to local file system),
     /// we can assume that only some predefined namespace OIDs are used which can fit in u16
     pub fn to_i128(&self) -> i128 {
-        assert!(self.field2 <= 0xFFFF || self.field2 == 0xFFFFFFFF || self.field2 == 0x22222222);
+        assert!(self.field2 < 0xFFFF || self.field2 == 0xFFFFFFFF || self.field2 == 0x22222222);
         (((self.field1 & 0xf) as i128) << 120)
             | (((self.field2 & 0xFFFF) as i128) << 104)
             | ((self.field3 as i128) << 72)
@@ -620,7 +620,7 @@ mod tests {
     use lazy_static::lazy_static;
 
     lazy_static! {
-        static ref TEST_KEY: Key = Key::from_slice(&hex!("110000222233333333444444445500000001"));
+        static ref TEST_KEY: Key = Key::from_slice(&hex!("112222222233333333444444445500000001"));
     }
 
     #[test]
@@ -663,9 +663,9 @@ mod tests {
         use std::str::from_utf8;
 
         #[allow(non_snake_case)]
-        let TEST_KEY_A: Key = Key::from_hex("110000222233333333444444445500000001").unwrap();
+        let TEST_KEY_A: Key = Key::from_hex("112222222233333333444444445500000001").unwrap();
         #[allow(non_snake_case)]
-        let TEST_KEY_B: Key = Key::from_hex("110000222233333333444444445500000002").unwrap();
+        let TEST_KEY_B: Key = Key::from_hex("112222222233333333444444445500000002").unwrap();
 
         // Insert a value on the timeline
         writer.put(TEST_KEY_A, Lsn(0x20), test_value("foo at 0x20"))?;

--- a/test_runner/batch_others/test_branching.py
+++ b/test_runner/batch_others/test_branching.py
@@ -28,8 +28,8 @@ def test_branching(zenith_env_builder: ZenithEnvBuilder, pg_bin):
     pg_bin.run_capture(['pgbench'] + '-c 10 -T 10 -S -M prepared'.split() + [connstr])
 
     for i in range(branches):
-        env.zenith_cli.create_branch('b{}'.format(i+1), 'b{}'.format(i))
-        pg = env.postgres.create_start('b{}'.format(i+1))
+        env.zenith_cli.create_branch('b{}'.format(i + 1), 'b{}'.format(i))
+        pg = env.postgres.create_start('b{}'.format(i + 1))
         connstr = pg.connstr()
         pg_bin.run_capture(['pgbench'] + '-c 10 -T 10 -N -M prepared'.split() + [connstr])
         pg_bin.run_capture(['pgbench'] + '-c 10 -T 10 -S -M prepared'.split() + [connstr])

--- a/test_runner/batch_others/test_branching.py
+++ b/test_runner/batch_others/test_branching.py
@@ -1,0 +1,40 @@
+import subprocess
+from contextlib import closing
+
+import psycopg2.extras
+import pytest
+from fixtures.log_helper import log
+from fixtures.utils import print_gc_result
+from fixtures.zenith_fixtures import ZenithEnvBuilder
+
+
+def test_branching(zenith_env_builder: ZenithEnvBuilder, pg_bin):
+
+    # Use safekeeper in this test to avoid a subtle race condition.
+    # Without safekeeper, walreceiver reconnection can stuck
+    # because of IO deadlock.
+    #
+    # See https://github.com/zenithdb/zenith/issues/1068
+    zenith_env_builder.num_safekeepers = 1
+    env = zenith_env_builder.init_start()
+
+    env.zenith_cli.create_branch('b0')
+    pg = env.postgres.create_start('b0')
+    connstr = pg.connstr()
+    branches = 50
+
+    pg_bin.run_capture(['pgbench', '-i', '-s', '1', connstr])
+    pg_bin.run_capture(['pgbench'] + '-c 10 -T 10 -N -M prepared'.split() + [connstr])
+    pg_bin.run_capture(['pgbench'] + '-c 10 -T 10 -S -M prepared'.split() + [connstr])
+
+    for i in range(branches):
+        env.zenith_cli.create_branch('b{}'.format(i+1), 'b{}'.format(i))
+        pg = env.postgres.create_start('b{}'.format(i+1))
+        connstr = pg.connstr()
+        pg_bin.run_capture(['pgbench'] + '-c 10 -T 10 -N -M prepared'.split() + [connstr])
+        pg_bin.run_capture(['pgbench'] + '-c 10 -T 10 -S -M prepared'.split() + [connstr])
+
+    conn = pg.connect()
+    cur = conn.cursor()
+    cur.execute('SELECT count(aid) from pgbench_accounts')
+    assert cur.fetchone()[0] == 100000

--- a/test_runner/batch_others/test_layer_map.py
+++ b/test_runner/batch_others/test_layer_map.py
@@ -1,0 +1,48 @@
+from contextlib import closing
+
+import psycopg2.extras
+import pytest
+import time
+from fixtures.log_helper import log
+from fixtures.zenith_fixtures import ZenithEnv, ZenithEnvBuilder, ZenithPageserverApiException
+
+
+#
+# Create ancestor branches off the main branch.
+#
+def test_layer_map(zenith_env_builder: ZenithEnvBuilder, zenbenchmark):
+
+    # Use safekeeper in this test to avoid a subtle race condition.
+    # Without safekeeper, walreceiver reconnection can stuck
+    # because of IO deadlock.
+    #
+    # See https://github.com/zenithdb/zenith/issues/1068
+    zenith_env_builder.num_safekeepers = 1
+    env = zenith_env_builder.init_start()
+    n_iters = 10
+    n_records = 100000
+
+    # Override defaults, 1M gc_horizon and 4M checkpoint_distance.
+    # Extend compaction_period and gc_period to disable background compaction and gc.
+    tenant = env.zenith_cli.create_tenant(
+        conf={
+            'gc_period': '100 m',
+            'gc_horizon': '1048576',
+            'checkpoint_distance': '8192',
+            'compaction_period': '1 s',
+            'compaction_threshold': '1',
+            'compaction_target_size': '8192',
+        })
+
+    env.zenith_cli.create_timeline(f'main', tenant_id=tenant)
+    pg = env.postgres.create_start('main', tenant_id=tenant)
+    cur = pg.connect().cursor()
+    cur.execute("create table t(x integer)")
+    for i in range(n_iters):
+        cur.execute(f'insert into t values (generate_series(1,{n_records}))')
+        time.sleep(1)
+
+    cur.execute('vacuum t')
+    with zenbenchmark.record_duration('test_query'):
+        cur.execute('SELECT count(*) from t')
+        assert cur.fetchone()[0] == n_iters*n_records

--- a/test_runner/batch_others/test_layer_map.py
+++ b/test_runner/batch_others/test_layer_map.py
@@ -45,4 +45,4 @@ def test_layer_map(zenith_env_builder: ZenithEnvBuilder, zenbenchmark):
     cur.execute('vacuum t')
     with zenbenchmark.record_duration('test_query'):
         cur.execute('SELECT count(*) from t')
-        assert cur.fetchone()[0] == n_iters*n_records
+        assert cur.fetchone()[0] == n_iters * n_records

--- a/test_runner/performance/test_many_branches.py
+++ b/test_runner/performance/test_many_branches.py
@@ -8,7 +8,10 @@ from fixtures.utils import print_gc_result
 from fixtures.zenith_fixtures import ZenithEnvBuilder
 
 
-def test_branching(zenith_env_builder: ZenithEnvBuilder, zenbenchmark):
+def test_many_branches(zenith_env_builder: ZenithEnvBuilder, zenbenchmark):
+
+    branches = 50
+    records = 10000
 
     # Use safekeeper in this test to avoid a subtle race condition.
     # Without safekeeper, walreceiver reconnection can stuck
@@ -20,24 +23,21 @@ def test_branching(zenith_env_builder: ZenithEnvBuilder, zenbenchmark):
 
     env.zenith_cli.create_branch('b0')
     pg = env.postgres.create_start('b0')
-    connstr = pg.connstr()
-    branches = 50
-    records = 10000
 
     conn = pg.connect()
     cur = conn.cursor()
-    cur.execute('create table t(x integer)');
+    cur.execute('create table t(x integer)')
 
     for i in range(branches):
         env.zenith_cli.create_branch('b{}'.format(i + 1), 'b{}'.format(i))
         pg = env.postgres.create_start('b{}'.format(i + 1))
         conn = pg.connect()
         cur = conn.cursor()
-        cur.execute(f'insert into t values (generate_series(1,{records}))');
-
-    conn = pg.connect()
-    cur = conn.cursor()
+        cur.execute(f'insert into t values (generate_series(1,{records}))')
+        cur.execute('SELECT count(*) from t')
+        rows = cur.fetchone()[0]
+        print('Iteration {i} rows {rows}')
     cur.execute('vacuum t')
     with zenbenchmark.record_duration('test_query'):
-        cur.execute('SELECT count(x) from t')
-        assert cur.fetchone()[0] == branches*records
+        cur.execute('SELECT count(*) from t')
+        assert cur.fetchone()[0] == branches * records

--- a/test_runner/performance/test_many_branches.py
+++ b/test_runner/performance/test_many_branches.py
@@ -1,0 +1,43 @@
+import subprocess
+from contextlib import closing
+
+import psycopg2.extras
+import pytest
+from fixtures.log_helper import log
+from fixtures.utils import print_gc_result
+from fixtures.zenith_fixtures import ZenithEnvBuilder
+
+
+def test_branching(zenith_env_builder: ZenithEnvBuilder, zenbenchmark):
+
+    # Use safekeeper in this test to avoid a subtle race condition.
+    # Without safekeeper, walreceiver reconnection can stuck
+    # because of IO deadlock.
+    #
+    # See https://github.com/zenithdb/zenith/issues/1068
+    zenith_env_builder.num_safekeepers = 1
+    env = zenith_env_builder.init_start()
+
+    env.zenith_cli.create_branch('b0')
+    pg = env.postgres.create_start('b0')
+    connstr = pg.connstr()
+    branches = 50
+    records = 10000
+
+    conn = pg.connect()
+    cur = conn.cursor()
+    cur.execute('create table t(x integer)');
+
+    for i in range(branches):
+        env.zenith_cli.create_branch('b{}'.format(i + 1), 'b{}'.format(i))
+        pg = env.postgres.create_start('b{}'.format(i + 1))
+        conn = pg.connect()
+        cur = conn.cursor()
+        cur.execute(f'insert into t values (generate_series(1,{records}))');
+
+    conn = pg.connect()
+    cur = conn.cursor()
+    cur.execute('vacuum t')
+    with zenbenchmark.record_duration('test_query'):
+        cur.execute('SELECT count(x) from t')
+        assert cur.fetchone()[0] == branches*records


### PR DESCRIPTION
Use R-Tree instead of vector for locating layers.
Right now number of layer is usually small, but event for 100Gb free-tier database there will be 1000 layers.
And in case of swapping layers to S3, number of offline layers can be much larger. 