### PR TITLE
Use proper cachepot bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,8 +117,6 @@ jobs:
             fi
 
             export CARGO_INCREMENTAL=0
-            export CACHEPOT_BUCKET=zenith-rust-cachepot
-            export RUSTC_WRAPPER=cachepot
             export AWS_ACCESS_KEY_ID="${CACHEPOT_AWS_ACCESS_KEY_ID}"
             export AWS_SECRET_ACCESS_KEY="${CACHEPOT_AWS_SECRET_ACCESS_KEY}"
             "${cov_prefix[@]}" mold -run cargo build $CARGO_FLAGS --bins --tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -e \
 FROM zimg/rust:1.58 AS build
 ARG GIT_VERSION=local
 
-ARG CACHEPOT_BUCKET=zenith-rust-cachepot-docker
+ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
 

--- a/Dockerfile.compute-tools
+++ b/Dockerfile.compute-tools
@@ -2,7 +2,7 @@
 # NB: keep in sync with rust image version in .circle/config.yml
 FROM zimg/rust:1.58 AS rust-build
 
-ARG CACHEPOT_BUCKET=zenith-rust-cachepot-docker
+ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
 


### PR DESCRIPTION
Reverts https://github.com/neondatabase/neon/commit/787f0d33f0f15209e1c7d803633280b6064ed11a accidentally pushed straight into `main` (such thing is not possible anymore, the settings are adjusted now).

The intent of that commit was to debug odd cachepot behaviour of the cloud build, that is now fixed in https://github.com/neondatabase/cloud/pull/1033

