### PR TITLE
Improve logging in test_wal_restore.py

### DIFF
--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1273,10 +1273,14 @@ class VanillaPostgres(PgProtocol):
         with open(os.path.join(self.pgdatadir, 'postgresql.conf'), 'a') as conf_file:
             conf_file.writelines(options)
 
-    def start(self):
+    def start(self, log_path: Optional[str] = None):
         assert not self.running
         self.running = True
-        self.pg_bin.run_capture(['pg_ctl', '-D', self.pgdatadir, 'start'])
+
+        if log_path is None:
+            log_path = os.path.join(self.pgdatadir, "pg.log")
+
+        self.pg_bin.run_capture(['pg_ctl', '-D', self.pgdatadir, '-l', log_path, 'start'])
 
     def stop(self):
         assert self.running

--- a/zenith_utils/scripts/restore_from_wal.sh
+++ b/zenith_utils/scripts/restore_from_wal.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 PG_BIN=$1
 WAL_PATH=$2
 DATA_DIR=$3


### PR DESCRIPTION
- Capture the output of the restore_from_wal.sh in a log file
- Capture log of the restored Postgres server.
- Kill "restored" Postgres server on test failure