### PR TITLE
Prepare tenant_mgr for etcd integration

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -347,7 +347,8 @@ async fn timeline_detach_handler(request: Request<Body>) -> Result<Response<Body
         let _enter =
             info_span!("timeline_detach_handler", tenant = %tenant_id, timeline = %timeline_id)
                 .entered();
-        tenant_mgr::detach_timeline(tenant_id, timeline_id)
+        let state = get_state(&request);
+        tenant_mgr::detach_timeline(state.conf, tenant_id, timeline_id)
     })
     .await
     .map_err(ApiError::from_err)??;

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -347,8 +347,7 @@ async fn timeline_detach_handler(request: Request<Body>) -> Result<Response<Body
         let _enter =
             info_span!("timeline_detach_handler", tenant = %tenant_id, timeline = %timeline_id)
                 .entered();
-        let repo = tenant_mgr::get_repository_for_tenant(tenant_id)?;
-        repo.detach_timeline(timeline_id)
+        tenant_mgr::detach_timeline(tenant_id, timeline_id)
     })
     .await
     .map_err(ApiError::from_err)??;

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1814,7 +1814,7 @@ impl LayeredTimeline {
         let target_file_size = self.get_checkpoint_distance();
 
         // Define partitioning schema if needed
-        if let Ok(pgdir) = tenant_mgr::get_timeline_for_tenant_load(self.tenantid, self.timelineid)
+        if let Ok(pgdir) = tenant_mgr::get_local_timeline_with_load(self.tenantid, self.timelineid)
         {
             let (partitioning, lsn) = pgdir.repartition(
                 self.get_last_record_lsn(),

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -392,7 +392,11 @@ impl Repository for LayeredRepository {
     }
 
     fn detach_timeline(&self, timeline_id: ZTimelineId) -> anyhow::Result<()> {
-        self.timelines.lock().unwrap().remove(&timeline_id);
+        let mut timelines = self.timelines.lock().unwrap();
+        ensure!(
+            timelines.remove(&timeline_id).is_some(),
+            "cannot detach timeline {timeline_id} that is not available locally"
+        );
         Ok(())
     }
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -326,7 +326,7 @@ impl PageServerHandler {
         let _enter = info_span!("pagestream", timeline = %timelineid, tenant = %tenantid).entered();
 
         // Check that the timeline exists
-        let timeline = tenant_mgr::get_timeline_for_tenant_load(tenantid, timelineid)
+        let timeline = tenant_mgr::get_local_timeline_with_load(tenantid, timelineid)
             .context("Cannot load local timeline")?;
 
         /* switch client to COPYBOTH */
@@ -522,7 +522,7 @@ impl PageServerHandler {
         info!("starting");
 
         // check that the timeline exists
-        let timeline = tenant_mgr::get_timeline_for_tenant_load(tenantid, timelineid)
+        let timeline = tenant_mgr::get_local_timeline_with_load(tenantid, timelineid)
             .context("Cannot load local timeline")?;
         let latest_gc_cutoff_lsn = timeline.tline.get_latest_gc_cutoff_lsn();
         if let Some(lsn) = lsn {
@@ -656,7 +656,7 @@ impl postgres_backend::Handler for PageServerHandler {
                 info_span!("callmemaybe", timeline = %timelineid, tenant = %tenantid).entered();
 
             // Check that the timeline exists
-            tenant_mgr::get_timeline_for_tenant_load(tenantid, timelineid)
+            tenant_mgr::get_local_timeline_with_load(tenantid, timelineid)
                 .context("Cannot load local timeline")?;
 
             walreceiver::launch_wal_receiver(self.conf, tenantid, timelineid, &connstr)?;
@@ -768,7 +768,7 @@ impl postgres_backend::Handler for PageServerHandler {
 
             let tenantid = ZTenantId::from_str(caps.get(1).unwrap().as_str())?;
             let timelineid = ZTimelineId::from_str(caps.get(2).unwrap().as_str())?;
-            let timeline = tenant_mgr::get_timeline_for_tenant_load(tenantid, timelineid)
+            let timeline = tenant_mgr::get_local_timeline_with_load(tenantid, timelineid)
                 .context("Couldn't load timeline")?;
             timeline.tline.compact()?;
 
@@ -787,7 +787,7 @@ impl postgres_backend::Handler for PageServerHandler {
             let tenantid = ZTenantId::from_str(caps.get(1).unwrap().as_str())?;
             let timelineid = ZTimelineId::from_str(caps.get(2).unwrap().as_str())?;
 
-            let timeline = tenant_mgr::get_timeline_for_tenant_load(tenantid, timelineid)
+            let timeline = tenant_mgr::get_local_timeline_with_load(tenantid, timelineid)
                 .context("Cannot load local timeline")?;
 
             timeline.tline.checkpoint(CheckpointConfig::Forced)?;

--- a/pageserver/src/remote_storage/storage_sync/download.rs
+++ b/pageserver/src/remote_storage/storage_sync/download.rs
@@ -332,7 +332,7 @@ mod tests {
         .await;
         assert!(
             matches!(
-                dbg!(already_downloading_remote_timeline_download),
+                already_downloading_remote_timeline_download,
                 DownloadedTimeline::Abort,
             ),
             "Should not allow downloading for remote timeline that does not expect it"

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -259,7 +259,7 @@ pub trait Repository: Send + Sync {
     /// api's 'compact' command.
     fn compaction_iteration(&self) -> Result<()>;
 
-    /// detaches locally available timeline by stopping all threads and removing all the data.
+    /// detaches timeline-related in-memory data.
     fn detach_timeline(&self, timeline_id: ZTimelineId) -> Result<()>;
 
     // Allows to retrieve remote timeline index from the repo. Used in walreceiver to grab remote consistent lsn.

--- a/pageserver/src/timelines.rs
+++ b/pageserver/src/timelines.rs
@@ -2,7 +2,7 @@
 //! Timeline management code
 //
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use postgres_ffi::ControlFileData;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
@@ -106,7 +106,7 @@ impl LocalTimelineInfo {
         match repo_timeline {
             RepositoryTimeline::Loaded(_) => {
                 let datadir_tline =
-                    tenant_mgr::get_timeline_for_tenant_load(tenant_id, timeline_id)?;
+                    tenant_mgr::get_local_timeline_with_load(tenant_id, timeline_id)?;
                 Self::from_loaded_timeline(&datadir_tline, include_non_incremental_logical_size)
             }
             RepositoryTimeline::Unloaded { metadata } => Ok(Self::from_unloaded_timeline(metadata)),
@@ -152,7 +152,7 @@ pub fn init_pageserver(
 
     if let Some(tenant_id) = create_tenant {
         println!("initializing tenantid {}", tenant_id);
-        let repo = create_repo(conf, Default::default(), tenant_id, CreateRepo::Dummy)
+        let repo = create_repo(conf, TenantConfOpt::default(), tenant_id, CreateRepo::Dummy)
             .context("failed to create repo")?;
         let new_timeline_id = initial_timeline_id.unwrap_or_else(ZTimelineId::generate);
         bootstrap_timeline(conf, tenant_id, new_timeline_id, repo.as_ref())
@@ -203,9 +203,11 @@ pub fn create_repo(
     };
 
     let repo_dir = conf.tenant_path(&tenant_id);
-    if repo_dir.exists() {
-        bail!("tenant {} directory already exists", tenant_id);
-    }
+    ensure!(
+        repo_dir.exists(),
+        "cannot create new tenant repo: '{}' directory already exists",
+        tenant_id
+    );
 
     // top-level dir may exist if we are creating it through CLI
     crashsafe_dir::create_dir_all(&repo_dir)
@@ -383,7 +385,7 @@ pub(crate) fn create_timeline(
             repo.branch_timeline(ancestor_timeline_id, new_timeline_id, start_lsn)?;
             // load the timeline into memory
             let loaded_timeline =
-                tenant_mgr::get_timeline_for_tenant_load(tenant_id, new_timeline_id)?;
+                tenant_mgr::get_local_timeline_with_load(tenant_id, new_timeline_id)?;
             LocalTimelineInfo::from_loaded_timeline(&loaded_timeline, false)
                 .context("cannot fill timeline info")?
         }
@@ -391,7 +393,7 @@ pub(crate) fn create_timeline(
             bootstrap_timeline(conf, tenant_id, new_timeline_id, repo.as_ref())?;
             // load the timeline into memory
             let new_timeline =
-                tenant_mgr::get_timeline_for_tenant_load(tenant_id, new_timeline_id)?;
+                tenant_mgr::get_local_timeline_with_load(tenant_id, new_timeline_id)?;
             LocalTimelineInfo::from_loaded_timeline(&new_timeline, false)
                 .context("cannot fill timeline info")?
         }

--- a/pageserver/src/timelines.rs
+++ b/pageserver/src/timelines.rs
@@ -204,7 +204,7 @@ pub fn create_repo(
 
     let repo_dir = conf.tenant_path(&tenant_id);
     ensure!(
-        repo_dir.exists(),
+        !repo_dir.exists(),
         "cannot create new tenant repo: '{}' directory already exists",
         tenant_id
     );

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -184,7 +184,7 @@ fn walreceiver_main(
     let repo = tenant_mgr::get_repository_for_tenant(tenant_id)
         .with_context(|| format!("no repository found for tenant {}", tenant_id))?;
     let timeline =
-        tenant_mgr::get_timeline_for_tenant_load(tenant_id, timeline_id).with_context(|| {
+        tenant_mgr::get_local_timeline_with_load(tenant_id, timeline_id).with_context(|| {
             format!(
                 "local timeline {} not found for tenant {}",
                 timeline_id, tenant_id

--- a/test_runner/batch_others/test_tenant_relocation.py
+++ b/test_runner/batch_others/test_tenant_relocation.py
@@ -217,6 +217,13 @@ def test_tenant_relocation(zenith_env_builder: ZenithEnvBuilder,
 
         tenant_pg.start()
 
+        timeline_to_detach_local_path = env.repo_dir / 'tenants' / tenant.hex / 'timelines' / timeline.hex
+        files_before_detach = os.listdir(timeline_to_detach_local_path)
+        assert 'metadata' in files_before_detach, f'Regular timeline {timeline_to_detach_local_path} should have the metadata file,\
+             but got: {files_before_detach}'
+        assert len(files_before_detach) > 2, f'Regular timeline {timeline_to_detach_local_path} should have at least one layer file,\
+             but got {files_before_detach}'
+
         # detach tenant from old pageserver before we check
         # that all the data is there to be sure that old pageserver
         # is no longer involved, and if it is, we will see the errors
@@ -237,6 +244,8 @@ def test_tenant_relocation(zenith_env_builder: ZenithEnvBuilder,
             load_stop_event.set()
             load_thread.join(timeout=10)
             log.info('load thread stopped')
+
+        assert not os.path.exists(timeline_to_detach_local_path), f'After detach, local timeline dir {timeline_to_detach_local_path} should be removed'
 
         # bring old pageserver back for clean shutdown via zenith cli
         # new pageserver will be shut down by the context manager


### PR DESCRIPTION
We're supposed to subscribe for safekeeper info from etcd on a certain timeline(s), and update timeline state accordingly: start/stop walreceiver, disable/enable various related threads.
To do so, we need more info on which timeline is located locally and every timeline's `disk_consistent_lsn` + have a place to store the channel end to receive etcd updates from the async code.

Currently, there looks to be a somewhat confusingly implemented separation of "local" timelines, `DatadirTimelineImpl`, stored in the tenant map and the "inmem" timelines, stored in the `LayeredRepository` map.
Both objects reference each other, but now the "local" timelines were not properly updated in the map sometimes (not removed at all on detach, had complex code to create on attach)

A refactoring of tenant_mgr had brought the following:

* `Mutex` replaced with `RwLock` on the tenants data, along with the data hidden more into the inner module.
Ideally, `tenant_mgr` might be converted into some mockable struct later, but it's quite a big refactoring to take now, but its data is now somehow hidden
* `register_new_timeline` method to add local and remote timeline data on either timeline download or local timeline load on start
* `detach_timeline` reworked: now it does not delete local files, but unloads both local and inmem timeline data from memory, allowing to reload the local files on `attach`. I don't think we should delete anything from disk from the pageserver process.
* general style fixes (`{formatting_args}`, `tenantid -> tenant_id`, method renames to highlight the local nature of timeline data)