### PR TITLE
Fix compute tools build

### DIFF
--- a/Dockerfile.compute-tools
+++ b/Dockerfile.compute-tools
@@ -2,8 +2,6 @@
 # NB: keep in sync with rust image version in .circle/config.yml
 FROM zimg/rust:1.58 AS rust-build
 
-WORKDIR /zenith
-
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
@@ -15,4 +13,4 @@ RUN cargo build -p compute_tools --release && cachepot -s
 # Final image that only has one binary
 FROM debian:buster-slim
 
-COPY --from=rust-build /zenith/target/release/zenith_ctl /usr/local/bin/zenith_ctl
+COPY --from=rust-build /home/circleci/project/target/release/zenith_ctl /usr/local/bin/zenith_ctl


### PR DESCRIPTION
A follow-up of https://github.com/neondatabase/neon/pull/1520

fixing the compute-tools Docker image build [error](https://app.circleci.com/pipelines/github/neondatabase/neon/5568/workflows/c702af37-6647-4eec-b2de-e9a8459a85a4/jobs/53838):

> error: Permission denied (os error 13) at path "/zenith/targetO0c3ad"
The command '/bin/bash -exo pipefail -c cargo build -p compute_tools --release && cachepot -s' returned a non-zero code: 101


Here's the test build run of these changes, it passes: https://app.circleci.com/pipelines/github/neondatabase/neon/5572/workflows/5a370d50-8514-4a12-8c23-159100e884ea/jobs/53871

Apparently, the combination of 

* `zimg/rust:1.58` (based on CircleCI image) 
* An image used in our CI agent 
```
docker-image-compute:
    docker:
      - image: cimg/base:2021.04
```

* and `WORKDIR /zenith` causes some special effects

Not sure if there's a better way to fix the underlying issue to enable arbitrary workdir usage, but I don't think it's needed: 
* we plan to move away from CircleCI eventually, so using `cimg` might not be a good idea later
* we plan to add `aarch64` image builds later, but `cimg` do not have such builds, so we cannot really use them

So it feels like a proper fix is to get rid of `cimg` images entirely, but that's quite a big task to do now.