### PR TITLE
Add delta page cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,7 +1899,7 @@ dependencies = [
  "libc",
  "log",
  "nix",
- "parking_lot",
+ "parking_lot 0.11.2",
  "symbolic-demangle",
  "tempfile",
  "thiserror",

--- a/pageserver/src/big_cache.rs
+++ b/pageserver/src/big_cache.rs
@@ -1,31 +1,36 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Write, path::Path};
 
 use bytes::Bytes;
 use anyhow::Result;
 use once_cell::{sync::OnceCell, sync::Lazy};
 use utils::lsn::Lsn;
 use std::sync::Mutex;
+use std::fs::File;
 
-use crate::repository::Key;
+use crate::{layered_repository::ephemeral_file::EphemeralFile, repository::Key};
 
 pub static BIG_CACHE: Lazy<BigCache> = Lazy::new(|| {
     BigCache {
         index: Mutex::new(HashMap::new()),
+        file: Mutex::new(File::create(Path::new("big_cache.tmp")).unwrap()),
     }
 });
 
 pub struct BigCache {
-    // TODO point to offset in ephemeral file instead
+    // TODO point to file offset instead
     index: Mutex<HashMap<Key, (Lsn, Bytes)>>,
+    file: Mutex<File>,  // TODO use ephemeral file instead
 }
 
 impl BigCache {
     pub fn lookup(&self, key: &Key) -> Result<Option<(Lsn, Bytes)>> {
+        // TODO read this from the file instead
         Ok(self.index.lock().unwrap().get(key).map(|img| img.clone()))
     }
 
     pub fn memorize(&self, key: Key, img: (Lsn, Bytes)) -> Result<()> {
-        self.index.lock().unwrap().insert(key, img);
+        self.index.lock().unwrap().insert(key, img.clone());
+        self.file.lock().unwrap().write(&img.1)?;
         Ok(())
     }
 }

--- a/pageserver/src/big_cache.rs
+++ b/pageserver/src/big_cache.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use anyhow::Result;
+use once_cell::{sync::OnceCell, sync::Lazy};
+use utils::lsn::Lsn;
+use std::sync::Mutex;
+
+use crate::repository::Key;
+
+pub static BIG_CACHE: Lazy<BigCache> = Lazy::new(|| {
+    BigCache {
+        index: Mutex::new(HashMap::new()),
+    }
+});
+
+pub struct BigCache {
+    // TODO point to offset in ephemeral file instead
+    index: Mutex<HashMap<Key, (Lsn, Bytes)>>,
+}
+
+impl BigCache {
+    pub fn lookup(&self, key: &Key) -> Result<Option<(Lsn, Bytes)>> {
+        Ok(self.index.lock().unwrap().get(key).map(|img| img.clone()))
+    }
+
+    pub fn memorize(&self, key: Key, img: (Lsn, Bytes)) -> Result<()> {
+        self.index.lock().unwrap().insert(key, img);
+        Ok(())
+    }
+}

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1683,6 +1683,7 @@ impl LayeredTimeline {
         let end_lsn = frozen_layer.get_lsn_range().end;
         for key in frozen_layer.inner.read().unwrap().index.keys() {
             let img = self.get(*key, end_lsn)?;
+            // TODO maybe don't memorize all pages, but most updates ones only
             BIG_CACHE.memorize(*key, (end_lsn, img))?;
         }
 

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -43,7 +43,7 @@ pub struct InMemoryLayer {
 
     /// The above fields never change. The parts that do change are in 'inner',
     /// and protected by mutex.
-    inner: RwLock<InMemoryLayerInner>,
+    pub inner: RwLock<InMemoryLayerInner>,
 }
 
 pub struct InMemoryLayerInner {
@@ -56,7 +56,7 @@ pub struct InMemoryLayerInner {
     /// by block number and LSN. The value is an offset into the
     /// ephemeral file where the page version is stored.
     ///
-    index: HashMap<Key, VecMap<Lsn, u64>>,
+    pub index: HashMap<Key, VecMap<Lsn, u64>>,
 
     /// The values are stored in a serialized format in this file.
     /// Each serialized Value is preceded by a 'u32' length field.

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -21,6 +21,7 @@ pub mod walingest;
 pub mod walreceiver;
 pub mod walrecord;
 pub mod walredo;
+pub mod big_cache;
 
 use lazy_static::lazy_static;
 use tracing::info;


### PR DESCRIPTION
As an experiment only, I'm caching all modified pages during checkpoint into an ephemeral file cache.

Results:
```
old:
test_pgbench[zenith-45-10].simple-update.latency_average: 0.669 ms
test_pgbench[zenith-45-10].simple-update.latency_stddev: 0.216 ms
test_pgbench[zenith-45-10].simple-update.tps: 5,958.3685
test_pgbench[zenith-45-10].select-only.latency_average: 0.365 ms
test_pgbench[zenith-45-10].select-only.latency_stddev: 0.621 ms
test_pgbench[zenith-45-10].select-only.tps: 10,958.0510

new:
test_pgbench[zenith-45-10].simple-update.latency_average: 0.630 ms
test_pgbench[zenith-45-10].simple-update.latency_stddev: 0.218 ms
test_pgbench[zenith-45-10].simple-update.tps: 6,327.8910
test_pgbench[zenith-45-10].select-only.latency_average: 0.212 ms
test_pgbench[zenith-45-10].select-only.latency_stddev: 0.160 ms
test_pgbench[zenith-45-10].select-only.tps: 18,705.8595
```
Summary: `simple-update` is not worse (surprising!), `select-only` is much better. I'll measure how much ephemeral file bloat this cache creates. I'm sure the [hot_page test](https://github.com/neondatabase/neon/pull/1479) is also much better but I haven't tested yet.

The `get_reconstruct_data` function still shows up at 11% on the flame graph. Not sure why. All pages should be either inmem or in the big cache.

The purpose of this draft PR is to share results, and maybe later arrive at something mergeable. If you have experiments you'd like me to run pls share.
