### PR TITLE
Show better layer load errors

### DIFF
--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -254,7 +254,9 @@ impl ImageLayer {
             drop(inner);
             let mut inner = self.inner.write().unwrap();
             if !inner.loaded {
-                self.load_inner(&mut inner)?;
+                self.load_inner(&mut inner).with_context(|| {
+                    format!("Failed to load image layer {}", self.path().display())
+                })?
             } else {
                 // Another thread loaded it while we were not holding the lock.
             }


### PR DESCRIPTION
Based on https://neondb.slack.com/archives/C034ED3MM7A/p1650624886422879

Trace from staging: 
```
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]: 2022-04-22T11:46:50.456965Z ERROR Error processing HTTP request: InternalServerError(failed to fill whole buffer
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]: Stack backtrace:
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:    0: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:              at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/result.rs:1911:27
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:       pageserver::layered_repository::delta_layer::DeltaLayer::load_inner
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:              at /home/circleci/project/pageserver/src/layered_repository/delta_layer.rs:449:27
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:       pageserver::layered_repository::delta_layer::DeltaLayer::load
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:              at /home/circleci/project/pageserver/src/layered_repository/delta_layer.rs:425:17
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:    1: <pageserver::layered_repository::delta_layer::DeltaLayer as pageserver::layered_repository::storage_layer::Layer>::get_value_reconstruct_data
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:              at /home/circleci/project/pageserver/src/layered_repository/delta_layer.rs:234:25
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:    2: pageserver::layered_repository::LayeredTimeline::get_reconstruct_data
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:              at /home/circleci/project/pageserver/src/layered_repository.rs:1462:26
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:       <pageserver::layered_repository::LayeredTimeline as pageserver::repository::Timeline>::get
Apr 22 11:46:50 zenith-us-stage-ps-2.local pageserver[9980]:              at /home/circleci/project/pageserver/src/layered_repository.rs:1072:9
.....snip
```