### PR TITLE
Add materialized page cache invalidation mechanism to avoid delta lookups

### DIFF
--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -50,6 +50,7 @@ where
 pub struct ValueReconstructState {
     pub records: Vec<(Lsn, ZenithWalRecord)>,
     pub img: Option<(Lsn, Bytes)>,
+    pub latest_version: bool,
 }
 
 /// Return value from Layer::get_page_reconstruct_data

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -498,7 +498,7 @@ impl PageServerHandler {
             std::thread::sleep(std::time::Duration::from_millis(1000));
         }
         */
-        let page = timeline.get_rel_page_at_lsn(req.rel, req.blkno, lsn)?;
+        let page = timeline.get_rel_page_at_lsn(req.rel, req.blkno, lsn, req.latest)?;
 
         Ok(PagestreamBeMessage::GetPage(PagestreamGetPageResponse {
             page,

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -100,7 +100,13 @@ impl<R: Repository> DatadirTimeline<R> {
     //------------------------------------------------------------------------------
 
     /// Look up given page version.
-    pub fn get_rel_page_at_lsn(&self, tag: RelTag, blknum: BlockNumber, lsn: Lsn) -> Result<Bytes> {
+    pub fn get_rel_page_at_lsn(
+        &self,
+        tag: RelTag,
+        blknum: BlockNumber,
+        lsn: Lsn,
+        latest: bool,
+    ) -> Result<Bytes> {
         ensure!(tag.relnode != 0, "invalid relnode");
 
         let nblocks = self.get_rel_size(tag, lsn)?;
@@ -113,7 +119,11 @@ impl<R: Repository> DatadirTimeline<R> {
         }
 
         let key = rel_block_to_key(tag, blknum);
-        self.tline.get(key, lsn)
+        if latest {
+            self.tline.get_latest(key)
+        } else {
+            self.tline.get(key, lsn)
+        }
     }
 
     /// Get size of a relation file

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -350,6 +350,9 @@ pub trait Timeline: Send + Sync {
     ///
     fn get(&self, key: Key, lsn: Lsn) -> Result<Bytes>;
 
+    /// Lookup latest page version
+    fn get_latest(&self, key: Key) -> Result<Bytes>;
+
     /// Get the ancestor's timeline id
     fn get_ancestor_timeline_id(&self) -> Option<ZTimelineId>;
 

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -514,7 +514,7 @@ impl<'a, R: Repository> WalIngest<'a, R> {
 
                 let content = modification
                     .tline
-                    .get_rel_page_at_lsn(src_rel, blknum, req_lsn)?;
+                    .get_rel_page_at_lsn(src_rel, blknum, req_lsn, true)?;
                 modification.put_rel_page_image(dst_rel, blknum, content)?;
                 num_blocks_copied += 1;
             }

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1096,34 +1096,34 @@ mod tests {
 
         // Check page contents at each LSN
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x20))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x20), false)?,
             TEST_IMG("foo blk 0 at 2")
         );
 
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x30))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x30), false)?,
             TEST_IMG("foo blk 0 at 3")
         );
 
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x40))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x40), false)?,
             TEST_IMG("foo blk 0 at 3")
         );
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 1, Lsn(0x40))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 1, Lsn(0x40), false)?,
             TEST_IMG("foo blk 1 at 4")
         );
 
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x50))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x50), false)?,
             TEST_IMG("foo blk 0 at 3")
         );
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 1, Lsn(0x50))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 1, Lsn(0x50), false)?,
             TEST_IMG("foo blk 1 at 4")
         );
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 2, Lsn(0x50))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 2, Lsn(0x50), false)?,
             TEST_IMG("foo blk 2 at 5")
         );
 
@@ -1136,18 +1136,18 @@ mod tests {
         // Check reported size and contents after truncation
         assert_eq!(tline.get_rel_size(TESTREL_A, Lsn(0x60))?, 2);
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x60))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x60), false)?,
             TEST_IMG("foo blk 0 at 3")
         );
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 1, Lsn(0x60))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 1, Lsn(0x60), false)?,
             TEST_IMG("foo blk 1 at 4")
         );
 
         // should still see the truncated block with older LSN
         assert_eq!(tline.get_rel_size(TESTREL_A, Lsn(0x50))?, 3);
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 2, Lsn(0x50))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 2, Lsn(0x50), false)?,
             TEST_IMG("foo blk 2 at 5")
         );
 
@@ -1163,11 +1163,11 @@ mod tests {
         m.commit()?;
         assert_eq!(tline.get_rel_size(TESTREL_A, Lsn(0x70))?, 2);
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x70))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 0, Lsn(0x70), false)?,
             ZERO_PAGE
         );
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 1, Lsn(0x70))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 1, Lsn(0x70), false)?,
             TEST_IMG("foo blk 1")
         );
 
@@ -1178,12 +1178,12 @@ mod tests {
         assert_eq!(tline.get_rel_size(TESTREL_A, Lsn(0x80))?, 1501);
         for blk in 2..1500 {
             assert_eq!(
-                tline.get_rel_page_at_lsn(TESTREL_A, blk, Lsn(0x80))?,
+                tline.get_rel_page_at_lsn(TESTREL_A, blk, Lsn(0x80), false)?,
                 ZERO_PAGE
             );
         }
         assert_eq!(
-            tline.get_rel_page_at_lsn(TESTREL_A, 1500, Lsn(0x80))?,
+            tline.get_rel_page_at_lsn(TESTREL_A, 1500, Lsn(0x80), false)?,
             TEST_IMG("foo blk 1500")
         );
 
@@ -1259,7 +1259,7 @@ mod tests {
             let lsn = Lsn(0x20);
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
-                tline.get_rel_page_at_lsn(TESTREL_A, blkno, lsn)?,
+                tline.get_rel_page_at_lsn(TESTREL_A, blkno, lsn, false)?,
                 TEST_IMG(&data)
             );
         }
@@ -1277,7 +1277,7 @@ mod tests {
             let lsn = Lsn(0x20);
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
-                tline.get_rel_page_at_lsn(TESTREL_A, blkno, Lsn(0x60))?,
+                tline.get_rel_page_at_lsn(TESTREL_A, blkno, Lsn(0x60), false)?,
                 TEST_IMG(&data)
             );
         }
@@ -1288,7 +1288,7 @@ mod tests {
             let lsn = Lsn(0x20);
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
-                tline.get_rel_page_at_lsn(TESTREL_A, blkno, Lsn(0x50))?,
+                tline.get_rel_page_at_lsn(TESTREL_A, blkno, Lsn(0x50), false)?,
                 TEST_IMG(&data)
             );
         }
@@ -1310,7 +1310,7 @@ mod tests {
             let lsn = Lsn(0x80);
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
-                tline.get_rel_page_at_lsn(TESTREL_A, blkno, Lsn(0x80))?,
+                tline.get_rel_page_at_lsn(TESTREL_A, blkno, Lsn(0x80), false)?,
                 TEST_IMG(&data)
             );
         }


### PR DESCRIPTION
Right now page cache is used for storing materialized pages.
But if LSN of materialized page is smaller than LSN requested in `get_page_at_lsn`, then page server will have to check if there are some wal records in this range which is not so fast operation.

My proposal is to use cache invalidation mechanism: cached image layers is marked as _latest_.
If some wal record is received for this pages then `latest` flag is cleared.
It allows to use cached page without any extra checks is  `latest`  flag is set.

It gives at my compute speed advance at select-only `pgbench -S -c 10` from 16k to 22k TPS.
