### PR TITLE
Change shutdown_process_on_error thread spawn settings.

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -287,7 +287,7 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
         None,
         None,
         "http_endpoint_thread",
-        false,
+        true,
         move || {
             let router = http::make_router(conf, auth_cloned, remote_index)?;
             endpoint::serve_thread_main(router, http_listener, thread_mgr::shutdown_watcher())
@@ -301,7 +301,7 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
         None,
         None,
         "libpq endpoint thread",
-        false,
+        true,
         move || page_service::thread_main(conf, auth, pageserver_listener, conf.auth_type),
     )?;
 

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -244,7 +244,7 @@ pub fn activate_tenant(tenant_id: ZTenantId) -> anyhow::Result<()> {
                 Some(tenant_id),
                 None,
                 "Compactor thread",
-                true,
+                false,
                 move || crate::tenant_threads::compact_loop(tenant_id),
             )?;
 
@@ -253,7 +253,7 @@ pub fn activate_tenant(tenant_id: ZTenantId) -> anyhow::Result<()> {
                 Some(tenant_id),
                 None,
                 "GC thread",
-                true,
+                false,
                 move || crate::tenant_threads::gc_loop(tenant_id),
             )
             .with_context(|| format!("Failed to launch GC thread for tenant {tenant_id}"));


### PR DESCRIPTION
Now princeple is following: acceptor threads (libpq and http) error will
bring the pageserver down, but all per-tenant thread failures will be treated
as an error.