### PR TITLE
Migrate from CircleCI to Github Actions: python codestyle, build and tests

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -41,7 +41,7 @@ runs:
         rm -rf ./neon-artifact/
 
     - name: Checkout
-      #checkout postgres only if needs_postgres_source
+      if: inputs.needs_postgres_source == 'true'
       uses: actions/checkout@v3
       with:
         submodules: true
@@ -86,8 +86,6 @@ runs:
             EXTRA_PARAMS="--out-dir $PERF_REPORT_DIR $EXTRA_PARAMS"
           fi
         fi
-
-        # export GITHUB_SHA=$CIRCLE_SHA1
 
         if [[ "${{ inputs.build_type }}" == "debug" ]]; then
           cov_prefix=(scripts/coverage "--profraw-prefix=$GITHUB_JOB" --dir=/tmp/neon/coverage run)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,7 +97,6 @@ jobs:
             CARGO_FLAGS="--release --features profiling"
           fi
 
-          export CARGO_INCREMENTAL=0
           export CACHEPOT_BUCKET=zenith-rust-cachepot
           export RUSTC_WRAPPER=cachepot
           export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
@@ -230,7 +229,7 @@ jobs:
           build_type: ${{ matrix.build_type }}
           rust_toolchain: ${{ matrix.rust_toolchain }}
           test_selection: batch_pg_regress
-          needs_postgres_source: false
+          needs_postgres_source: true
 
   other-tests:
     runs-on: [ self-hosted, Linux, k8s-runner ]
@@ -252,7 +251,6 @@ jobs:
           build_type: ${{ matrix.build_type }}
           rust_toolchain: ${{ matrix.rust_toolchain }}
           test_selection: batch_others
-          needs_postgres_source: false
 
   benchmarks:
     runs-on: [ self-hosted, Linux, k8s-runner ]
@@ -274,6 +272,5 @@ jobs:
           build_type: ${{ matrix.build_type }}
           rust_toolchain: ${{ matrix.rust_toolchain }}
           test_selection: performance
-          needs_postgres_source: false
           run_in_parallel: false
           # save_perf_report: true


### PR DESCRIPTION
Duplicate postgres and neon build and test jobs from CircleCI to Github actions.
