### PR TITLE
Exit pageserver process with correct error code

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -295,7 +295,7 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
                 signal.name()
             );
             profiling::exit_profiler(conf, &profiler_guard);
-            pageserver::shutdown_pageserver();
+            pageserver::shutdown_pageserver(0);
             unreachable!()
         }
     })

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -67,7 +67,7 @@ pub type RepositoryImpl = LayeredRepository;
 
 pub type DatadirTimelineImpl = DatadirTimeline<RepositoryImpl>;
 
-pub fn shutdown_pageserver() {
+pub fn shutdown_pageserver(exit_code: i32) {
     // Shut down the libpq endpoint thread. This prevents new connections from
     // being accepted.
     thread_mgr::shutdown_threads(Some(ThreadKind::LibpqEndpointListener), None, None);
@@ -94,5 +94,5 @@ pub fn shutdown_pageserver() {
     thread_mgr::shutdown_threads(None, None, None);
 
     info!("Shut down successfully completed");
-    std::process::exit(0);
+    std::process::exit(exit_code);
 }

--- a/pageserver/src/thread_mgr.rs
+++ b/pageserver/src/thread_mgr.rs
@@ -231,7 +231,7 @@ fn thread_wrapper<F>(
                     "Shutting down: thread '{}' exited with error: {:?}",
                     thread_name, err
                 );
-                shutdown_pageserver();
+                shutdown_pageserver(1);
             } else {
                 error!("Thread '{}' exited with error: {:?}", thread_name, err);
             }
@@ -241,7 +241,7 @@ fn thread_wrapper<F>(
                 "Shutting down: thread '{}' panicked: {:?}",
                 thread_name, err
             );
-            shutdown_pageserver();
+            shutdown_pageserver(1);
         }
     }
 }


### PR DESCRIPTION
When we shutdown pageserver due to an error (e g one of the important
threads panicked) use 1 exit code so systemd can properly restart it

This is sort of a bandaid for #1606 so pageserver can properly restart and try to continue working after such crash