### PR TITLE
Update 'routerify' dependency in proxy.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
  "rand",
  "rcgen",
  "reqwest",
- "routerify 2.2.0",
+ "routerify",
  "rstest",
  "rustls",
  "rustls-pemfile",
@@ -2077,19 +2077,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "routerify"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6bb49594c791cadb5ccfa5f36d41b498d40482595c199d10cd318800280bd9"
-dependencies = [
- "http",
- "hyper",
- "lazy_static",
- "percent-encoding",
- "regex",
 ]
 
 [[package]]
@@ -3379,7 +3366,7 @@ dependencies = [
  "postgres",
  "postgres-protocol",
  "rand",
- "routerify 3.0.0",
+ "routerify",
  "rustls",
  "rustls-pemfile",
  "rustls-split",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot = "0.11.2"
 pin-project-lite = "0.2.7"
 rand = "0.8.3"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-routerify = "2"
+routerify = "3"
 rustls = "0.20.0"
 rustls-pemfile = "0.2.1"
 scopeguard = "1.1.0"


### PR DESCRIPTION
routerify version 3 is used in zenith_utils, use the same version in proxy
to avoid having to build two versions.