### PR TITLE
Add local paths to historic layers

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -11,7 +11,7 @@ use super::models::{
 };
 use crate::config::RemoteStorageKind;
 use crate::remote_storage::{
-    download_index_part, schedule_timeline_download, LocalFs, RemoteIndex, RemoteTimeline, S3Bucket,
+    download_index_part, schedule_layer_download, LocalFs, RemoteIndex, RemoteTimeline, S3Bucket,
 };
 use crate::repository::Repository;
 use crate::tenant_config::TenantConfOpt;
@@ -273,7 +273,7 @@ async fn timeline_attach_handler(request: Request<Body>) -> Result<Response<Body
         }
 
         remote_timeline.awaits_download = true;
-        schedule_timeline_download(tenant_id, timeline_id);
+        schedule_layer_download(tenant_id, timeline_id);
         return json_response(StatusCode::ACCEPTED, ());
     } else {
         // no timeline in the index, release the lock to make the potentially lengthy download opetation
@@ -309,7 +309,7 @@ async fn timeline_attach_handler(request: Request<Body>) -> Result<Response<Body
         }
         None => index_accessor.add_timeline_entry(sync_id, new_timeline),
     }
-    schedule_timeline_download(tenant_id, timeline_id);
+    schedule_layer_download(tenant_id, timeline_id);
     json_response(StatusCode::ACCEPTED, ())
 }
 

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1776,7 +1776,7 @@ impl LayeredTimeline {
                     self.tenantid,
                     self.timelineid,
                     HashSet::from([new_delta_path]),
-                    metadata,
+                    Some(metadata),
                 );
             }
 
@@ -1844,13 +1844,11 @@ impl LayeredTimeline {
                 }
             }
             if self.upload_layers.load(atomic::Ordering::Relaxed) {
-                let metadata = load_metadata(self.conf, self.timelineid, self.tenantid)
-                    .context("failed to load local metadata")?;
                 remote_storage::schedule_layer_upload(
                     self.tenantid,
                     self.timelineid,
                     layer_paths_to_upload,
-                    metadata,
+                    None,
                 );
             }
             timer.stop_and_record();
@@ -2032,17 +2030,6 @@ impl LayeredTimeline {
             layers.insert_historic(Arc::new(l));
         }
 
-        if self.upload_layers.load(atomic::Ordering::Relaxed) {
-            let metadata = load_metadata(self.conf, self.timelineid, self.tenantid)
-                .context("failed to load local metadata")?;
-            remote_storage::schedule_layer_upload(
-                self.tenantid,
-                self.timelineid,
-                new_layer_paths,
-                metadata,
-            );
-        }
-
         // Now that we have reshuffled the data to set of new delta layers, we can
         // delete the old ones
         let mut layer_paths_do_delete = HashSet::with_capacity(level0_deltas.len());
@@ -2056,6 +2043,12 @@ impl LayeredTimeline {
         drop(layers);
 
         if self.upload_layers.load(atomic::Ordering::Relaxed) {
+            remote_storage::schedule_layer_upload(
+                self.tenantid,
+                self.timelineid,
+                new_layer_paths,
+                None,
+            );
             remote_storage::schedule_layer_delete(
                 self.tenantid,
                 self.timelineid,

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -218,6 +218,10 @@ impl Layer for DeltaLayer {
         PathBuf::from(self.layer_name().to_string())
     }
 
+    fn local_path(&self) -> Option<PathBuf> {
+        Some(self.path())
+    }
+
     fn get_value_reconstruct_data(
         &self,
         key: Key,

--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -125,6 +125,10 @@ impl Layer for ImageLayer {
         PathBuf::from(self.layer_name().to_string())
     }
 
+    fn local_path(&self) -> Option<PathBuf> {
+        Some(self.path())
+    }
+
     fn get_tenant_id(&self) -> ZTenantId {
         self.tenantid
     }

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -85,6 +85,10 @@ impl Layer for InMemoryLayer {
         ))
     }
 
+    fn local_path(&self) -> Option<PathBuf> {
+        None
+    }
+
     fn get_tenant_id(&self) -> ZTenantId {
         self.tenantid
     }

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -253,7 +253,7 @@ impl LayerMap {
         }
     }
 
-    pub fn iter_historic_layers(&self) -> std::slice::Iter<Arc<dyn Layer>> {
+    pub fn iter_historic_layers(&self) -> impl Iterator<Item = &Arc<dyn Layer>> {
         self.historic_layers.iter()
     }
 

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -105,7 +105,7 @@ pub trait Layer: Send + Sync {
     /// log messages, even though they're never not on disk.)
     fn filename(&self) -> PathBuf;
 
-    /// If a layer has a corresponding file on a local filesystem, return its path.
+    /// If a layer has a corresponding file on a local filesystem, return its absolute path.
     fn local_path(&self) -> Option<PathBuf>;
 
     ///

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -105,6 +105,9 @@ pub trait Layer: Send + Sync {
     /// log messages, even though they're never not on disk.)
     fn filename(&self) -> PathBuf;
 
+    /// If a layer has a corresponding file on a local filesystem, return its path.
+    fn local_path(&self) -> Option<PathBuf>;
+
     ///
     /// Return data needed to reconstruct given page at LSN.
     ///

--- a/pageserver/src/remote_storage.rs
+++ b/pageserver/src/remote_storage.rs
@@ -14,7 +14,7 @@
 //!
 //! * public API via to interact with the external world:
 //!     * [`start_local_timeline_sync`] to launch a background async loop to handle the synchronization
-//!     * [`schedule_timeline_checkpoint_upload`] and [`schedule_timeline_download`] to enqueue a new upload and download tasks,
+//!     * [`schedule_layer_upload`], [`schedule_layer_download`] and [`schedule_layer_delete`] to enqueue a new upload and download tasks,
 //!       to be processed by the async loop
 //!
 //! Here's a schematic overview of all interactions backup and the rest of the pageserver perform:
@@ -71,10 +71,10 @@
 //! when the newer image is downloaded
 //!
 //! Pageserver maintains similar to the local file structure remotely: all layer files are uploaded with the same names under the same directory structure.
-//! Yet instead of keeping the `metadata` file remotely, we wrap it with more data in [`IndexShard`], containing the list of remote files.
+//! Yet instead of keeping the `metadata` file remotely, we wrap it with more data in [`IndexPart`], containing the list of remote files.
 //! This file gets read to populate the cache, if the remote timeline data is missing from it and gets updated after every successful download.
 //! This way, we optimize S3 storage access by not running the `S3 list` command that could be expencive and slow: knowing both [`ZTenantId`] and [`ZTimelineId`],
-//! we can always reconstruct the path to the timeline, use this to get the same path on the remote storage and retrive its shard contents, if needed, same as any layer files.
+//! we can always reconstruct the path to the timeline, use this to get the same path on the remote storage and retrive its part contents, if needed, same as any layer files.
 //!
 //! By default, pageserver reads the remote storage index data only for timelines located locally, to synchronize those, if needed.
 //! Bulk index data download happens only initially, on pageserer startup. The rest of the remote storage stays unknown to pageserver and loaded on demand only,
@@ -108,7 +108,7 @@ pub use self::{
     storage_sync::{
         download_index_part,
         index::{IndexPart, RemoteIndex, RemoteTimeline},
-        schedule_timeline_checkpoint_upload, schedule_timeline_download,
+        schedule_layer_delete, schedule_layer_download, schedule_layer_upload,
     },
 };
 use crate::{

--- a/pageserver/src/remote_storage/storage_sync.rs
+++ b/pageserver/src/remote_storage/storage_sync.rs
@@ -427,10 +427,10 @@ pub struct TimelineDownload {
 /// On task failure, it gets retried again from the start a number of times.
 ///
 /// Ensure that the loop is started otherwise the task is never processed.
-pub fn schedule_timeline_checkpoint_upload(
+pub fn schedule_layer_upload(
     tenant_id: ZTenantId,
     timeline_id: ZTimelineId,
-    new_layer: PathBuf,
+    layers_to_upload: HashSet<PathBuf>,
     metadata: TimelineMetadata,
 ) {
     if !sync_queue::push(
@@ -439,7 +439,7 @@ pub fn schedule_timeline_checkpoint_upload(
             timeline_id,
         },
         SyncTask::upload(TimelineUpload {
-            layers_to_upload: HashSet::from([new_layer]),
+            layers_to_upload,
             uploaded_layers: HashSet::new(),
             metadata,
         }),
@@ -450,6 +450,14 @@ pub fn schedule_timeline_checkpoint_upload(
     }
 }
 
+pub fn schedule_layer_delete(
+    _tenant_id: ZTenantId,
+    _timeline_id: ZTimelineId,
+    _layers_to_delete: HashSet<PathBuf>,
+) {
+    // TODO kb implement later
+}
+
 /// Requests the download of the entire timeline for a given tenant.
 /// No existing local files are currently overwritten, except the metadata file (if its disk_consistent_lsn is less than the downloaded one).
 /// The metadata file is always updated last, to avoid inconsistencies.
@@ -457,8 +465,8 @@ pub fn schedule_timeline_checkpoint_upload(
 /// On any failure, the task gets retried, omitting already downloaded layers.
 ///
 /// Ensure that the loop is started otherwise the task is never processed.
-pub fn schedule_timeline_download(tenant_id: ZTenantId, timeline_id: ZTimelineId) {
-    debug!("Scheduling timeline download for tenant {tenant_id}, timeline {timeline_id}");
+pub fn schedule_layer_download(tenant_id: ZTenantId, timeline_id: ZTimelineId) {
+    debug!("Scheduling layer download for tenant {tenant_id}, timeline {timeline_id}");
     sync_queue::push(
         ZTenantTimelineId {
             tenant_id,


### PR DESCRIPTION
Extracted from https://github.com/neondatabase/neon/pull/1603

For scheduling timeline sync tasks, we need to know its local path, since remote_storage knows nothing about pageserver internal kinds of files.

We could go even further and define `HistoricLayer` as

```rust
pub enum HistoricLayer {
    Delta(DeltaLayer),
    Image(ImageLayer),
}
```

the trick to avoid `Arc::clone` and borrow checker issues is to use `HistoricLayer::path` since every such layer is uniquely identified (?) by the local file path.

Alas, both this and the Arc-less versions break test and I'm not really sure why, so any help is appreciated.