### PR TITLE
WIP Separate page reconstruction from layers compaction

### DIFF
--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -38,6 +38,8 @@ pub mod defaults {
     pub const DEFAULT_COMPACTION_TARGET_SIZE: u64 = 128 * 1024 * 1024;
 
     pub const DEFAULT_COMPACTION_PERIOD: &str = "1 s";
+    pub const DEFAULT_RECONSTRUCT_MIN_INTERVAL: &str = "10 s";
+    pub const DEFAULT_RECONSTRUCT_MAX_INTERVAL: &str = "100 s";
 
     pub const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
     pub const DEFAULT_GC_PERIOD: &str = "100 s";
@@ -49,7 +51,10 @@ pub mod defaults {
     pub const DEFAULT_REMOTE_STORAGE_MAX_CONCURRENT_SYNC: usize = 10;
     pub const DEFAULT_REMOTE_STORAGE_MAX_SYNC_ERRORS: u32 = 10;
 
-    pub const DEFAULT_PAGE_CACHE_SIZE: usize = 8192;
+    // It should not be smaller than DEFAULT_CHECKPOINT_DISTANCE because
+    // get_reconstruct_data looks first for open layers.
+    // So even if image layer will be generated, page server prefer to reconstruct page from inmem layer.
+    pub const DEFAULT_PAGE_CACHE_SIZE: usize = 128 * 1024; // 1Gb
     pub const DEFAULT_MAX_FILE_DESCRIPTORS: usize = 100;
 
     ///
@@ -65,6 +70,8 @@ pub mod defaults {
 #checkpoint_distance = {DEFAULT_CHECKPOINT_DISTANCE} # in bytes
 #compaction_target_size = {DEFAULT_COMPACTION_TARGET_SIZE} # in bytes
 #compaction_period = '{DEFAULT_COMPACTION_PERIOD}'
+#reconstruct_min_interval = '{DEFAULT_RECONSTRUCT_MIN_INTERVAL}'
+#reconstruct_max_interval = '{DEFAULT_RECONSTRUCT_MAX_INTERVAL}'
 
 #gc_period = '{DEFAULT_GC_PERIOD}'
 #gc_horizon = {DEFAULT_GC_HORIZON}
@@ -106,6 +113,10 @@ pub struct PageServerConf {
 
     // How often to check if there's compaction work to be done.
     pub compaction_period: Duration,
+
+    // How often to check if there's reconstruction work to be done.
+    pub reconstruct_min_interval: Duration,
+    pub reconstruct_max_interval: Duration,
 
     pub gc_horizon: u64,
     pub gc_period: Duration,
@@ -162,6 +173,8 @@ struct PageServerConfigBuilder {
 
     compaction_target_size: BuilderValue<u64>,
     compaction_period: BuilderValue<Duration>,
+    reconstruct_min_interval: BuilderValue<Duration>,
+    reconstruct_max_interval: BuilderValue<Duration>,
 
     gc_horizon: BuilderValue<u64>,
     gc_period: BuilderValue<Duration>,
@@ -198,6 +211,14 @@ impl Default for PageServerConfigBuilder {
             compaction_target_size: Set(DEFAULT_COMPACTION_TARGET_SIZE),
             compaction_period: Set(humantime::parse_duration(DEFAULT_COMPACTION_PERIOD)
                 .expect("cannot parse default compaction period")),
+            reconstruct_min_interval: Set(humantime::parse_duration(
+                DEFAULT_RECONSTRUCT_MIN_INTERVAL,
+            )
+            .expect("cannot parse default reconstruct period")),
+            reconstruct_max_interval: Set(humantime::parse_duration(
+                DEFAULT_RECONSTRUCT_MAX_INTERVAL,
+            )
+            .expect("cannot parse default reconstruct period")),
             gc_horizon: Set(DEFAULT_GC_HORIZON),
             gc_period: Set(humantime::parse_duration(DEFAULT_GC_PERIOD)
                 .expect("cannot parse default gc period")),
@@ -239,6 +260,14 @@ impl PageServerConfigBuilder {
 
     pub fn compaction_period(&mut self, compaction_period: Duration) {
         self.compaction_period = BuilderValue::Set(compaction_period)
+    }
+
+    pub fn reconstruct_min_interval(&mut self, reconstruct_period: Duration) {
+        self.reconstruct_min_interval = BuilderValue::Set(reconstruct_period)
+    }
+
+    pub fn reconstruct_max_interval(&mut self, reconstruct_period: Duration) {
+        self.reconstruct_max_interval = BuilderValue::Set(reconstruct_period)
     }
 
     pub fn gc_horizon(&mut self, gc_horizon: u64) {
@@ -313,6 +342,12 @@ impl PageServerConfigBuilder {
             compaction_period: self
                 .compaction_period
                 .ok_or(anyhow::anyhow!("missing compaction_period"))?,
+            reconstruct_min_interval: self
+                .reconstruct_min_interval
+                .ok_or(anyhow::anyhow!("missing reconstruct_min_interval"))?,
+            reconstruct_max_interval: self
+                .reconstruct_max_interval
+                .ok_or(anyhow::anyhow!("missing reconstruct_max_interval"))?,
             gc_horizon: self
                 .gc_horizon
                 .ok_or(anyhow::anyhow!("missing gc_horizon"))?,
@@ -453,6 +488,12 @@ impl PageServerConf {
                     builder.compaction_target_size(parse_toml_u64(key, item)?)
                 }
                 "compaction_period" => builder.compaction_period(parse_toml_duration(key, item)?),
+                "reconstruct_min_interval" => {
+                    builder.reconstruct_min_interval(parse_toml_duration(key, item)?)
+                }
+                "reconstruct_max_interval" => {
+                    builder.reconstruct_max_interval(parse_toml_duration(key, item)?)
+                }
                 "gc_horizon" => builder.gc_horizon(parse_toml_u64(key, item)?),
                 "gc_period" => builder.gc_period(parse_toml_duration(key, item)?),
                 "wait_lsn_timeout" => builder.wait_lsn_timeout(parse_toml_duration(key, item)?),
@@ -590,6 +631,8 @@ impl PageServerConf {
             checkpoint_distance: defaults::DEFAULT_CHECKPOINT_DISTANCE,
             compaction_target_size: 4 * 1024 * 1024,
             compaction_period: Duration::from_secs(10),
+            reconstruct_min_interval: Duration::from_secs(10),
+            reconstruct_max_interval: Duration::from_secs(100),
             gc_horizon: defaults::DEFAULT_GC_HORIZON,
             gc_period: Duration::from_secs(10),
             wait_lsn_timeout: Duration::from_secs(60),
@@ -662,6 +705,8 @@ checkpoint_distance = 111 # in bytes
 
 compaction_target_size = 111 # in bytes
 compaction_period = '111 s'
+reconstruct_min_interval = '11 s'
+reconstruct_max_interval = '111 s'
 
 gc_period = '222 s'
 gc_horizon = 222
@@ -700,6 +745,12 @@ id = 10
                 checkpoint_distance: defaults::DEFAULT_CHECKPOINT_DISTANCE,
                 compaction_target_size: defaults::DEFAULT_COMPACTION_TARGET_SIZE,
                 compaction_period: humantime::parse_duration(defaults::DEFAULT_COMPACTION_PERIOD)?,
+                reconstruct_min_interval: humantime::parse_duration(
+                    defaults::DEFAULT_RECONSTRUCT_MIN_INTERVAL
+                )?,
+                reconstruct_max_interval: humantime::parse_duration(
+                    defaults::DEFAULT_RECONSTRUCT_MAX_INTERVAL
+                )?,
                 gc_horizon: defaults::DEFAULT_GC_HORIZON,
                 gc_period: humantime::parse_duration(defaults::DEFAULT_GC_PERIOD)?,
                 wait_lsn_timeout: humantime::parse_duration(defaults::DEFAULT_WAIT_LSN_TIMEOUT)?,
@@ -745,6 +796,8 @@ id = 10
                 checkpoint_distance: 111,
                 compaction_target_size: 111,
                 compaction_period: Duration::from_secs(111),
+                reconstruct_min_interval: Duration::from_secs(11),
+                reconstruct_max_interval: Duration::from_secs(111),
                 gc_horizon: 222,
                 gc_period: Duration::from_secs(222),
                 wait_lsn_timeout: Duration::from_secs(111),

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -2043,7 +2043,6 @@ impl LayeredTimeline {
 
                 if img.len() == page_cache::PAGE_SZ {
                     let cache = page_cache::get();
-                    info!("Put in cache key={:?} lsn={}", key, last_rec_lsn);
                     cache.memorize_materialized_page(
                         self.tenantid,
                         self.timelineid,

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -138,6 +138,15 @@ impl Layer for DeltaLayer {
         self.lsn_range.clone()
     }
 
+    fn path(&self) -> PathBuf {
+        Self::path_for(
+            &self.path_or_conf,
+            self.timelineid,
+            self.tenantid,
+            &self.layer_name(),
+        )
+    }
+
     fn filename(&self) -> PathBuf {
         PathBuf::from(self.layer_name().to_string())
     }
@@ -469,16 +478,6 @@ impl DeltaLayer {
             key_range: self.key_range.clone(),
             lsn_range: self.lsn_range.clone(),
         }
-    }
-
-    /// Path to the layer file in pageserver workdir.
-    pub fn path(&self) -> PathBuf {
-        Self::path_for(
-            &self.path_or_conf,
-            self.timelineid,
-            self.tenantid,
-            &self.layer_name(),
-        )
     }
 }
 

--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -110,6 +110,15 @@ impl Layer for ImageLayer {
         PathBuf::from(self.layer_name().to_string())
     }
 
+    fn path(&self) -> PathBuf {
+        Self::path_for(
+            &self.path_or_conf,
+            self.timelineid,
+            self.tenantid,
+            &self.layer_name(),
+        )
+    }
+
     fn get_tenant_id(&self) -> ZTenantId {
         self.tenantid
     }
@@ -386,16 +395,6 @@ impl ImageLayer {
             key_range: self.key_range.clone(),
             lsn: self.lsn,
         }
-    }
-
-    /// Path to the layer file in pageserver workdir.
-    pub fn path(&self) -> PathBuf {
-        Self::path_for(
-            &self.path_or_conf,
-            self.timelineid,
-            self.tenantid,
-            &self.layer_name(),
-        )
     }
 }
 

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -24,6 +24,7 @@ use std::ops::Range;
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
 use std::sync::RwLock;
+use std::time::SystemTime;
 use zenith_utils::bin_ser::BeSer;
 use zenith_utils::lsn::Lsn;
 use zenith_utils::vec_map::VecMap;
@@ -38,6 +39,8 @@ pub struct InMemoryLayer {
     /// start is inclusive.
     ///
     start_lsn: Lsn,
+
+    creation_time: SystemTime,
 
     /// The above fields never change. The parts that do change are in 'inner',
     /// and protected by mutex.
@@ -83,6 +86,14 @@ impl Layer for InMemoryLayer {
             "inmem-{:016X}-{:016X}",
             self.start_lsn.0, end_lsn.0
         ))
+    }
+
+    fn path(&self) -> PathBuf {
+        self.filename()
+    }
+
+    fn get_creation_time(&self) -> Result<SystemTime> {
+        Ok(self.creation_time)
     }
 
     fn get_tenant_id(&self) -> ZTenantId {
@@ -254,7 +265,7 @@ impl InMemoryLayer {
         trace!(
             "initializing new empty InMemoryLayer for writing on timeline {} at {}",
             timelineid,
-            start_lsn
+            start_lsn,
         );
 
         let file = EphemeralFile::create(conf, tenantid, timelineid)?;
@@ -264,6 +275,7 @@ impl InMemoryLayer {
             timelineid,
             tenantid,
             start_lsn,
+            creation_time: SystemTime::now(),
             inner: RwLock::new(InMemoryLayerInner {
                 end_lsn: None,
                 index: HashMap::new(),

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -256,7 +256,7 @@ impl LayerMap {
 
     /// Find the last image layer that covers 'key', ignoring any image layers
     /// newer than 'lsn'.
-    fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<Arc<dyn Layer>> {
+    pub fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<Arc<dyn Layer>> {
         let mut candidate_lsn = Lsn(0);
         let mut candidate = None;
         for l in self.historic_layers.iter() {

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -92,7 +92,8 @@ pub trait Layer: Send + Sync {
     /// Range of keys that this layer covers
     fn get_key_range(&self) -> Range<Key>;
 
-    /// Get layer creation time
+    /// Get layer creation time. Right now we are using file creation time,
+    /// but it can be not so accurate, because layer can be evicted and reloaded from S3.
     fn get_creation_time(&self) -> Result<SystemTime> {
         Ok(std::fs::metadata(&self.path())?.created()?)
     }

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -10,6 +10,7 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 use zenith_utils::lsn::Lsn;
 
@@ -91,6 +92,11 @@ pub trait Layer: Send + Sync {
     /// Range of keys that this layer covers
     fn get_key_range(&self) -> Range<Key>;
 
+    /// Get layer creation time
+    fn get_creation_time(&self) -> Result<SystemTime> {
+        Ok(std::fs::metadata(&self.path())?.created()?)
+    }
+
     /// Inclusive start bound of the LSN range that this layer holds
     /// Exclusive end bound of the LSN range that this layer holds.
     ///
@@ -103,6 +109,9 @@ pub trait Layer: Send + Sync {
     /// implement this, to print a handy unique identifier for the layer for
     /// log messages, even though they're never not on disk.)
     fn filename(&self) -> PathBuf;
+
+    /// Path to the layer file in pageserver workdir.
+    fn path(&self) -> PathBuf;
 
     ///
     /// Return data needed to reconstruct given page at LSN.

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -244,6 +244,10 @@ pub trait Repository: Send + Sync {
     /// this function is periodically called by compactor thread.
     fn compaction_iteration(&self) -> Result<()>;
 
+    /// perform one materialize iteration.
+    /// this function is periodically called by reconstructor thread.
+    fn materialize_iteration(&self) -> Result<()>;
+
     /// detaches locally available timeline by stopping all threads and removing all the data.
     fn detach_timeline(&self, timeline_id: ZTimelineId) -> Result<()>;
 

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -244,7 +244,7 @@ pub fn activate_tenant(conf: &'static PageServerConf, tenant_id: ZTenantId) -> R
             )
             .with_context(|| {
                 format!(
-                    "Failed to launch reconstructC thread for tenant {}",
+                    "Failed to launch reconstruct thread for tenant {}",
                     tenant_id
                 )
             });

--- a/pageserver/src/thread_mgr.rs
+++ b/pageserver/src/thread_mgr.rs
@@ -97,6 +97,9 @@ pub enum ThreadKind {
     // Thread that handles compaction of all timelines for a tenant.
     Compactor,
 
+    // Thread that handles materialization of all timelines for a tenant.
+    Reconstructor,
+
     // Thread that handles GC of a tenant
     GarbageCollector,
 

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1418,7 +1418,7 @@ class Postgres(PgProtocol):
 
         # set small 'max_replication_write_lag' to enable backpressure
         # and make tests more stable.
-        config_lines = ['max_replication_write_lag=15MB'] + config_lines
+        config_lines = ['max_replication_write_lag=50MB'] + config_lines
         self.config(config_lines)
 
         return self


### PR DESCRIPTION
This PR separates page reconstruction (image layers creation) and compaction of layers.
Also it tries to generate image layers more intensively, but introducing two parameter: min and max reconstruction timeout.
First specify sleep interval for reconstruction thread (how frequently it will check if new image layer needs to be generated). Second parameter force generation of image layer even if other criteria are not satisfied.
May be such policy will cause generation of too many image layers.

But please notice that right now pgbench with scale up to 300 (may be even larger - I have not tested) doesn't create image layers at all. It seems to be strange because: 
1. We are first of all oriented on small free-tier databases
2. Reconstruction of page from delta layer is about 5 times slower than reading it from image layer.
 