### PR TITLE
Remember timeline_start_lsn and local_start_lsn on safekeeper.

### DIFF
--- a/safekeeper/src/http/routes.rs
+++ b/safekeeper/src/http/routes.rs
@@ -69,6 +69,10 @@ struct TimelineStatus {
     timeline_id: ZTimelineId,
     acceptor_state: AcceptorStateStatus,
     #[serde(serialize_with = "display_serialize")]
+    timeline_start_lsn: Lsn,
+    #[serde(serialize_with = "display_serialize")]
+    local_start_lsn: Lsn,
+    #[serde(serialize_with = "display_serialize")]
     commit_lsn: Lsn,
     #[serde(serialize_with = "display_serialize")]
     s3_wal_lsn: Lsn,
@@ -102,6 +106,8 @@ async fn timeline_status_handler(request: Request<Body>) -> Result<Response<Body
         tenant_id: zttid.tenant_id,
         timeline_id: zttid.timeline_id,
         acceptor_state: acc_state,
+        timeline_start_lsn: state.timeline_start_lsn,
+        local_start_lsn: state.local_start_lsn,
         commit_lsn: inmem.commit_lsn,
         s3_wal_lsn: inmem.s3_wal_lsn,
         peer_horizon_lsn: inmem.peer_horizon_lsn,

--- a/safekeeper/src/json_ctrl.rs
+++ b/safekeeper/src/json_ctrl.rs
@@ -95,7 +95,7 @@ pub fn handle_json_ctrl(
 /// by sending ProposerGreeting with default server.wal_seg_size.
 fn prepare_safekeeper(spg: &mut SafekeeperPostgresHandler) -> Result<()> {
     let greeting_request = ProposerAcceptorMessage::Greeting(ProposerGreeting {
-        protocol_version: 1, // current protocol
+        protocol_version: 2, // current protocol
         pg_version: 0,       // unknown
         proposer_id: [0u8; 16],
         system_id: 0,
@@ -124,6 +124,7 @@ fn send_proposer_elected(spg: &mut SafekeeperPostgresHandler, term: Term, lsn: L
         term,
         start_streaming_at: lsn,
         term_history: history,
+        timeline_start_lsn: Lsn(0),
     });
 
     spg.timeline.get().process_msg(&proposer_elected_request)?;

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -102,7 +102,7 @@ impl SharedState {
         let state = SafeKeeperState::new(zttid, peer_ids);
         let control_store = control_file::FileStorage::create_new(zttid, conf, state)?;
         let wal_store = wal_storage::PhysicalStorage::new(zttid, conf);
-        let sk = SafeKeeper::new(zttid.timeline_id, control_store, wal_store)?;
+        let sk = SafeKeeper::new(zttid.timeline_id, control_store, wal_store, conf.my_id)?;
 
         Ok(Self {
             notified_commit_lsn: Lsn(0),
@@ -125,7 +125,7 @@ impl SharedState {
 
         Ok(Self {
             notified_commit_lsn: Lsn(0),
-            sk: SafeKeeper::new(zttid.timeline_id, control_store, wal_store)?,
+            sk: SafeKeeper::new(zttid.timeline_id, control_store, wal_store, conf.my_id)?,
             replicas: Vec::new(),
             active: false,
             num_computes: 0,

--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -573,7 +573,9 @@ def test_timeline_status(zenith_env_builder: ZenithEnvBuilder):
     timeline_id = pg.safe_psql("show zenith.zenith_timeline")[0][0]
 
     # fetch something sensible from status
-    epoch = wa_http_cli.timeline_status(tenant_id, timeline_id).acceptor_epoch
+    tli_status = wa_http_cli.timeline_status(tenant_id, timeline_id)
+    epoch = tli_status.acceptor_epoch
+    timeline_start_lsn = tli_status.timeline_start_lsn
 
     pg.safe_psql("create table t(i int)")
 
@@ -581,8 +583,12 @@ def test_timeline_status(zenith_env_builder: ZenithEnvBuilder):
     pg.stop().start()
     pg.safe_psql("insert into t values(10)")
 
-    epoch_after_reboot = wa_http_cli.timeline_status(tenant_id, timeline_id).acceptor_epoch
+    tli_status = wa_http_cli.timeline_status(tenant_id, timeline_id)
+    epoch_after_reboot = tli_status.acceptor_epoch
     assert epoch_after_reboot > epoch
+
+    # and timeline_start_lsn stays the same
+    assert tli_status.timeline_start_lsn == timeline_start_lsn
 
 
 class SafekeeperEnv:

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1762,6 +1762,7 @@ class SafekeeperTimelineStatus:
     acceptor_epoch: int
     flush_lsn: str
     remote_consistent_lsn: str
+    timeline_start_lsn: str
 
 
 @dataclass
@@ -1786,7 +1787,8 @@ class SafekeeperHttpClient(requests.Session):
         resj = res.json()
         return SafekeeperTimelineStatus(acceptor_epoch=resj['acceptor_state']['epoch'],
                                         flush_lsn=resj['flush_lsn'],
-                                        remote_consistent_lsn=resj['remote_consistent_lsn'])
+                                        remote_consistent_lsn=resj['remote_consistent_lsn'],
+                                        timeline_start_lsn=resj['timeline_start_lsn'])
 
     def record_safekeeper_info(self, tenant_id: str, timeline_id: str, body):
         res = self.post(


### PR DESCRIPTION
```
    Remember timeline_start_lsn and local_start_lsn on safekeeper.
    
    Make it remember when timeline starts in general and on this safekeeper in
    particular (the point might be later on new safekeeper replacing failed one).
    
    Bumps control file and walproposer protocol versions.
    
    ref #1561
```