### PR TITLE
allow the users to create trusted extensions: GRANT CREATE ON DATABASE

### DIFF
--- a/compute_tools/src/bin/zenith_ctl.rs
+++ b/compute_tools/src/bin/zenith_ctl.rs
@@ -129,6 +129,7 @@ fn run_compute(state: &Arc<RwLock<ComputeState>>) -> Result<ExitStatus> {
 
     handle_roles(&read_state.spec, &mut client)?;
     handle_databases(&read_state.spec, &mut client)?;
+    handle_grants(&read_state.spec, &mut client)?;
     create_writablity_check_data(&mut client)?;
 
     // 'Close' connection

--- a/compute_tools/src/spec.rs
+++ b/compute_tools/src/spec.rs
@@ -244,3 +244,24 @@ pub fn handle_databases(spec: &ClusterSpec, client: &mut Client) -> Result<()> {
 
     Ok(())
 }
+
+// Grant CREATE ON DATABASE to the database owner
+// to allow clients create trusted extensions.
+pub fn handle_grants(spec: &ClusterSpec, client: &mut Client) -> Result<()> {
+    info!("cluster spec grants:");
+
+    for db in &spec.cluster.databases {
+        let dbname = &db.name;
+
+        let query: String = format!(
+            "GRANT CREATE ON DATABASE {} TO {}",
+            dbname.quote(),
+            db.owner.quote()
+        );
+        info!("grant query {}", &query);
+
+        client.execute(query.as_str(), &[])?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
GRANT CREATE ON DATABASE postgres TO usr ;

from PostgreSQL docs:
CREATE privilege for databases, allows new schemas and publications to be created within the database, and allows trusted extensions to be installed within the database.

To check if user has this privilege, run:
```
select datname, datacl from pg_database ;
  datname  |                                         datacl                                         
-----------+----------------------------------------------------------------------------------------
 template1 | {=c/anastasia,anastasia=CTc/anastasia}
 template0 | {=c/anastasia,anastasia=CTc/anastasia}
 postgres  | {=Tc/anastasia,anastasia=CTc/anastasia,usr=C/anastasia}
 ```
 C is for Create
 
 The only way to check if extension is trusted is to grep its *.control file.