### PR TITLE
Bump rustc version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ executors:
     resource_class: xlarge
     docker:
       # NB: when changed, do not forget to update rust image tag in all Dockerfiles
-      - image: zimg/rust:1.56
+      - image: zimg/rust:1.58
   zenith-executor:
     docker:
-      - image: zimg/rust:1.56
+      - image: zimg/rust:1.58
 
 jobs:
   check-codestyle-rust:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Postgres
 #
-#FROM zimg/rust:1.56 AS pg-build
-FROM zenithdb/build:buster-20220309 AS pg-build
+#FROM zimg/rust:1.58 AS pg-build
+FROM zenithdb/build:buster-20220414 AS pg-build
 WORKDIR /pg
 
 USER root
@@ -17,8 +17,8 @@ RUN set -e \
 
 # Build zenith binaries
 #
-#FROM zimg/rust:1.56 AS build
-FROM zenithdb/build:buster-20220309 AS build
+#FROM zimg/rust:1.58 AS build
+FROM zenithdb/build:buster-20220414 AS build
 ARG GIT_VERSION=local
 
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM rust:1.56.1-slim-buster
+FROM rust:1.58-slim-buster
 WORKDIR /home/circleci/project
 
 RUN set -e \

--- a/Dockerfile.compute-tools
+++ b/Dockerfile.compute-tools
@@ -1,6 +1,6 @@
 # First transient image to build compute_tools binaries
 # NB: keep in sync with rust image version in .circle/config.yml
-FROM zenithdb/build:buster-20220309 AS rust-build
+FROM zenithdb/build:buster-20220414 AS rust-build
 
 WORKDIR /zenith
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ apt install build-essential libtool libreadline-dev zlib1g-dev flex bison libsec
 libssl-dev clang pkg-config libpq-dev
 ```
 
-[Rust] 1.56.1 or later is also required.
+[Rust] 1.58 or later is also required.
 
 To run the `psql` client, install the `postgresql-client` package or modify `PATH` and `LD_LIBRARY_PATH` to include `tmp_install/bin` and `tmp_install/lib`, respectively.
 


### PR DESCRIPTION
Needs https://github.com/neondatabase/docker-images/pull/6/files and some decision on how to deal with the `zenithdb/build:buster-20220309` images (those are built and pushed locally now, they have old rustc still) and libc issues.

More context: https://neondb.slack.com/archives/C039YKBRZB4/p1649953776799949