### PR TITLE
Remove obsolete failpoint in proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,6 @@ dependencies = [
  "base64",
  "bytes",
  "clap 3.0.14",
- "fail",
  "futures",
  "hashbrown",
  "hex",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -8,7 +8,6 @@ anyhow = "1.0"
 base64 = "0.13.0"
 bytes = { version = "1.0.1", features = ['serde'] }
 clap = "3.0"
-fail = "0.5.0"
 futures = "0.3.13"
 hashbrown = "0.11.2"
 hex = "0.4.3"

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -48,10 +48,6 @@ impl ClientCredentials {
         config: &ProxyConfig,
         client: &mut PqStream<impl AsyncRead + AsyncWrite + Unpin>,
     ) -> Result<DatabaseInfo, AuthError> {
-        fail::fail_point!("proxy-authenticate", |_| {
-            Err(AuthError::auth_failed("failpoint triggered"))
-        });
-
         use crate::config::ClientAuthMethod::*;
         use crate::config::RouterConfig::*;
         match &config.router_config {


### PR DESCRIPTION
When failpoint feature is disabled it throws away passed code so code
inside is not guaranteed to compile when feature is disabled. In this
particular case code is obsolete so removing it.