### PR TITLE
[proxy] Update rustls to 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ dependencies = [
  "hyper",
  "rustls 0.20.2",
  "tokio",
- "tokio-rustls 0.23.2",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1926,7 +1926,8 @@ dependencies = [
  "reqwest",
  "routerify 2.2.0",
  "rstest",
- "rustls 0.19.1",
+ "rustls 0.20.2",
+ "rustls-pemfile",
  "scopeguard",
  "serde",
  "serde_json",
@@ -1936,7 +1937,7 @@ dependencies = [
  "tokio",
  "tokio-postgres 0.7.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=2949d98df52587d562986aad155dd4e889e408b7)",
  "tokio-postgres-rustls",
- "tokio-rustls 0.22.0",
+ "tokio-rustls",
  "workspace_hack",
  "zenith_metrics",
  "zenith_utils",
@@ -2111,7 +2112,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls 0.23.2",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2823,35 +2824,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres-rustls"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd8c37d8c23cb6ecdc32fc171bade4e9c7f1be65f693a17afbaad02091a0a19"
+checksum = "606f2b73660439474394432239c82249c0d45eb5f23d91f401be1e33590444a7"
 dependencies = [
  "futures",
  "ring",
- "rustls 0.19.1",
+ "rustls 0.20.2",
  "tokio",
  "tokio-postgres 0.7.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=2949d98df52587d562986aad155dd4e889e408b7)",
- "tokio-rustls 0.22.0",
- "webpki 0.21.4",
+ "tokio-rustls",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d5f2b839802bd8267fa19b0530f5a08b9c08cd417976be2a65d130fe1c11b"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
  "rustls 0.20.2",
  "tokio",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -21,7 +21,8 @@ pin-project-lite = "0.2.7"
 rand = "0.8.3"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 routerify = "2"
-rustls = "0.19.1"
+rustls = "0.20.0"
+rustls-pemfile = "0.2.1"
 scopeguard = "1.1.0"
 serde = "1"
 serde_json = "1"
@@ -30,7 +31,7 @@ socket2 = "0.4.4"
 thiserror = "1.0.30"
 tokio = { version = "1.17", features = ["macros"] }
 tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="2949d98df52587d562986aad155dd4e889e408b7" }
-tokio-rustls = "0.22.0"
+tokio-rustls = "0.23.0"
 
 zenith_utils = { path = "../zenith_utils" }
 zenith_metrics = { path = "../zenith_metrics" }
@@ -40,4 +41,4 @@ workspace_hack = { version = "0.1", path = "../workspace_hack" }
 async-trait = "0.1"
 rcgen = "0.8.14"
 rstest = "0.12"
-tokio-postgres-rustls = "0.8.0"
+tokio-postgres-rustls = "0.9.0"

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -265,14 +265,24 @@ mod tests {
         let (ca, cert, key) = generate_certs(hostname)?;
 
         let server_config = {
-            let mut config = rustls::ServerConfig::new(rustls::NoClientAuth::new());
-            config.set_single_cert(vec![cert], key)?;
+            let config = rustls::ServerConfig::builder()
+                .with_safe_defaults()
+                .with_no_client_auth()
+                .with_single_cert(vec![cert], key)?;
+
             config.into()
         };
 
         let client_config = {
-            let mut config = rustls::ClientConfig::new();
-            config.root_store.add(&ca)?;
+            let config = rustls::ClientConfig::builder()
+                .with_safe_defaults()
+                .with_root_certificates({
+                    let mut store = rustls::RootCertStore::empty();
+                    store.add(&ca)?;
+                    store
+                })
+                .with_no_client_auth();
+
             ClientConfig { config, hostname }
         };
 


### PR DESCRIPTION
Driven by @hlinnaka's idea to have only one rustls version, I decided to update it in proxy as well.

See also https://github.com/neondatabase/rustls-split/pull/13.