### PR TITLE
Limit concurrent S3 and IAM interactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,7 +1899,7 @@ dependencies = [
  "libc",
  "log",
  "nix",
- "parking_lot",
+ "parking_lot 0.11.2",
  "symbolic-demangle",
  "tempfile",
  "thiserror",

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -156,6 +156,9 @@ access_key_id = 'SOMEKEYAAAAASADSAH*#'
 
 # Secret access key to connect to the bucket ("password" part of the credentials)
 secret_access_key = 'SOMEsEcReTsd292v'
+
+# S3 API query limit to avoid getting errors/throttling from AWS.
+concurrency_limit = 100
 ```
 
 ###### General remote storage configuration
@@ -167,8 +170,8 @@ Besides, there are parameters common for all types of remote storage that can be
 
 ```toml
 [remote_storage]
-# Max number of concurrent connections to open for uploading to or downloading from the remote storage.
-max_concurrent_sync = 100
+# Max number of concurrent timeline synchronized (layers uploaded or downloaded) with the remote storage at the same time.
+max_concurrent_timelines_sync = 50
 
 # Max number of errors a single task can have before it's considered failed and not attempted to run anymore.
 max_sync_errors = 10

--- a/pageserver/src/remote_storage.rs
+++ b/pageserver/src/remote_storage.rs
@@ -161,7 +161,7 @@ pub fn start_local_timeline_sync(
                     config,
                     local_timeline_files,
                     LocalFs::new(root.clone(), &config.workdir)?,
-                    storage_config.max_concurrent_sync,
+                    storage_config.max_concurrent_timelines_sync,
                     storage_config.max_sync_errors,
                 )
             },
@@ -172,7 +172,7 @@ pub fn start_local_timeline_sync(
                     config,
                     local_timeline_files,
                     S3Bucket::new(s3_config, &config.workdir)?,
-                    storage_config.max_concurrent_sync,
+                    storage_config.max_concurrent_timelines_sync,
                     storage_config.max_sync_errors,
                 )
             },


### PR DESCRIPTION
Based on https://neondb.slack.com/archives/C034ED3MM7A/p1650624886422879

Number 50 for concurrency limit is chosen arbitrarily, but looks like we're rather limited by IAM server here?

```rust
/// Currently, sync happens with AWS S3, that has two limits on requests per second:
/// ~200 RPS for IAM services
/// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
/// ~3500 PUT/COPY/POST/DELETE or 5500 GET/HEAD S3 requests
/// https://aws.amazon.com/premiumsupport/knowledge-center/s3-request-limit-avoid-throttling/
```