### PR TITLE
Split ephemeral, imutable and materialized caches

### DIFF
--- a/pageserver/src/bin/dump_layerfile.rs
+++ b/pageserver/src/bin/dump_layerfile.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
 
     // Basic initialization of things that don't change after startup
     virtual_file::init(10);
-    page_cache::init(100);
+    page_cache::init(100, 100, 100);
 
     dump_layerfile_from_path(&path, true)?;
 

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -162,7 +162,12 @@ fn main() -> anyhow::Result<()> {
 
     // Basic initialization of things that don't change after startup
     virtual_file::init(conf.max_file_descriptors);
-    page_cache::init(conf.page_cache_size);
+    // TODO: add ephemeral and immutable cache size to parameters
+    page_cache::init(
+        page_cache::EPHEMERAL_CACHE_SIZE,
+        page_cache::IMMUTABLE_CACHE_SIZE,
+        conf.page_cache_size,
+    );
 
     // Create repo and exit if init was requested
     if init {

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1264,7 +1264,7 @@ impl LayeredTimeline {
     }
 
     fn lookup_cached_page(&self, key: &Key, lsn: Lsn) -> Option<(Lsn, Bytes)> {
-        let cache = page_cache::get();
+        let cache = &page_cache::get().materialized;
 
         // FIXME: It's pointless to check the cache for things that are not 8kB pages.
         // We should look at the key to determine if it's a cacheable object
@@ -2016,7 +2016,7 @@ impl LayeredTimeline {
                         .request_redo(key, request_lsn, base_img, data.records)?;
 
                 if img.len() == page_cache::PAGE_SZ {
-                    let cache = page_cache::get();
+                    let cache = &page_cache::get().materialized;
                     cache.memorize_materialized_page(
                         self.tenantid,
                         self.timelineid,

--- a/pageserver/src/layered_repository/block_io.rs
+++ b/pageserver/src/layered_repository/block_io.rs
@@ -157,9 +157,9 @@ where
 
     fn read_blk(&self, blknum: u32) -> Result<Self::BlockLease, std::io::Error> {
         // Look up the right page
-        let cache = page_cache::get();
+        let cache = &page_cache::get().immutable;
         loop {
-            match cache.read_immutable_buf(self.file_id, blknum) {
+            match cache.read_file_buf(self.file_id, blknum) {
                 ReadBufResult::Found(guard) => break Ok(guard),
                 ReadBufResult::NotFound(mut write_guard) => {
                     // Read the page from disk into the buffer


### PR DESCRIPTION
Working of get_page optimizations I noticed that even if the whole database fits in page cache, there are still cache misses for materialized pages, which have significant (~5 times) impact on performance. I thought that it is caused by flushing cache by ephemeral pages. Right now eviction algorithm is simple clock without any counters. It means that any new element added to the cache throw away some old one doesn't matter how frequently it is accessed.

Usually in most systems, cache is divided in two areas: accessed once and frequently accessed objects. 
If item is moved to the second area, then it can not be replaced by newly allocated items.

Later I found out that the problem with cache missed was caused by another bug: #1522
But still I think that splitting caches is right  thing: lifetimes and access patterns for materialized/ephemeral and immutable ages are completely different.
Also I have removed some duplicated code (handling of ephemeral and immutable pages is identical)
and store reference to page cache in WriteGuard to avoid extra cache lockup (do not think that it has some noticeable impact on performance, but it is always better not to do extra work).
 