### PR TITLE
temporary disable bench uploads

### DIFF
--- a/scripts/generate_and_push_perf_report.sh
+++ b/scripts/generate_and_push_perf_report.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 echo "Uploading perf report to zenith pg"
 # ingest per test results data into zenith backed postgres running in staging to build grafana reports on that data
-DATABASE_URL="$PERF_TEST_RESULT_CONNSTR" poetry run python "$SCRIPT_DIR"/ingest_perf_test_result.py --ingest "$REPORT_FROM"
+# DATABASE_URL="$PERF_TEST_RESULT_CONNSTR" poetry run python "$SCRIPT_DIR"/ingest_perf_test_result.py --ingest "$REPORT_FROM"
 
 # Activate poetry's venv. Needed because git upload does not run in a project dir (it uses tmp to store the repository)
 # so the problem occurs because poetry cannot find pyproject.toml in temp dir created by git upload


### PR DESCRIPTION
The cluster that we upload perf results to has some problems. Insert triggers this error:

```
psycopg2.errors.IoError: could not read block 0 in rel 1663/16385/24577.2 from page server at lsn 0/0247E400
DETAIL:  page server returned error: Failed to get reconstruct data 1663/16385/24577_vm.0 "rel_1663_16385_24577_2_0_00000000019EBD78_0000000001C66381" 0 0/247EA88
```

The cluster is in production env, id `dry-bar-041103`.

Currently, production runs on old version of storage, so I think we can disable the upload for now. Because new storage significantly changed related code, so IMO there is little sense in debugging. Thoughts?

Results are still collected and added to zenith-perf-results repo