### PR TITLE
Per tenant config + pitr

### DIFF
--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::io::Write;
 use std::net::TcpStream;
 use std::path::PathBuf;
@@ -9,7 +10,7 @@ use anyhow::{bail, Context};
 use nix::errno::Errno;
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
-use pageserver::http::models::{TenantCreateRequest, TimelineCreateRequest};
+use pageserver::http::models::{TenantConfigRequest, TenantCreateRequest, TimelineCreateRequest};
 use pageserver::timelines::TimelineInfo;
 use postgres::{Config, NoTls};
 use reqwest::blocking::{Client, RequestBuilder, Response};
@@ -344,10 +345,32 @@ impl PageServerNode {
     pub fn tenant_create(
         &self,
         new_tenant_id: Option<ZTenantId>,
+        settings: HashMap<&str, &str>,
     ) -> anyhow::Result<Option<ZTenantId>> {
         let tenant_id_string = self
             .http_request(Method::POST, format!("{}/tenant", self.http_base_url))
-            .json(&TenantCreateRequest { new_tenant_id })
+            .json(&TenantCreateRequest {
+                new_tenant_id,
+                checkpoint_distance: settings
+                    .get("checkpoint_distance")
+                    .map(|x| x.parse::<u64>())
+                    .transpose()?,
+                compaction_target_size: settings
+                    .get("compaction_target_size")
+                    .map(|x| x.parse::<u64>())
+                    .transpose()?,
+                compaction_period: settings.get("compaction_period").map(|x| x.to_string()),
+                compaction_threshold: settings
+                    .get("compaction_threshold")
+                    .map(|x| x.parse::<usize>())
+                    .transpose()?,
+                gc_horizon: settings
+                    .get("gc_horizon")
+                    .map(|x| x.parse::<u64>())
+                    .transpose()?,
+                gc_period: settings.get("gc_period").map(|x| x.to_string()),
+                pitr_interval: settings.get("pitr_interval").map(|x| x.to_string()),
+            })
             .send()?
             .error_from_body()?
             .json::<Option<String>>()?;
@@ -362,6 +385,32 @@ impl PageServerNode {
                 })
             })
             .transpose()
+    }
+
+    pub fn tenant_config(&self, tenant_id: ZTenantId, settings: HashMap<&str, &str>) -> Result<()> {
+        self.http_request(Method::PUT, format!("{}/tenant/config", self.http_base_url))
+            .json(&TenantConfigRequest {
+                tenant_id,
+                checkpoint_distance: settings
+                    .get("checkpoint_distance")
+                    .map(|x| x.parse::<u64>().unwrap()),
+                compaction_target_size: settings
+                    .get("compaction_target_size")
+                    .map(|x| x.parse::<u64>().unwrap()),
+                compaction_period: settings.get("compaction_period").map(|x| x.to_string()),
+                compaction_threshold: settings
+                    .get("compaction_threshold")
+                    .map(|x| x.parse::<usize>().unwrap()),
+                gc_horizon: settings
+                    .get("gc_horizon")
+                    .map(|x| x.parse::<u64>().unwrap()),
+                gc_period: settings.get("gc_period").map(|x| x.to_string()),
+                pitr_interval: settings.get("pitr_interval").map(|x| x.to_string()),
+            })
+            .send()?
+            .error_from_body()?;
+
+        Ok(())
     }
 
     pub fn timeline_list(&self, tenant_id: &ZTenantId) -> anyhow::Result<Vec<TimelineInfo>> {

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -246,11 +246,12 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
 
     for (tenant_id, local_timeline_init_statuses) in local_timeline_init_statuses {
         // initialize local tenant
-        let repo = tenant_mgr::load_local_repo(conf, tenant_id, &remote_index);
+        let repo = tenant_mgr::load_local_repo(conf, tenant_id, &remote_index)
+            .with_context(|| format!("Failed to load repo for tenant {}", tenant_id))?;
         for (timeline_id, init_status) in local_timeline_init_statuses {
             match init_status {
                 remote_storage::LocalTimelineInitStatus::LocallyComplete => {
-                    debug!("timeline {} for tenant {} is locally complete, registering it in repository", tenant_id, timeline_id);
+                    debug!("timeline {} for tenant {} is locally complete, registering it in repository", timeline_id, tenant_id);
                     // Lets fail here loudly to be on the safe side.
                     // XXX: It may be a better api to actually distinguish between repository startup
                     //   and processing of newly downloaded timelines.

--- a/pageserver/src/http/models.rs
+++ b/pageserver/src/http/models.rs
@@ -20,11 +20,18 @@ pub struct TimelineCreateRequest {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct TenantCreateRequest {
     #[serde(default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub new_tenant_id: Option<ZTenantId>,
+    pub checkpoint_distance: Option<u64>,
+    pub compaction_target_size: Option<u64>,
+    pub compaction_period: Option<String>,
+    pub compaction_threshold: Option<usize>,
+    pub gc_horizon: Option<u64>,
+    pub gc_period: Option<String>,
+    pub pitr_interval: Option<String>,
 }
 
 #[serde_as]
@@ -35,4 +42,43 @@ pub struct TenantCreateResponse(#[serde_as(as = "DisplayFromStr")] pub ZTenantId
 #[derive(Serialize)]
 pub struct StatusResponse {
     pub id: ZNodeId,
+}
+
+impl TenantCreateRequest {
+    pub fn new(new_tenant_id: Option<ZTenantId>) -> TenantCreateRequest {
+        TenantCreateRequest {
+            new_tenant_id,
+            ..Default::default()
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct TenantConfigRequest {
+    pub tenant_id: ZTenantId,
+    #[serde(default)]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub checkpoint_distance: Option<u64>,
+    pub compaction_target_size: Option<u64>,
+    pub compaction_period: Option<String>,
+    pub compaction_threshold: Option<usize>,
+    pub gc_horizon: Option<u64>,
+    pub gc_period: Option<String>,
+    pub pitr_interval: Option<String>,
+}
+
+impl TenantConfigRequest {
+    pub fn new(tenant_id: ZTenantId) -> TenantConfigRequest {
+        TenantConfigRequest {
+            tenant_id,
+            checkpoint_distance: None,
+            compaction_target_size: None,
+            compaction_period: None,
+            compaction_threshold: None,
+            gc_horizon: None,
+            gc_period: None,
+            pitr_interval: None,
+        }
+    }
 }

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -328,11 +328,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                new_tenant_id:
-                  type: string
-                  format: hex
+              $ref: "#/components/schemas/TenantCreateInfo"
       responses:
         "201":
           description: New tenant created successfully
@@ -371,7 +367,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-
+  /v1/tenant/config:
+    put:
+      description: |
+        Update tenant's config.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TenantConfigInfo"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TenantInfo"
+        "400":
+          description: Malformed tenant config request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Unauthorized Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: Forbidden Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "500":
+          description: Generic operation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   securitySchemes:
     JWT:
@@ -388,6 +425,45 @@ components:
         id:
           type: string
         state:
+          type: string
+    TenantCreateInfo:
+      type: object
+      properties:
+        new_tenant_id:
+          type: string
+          format: hex
+        tenant_id:
+          type: string
+          format: hex
+        gc_period:
+          type: string
+        gc_horizon:
+          type: integer
+        pitr_interval:
+          type: string
+        checkpoint_distance:
+          type: integer
+        compaction_period:
+          type: string
+        compaction_threshold:
+          type: string
+    TenantConfigInfo:
+      type: object
+      properties:
+        tenant_id:
+          type: string
+          format: hex
+        gc_period:
+          type: string
+        gc_horizon:
+          type: integer
+        pitr_interval:
+          type: string
+        checkpoint_distance:
+          type: integer
+        compaction_period:
+          type: string
+        compaction_threshold:
           type: string
     TimelineInfo:
       type: object

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -11,6 +11,7 @@ pub mod profiling;
 pub mod reltag;
 pub mod remote_storage;
 pub mod repository;
+pub mod tenant_config;
 pub mod tenant_mgr;
 pub mod tenant_threads;
 pub mod thread_mgr;

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -249,6 +249,7 @@ pub trait Repository: Send + Sync {
         &self,
         timelineid: Option<ZTimelineId>,
         horizon: u64,
+        pitr: Duration,
         checkpoint_before_gc: bool,
     ) -> Result<GcResult>;
 
@@ -305,6 +306,7 @@ impl<'a, T> From<&'a RepositoryTimeline<T>> for LocalTimelineState {
 pub struct GcResult {
     pub layers_total: u64,
     pub layers_needed_by_cutoff: u64,
+    pub layers_needed_by_pitr: u64,
     pub layers_needed_by_branches: u64,
     pub layers_not_updated: u64,
     pub layers_removed: u64, // # of layer files removed because they have been made obsolete by newer ondisk files.
@@ -315,6 +317,7 @@ pub struct GcResult {
 impl AddAssign for GcResult {
     fn add_assign(&mut self, other: Self) {
         self.layers_total += other.layers_total;
+        self.layers_needed_by_pitr += other.layers_needed_by_pitr;
         self.layers_needed_by_cutoff += other.layers_needed_by_cutoff;
         self.layers_needed_by_branches += other.layers_needed_by_branches;
         self.layers_not_updated += other.layers_not_updated;
@@ -432,6 +435,7 @@ pub mod repo_harness {
     };
 
     use super::*;
+    use crate::tenant_config::{TenantConf, TenantConfOpt};
     use hex_literal::hex;
     use utils::zid::ZTenantId;
 
@@ -454,8 +458,23 @@ pub mod repo_harness {
         static ref LOCK: RwLock<()> = RwLock::new(());
     }
 
+    impl From<TenantConf> for TenantConfOpt {
+        fn from(tenant_conf: TenantConf) -> Self {
+            Self {
+                checkpoint_distance: Some(tenant_conf.checkpoint_distance),
+                compaction_target_size: Some(tenant_conf.compaction_target_size),
+                compaction_period: Some(tenant_conf.compaction_period),
+                compaction_threshold: Some(tenant_conf.compaction_threshold),
+                gc_horizon: Some(tenant_conf.gc_horizon),
+                gc_period: Some(tenant_conf.gc_period),
+                pitr_interval: Some(tenant_conf.pitr_interval),
+            }
+        }
+    }
+
     pub struct RepoHarness<'a> {
         pub conf: &'static PageServerConf,
+        pub tenant_conf: TenantConf,
         pub tenant_id: ZTenantId,
 
         pub lock_guard: (
@@ -487,12 +506,15 @@ pub mod repo_harness {
             // OK in a test.
             let conf: &'static PageServerConf = Box::leak(Box::new(conf));
 
+            let tenant_conf = TenantConf::dummy_conf();
+
             let tenant_id = ZTenantId::generate();
             fs::create_dir_all(conf.tenant_path(&tenant_id))?;
             fs::create_dir_all(conf.timelines_path(&tenant_id))?;
 
             Ok(Self {
                 conf,
+                tenant_conf,
                 tenant_id,
                 lock_guard,
             })
@@ -507,6 +529,7 @@ pub mod repo_harness {
 
             let repo = LayeredRepository::new(
                 self.conf,
+                TenantConfOpt::from(self.tenant_conf),
                 walredo_mgr,
                 self.tenant_id,
                 RemoteIndex::empty(),
@@ -722,7 +745,7 @@ mod tests {
         // FIXME: this doesn't actually remove any layer currently, given how the checkpointing
         // and compaction works. But it does set the 'cutoff' point so that the cross check
         // below should fail.
-        repo.gc_iteration(Some(TIMELINE_ID), 0x10, false)?;
+        repo.gc_iteration(Some(TIMELINE_ID), 0x10, Duration::ZERO, false)?;
 
         // try to branch at lsn 25, should fail because we already garbage collected the data
         match repo.branch_timeline(TIMELINE_ID, NEW_TIMELINE_ID, Lsn(0x25)) {
@@ -773,7 +796,7 @@ mod tests {
         let tline = repo.create_empty_timeline(TIMELINE_ID, Lsn(0))?;
         make_some_layers(tline.as_ref(), Lsn(0x20))?;
 
-        repo.gc_iteration(Some(TIMELINE_ID), 0x10, false)?;
+        repo.gc_iteration(Some(TIMELINE_ID), 0x10, Duration::ZERO, false)?;
         let latest_gc_cutoff_lsn = tline.get_latest_gc_cutoff_lsn();
         assert!(*latest_gc_cutoff_lsn > Lsn(0x25));
         match tline.get(*TEST_KEY, Lsn(0x25)) {
@@ -796,7 +819,7 @@ mod tests {
             .get_timeline_load(NEW_TIMELINE_ID)
             .expect("Should have a local timeline");
         // this removes layers before lsn 40 (50 minus 10), so there are two remaining layers, image and delta for 31-50
-        repo.gc_iteration(Some(TIMELINE_ID), 0x10, false)?;
+        repo.gc_iteration(Some(TIMELINE_ID), 0x10, Duration::ZERO, false)?;
         assert!(newtline.get(*TEST_KEY, Lsn(0x25)).is_ok());
 
         Ok(())
@@ -815,7 +838,7 @@ mod tests {
         make_some_layers(newtline.as_ref(), Lsn(0x60))?;
 
         // run gc on parent
-        repo.gc_iteration(Some(TIMELINE_ID), 0x10, false)?;
+        repo.gc_iteration(Some(TIMELINE_ID), 0x10, Duration::ZERO, false)?;
 
         // Check that the data is still accessible on the branch.
         assert_eq!(

--- a/pageserver/src/tenant_config.rs
+++ b/pageserver/src/tenant_config.rs
@@ -1,0 +1,162 @@
+//! Functions for handling per-tenant configuration options
+//!
+//! If tenant is created with --config option,
+//! the tenant-specific config will be stored in tenant's directory.
+//! Otherwise, global pageserver's config is used.
+//!
+//! If the tenant config file is corrupted, the tenant will be disabled.
+//! We cannot use global or default config instead, because wrong settings
+//! may lead to a data loss.
+//!
+use crate::config::PageServerConf;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::Duration;
+use utils::zid::ZTenantId;
+
+pub const TENANT_CONFIG_NAME: &str = "config";
+
+pub mod defaults {
+    // FIXME: This current value is very low. I would imagine something like 1 GB or 10 GB
+    // would be more appropriate. But a low value forces the code to be exercised more,
+    // which is good for now to trigger bugs.
+    // This parameter actually determines L0 layer file size.
+    pub const DEFAULT_CHECKPOINT_DISTANCE: u64 = 256 * 1024 * 1024;
+
+    // Target file size, when creating image and delta layers.
+    // This parameter determines L1 layer file size.
+    pub const DEFAULT_COMPACTION_TARGET_SIZE: u64 = 128 * 1024 * 1024;
+
+    pub const DEFAULT_COMPACTION_PERIOD: &str = "1 s";
+    pub const DEFAULT_COMPACTION_THRESHOLD: usize = 10;
+
+    pub const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
+    pub const DEFAULT_GC_PERIOD: &str = "100 s";
+    pub const DEFAULT_PITR_INTERVAL: &str = "30 days";
+}
+
+/// Per-tenant configuration options
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TenantConf {
+    // Flush out an inmemory layer, if it's holding WAL older than this
+    // This puts a backstop on how much WAL needs to be re-digested if the
+    // page server crashes.
+    // This parameter actually determines L0 layer file size.
+    pub checkpoint_distance: u64,
+    // Target file size, when creating image and delta layers.
+    // This parameter determines L1 layer file size.
+    pub compaction_target_size: u64,
+    // How often to check if there's compaction work to be done.
+    pub compaction_period: Duration,
+    // Level0 delta layer threshold for compaction.
+    pub compaction_threshold: usize,
+    // Determines how much history is retained, to allow
+    // branching and read replicas at an older point in time.
+    // The unit is #of bytes of WAL.
+    // Page versions older than this are garbage collected away.
+    pub gc_horizon: u64,
+    // Interval at which garbage collection is triggered.
+    pub gc_period: Duration,
+    // Determines how much history is retained, to allow
+    // branching and read replicas at an older point in time.
+    // The unit is time.
+    // Page versions older than this are garbage collected away.
+    pub pitr_interval: Duration,
+}
+
+/// Same as TenantConf, but this struct preserves the information about
+/// which parameters are set and which are not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TenantConfOpt {
+    pub checkpoint_distance: Option<u64>,
+    pub compaction_target_size: Option<u64>,
+    pub compaction_period: Option<Duration>,
+    pub compaction_threshold: Option<usize>,
+    pub gc_horizon: Option<u64>,
+    pub gc_period: Option<Duration>,
+    pub pitr_interval: Option<Duration>,
+}
+
+impl TenantConfOpt {
+    pub fn merge(&self, global_conf: TenantConf) -> TenantConf {
+        TenantConf {
+            checkpoint_distance: self
+                .checkpoint_distance
+                .unwrap_or(global_conf.checkpoint_distance),
+            compaction_target_size: self
+                .compaction_target_size
+                .unwrap_or(global_conf.compaction_target_size),
+            compaction_period: self
+                .compaction_period
+                .unwrap_or(global_conf.compaction_period),
+            compaction_threshold: self
+                .compaction_threshold
+                .unwrap_or(global_conf.compaction_threshold),
+            gc_horizon: self.gc_horizon.unwrap_or(global_conf.gc_horizon),
+            gc_period: self.gc_period.unwrap_or(global_conf.gc_period),
+            pitr_interval: self.pitr_interval.unwrap_or(global_conf.pitr_interval),
+        }
+    }
+
+    pub fn update(&mut self, other: &TenantConfOpt) {
+        if let Some(checkpoint_distance) = other.checkpoint_distance {
+            self.checkpoint_distance = Some(checkpoint_distance);
+        }
+        if let Some(compaction_target_size) = other.compaction_target_size {
+            self.compaction_target_size = Some(compaction_target_size);
+        }
+        if let Some(compaction_period) = other.compaction_period {
+            self.compaction_period = Some(compaction_period);
+        }
+        if let Some(compaction_threshold) = other.compaction_threshold {
+            self.compaction_threshold = Some(compaction_threshold);
+        }
+        if let Some(gc_horizon) = other.gc_horizon {
+            self.gc_horizon = Some(gc_horizon);
+        }
+        if let Some(gc_period) = other.gc_period {
+            self.gc_period = Some(gc_period);
+        }
+        if let Some(pitr_interval) = other.pitr_interval {
+            self.pitr_interval = Some(pitr_interval);
+        }
+    }
+}
+
+impl TenantConf {
+    pub fn default() -> TenantConf {
+        use defaults::*;
+
+        TenantConf {
+            checkpoint_distance: DEFAULT_CHECKPOINT_DISTANCE,
+            compaction_target_size: DEFAULT_COMPACTION_TARGET_SIZE,
+            compaction_period: humantime::parse_duration(DEFAULT_COMPACTION_PERIOD)
+                .expect("cannot parse default compaction period"),
+            compaction_threshold: DEFAULT_COMPACTION_THRESHOLD,
+            gc_horizon: DEFAULT_GC_HORIZON,
+            gc_period: humantime::parse_duration(DEFAULT_GC_PERIOD)
+                .expect("cannot parse default gc period"),
+            pitr_interval: humantime::parse_duration(DEFAULT_PITR_INTERVAL)
+                .expect("cannot parse default PITR interval"),
+        }
+    }
+
+    /// Points to a place in pageserver's local directory,
+    /// where certain tenant's tenantconf file should be located.
+    pub fn path(conf: &'static PageServerConf, tenantid: ZTenantId) -> PathBuf {
+        conf.tenant_path(&tenantid).join(TENANT_CONFIG_NAME)
+    }
+
+    #[cfg(test)]
+    pub fn dummy_conf() -> Self {
+        TenantConf {
+            checkpoint_distance: defaults::DEFAULT_CHECKPOINT_DISTANCE,
+            compaction_target_size: 4 * 1024 * 1024,
+            compaction_period: Duration::from_secs(10),
+            compaction_threshold: defaults::DEFAULT_COMPACTION_THRESHOLD,
+            gc_horizon: defaults::DEFAULT_GC_HORIZON,
+            gc_period: Duration::from_secs(10),
+            pitr_interval: Duration::from_secs(60 * 60),
+        }
+    }
+}

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -5,6 +5,7 @@ use crate::config::PageServerConf;
 use crate::layered_repository::LayeredRepository;
 use crate::remote_storage::RemoteIndex;
 use crate::repository::{Repository, TimelineSyncStatusUpdate};
+use crate::tenant_config::TenantConfOpt;
 use crate::thread_mgr;
 use crate::thread_mgr::ThreadKind;
 use crate::timelines;
@@ -63,13 +64,13 @@ fn access_tenants() -> MutexGuard<'static, HashMap<ZTenantId, Tenant>> {
     TENANTS.lock().unwrap()
 }
 
-// Sets up wal redo manager and repository for tenant. Reduces code duplocation.
+// Sets up wal redo manager and repository for tenant. Reduces code duplication.
 // Used during pageserver startup, or when new tenant is attached to pageserver.
 pub fn load_local_repo(
     conf: &'static PageServerConf,
     tenant_id: ZTenantId,
     remote_index: &RemoteIndex,
-) -> Arc<RepositoryImpl> {
+) -> Result<Arc<RepositoryImpl>> {
     let mut m = access_tenants();
     let tenant = m.entry(tenant_id).or_insert_with(|| {
         // Set up a WAL redo manager, for applying WAL records.
@@ -78,6 +79,7 @@ pub fn load_local_repo(
         // Set up an object repository, for actual data storage.
         let repo: Arc<LayeredRepository> = Arc::new(LayeredRepository::new(
             conf,
+            Default::default(),
             Arc::new(walredo_mgr),
             tenant_id,
             remote_index.clone(),
@@ -89,7 +91,12 @@ pub fn load_local_repo(
             timelines: HashMap::new(),
         }
     });
-    Arc::clone(&tenant.repo)
+
+    // Restore tenant config
+    let tenant_conf = LayeredRepository::load_tenant_config(conf, tenant_id)?;
+    tenant.repo.update_tenant_config(tenant_conf)?;
+
+    Ok(Arc::clone(&tenant.repo))
 }
 
 /// Updates tenants' repositories, changing their timelines state in memory.
@@ -109,7 +116,16 @@ pub fn apply_timeline_sync_status_updates(
     trace!("Sync status updates: {:?}", sync_status_updates);
 
     for (tenant_id, tenant_timelines_sync_status_updates) in sync_status_updates {
-        let repo = load_local_repo(conf, tenant_id, remote_index);
+        let repo = match load_local_repo(conf, tenant_id, remote_index) {
+            Ok(repo) => repo,
+            Err(e) => {
+                error!(
+                    "Failed to load repo for tenant {} Error: {:#}",
+                    tenant_id, e
+                );
+                continue;
+            }
+        };
 
         for (timeline_id, timeline_sync_status_update) in tenant_timelines_sync_status_updates {
             match repo.apply_timeline_remote_sync_status_update(timeline_id, timeline_sync_status_update)
@@ -174,6 +190,7 @@ pub fn shutdown_all_tenants() {
 
 pub fn create_tenant_repository(
     conf: &'static PageServerConf,
+    tenant_conf: TenantConfOpt,
     tenantid: ZTenantId,
     remote_index: RemoteIndex,
 ) -> Result<Option<ZTenantId>> {
@@ -186,6 +203,7 @@ pub fn create_tenant_repository(
             let wal_redo_manager = Arc::new(PostgresRedoManager::new(conf, tenantid));
             let repo = timelines::create_repo(
                 conf,
+                tenant_conf,
                 tenantid,
                 CreateRepo::Real {
                     wal_redo_manager,
@@ -202,6 +220,14 @@ pub fn create_tenant_repository(
     }
 }
 
+pub fn update_tenant_config(tenant_conf: TenantConfOpt, tenantid: ZTenantId) -> Result<()> {
+    info!("configuring tenant {}", tenantid);
+    let repo = get_repository_for_tenant(tenantid)?;
+
+    repo.update_tenant_config(tenant_conf)?;
+    Ok(())
+}
+
 pub fn get_tenant_state(tenantid: ZTenantId) -> Option<TenantState> {
     Some(access_tenants().get(&tenantid)?.state)
 }
@@ -210,7 +236,7 @@ pub fn get_tenant_state(tenantid: ZTenantId) -> Option<TenantState> {
 /// Change the state of a tenant to Active and launch its compactor and GC
 /// threads. If the tenant was already in Active state or Stopping, does nothing.
 ///
-pub fn activate_tenant(conf: &'static PageServerConf, tenant_id: ZTenantId) -> Result<()> {
+pub fn activate_tenant(tenant_id: ZTenantId) -> Result<()> {
     let mut m = access_tenants();
     let tenant = m
         .get_mut(&tenant_id)
@@ -230,7 +256,7 @@ pub fn activate_tenant(conf: &'static PageServerConf, tenant_id: ZTenantId) -> R
                 None,
                 "Compactor thread",
                 true,
-                move || crate::tenant_threads::compact_loop(tenant_id, conf),
+                move || crate::tenant_threads::compact_loop(tenant_id),
             )?;
 
             let gc_spawn_result = thread_mgr::spawn(
@@ -239,7 +265,7 @@ pub fn activate_tenant(conf: &'static PageServerConf, tenant_id: ZTenantId) -> R
                 None,
                 "GC thread",
                 true,
-                move || crate::tenant_threads::gc_loop(tenant_id, conf),
+                move || crate::tenant_threads::gc_loop(tenant_id),
             )
             .with_context(|| format!("Failed to launch GC thread for tenant {}", tenant_id));
 
@@ -251,7 +277,6 @@ pub fn activate_tenant(conf: &'static PageServerConf, tenant_id: ZTenantId) -> R
                 thread_mgr::shutdown_threads(Some(ThreadKind::Compactor), Some(tenant_id), None);
                 return gc_spawn_result;
             }
-
             tenant.state = TenantState::Active;
         }
 
@@ -290,7 +315,7 @@ pub fn get_timeline_for_tenant_load(
         .get_timeline_load(timelineid)
         .with_context(|| format!("Timeline {} not found for tenant {}", timelineid, tenantid))?;
 
-    let repartition_distance = tenant.repo.conf.checkpoint_distance / 10;
+    let repartition_distance = tenant.repo.get_checkpoint_distance() / 10;
 
     let page_tline = Arc::new(DatadirTimelineImpl::new(tline, repartition_distance));
     page_tline.init_logical_size()?;

--- a/pageserver/src/tenant_threads.rs
+++ b/pageserver/src/tenant_threads.rs
@@ -1,6 +1,5 @@
 //! This module contains functions to serve per-tenant background processes,
 //! such as compaction and GC
-use crate::config::PageServerConf;
 use crate::repository::Repository;
 use crate::tenant_mgr;
 use crate::tenant_mgr::TenantState;
@@ -12,8 +11,8 @@ use utils::zid::ZTenantId;
 ///
 /// Compaction thread's main loop
 ///
-pub fn compact_loop(tenantid: ZTenantId, conf: &'static PageServerConf) -> Result<()> {
-    if let Err(err) = compact_loop_ext(tenantid, conf) {
+pub fn compact_loop(tenantid: ZTenantId) -> Result<()> {
+    if let Err(err) = compact_loop_ext(tenantid) {
         error!("compact loop terminated with error: {:?}", err);
         Err(err)
     } else {
@@ -21,13 +20,15 @@ pub fn compact_loop(tenantid: ZTenantId, conf: &'static PageServerConf) -> Resul
     }
 }
 
-fn compact_loop_ext(tenantid: ZTenantId, conf: &'static PageServerConf) -> Result<()> {
+fn compact_loop_ext(tenantid: ZTenantId) -> Result<()> {
     loop {
         if tenant_mgr::get_tenant_state(tenantid) != Some(TenantState::Active) {
             break;
         }
+        let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
+        let compaction_period = repo.get_compaction_period();
 
-        std::thread::sleep(conf.compaction_period);
+        std::thread::sleep(compaction_period);
         trace!("compaction thread for tenant {} waking up", tenantid);
 
         // Compact timelines
@@ -46,23 +47,23 @@ fn compact_loop_ext(tenantid: ZTenantId, conf: &'static PageServerConf) -> Resul
 ///
 /// GC thread's main loop
 ///
-pub fn gc_loop(tenantid: ZTenantId, conf: &'static PageServerConf) -> Result<()> {
+pub fn gc_loop(tenantid: ZTenantId) -> Result<()> {
     loop {
         if tenant_mgr::get_tenant_state(tenantid) != Some(TenantState::Active) {
             break;
         }
 
         trace!("gc thread for tenant {} waking up", tenantid);
-
+        let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
+        let gc_horizon = repo.get_gc_horizon();
         // Garbage collect old files that are not needed for PITR anymore
-        if conf.gc_horizon > 0 {
-            let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
-            repo.gc_iteration(None, conf.gc_horizon, false)?;
+        if gc_horizon > 0 {
+            repo.gc_iteration(None, gc_horizon, repo.get_pitr_interval(), false)?;
         }
 
         // TODO Write it in more adequate way using
         // condvar.wait_timeout() or something
-        let mut sleep_time = conf.gc_period.as_secs();
+        let mut sleep_time = repo.get_gc_period().as_secs();
         while sleep_time > 0 && tenant_mgr::get_tenant_state(tenantid) == Some(TenantState::Active)
         {
             sleep_time -= 1;

--- a/pageserver/src/timelines.rs
+++ b/pageserver/src/timelines.rs
@@ -25,6 +25,7 @@ use crate::{
     layered_repository::metadata::TimelineMetadata,
     remote_storage::RemoteIndex,
     repository::{LocalTimelineState, Repository},
+    tenant_config::TenantConfOpt,
     DatadirTimeline, RepositoryImpl,
 };
 use crate::{import_datadir, LOG_FILE_NAME};
@@ -151,8 +152,8 @@ pub fn init_pageserver(
 
     if let Some(tenant_id) = create_tenant {
         println!("initializing tenantid {}", tenant_id);
-        let repo =
-            create_repo(conf, tenant_id, CreateRepo::Dummy).context("failed to create repo")?;
+        let repo = create_repo(conf, Default::default(), tenant_id, CreateRepo::Dummy)
+            .context("failed to create repo")?;
         let new_timeline_id = initial_timeline_id.unwrap_or_else(ZTimelineId::generate);
         bootstrap_timeline(conf, tenant_id, new_timeline_id, repo.as_ref())
             .context("failed to create initial timeline")?;
@@ -175,6 +176,7 @@ pub enum CreateRepo {
 
 pub fn create_repo(
     conf: &'static PageServerConf,
+    tenant_conf: TenantConfOpt,
     tenant_id: ZTenantId,
     create_repo: CreateRepo,
 ) -> Result<Arc<RepositoryImpl>> {
@@ -211,8 +213,12 @@ pub fn create_repo(
     crashsafe_dir::create_dir(conf.timelines_path(&tenant_id))?;
     info!("created directory structure in {}", repo_dir.display());
 
+    // Save tenant's config
+    LayeredRepository::persist_tenant_config(conf, tenant_id, tenant_conf)?;
+
     Ok(Arc::new(LayeredRepository::new(
         conf,
+        tenant_conf,
         wal_redo_manager,
         tenant_id,
         remote_index,

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -93,7 +93,7 @@ pub fn launch_wal_receiver(
             receivers.insert((tenantid, timelineid), receiver);
 
             // Update tenant state and start tenant threads, if they are not running yet.
-            tenant_mgr::activate_tenant(conf, tenantid)?;
+            tenant_mgr::activate_tenant(tenantid)?;
         }
     };
     Ok(())

--- a/test_runner/batch_others/test_tenant_conf.py
+++ b/test_runner/batch_others/test_tenant_conf.py
@@ -1,0 +1,49 @@
+from contextlib import closing
+
+import pytest
+
+from fixtures.zenith_fixtures import ZenithEnvBuilder
+
+
+def test_tenant_config(zenith_env_builder: ZenithEnvBuilder):
+    env = zenith_env_builder.init_start()
+    """Test per tenant configuration"""
+    tenant = env.zenith_cli.create_tenant(
+        conf={
+            'checkpoint_distance': '10000',
+            'compaction_target_size': '1048576',
+            'compaction_period': '60sec',
+            'compaction_threshold': '20',
+            'gc_horizon': '1024',
+            'gc_period': '100sec',
+            'pitr_interval': '3600sec',
+        })
+
+    env.zenith_cli.create_timeline(f'test_tenant_conf', tenant_id=tenant)
+    pg = env.postgres.create_start(
+        "test_tenant_conf",
+        "main",
+        tenant,
+    )
+
+    with closing(env.pageserver.connect()) as psconn:
+        with psconn.cursor() as pscur:
+            pscur.execute(f"show {tenant.hex}")
+            assert pscur.fetchone() == (10000, 1048576, 60, 20, 1024, 100, 3600)
+
+    # update the config and ensure that it has changed
+    env.zenith_cli.config_tenant(tenant_id=tenant,
+                                 conf={
+                                     'checkpoint_distance': '100000',
+                                     'compaction_target_size': '1048576',
+                                     'compaction_period': '30sec',
+                                     'compaction_threshold': '15',
+                                     'gc_horizon': '256',
+                                     'gc_period': '10sec',
+                                     'pitr_interval': '360sec',
+                                 })
+
+    with closing(env.pageserver.connect()) as psconn:
+        with psconn.cursor() as pscur:
+            pscur.execute(f"show {tenant.hex}")
+            assert pscur.fetchone() == (100000, 1048576, 30, 15, 256, 10, 360)

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -835,15 +835,34 @@ class ZenithCli:
         self.env = env
         pass
 
-    def create_tenant(self, tenant_id: Optional[uuid.UUID] = None) -> uuid.UUID:
+    def create_tenant(self,
+                      tenant_id: Optional[uuid.UUID] = None,
+                      conf: Optional[Dict[str, str]] = None) -> uuid.UUID:
         """
         Creates a new tenant, returns its id and its initial timeline's id.
         """
         if tenant_id is None:
             tenant_id = uuid.uuid4()
-        res = self.raw_cli(['tenant', 'create', '--tenant-id', tenant_id.hex])
+        if conf is None:
+            res = self.raw_cli(['tenant', 'create', '--tenant-id', tenant_id.hex])
+        else:
+            res = self.raw_cli(
+                ['tenant', 'create', '--tenant-id', tenant_id.hex] +
+                sum(list(map(lambda kv: (['-c', kv[0] + ':' + kv[1]]), conf.items())), []))
         res.check_returncode()
         return tenant_id
+
+    def config_tenant(self, tenant_id: uuid.UUID, conf: Dict[str, str]):
+        """
+        Update tenant config.
+        """
+        if conf is None:
+            res = self.raw_cli(['tenant', 'config', '--tenant-id', tenant_id.hex])
+        else:
+            res = self.raw_cli(
+                ['tenant', 'config', '--tenant-id', tenant_id.hex] +
+                sum(list(map(lambda kv: (['-c', kv[0] + ':' + kv[1]]), conf.items())), []))
+        res.check_returncode()
 
     def list_tenants(self) -> 'subprocess.CompletedProcess[str]':
         res = self.raw_cli(['tenant', 'list'])


### PR DESCRIPTION
New version of @knizhnik PR #1332 

This PR implements per-tenant config and also adds new `pitr_interval` parameter.
Maybe it's worth to split pitr part into a separate commit, as there were some questions about the proper implementation of pitr.

TenantConf is still stored as a part of the global PageserverConf, but one can also pass per-tenant conf parameters when tenant is created or using newAPI or  `zenith tenant config` CLI command.
This custom TenantConfOpt is stored in LayeredRepository struct.  
To get the parameter value, check TenantConfOpt, if it is not set, use value from global config.

When updated, tenant conf is saved to the tenant's directory, to recover it on pageserver restart.

To support tenant migraiton, this config must be stored in the console along with other tenant information. @ololobus, FYI