### PR TITLE
Revert libc upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build Postgres
-FROM zimg/rust:1.58 AS pg-build
+#FROM zimg/rust:1.58 AS pg-build
+FROM zenithdb/build:buster-20220414 AS pg-build
 WORKDIR /pg
 
 USER root
@@ -14,7 +15,8 @@ RUN set -e \
     && tar -C tmp_install -czf /postgres_install.tar.gz .
 
 # Build zenith binaries
-FROM zimg/rust:1.58 AS build
+#FROM zimg/rust:1.58 AS build
+FROM zenithdb/build:buster-20220414 AS build
 ARG GIT_VERSION=local
 
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot
@@ -26,7 +28,9 @@ COPY . .
 
 # Show build caching stats to check if it was used in the end.
 # Has to be the part of the same RUN since cachepot daemon is killed in the end of this RUN, loosing the compilation stats.
-RUN cargo build --release && cachepot -s
+#RUN cargo build --release && cachepot -s
+ENV RUSTC_WRAPPER /usr/local/cargo/bin/cachepot
+RUN cargo build --release && /usr/local/cargo/bin/cachepot -s
 
 # Build final image
 #

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,23 @@
+FROM rust:1.58-slim-buster
+WORKDIR /home/circleci/project
+
+RUN set -e \
+    && apt-get update \
+    && apt-get -yq install \
+        automake \
+        libtool \
+        build-essential \
+        bison \
+        flex \
+        libreadline-dev \
+        zlib1g-dev \
+        libxml2-dev \
+        libseccomp-dev \
+        pkg-config \
+        libssl-dev \
+        clang
+
+RUN set -e \
+    && rustup component add clippy \
+    && cargo install cargo-audit \
+    && cargo install --git https://github.com/paritytech/cachepot

--- a/Dockerfile.compute-tools
+++ b/Dockerfile.compute-tools
@@ -1,6 +1,10 @@
 # First transient image to build compute_tools binaries
 # NB: keep in sync with rust image version in .circle/config.yml
-FROM zimg/rust:1.58 AS rust-build
+
+#FROM zimg/rust:1.58 AS rust-build
+FROM zenithdb/build:buster-20220414 AS rust-build
+
+WORKDIR /zenith
 
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
@@ -8,9 +12,12 @@ ARG AWS_SECRET_ACCESS_KEY
 
 COPY . .
 
-RUN cargo build -p compute_tools --release && cachepot -s
+#RUN cargo build -p compute_tools --release && cachepot -s
+ENV RUSTC_WRAPPER /usr/local/cargo/bin/cachepot
+RUN cargo build -p compute_tools --release && /usr/local/cargo/bin/cachepot -s
 
 # Final image that only has one binary
 FROM debian:buster-slim
 
-COPY --from=rust-build /home/circleci/project/target/release/zenith_ctl /usr/local/bin/zenith_ctl
+#COPY --from=rust-build /home/circleci/project/target/release/zenith_ctl /usr/local/bin/zenith_ctl
+COPY --from=rust-build /zenith/target/release/zenith_ctl /usr/local/bin/zenith_ctl


### PR DESCRIPTION
Despite manual updates to staring libc, I see that there are no logs from all instances approx. after the initial libc PR bump merge:

![image](https://user-images.githubusercontent.com/2690773/163665309-e5d73017-b0eb-4e0c-9eb0-b397131483a1.png)

Reverting those changes to see if that helps.