### PR TITLE
Restore missing cachepot env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,8 @@ jobs:
             fi
 
             export CARGO_INCREMENTAL=0
+            export CACHEPOT_BUCKET=zenith-rust-cachepot
+            export RUSTC_WRAPPER=cachepot
             export AWS_ACCESS_KEY_ID="${CACHEPOT_AWS_ACCESS_KEY_ID}"
             export AWS_SECRET_ACCESS_KEY="${CACHEPOT_AWS_SECRET_ACCESS_KEY}"
             "${cov_prefix[@]}" mold -run cargo build $CARGO_FLAGS --bins --tests


### PR DESCRIPTION
https://github.com/neondatabase/neon/pull/1529/ removed those, which resulted in cachepot not using S3 cache, but a local one instead:

> Cache location                  Local disk: "/home/circleci/.cache/cachepot"

https://app.circleci.com/pipelines/github/neondatabase/neon/5605/workflows/6c939b87-aa21-41f5-92e9-4119d728d3e6/jobs/54318?invite=true#step-105-51

this fixes it and restores S3 cache usage:

> Cache location                  S3, bucket: zenith-rust-cachepot

(https://app.circleci.com/pipelines/github/neondatabase/neon/5606/workflows/a1dd4215-3573-404e-8d51-66dae69d0820/jobs/54325?invite=true#step-105-54)
