### PR TITLE
Enable etcd and safekeepers in all tests

### DIFF
--- a/.circleci/ansible/systemd/pageserver.service
+++ b/.circleci/ansible/systemd/pageserver.service
@@ -6,7 +6,7 @@ After=network.target auditd.service
 Type=simple
 User=pageserver
 Environment=RUST_BACKTRACE=1 ZENITH_REPO_DIR=/storage/pageserver LD_LIBRARY_PATH=/usr/local/lib
-ExecStart=/usr/local/bin/pageserver -c "pg_distrib_dir='/usr/local'" -c "listen_pg_addr='0.0.0.0:6400'" -c "listen_http_addr='0.0.0.0:9898'" -D /storage/pageserver/data
+ExecStart=/usr/local/bin/pageserver -c "pg_distrib_dir='/usr/local'" -c "listen_pg_addr='0.0.0.0:6400'" -c "listen_http_addr='0.0.0.0:9898'" -c "broker_endpoints=['{{ etcd_endpoints }}']" -D /storage/pageserver/data
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
 KillSignal=SIGINT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ jobs:
           when: always
           command: |
             du -sh /tmp/test_output/*
-            find /tmp/test_output -type f ! -name "pg.log" ! -name "pageserver.log" ! -name "safekeeper.log" ! -name "regression.diffs" ! -name "junit.xml" ! -name "*.filediff" ! -name "*.stdout" ! -name "*.stderr" ! -name "flamegraph.svg" -delete
+            find /tmp/test_output -type f ! -name "pg.log" ! -name "pageserver.log" ! -name "safekeeper.log" ! -name "etcd.log" ! -name "regression.diffs" ! -name "junit.xml" ! -name "*.filediff" ! -name "*.stdout" ! -name "*.stderr" ! -name "flamegraph.svg" -delete
             du -sh /tmp/test_output/*
       - store_artifacts:
           path: /tmp/test_output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,6 +1772,7 @@ dependencies = [
  "crc32c",
  "crossbeam-utils",
  "daemonize",
+ "etcd_broker",
  "fail",
  "futures",
  "git-version",

--- a/control_plane/simple.conf
+++ b/control_plane/simple.conf
@@ -9,3 +9,6 @@ auth_type = 'Trust'
 id = 1
 pg_port = 5454
 http_port = 7676
+
+[etcd_broker]
+broker_endpoints = ['http://127.0.0.1:2379']

--- a/control_plane/src/etcd.rs
+++ b/control_plane/src/etcd.rs
@@ -1,0 +1,93 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+use anyhow::Context;
+use nix::{
+    sys::signal::{kill, Signal},
+    unistd::Pid,
+};
+
+use crate::{local_env, read_pidfile};
+
+pub fn start_etcd_process(env: &local_env::LocalEnv) -> anyhow::Result<()> {
+    let etcd_broker = &env.etcd_broker;
+    println!(
+        "Starting etcd broker using {}",
+        etcd_broker.etcd_binary_path.display()
+    );
+
+    let etcd_data_dir = env.base_data_dir.join("etcd");
+    fs::create_dir_all(&etcd_data_dir).with_context(|| {
+        format!(
+            "Failed to create etcd data dir: {}",
+            etcd_data_dir.display()
+        )
+    })?;
+
+    let etcd_stdout_file =
+        fs::File::create(etcd_data_dir.join("etcd.stdout.log")).with_context(|| {
+            format!(
+                "Failed to create ectd stout file in directory {}",
+                etcd_data_dir.display()
+            )
+        })?;
+    let etcd_stderr_file =
+        fs::File::create(etcd_data_dir.join("etcd.stderr.log")).with_context(|| {
+            format!(
+                "Failed to create ectd stderr file in directory {}",
+                etcd_data_dir.display()
+            )
+        })?;
+    let client_urls = etcd_broker.comma_separated_endpoints();
+
+    let etcd_process = Command::new(&etcd_broker.etcd_binary_path)
+        .args(&[
+            format!("--data-dir={}", etcd_data_dir.display()),
+            format!("--listen-client-urls={client_urls}"),
+            format!("--advertise-client-urls={client_urls}"),
+        ])
+        .stdout(Stdio::from(etcd_stdout_file))
+        .stderr(Stdio::from(etcd_stderr_file))
+        .spawn()
+        .context("Failed to spawn etcd subprocess")?;
+    let pid = etcd_process.id();
+
+    let etcd_pid_file_path = etcd_pid_file_path(env);
+    fs::write(&etcd_pid_file_path, pid.to_string()).with_context(|| {
+        format!(
+            "Failed to create etcd pid file at {}",
+            etcd_pid_file_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+pub fn stop_etcd_process(env: &local_env::LocalEnv) -> anyhow::Result<()> {
+    let etcd_path = &env.etcd_broker.etcd_binary_path;
+    println!("Stopping etcd broker at {}", etcd_path.display());
+
+    let etcd_pid_file_path = etcd_pid_file_path(env);
+    let pid = Pid::from_raw(read_pidfile(&etcd_pid_file_path).with_context(|| {
+        format!(
+            "Failed to read etcd pid filea at {}",
+            etcd_pid_file_path.display()
+        )
+    })?);
+
+    kill(pid, Signal::SIGTERM).with_context(|| {
+        format!(
+            "Failed to stop etcd with pid {pid} at {}",
+            etcd_pid_file_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+fn etcd_pid_file_path(env: &local_env::LocalEnv) -> PathBuf {
+    env.base_data_dir.join("etcd.pid")
+}

--- a/control_plane/src/lib.rs
+++ b/control_plane/src/lib.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use std::process::Command;
 
 pub mod compute;
+pub mod etcd;
 pub mod local_env;
 pub mod postgresql_conf;
 pub mod safekeeper;

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -97,6 +97,7 @@ pub struct PageServerConf {
 
     // jwt auth token used for communication with pageserver
     pub auth_token: String,
+    pub broker_endpoints: Vec<String>,
 }
 
 impl Default for PageServerConf {
@@ -107,6 +108,7 @@ impl Default for PageServerConf {
             listen_http_addr: String::new(),
             auth_type: AuthType::Trust,
             auth_token: String::new(),
+            broker_endpoints: Vec::new(),
         }
     }
 }
@@ -401,6 +403,7 @@ impl LocalEnv {
 
         self.pageserver.auth_token =
             self.generate_auth_token(&Claims::new(None, Scope::PageServerApi))?;
+        self.pageserver.broker_endpoints = self.broker_endpoints.clone();
 
         fs::create_dir_all(self.pg_data_dirs_path())?;
 

--- a/control_plane/src/safekeeper.rs
+++ b/control_plane/src/safekeeper.rs
@@ -132,10 +132,6 @@ impl SafekeeperNode {
                 .args(&["--listen-pg", &listen_pg])
                 .args(&["--listen-http", &listen_http])
                 .args(&["--recall", "1 second"])
-                .args(&[
-                    "--broker-endpoints",
-                    &self.env.etcd_broker.comma_separated_endpoints(),
-                ])
                 .arg("--daemonize"),
         );
         if !self.conf.sync {

--- a/control_plane/src/safekeeper.rs
+++ b/control_plane/src/safekeeper.rs
@@ -137,6 +137,7 @@ impl SafekeeperNode {
                 .args(&["--listen-pg", &listen_pg])
                 .args(&["--listen-http", &listen_http])
                 .args(&["--recall", "1 second"])
+                .args(&["--broker-endpoints", &self.broker_endpoints.join(",")])
                 .arg("--daemonize"),
         );
         if !self.conf.sync {

--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -121,6 +121,16 @@ impl PageServerNode {
         );
         let listen_pg_addr_param =
             format!("listen_pg_addr='{}'", self.env.pageserver.listen_pg_addr);
+        let broker_endpoints_param = format!(
+            "broker_endpoints=[{}]",
+            self.env
+                .pageserver
+                .broker_endpoints
+                .iter()
+                .map(|url| format!("'{url}'"))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
         let mut args = Vec::with_capacity(20);
 
         args.push("--init");
@@ -129,6 +139,7 @@ impl PageServerNode {
         args.extend(["-c", &authg_type_param]);
         args.extend(["-c", &listen_http_addr_param]);
         args.extend(["-c", &listen_pg_addr_param]);
+        args.extend(["-c", &broker_endpoints_param]);
         args.extend(["-c", &id]);
 
         for config_override in config_overrides {

--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -124,7 +124,7 @@ impl PageServerNode {
         let broker_endpoints_param = format!(
             "broker_endpoints=[{}]",
             self.env
-                .pageserver
+                .etcd_broker
                 .broker_endpoints
                 .iter()
                 .map(|url| format!("'{url}'"))
@@ -141,6 +141,16 @@ impl PageServerNode {
         args.extend(["-c", &listen_pg_addr_param]);
         args.extend(["-c", &broker_endpoints_param]);
         args.extend(["-c", &id]);
+
+        let broker_etcd_prefix_param = self
+            .env
+            .etcd_broker
+            .broker_etcd_prefix
+            .as_ref()
+            .map(|prefix| format!("broker_etcd_prefix='{prefix}'"));
+        if let Some(broker_etcd_prefix_param) = broker_etcd_prefix_param.as_deref() {
+            args.extend(["-c", broker_etcd_prefix_param]);
+        }
 
         for config_override in config_overrides {
             args.extend(["-c", config_override]);

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,11 @@ if [ "$1" = 'pageserver' ]; then
         pageserver --init -D /data -c "pg_distrib_dir='/usr/local'" -c "id=10"
     fi
     echo "Staring pageserver at 0.0.0.0:6400"
-    pageserver -c "listen_pg_addr='0.0.0.0:6400'" -c "listen_http_addr='0.0.0.0:9898'" -D /data
+    if [ -z '${BROKER_ENDPOINTS}' ]; then
+        pageserver -c "listen_pg_addr='0.0.0.0:6400'" -c "listen_http_addr='0.0.0.0:9898'" -D /data
+    else
+        pageserver -c "listen_pg_addr='0.0.0.0:6400'" -c "listen_http_addr='0.0.0.0:9898'" -c "broker_endpoints=['${BROKER_ENDPOINTS}']" -D /data
+    fi
 else
     "$@"
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,17 +1,20 @@
 #!/bin/sh
 set -eux
 
+broker_endpoints_param="${BROKER_ENDPOINT:-absent}"
+if [ "$broker_endpoints_param" != "absent" ]; then
+    broker_endpoints_param="-c broker_endpoints=['$broker_endpoints_param']"
+else
+    broker_endpoints_param=''
+fi
+
 if [ "$1" = 'pageserver' ]; then
     if [ ! -d "/data/tenants" ]; then
         echo "Initializing pageserver data directory"
-        pageserver --init -D /data -c "pg_distrib_dir='/usr/local'" -c "id=10"
+        pageserver --init -D /data -c "pg_distrib_dir='/usr/local'" -c "id=10" $broker_endpoints_param
     fi
     echo "Staring pageserver at 0.0.0.0:6400"
-    if [ -z '${BROKER_ENDPOINTS}' ]; then
-        pageserver -c "listen_pg_addr='0.0.0.0:6400'" -c "listen_http_addr='0.0.0.0:9898'" -D /data
-    else
-        pageserver -c "listen_pg_addr='0.0.0.0:6400'" -c "listen_http_addr='0.0.0.0:9898'" -c "broker_endpoints=['${BROKER_ENDPOINTS}']" -D /data
-    fi
+    pageserver -c "listen_pg_addr='0.0.0.0:6400'" -c "listen_http_addr='0.0.0.0:9898'" $broker_endpoints_param -D /data
 else
     "$@"
 fi

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -25,10 +25,14 @@ max_file_descriptors = '100'
 # initial superuser role name to use when creating a new tenant
 initial_superuser_name = 'zenith_admin'
 
+broker_etcd_prefix = 'neon'
+broker_endpoints = ['some://etcd']
+
 # [remote_storage]
 ```
 
-The config above shows default values for all basic pageserver settings.
+The config above shows default values for all basic pageserver settings, besides `broker_endpoints`: that one has to be set by the user, 
+see the corresponding section below.
 Pageserver uses default values for all files that are missing in the config, so it's not a hard error to leave the config blank.
 Yet, it validates the config values it can (e.g. postgres install dir) and errors if the validation fails, refusing to start.
 
@@ -45,6 +49,17 @@ All values can be passed as an argument to the pageserver binary, using the `-c`
 Example: `${PAGESERVER_BIN} -c "checkpoint_period = '100 s'" -c "remote_storage={local_path='/some/local/path/'}"`
 
 Note that TOML distinguishes between strings and integers, the former require single or double quotes around them.
+
+#### broker_endpoints
+
+A list of endpoints (etcd currently) to connect and pull the information from.
+Mandatory, does not have a default, since requires etcd to be started as a separate process,
+and its connection url should be specified separately. 
+
+#### broker_etcd_prefix
+
+A prefix to add for every etcd key used, to separate one group of related instances from another, in the same cluster.
+Default is `neon`.
 
 #### checkpoint_distance
 

--- a/neon_local/src/main.rs
+++ b/neon_local/src/main.rs
@@ -1,10 +1,10 @@
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{App, AppSettings, Arg, ArgMatches};
 use control_plane::compute::ComputeControlPlane;
-use control_plane::local_env;
-use control_plane::local_env::LocalEnv;
+use control_plane::local_env::{EtcdBroker, LocalEnv};
 use control_plane::safekeeper::SafekeeperNode;
 use control_plane::storage::PageServerNode;
+use control_plane::{etcd, local_env};
 use pageserver::config::defaults::{
     DEFAULT_HTTP_LISTEN_ADDR as DEFAULT_PAGESERVER_HTTP_ADDR,
     DEFAULT_PG_LISTEN_ADDR as DEFAULT_PAGESERVER_PG_ADDR,
@@ -14,6 +14,7 @@ use safekeeper::defaults::{
     DEFAULT_PG_LISTEN_PORT as DEFAULT_SAFEKEEPER_PG_PORT,
 };
 use std::collections::{BTreeSet, HashMap};
+use std::path::Path;
 use std::process::exit;
 use std::str::FromStr;
 use utils::{
@@ -32,28 +33,27 @@ const DEFAULT_PAGESERVER_ID: ZNodeId = ZNodeId(1);
 const DEFAULT_BRANCH_NAME: &str = "main";
 project_git_version!(GIT_VERSION);
 
-fn default_conf() -> String {
+fn default_conf(etcd_binary_path: &Path) -> String {
     format!(
         r#"
 # Default built-in configuration, defined in main.rs
+[etcd_broker]
+broker_endpoints = ['http://localhost:2379']
+etcd_binary_path = '{etcd_binary_path}'
+
 [pageserver]
-id = {pageserver_id}
-listen_pg_addr = '{pageserver_pg_addr}'
-listen_http_addr = '{pageserver_http_addr}'
+id = {DEFAULT_PAGESERVER_ID}
+listen_pg_addr = '{DEFAULT_PAGESERVER_PG_ADDR}'
+listen_http_addr = '{DEFAULT_PAGESERVER_HTTP_ADDR}'
 auth_type = '{pageserver_auth_type}'
 
 [[safekeepers]]
-id = {safekeeper_id}
-pg_port = {safekeeper_pg_port}
-http_port = {safekeeper_http_port}
+id = {DEFAULT_SAFEKEEPER_ID}
+pg_port = {DEFAULT_SAFEKEEPER_PG_PORT}
+http_port = {DEFAULT_SAFEKEEPER_HTTP_PORT}
 "#,
-        pageserver_id = DEFAULT_PAGESERVER_ID,
-        pageserver_pg_addr = DEFAULT_PAGESERVER_PG_ADDR,
-        pageserver_http_addr = DEFAULT_PAGESERVER_HTTP_ADDR,
+        etcd_binary_path = etcd_binary_path.display(),
         pageserver_auth_type = AuthType::Trust,
-        safekeeper_id = DEFAULT_SAFEKEEPER_ID,
-        safekeeper_pg_port = DEFAULT_SAFEKEEPER_PG_PORT,
-        safekeeper_http_port = DEFAULT_SAFEKEEPER_HTTP_PORT,
     )
 }
 
@@ -167,12 +167,12 @@ fn main() -> Result<()> {
             .subcommand(App::new("create")
                 .arg(tenant_id_arg.clone())
                 .arg(timeline_id_arg.clone().help("Use a specific timeline id when creating a tenant and its initial timeline"))
-				.arg(Arg::new("config").short('c').takes_value(true).multiple_occurrences(true).required(false))
-				)
+                .arg(Arg::new("config").short('c').takes_value(true).multiple_occurrences(true).required(false))
+                )
             .subcommand(App::new("config")
                 .arg(tenant_id_arg.clone())
-				.arg(Arg::new("config").short('c').takes_value(true).multiple_occurrences(true).required(false))
-				)
+                .arg(Arg::new("config").short('c').takes_value(true).multiple_occurrences(true).required(false))
+                )
         )
         .subcommand(
             App::new("pageserver")
@@ -468,17 +468,17 @@ fn parse_timeline_id(sub_match: &ArgMatches) -> anyhow::Result<Option<ZTimelineI
         .context("Failed to parse timeline id from the argument string")
 }
 
-fn handle_init(init_match: &ArgMatches) -> Result<LocalEnv> {
+fn handle_init(init_match: &ArgMatches) -> anyhow::Result<LocalEnv> {
     let initial_timeline_id_arg = parse_timeline_id(init_match)?;
 
     // Create config file
     let toml_file: String = if let Some(config_path) = init_match.value_of("config") {
         // load and parse the file
         std::fs::read_to_string(std::path::Path::new(config_path))
-            .with_context(|| format!("Could not read configuration file \"{}\"", config_path))?
+            .with_context(|| format!("Could not read configuration file '{config_path}'"))?
     } else {
         // Built-in default config
-        default_conf()
+        default_conf(&EtcdBroker::locate_etcd()?)
     };
 
     let mut env =
@@ -497,7 +497,7 @@ fn handle_init(init_match: &ArgMatches) -> Result<LocalEnv> {
             &pageserver_config_overrides(init_match),
         )
         .unwrap_or_else(|e| {
-            eprintln!("pageserver init failed: {}", e);
+            eprintln!("pageserver init failed: {e}");
             exit(1);
         });
 
@@ -920,20 +920,23 @@ fn handle_safekeeper(sub_match: &ArgMatches, env: &local_env::LocalEnv) -> Resul
     Ok(())
 }
 
-fn handle_start_all(sub_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<()> {
+fn handle_start_all(sub_match: &ArgMatches, env: &local_env::LocalEnv) -> anyhow::Result<()> {
+    etcd::start_etcd_process(env)?;
     let pageserver = PageServerNode::from_env(env);
 
     // Postgres nodes are not started automatically
 
     if let Err(e) = pageserver.start(&pageserver_config_overrides(sub_match)) {
-        eprintln!("pageserver start failed: {}", e);
+        eprintln!("pageserver start failed: {e}");
+        try_stop_etcd_process(env);
         exit(1);
     }
 
     for node in env.safekeepers.iter() {
         let safekeeper = SafekeeperNode::from_env(env, node);
         if let Err(e) = safekeeper.start() {
-            eprintln!("safekeeper '{}' start failed: {}", safekeeper.id, e);
+            eprintln!("safekeeper '{}' start failed: {e}", safekeeper.id);
+            try_stop_etcd_process(env);
             exit(1);
         }
     }
@@ -963,5 +966,14 @@ fn handle_stop_all(sub_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<
             eprintln!("safekeeper '{}' stop failed: {}", safekeeper.id, e);
         }
     }
+
+    try_stop_etcd_process(env);
+
     Ok(())
+}
+
+fn try_stop_etcd_process(env: &local_env::LocalEnv) {
+    if let Err(e) = etcd::stop_etcd_process(env) {
+        eprintln!("etcd stop failed: {e}");
+    }
 }

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -55,6 +55,7 @@ fail = "0.5.0"
 git-version = "0.3.5"
 
 postgres_ffi = { path = "../libs/postgres_ffi" }
+etcd_broker = { path = "../libs/etcd_broker" }
 metrics = { path = "../libs/metrics" }
 utils = { path = "../libs/utils" }
 remote_storage = { path = "../libs/remote_storage" }

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use toml_edit;
 use toml_edit::{Document, Item};
+use url::Url;
 use utils::{
     postgres_backend::AuthType,
     zid::{ZNodeId, ZTenantId, ZTimelineId},
@@ -111,6 +112,9 @@ pub struct PageServerConf {
 
     pub profiling: ProfilingConfig,
     pub default_tenant_conf: TenantConf,
+
+    /// Etcd broker endpoints to connect to.
+    pub broker_endpoints: Vec<Url>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -175,6 +179,7 @@ struct PageServerConfigBuilder {
     id: BuilderValue<ZNodeId>,
 
     profiling: BuilderValue<ProfilingConfig>,
+    broker_endpoints: BuilderValue<Vec<Url>>,
 }
 
 impl Default for PageServerConfigBuilder {
@@ -200,6 +205,7 @@ impl Default for PageServerConfigBuilder {
             remote_storage_config: Set(None),
             id: NotSet,
             profiling: Set(ProfilingConfig::Disabled),
+            broker_endpoints: NotSet,
         }
     }
 }
@@ -256,6 +262,10 @@ impl PageServerConfigBuilder {
         self.remote_storage_config = BuilderValue::Set(remote_storage_config)
     }
 
+    pub fn broker_endpoints(&mut self, broker_endpoints: Vec<Url>) {
+        self.broker_endpoints = BuilderValue::Set(broker_endpoints)
+    }
+
     pub fn id(&mut self, node_id: ZNodeId) {
         self.id = BuilderValue::Set(node_id)
     }
@@ -264,7 +274,15 @@ impl PageServerConfigBuilder {
         self.profiling = BuilderValue::Set(profiling)
     }
 
-    pub fn build(self) -> Result<PageServerConf> {
+    pub fn build(self) -> anyhow::Result<PageServerConf> {
+        let broker_endpoints = self
+            .broker_endpoints
+            .ok_or(anyhow!("No broker endpoints provided"))?;
+        ensure!(
+            !broker_endpoints.is_empty(),
+            "Empty broker endpoints collection provided"
+        );
+
         Ok(PageServerConf {
             listen_pg_addr: self
                 .listen_pg_addr
@@ -300,6 +318,7 @@ impl PageServerConfigBuilder {
             profiling: self.profiling.ok_or(anyhow!("missing profiling"))?,
             // TenantConf is handled separately
             default_tenant_conf: TenantConf::default(),
+            broker_endpoints,
         })
     }
 }
@@ -341,7 +360,7 @@ impl PageServerConf {
     /// validating the input and failing on errors.
     ///
     /// This leaves any options not present in the file in the built-in defaults.
-    pub fn parse_and_validate(toml: &Document, workdir: &Path) -> Result<Self> {
+    pub fn parse_and_validate(toml: &Document, workdir: &Path) -> anyhow::Result<Self> {
         let mut builder = PageServerConfigBuilder::default();
         builder.workdir(workdir.to_owned());
 
@@ -373,6 +392,16 @@ impl PageServerConf {
                 }
                 "id" => builder.id(ZNodeId(parse_toml_u64(key, item)?)),
                 "profiling" => builder.profiling(parse_toml_from_str(key, item)?),
+                "broker_endpoints" => builder.broker_endpoints(
+                    parse_toml_array(key, item)?
+                        .into_iter()
+                        .map(|endpoint_str| {
+                            endpoint_str.parse::<Url>().with_context(|| {
+                                format!("Array item {endpoint_str} for key {key} is not a valid url endpoint")
+                            })
+                        })
+                        .collect::<anyhow::Result<_>>()?,
+                ),
                 _ => bail!("unrecognized pageserver option '{key}'"),
             }
         }
@@ -526,6 +555,7 @@ impl PageServerConf {
             remote_storage_config: None,
             profiling: ProfilingConfig::Disabled,
             default_tenant_conf: TenantConf::dummy_conf(),
+            broker_endpoints: Vec::new(),
         }
     }
 }
@@ -576,14 +606,36 @@ fn parse_toml_duration(name: &str, item: &Item) -> Result<Duration> {
     Ok(humantime::parse_duration(s)?)
 }
 
-fn parse_toml_from_str<T>(name: &str, item: &Item) -> Result<T>
+fn parse_toml_from_str<T>(name: &str, item: &Item) -> anyhow::Result<T>
 where
-    T: FromStr<Err = anyhow::Error>,
+    T: FromStr,
+    <T as FromStr>::Err: std::fmt::Display,
 {
     let v = item
         .as_str()
         .with_context(|| format!("configure option {name} is not a string"))?;
-    T::from_str(v)
+    T::from_str(v).map_err(|e| {
+        anyhow!(
+            "Failed to parse string as {parse_type} for configure option {name}: {e}",
+            parse_type = stringify!(T)
+        )
+    })
+}
+
+fn parse_toml_array(name: &str, item: &Item) -> anyhow::Result<Vec<String>> {
+    let array = item
+        .as_array()
+        .with_context(|| format!("configure option {name} is not an array"))?;
+
+    array
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .with_context(|| format!("Array item {value:?} for key {name} is not a string"))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -616,12 +668,16 @@ id = 10
     fn parse_defaults() -> anyhow::Result<()> {
         let tempdir = tempdir()?;
         let (workdir, pg_distrib_dir) = prepare_fs(&tempdir)?;
-        // we have to create dummy pathes to overcome the validation errors
-        let config_string = format!("pg_distrib_dir='{}'\nid=10", pg_distrib_dir.display());
+        let broker_endpoint = "http://127.0.0.1:7777";
+        // we have to create dummy values to overcome the validation errors
+        let config_string = format!(
+            "pg_distrib_dir='{}'\nid=10\nbroker_endpoints = ['{broker_endpoint}']",
+            pg_distrib_dir.display()
+        );
         let toml = config_string.parse()?;
 
         let parsed_config = PageServerConf::parse_and_validate(&toml, &workdir)
-            .unwrap_or_else(|e| panic!("Failed to parse config '{config_string}', reason: {e}"));
+            .unwrap_or_else(|e| panic!("Failed to parse config '{config_string}', reason: {e:?}"));
 
         assert_eq!(
             parsed_config,
@@ -641,6 +697,9 @@ id = 10
                 remote_storage_config: None,
                 profiling: ProfilingConfig::Disabled,
                 default_tenant_conf: TenantConf::default(),
+                broker_endpoints: vec![broker_endpoint
+                    .parse()
+                    .expect("Failed to parse a valid broker endpoint URL")],
             },
             "Correct defaults should be used when no config values are provided"
         );
@@ -652,15 +711,16 @@ id = 10
     fn parse_basic_config() -> anyhow::Result<()> {
         let tempdir = tempdir()?;
         let (workdir, pg_distrib_dir) = prepare_fs(&tempdir)?;
+        let broker_endpoint = "http://127.0.0.1:7777";
 
         let config_string = format!(
-            "{ALL_BASE_VALUES_TOML}pg_distrib_dir='{}'",
+            "{ALL_BASE_VALUES_TOML}pg_distrib_dir='{}'\nbroker_endpoints = ['{broker_endpoint}']",
             pg_distrib_dir.display()
         );
         let toml = config_string.parse()?;
 
         let parsed_config = PageServerConf::parse_and_validate(&toml, &workdir)
-            .unwrap_or_else(|e| panic!("Failed to parse config '{config_string}', reason: {e}"));
+            .unwrap_or_else(|e| panic!("Failed to parse config '{config_string}', reason: {e:?}"));
 
         assert_eq!(
             parsed_config,
@@ -680,6 +740,9 @@ id = 10
                 remote_storage_config: None,
                 profiling: ProfilingConfig::Disabled,
                 default_tenant_conf: TenantConf::default(),
+                broker_endpoints: vec![broker_endpoint
+                    .parse()
+                    .expect("Failed to parse a valid broker endpoint URL")],
             },
             "Should be able to parse all basic config values correctly"
         );
@@ -691,6 +754,7 @@ id = 10
     fn parse_remote_fs_storage_config() -> anyhow::Result<()> {
         let tempdir = tempdir()?;
         let (workdir, pg_distrib_dir) = prepare_fs(&tempdir)?;
+        let broker_endpoint = "http://127.0.0.1:7777";
 
         let local_storage_path = tempdir.path().join("local_remote_storage");
 
@@ -710,6 +774,7 @@ local_path = '{}'"#,
             let config_string = format!(
                 r#"{ALL_BASE_VALUES_TOML}
 pg_distrib_dir='{}'
+broker_endpoints = ['{broker_endpoint}']
 
 {remote_storage_config_str}"#,
                 pg_distrib_dir.display(),
@@ -718,7 +783,9 @@ pg_distrib_dir='{}'
             let toml = config_string.parse()?;
 
             let parsed_remote_storage_config = PageServerConf::parse_and_validate(&toml, &workdir)
-                .unwrap_or_else(|e| panic!("Failed to parse config '{config_string}', reason: {e}"))
+                .unwrap_or_else(|e| {
+                    panic!("Failed to parse config '{config_string}', reason: {e:?}")
+                })
                 .remote_storage_config
                 .expect("Should have remote storage config for the local FS");
 
@@ -751,6 +818,7 @@ pg_distrib_dir='{}'
         let max_concurrent_syncs = NonZeroUsize::new(111).unwrap();
         let max_sync_errors = NonZeroU32::new(222).unwrap();
         let s3_concurrency_limit = NonZeroUsize::new(333).unwrap();
+        let broker_endpoint = "http://127.0.0.1:7777";
 
         let identical_toml_declarations = &[
             format!(
@@ -773,6 +841,7 @@ concurrency_limit = {s3_concurrency_limit}"#
             let config_string = format!(
                 r#"{ALL_BASE_VALUES_TOML}
 pg_distrib_dir='{}'
+broker_endpoints = ['{broker_endpoint}']
 
 {remote_storage_config_str}"#,
                 pg_distrib_dir.display(),
@@ -781,7 +850,9 @@ pg_distrib_dir='{}'
             let toml = config_string.parse()?;
 
             let parsed_remote_storage_config = PageServerConf::parse_and_validate(&toml, &workdir)
-                .unwrap_or_else(|e| panic!("Failed to parse config '{config_string}', reason: {e}"))
+                .unwrap_or_else(|e| {
+                    panic!("Failed to parse config '{config_string}', reason: {e:?}")
+                })
                 .remote_storage_config
                 .expect("Should have remote storage config for S3");
 

--- a/safekeeper/src/broker.rs
+++ b/safekeeper/src/broker.rs
@@ -46,7 +46,7 @@ fn timeline_safekeeper_path(
 
 /// Push once in a while data about all active timelines to the broker.
 async fn push_loop(conf: SafeKeeperConf) -> anyhow::Result<()> {
-    let mut client = Client::connect(&conf.broker_endpoints.as_ref().unwrap(), None).await?;
+    let mut client = Client::connect(&conf.broker_endpoints, None).await?;
 
     // Get and maintain lease to automatically delete obsolete data
     let lease = client.lease_grant(LEASE_TTL_SEC, None).await?;
@@ -91,7 +91,7 @@ async fn push_loop(conf: SafeKeeperConf) -> anyhow::Result<()> {
 
 /// Subscribe and fetch all the interesting data from the broker.
 async fn pull_loop(conf: SafeKeeperConf) -> Result<()> {
-    let mut client = Client::connect(&conf.broker_endpoints.as_ref().unwrap(), None).await?;
+    let mut client = Client::connect(&conf.broker_endpoints, None).await?;
 
     let mut subscription = etcd_broker::subscribe_to_safekeeper_timeline_updates(
         &mut client,
@@ -99,7 +99,6 @@ async fn pull_loop(conf: SafeKeeperConf) -> Result<()> {
     )
     .await
     .context("failed to subscribe for safekeeper info")?;
-
     loop {
         match subscription.fetch_data().await {
             Some(new_info) => {

--- a/safekeeper/src/broker.rs
+++ b/safekeeper/src/broker.rs
@@ -34,13 +34,13 @@ pub fn thread_main(conf: SafeKeeperConf) {
 
 /// Key to per timeline per safekeeper data.
 fn timeline_safekeeper_path(
-    broker_prefix: String,
+    broker_etcd_prefix: String,
     zttid: ZTenantTimelineId,
     sk_id: ZNodeId,
 ) -> String {
     format!(
         "{}/{sk_id}",
-        SkTimelineSubscriptionKind::timeline(broker_prefix, zttid).watch_key()
+        SkTimelineSubscriptionKind::timeline(broker_etcd_prefix, zttid).watch_key()
     )
 }
 

--- a/safekeeper/src/lib.rs
+++ b/safekeeper/src/lib.rs
@@ -51,7 +51,7 @@ pub struct SafeKeeperConf {
     pub ttl: Option<Duration>,
     pub recall_period: Duration,
     pub my_id: ZNodeId,
-    pub broker_endpoints: Option<Vec<Url>>,
+    pub broker_endpoints: Vec<Url>,
     pub broker_etcd_prefix: String,
     pub s3_offload_enabled: bool,
 }
@@ -81,7 +81,7 @@ impl Default for SafeKeeperConf {
             ttl: None,
             recall_period: defaults::DEFAULT_RECALL_PERIOD,
             my_id: ZNodeId(0),
-            broker_endpoints: None,
+            broker_endpoints: Vec::new(),
             broker_etcd_prefix: defaults::DEFAULT_NEON_BROKER_PREFIX.to_string(),
             s3_offload_enabled: true,
         }

--- a/safekeeper/src/lib.rs
+++ b/safekeeper/src/lib.rs
@@ -27,7 +27,6 @@ pub mod defaults {
 
     pub const DEFAULT_PG_LISTEN_PORT: u16 = 5454;
     pub const DEFAULT_PG_LISTEN_ADDR: &str = formatcp!("127.0.0.1:{DEFAULT_PG_LISTEN_PORT}");
-    pub const DEFAULT_NEON_BROKER_PREFIX: &str = "neon";
 
     pub const DEFAULT_HTTP_LISTEN_PORT: u16 = 7676;
     pub const DEFAULT_HTTP_LISTEN_ADDR: &str = formatcp!("127.0.0.1:{DEFAULT_HTTP_LISTEN_PORT}");
@@ -82,7 +81,7 @@ impl Default for SafeKeeperConf {
             recall_period: defaults::DEFAULT_RECALL_PERIOD,
             my_id: ZNodeId(0),
             broker_endpoints: Vec::new(),
-            broker_etcd_prefix: defaults::DEFAULT_NEON_BROKER_PREFIX.to_string(),
+            broker_etcd_prefix: etcd_broker::DEFAULT_NEON_BROKER_ETCD_PREFIX.to_string(),
             s3_offload_enabled: true,
         }
     }

--- a/test_runner/README.md
+++ b/test_runner/README.md
@@ -51,7 +51,6 @@ Useful environment variables:
 should go.
 `TEST_SHARED_FIXTURES`: Try to re-use a single pageserver for all the tests.
 `ZENITH_PAGESERVER_OVERRIDES`: add a `;`-separated set of configs that will be passed as
-`FORCE_MOCK_S3`: inits every test's pageserver with a mock S3 used as a remote storage.
 `--pageserver-config-override=${value}` parameter values when zenith cli is invoked
 `RUST_LOG`: logging configuration to pass into Zenith CLI
 

--- a/test_runner/batch_others/test_ancestor_branch.py
+++ b/test_runner/batch_others/test_ancestor_branch.py
@@ -10,13 +10,6 @@ from fixtures.zenith_fixtures import ZenithEnv, ZenithEnvBuilder, ZenithPageserv
 # Create ancestor branches off the main branch.
 #
 def test_ancestor_branch(zenith_env_builder: ZenithEnvBuilder):
-
-    # Use safekeeper in this test to avoid a subtle race condition.
-    # Without safekeeper, walreceiver reconnection can stuck
-    # because of IO deadlock.
-    #
-    # See https://github.com/zenithdb/zenith/issues/1068
-    zenith_env_builder.num_safekeepers = 1
     env = zenith_env_builder.init_start()
 
     # Override defaults, 1M gc_horizon and 4M checkpoint_distance.

--- a/test_runner/batch_others/test_backpressure.py
+++ b/test_runner/batch_others/test_backpressure.py
@@ -94,7 +94,6 @@ def check_backpressure(pg: Postgres, stop_event: threading.Event, polling_interv
 
 @pytest.mark.skip("See https://github.com/neondatabase/neon/issues/1587")
 def test_backpressure_received_lsn_lag(zenith_env_builder: ZenithEnvBuilder):
-    zenith_env_builder.num_safekeepers = 1
     env = zenith_env_builder.init_start()
     # Create a branch for us
     env.zenith_cli.create_branch('test_backpressure')

--- a/test_runner/batch_others/test_next_xid.py
+++ b/test_runner/batch_others/test_next_xid.py
@@ -6,8 +6,6 @@ from fixtures.zenith_fixtures import ZenithEnvBuilder
 # Test restarting page server, while safekeeper and compute node keep
 # running.
 def test_next_xid(zenith_env_builder: ZenithEnvBuilder):
-    # One safekeeper is enough for this test.
-    zenith_env_builder.num_safekeepers = 1
     env = zenith_env_builder.init_start()
 
     pg = env.postgres.create_start('main')

--- a/test_runner/batch_others/test_pageserver_restart.py
+++ b/test_runner/batch_others/test_pageserver_restart.py
@@ -5,8 +5,6 @@ from fixtures.log_helper import log
 # Test restarting page server, while safekeeper and compute node keep
 # running.
 def test_pageserver_restart(zenith_env_builder: ZenithEnvBuilder):
-    # One safekeeper is enough for this test.
-    zenith_env_builder.num_safekeepers = 1
     env = zenith_env_builder.init_start()
 
     env.zenith_cli.create_branch('test_pageserver_restart')

--- a/test_runner/batch_others/test_remote_storage.py
+++ b/test_runner/batch_others/test_remote_storage.py
@@ -32,7 +32,6 @@ import pytest
 @pytest.mark.parametrize('storage_type', ['local_fs', 'mock_s3'])
 def test_remote_storage_backup_and_restore(zenith_env_builder: ZenithEnvBuilder, storage_type: str):
     # zenith_env_builder.rust_log_override = 'debug'
-    zenith_env_builder.num_safekeepers = 1
     if storage_type == 'local_fs':
         zenith_env_builder.enable_local_fs_remote_storage()
     elif storage_type == 'mock_s3':

--- a/test_runner/batch_others/test_tenant_relocation.py
+++ b/test_runner/batch_others/test_tenant_relocation.py
@@ -3,8 +3,10 @@ import os
 import pathlib
 import subprocess
 import threading
+import typing
 from uuid import UUID
 from fixtures.log_helper import log
+from typing import Optional
 import signal
 import pytest
 
@@ -22,7 +24,7 @@ def new_pageserver_helper(new_pageserver_dir: pathlib.Path,
                           remote_storage_mock_path: pathlib.Path,
                           pg_port: int,
                           http_port: int,
-                          broker: Etcd):
+                          broker: Optional[Etcd]):
     """
     cannot use ZenithPageserver yet because it depends on zenith cli
     which currently lacks support for multiple pageservers
@@ -37,8 +39,10 @@ def new_pageserver_helper(new_pageserver_dir: pathlib.Path,
         f"-c pg_distrib_dir='{pg_distrib_dir}'",
         f"-c id=2",
         f"-c remote_storage={{local_path='{remote_storage_mock_path}'}}",
-        f"-c broker_endpoints=['{broker.client_url()}']",
     ]
+
+    if broker is not None:
+        cmd.append(f"-c broker_endpoints=['{broker.client_url()}']", )
 
     subprocess.check_output(cmd, text=True)
 

--- a/test_runner/batch_others/test_timeline_size.py
+++ b/test_runner/batch_others/test_timeline_size.py
@@ -70,7 +70,6 @@ def wait_for_pageserver_catchup(pgmain: Postgres, polling_interval=1, timeout=60
 
 
 def test_timeline_size_quota(zenith_env_builder: ZenithEnvBuilder):
-    zenith_env_builder.num_safekeepers = 1
     env = zenith_env_builder.init_start()
     new_timeline_id = env.zenith_cli.create_branch('test_timeline_size_quota')
 

--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from multiprocessing import Process, Value
 from pathlib import Path
 from fixtures.zenith_fixtures import PgBin, Etcd, Postgres, Safekeeper, ZenithEnv, ZenithEnvBuilder, PortDistributor, SafekeeperPort, zenith_binpath, PgProtocol
-from fixtures.utils import etcd_path, get_dir_size, lsn_to_hex, mkdir_if_needed, lsn_from_hex
+from fixtures.utils import get_dir_size, lsn_to_hex, mkdir_if_needed, lsn_from_hex
 from fixtures.log_helper import log
 from typing import List, Optional, Any
 
@@ -327,7 +327,6 @@ def test_race_conditions(zenith_env_builder: ZenithEnvBuilder, stop_value):
 
 
 # Test that safekeepers push their info to the broker and learn peer status from it
-@pytest.mark.skipif(etcd_path() is None, reason="requires etcd which is not present in PATH")
 def test_broker(zenith_env_builder: ZenithEnvBuilder):
     zenith_env_builder.num_safekeepers = 3
     zenith_env_builder.enable_local_fs_remote_storage()
@@ -369,7 +368,6 @@ def test_broker(zenith_env_builder: ZenithEnvBuilder):
 
 
 # Test that old WAL consumed by peers and pageserver is removed from safekeepers.
-@pytest.mark.skipif(etcd_path() is None, reason="requires etcd which is not present in PATH")
 def test_wal_removal(zenith_env_builder: ZenithEnvBuilder):
     zenith_env_builder.num_safekeepers = 2
     # to advance remote_consistent_llsn

--- a/test_runner/batch_others/test_wal_restore.py
+++ b/test_runner/batch_others/test_wal_restore.py
@@ -15,7 +15,6 @@ def test_wal_restore(zenith_env_builder: ZenithEnvBuilder,
                      pg_bin: PgBin,
                      test_output_dir,
                      port_distributor: PortDistributor):
-    zenith_env_builder.num_safekeepers = 1
     env = zenith_env_builder.init_start()
     env.zenith_cli.create_branch("test_wal_restore")
     pg = env.postgres.create_start('test_wal_restore')

--- a/test_runner/batch_others/test_zenith_cli.py
+++ b/test_runner/batch_others/test_zenith_cli.py
@@ -94,8 +94,6 @@ def test_cli_tenant_create(zenith_simple_env: ZenithEnv):
 
 
 def test_cli_ipv4_listeners(zenith_env_builder: ZenithEnvBuilder):
-    # Start with single sk
-    zenith_env_builder.num_safekeepers = 1
     env = zenith_env_builder.init_start()
 
     # Connect to sk port on v4 loopback
@@ -111,8 +109,6 @@ def test_cli_ipv4_listeners(zenith_env_builder: ZenithEnvBuilder):
 
 
 def test_cli_start_stop(zenith_env_builder: ZenithEnvBuilder):
-    # Start with single sk
-    zenith_env_builder.num_safekeepers = 1
     env = zenith_env_builder.init_start()
 
     # Stop default ps/sk

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -1,8 +1,9 @@
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
-from typing import Any, List
+from typing import Any, List, Optional
 from fixtures.log_helper import log
 
 
@@ -80,9 +81,12 @@ def print_gc_result(row):
         .format_map(row))
 
 
-# path to etcd binary or None if not present.
-def etcd_path():
-    return shutil.which("etcd")
+def etcd_path() -> Path:
+    path_output = shutil.which("etcd")
+    if path_output is None:
+        raise RuntimeError('etcd not found in PATH')
+    else:
+        return Path(path_output)
 
 
 # Traverse directory to get total size.

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -61,7 +61,7 @@ DEFAULT_POSTGRES_DIR = 'tmp_install'
 DEFAULT_BRANCH_NAME = 'main'
 
 BASE_PORT = 15000
-WORKER_PORT_NUM = 100
+WORKER_PORT_NUM = 1000
 
 
 def pytest_addoption(parser):
@@ -178,7 +178,7 @@ def shareable_scope(fixture_name, config) -> Literal["session", "function"]:
     return 'function' if os.environ.get('TEST_SHARED_FIXTURES') is None else 'session'
 
 
-@pytest.fixture(scope=shareable_scope)
+@pytest.fixture(scope='session')
 def worker_seq_no(worker_id: str):
     # worker_id is a pytest-xdist fixture
     # it can be master or gw<number>
@@ -189,7 +189,7 @@ def worker_seq_no(worker_id: str):
     return int(worker_id[2:])
 
 
-@pytest.fixture(scope=shareable_scope)
+@pytest.fixture(scope='session')
 def worker_base_port(worker_seq_no: int):
     # so we divide ports in ranges of 100 ports
     # so workers have disjoint set of ports for services
@@ -242,9 +242,28 @@ class PortDistributor:
                 'port range configured for test is exhausted, consider enlarging the range')
 
 
-@pytest.fixture(scope=shareable_scope)
+@pytest.fixture(scope='session')
 def port_distributor(worker_base_port):
     return PortDistributor(base_port=worker_base_port, port_number=WORKER_PORT_NUM)
+
+
+@pytest.fixture(scope='session')
+def default_broker(request: Any, port_distributor: PortDistributor):
+    client_port = port_distributor.get_port()
+    # multiple pytest sessions could get launched in parallel, get them different datadirs
+    etcd_datadir = os.path.join(get_test_output_dir(request), f"etcd_datadir_{client_port}")
+    pathlib.Path(etcd_datadir).mkdir(exist_ok=True, parents=True)
+
+    broker = Etcd(datadir=etcd_datadir, port=client_port, peer_port=port_distributor.get_port())
+    yield broker
+    broker.stop()
+
+
+@pytest.fixture(scope='session')
+def mock_s3_server(port_distributor: PortDistributor):
+    mock_s3_server = MockS3Server(port_distributor.get_port())
+    yield mock_s3_server
+    mock_s3_server.kill()
 
 
 class PgProtocol:
@@ -410,7 +429,9 @@ class ZenithEnvBuilder:
     def __init__(self,
                  repo_dir: Path,
                  port_distributor: PortDistributor,
-                 pageserver_remote_storage: Optional[RemoteStorage] = None,
+                 broker: Etcd,
+                 mock_s3_server: MockS3Server,
+                 remote_storage: Optional[RemoteStorage] = None,
                  pageserver_config_override: Optional[str] = None,
                  num_safekeepers: int = 1,
                  pageserver_auth_enabled: bool = False,
@@ -419,23 +440,14 @@ class ZenithEnvBuilder:
         self.repo_dir = repo_dir
         self.rust_log_override = rust_log_override
         self.port_distributor = port_distributor
-        self.pageserver_remote_storage = pageserver_remote_storage
+        self.remote_storage = remote_storage
+        self.broker = broker
+        self.mock_s3_server = mock_s3_server
         self.pageserver_config_override = pageserver_config_override
         self.num_safekeepers = num_safekeepers
         self.pageserver_auth_enabled = pageserver_auth_enabled
         self.default_branch_name = default_branch_name
-        # keep etcd datadir inside 'repo'
-        self.broker = Etcd(datadir=os.path.join(self.repo_dir, "etcd"),
-                           port=self.port_distributor.get_port(),
-                           peer_port=self.port_distributor.get_port())
         self.env: Optional[ZenithEnv] = None
-
-        self.s3_mock_server: Optional[MockS3Server] = None
-
-        if os.getenv('FORCE_MOCK_S3') is not None:
-            bucket_name = f'{repo_dir.name}_bucket'
-            log.warning(f'Unconditionally initializing mock S3 server for bucket {bucket_name}')
-            self.enable_s3_mock_remote_storage(bucket_name)
 
     def init(self) -> ZenithEnv:
         # Cannot create more than one environment from one builder
@@ -457,9 +469,8 @@ class ZenithEnvBuilder:
     """
 
     def enable_local_fs_remote_storage(self, force_enable=True):
-        assert force_enable or self.pageserver_remote_storage is None, "remote storage is enabled already"
-        self.pageserver_remote_storage = LocalFsStorage(
-            Path(self.repo_dir / 'local_fs_remote_storage'))
+        assert force_enable or self.remote_storage is None, "remote storage is enabled already"
+        self.remote_storage = LocalFsStorage(Path(self.repo_dir / 'local_fs_remote_storage'))
 
     """
     Sets up the pageserver to use the S3 mock server, creates the bucket, if it's not present already.
@@ -468,22 +479,19 @@ class ZenithEnvBuilder:
     """
 
     def enable_s3_mock_remote_storage(self, bucket_name: str, force_enable=True):
-        assert force_enable or self.pageserver_remote_storage is None, "remote storage is enabled already"
-        if not self.s3_mock_server:
-            self.s3_mock_server = MockS3Server(self.port_distributor.get_port())
-
-        mock_endpoint = self.s3_mock_server.endpoint()
-        mock_region = self.s3_mock_server.region()
+        assert force_enable or self.remote_storage is None, "remote storage is enabled already"
+        mock_endpoint = self.mock_s3_server.endpoint()
+        mock_region = self.mock_s3_server.region()
         boto3.client(
             's3',
             endpoint_url=mock_endpoint,
             region_name=mock_region,
-            aws_access_key_id=self.s3_mock_server.access_key(),
-            aws_secret_access_key=self.s3_mock_server.secret_key(),
+            aws_access_key_id=self.mock_s3_server.access_key(),
+            aws_secret_access_key=self.mock_s3_server.secret_key(),
         ).create_bucket(Bucket=bucket_name)
-        self.pageserver_remote_storage = S3Storage(bucket=bucket_name,
-                                                   endpoint=mock_endpoint,
-                                                   region=mock_region)
+        self.remote_storage = S3Storage(bucket=bucket_name,
+                                        endpoint=mock_endpoint,
+                                        region=mock_region)
 
     def __enter__(self):
         return self
@@ -497,10 +505,6 @@ class ZenithEnvBuilder:
             for sk in self.env.safekeepers:
                 sk.stop(immediate=True)
             self.env.pageserver.stop(immediate=True)
-            if self.s3_mock_server:
-                self.s3_mock_server.kill()
-            if self.env.broker is not None:
-                self.env.broker.stop()
 
 
 class ZenithEnv:
@@ -539,10 +543,12 @@ class ZenithEnv:
         self.repo_dir = config.repo_dir
         self.rust_log_override = config.rust_log_override
         self.port_distributor = config.port_distributor
-        self.s3_mock_server = config.s3_mock_server
+        self.s3_mock_server = config.mock_s3_server
         self.zenith_cli = ZenithCli(env=self)
         self.postgres = PostgresFactory(self)
         self.safekeepers: List[Safekeeper] = []
+        self.broker = config.broker
+        self.remote_storage = config.remote_storage
 
         # generate initial tenant ID here instead of letting 'zenith init' generate it,
         # so that we don't need to dig it out of the config file afterwards.
@@ -553,7 +559,6 @@ class ZenithEnv:
             default_tenant_id = '{self.initial_tenant.hex}'
         """)
 
-        self.broker = config.broker
         toml += textwrap.dedent(f"""
             [etcd_broker]
             broker_endpoints = ['{self.broker.client_url()}']
@@ -578,7 +583,6 @@ class ZenithEnv:
         # Create a corresponding ZenithPageserver object
         self.pageserver = ZenithPageserver(self,
                                            port=pageserver_port,
-                                           remote_storage=config.pageserver_remote_storage,
                                            config_override=config.pageserver_config_override)
 
         # Create config and a Safekeeper object for each safekeeper
@@ -602,14 +606,12 @@ class ZenithEnv:
         self.zenith_cli.init(toml)
 
     def start(self):
-        # Start up the page server, all the safekeepers and the broker
+        # Start up broker, pageserver and all safekeepers
+        self.broker.try_start()
         self.pageserver.start()
 
         for safekeeper in self.safekeepers:
             safekeeper.start()
-
-        if self.broker is not None:
-            self.broker.start()
 
     def get_safekeeper_connstrs(self) -> str:
         """ Get list of safekeeper endpoints suitable for safekeepers GUC  """
@@ -623,7 +625,10 @@ class ZenithEnv:
 
 
 @pytest.fixture(scope=shareable_scope)
-def _shared_simple_env(request: Any, port_distributor) -> Iterator[ZenithEnv]:
+def _shared_simple_env(request: Any,
+                       port_distributor: PortDistributor,
+                       mock_s3_server: MockS3Server,
+                       default_broker: Etcd) -> Iterator[ZenithEnv]:
     """
     Internal fixture backing the `zenith_simple_env` fixture. If TEST_SHARED_FIXTURES
     is set, this is shared by all tests using `zenith_simple_env`.
@@ -637,7 +642,8 @@ def _shared_simple_env(request: Any, port_distributor) -> Iterator[ZenithEnv]:
         repo_dir = os.path.join(str(top_output_dir), "shared_repo")
         shutil.rmtree(repo_dir, ignore_errors=True)
 
-    with ZenithEnvBuilder(Path(repo_dir), port_distributor) as builder:
+    with ZenithEnvBuilder(Path(repo_dir), port_distributor, default_broker,
+                          mock_s3_server) as builder:
         env = builder.init_start()
 
         # For convenience in tests, create a branch from the freshly-initialized cluster.
@@ -659,12 +665,13 @@ def zenith_simple_env(_shared_simple_env: ZenithEnv) -> Iterator[ZenithEnv]:
     yield _shared_simple_env
 
     _shared_simple_env.postgres.stop_all()
-    if _shared_simple_env.s3_mock_server:
-        _shared_simple_env.s3_mock_server.kill()
 
 
 @pytest.fixture(scope='function')
-def zenith_env_builder(test_output_dir, port_distributor) -> Iterator[ZenithEnvBuilder]:
+def zenith_env_builder(test_output_dir,
+                       port_distributor: PortDistributor,
+                       mock_s3_server: MockS3Server,
+                       default_broker: Etcd) -> Iterator[ZenithEnvBuilder]:
     """
     Fixture to create a Zenith environment for test.
 
@@ -682,7 +689,8 @@ def zenith_env_builder(test_output_dir, port_distributor) -> Iterator[ZenithEnvB
     repo_dir = os.path.join(test_output_dir, "repo")
 
     # Return the builder to the caller
-    with ZenithEnvBuilder(Path(repo_dir), port_distributor) as builder:
+    with ZenithEnvBuilder(Path(repo_dir), port_distributor, default_broker,
+                          mock_s3_server) as builder:
         yield builder
 
 
@@ -970,9 +978,10 @@ class ZenithCli:
             cmd = ['init', f'--config={tmp.name}']
             if initial_timeline_id:
                 cmd.extend(['--timeline-id', initial_timeline_id.hex])
-            append_pageserver_param_overrides(cmd,
-                                              self.env.pageserver.remote_storage,
-                                              self.env.pageserver.config_override)
+            append_pageserver_param_overrides(
+                params_to_update=cmd,
+                remote_storage=self.env.remote_storage,
+                pageserver_config_override=self.env.pageserver.config_override)
 
             res = self.raw_cli(cmd)
             res.check_returncode()
@@ -993,9 +1002,10 @@ class ZenithCli:
 
     def pageserver_start(self, overrides=()) -> 'subprocess.CompletedProcess[str]':
         start_args = ['pageserver', 'start', *overrides]
-        append_pageserver_param_overrides(start_args,
-                                          self.env.pageserver.remote_storage,
-                                          self.env.pageserver.config_override)
+        append_pageserver_param_overrides(
+            params_to_update=start_args,
+            remote_storage=self.env.remote_storage,
+            pageserver_config_override=self.env.pageserver.config_override)
 
         s3_env_vars = None
         if self.env.s3_mock_server:
@@ -1165,16 +1175,11 @@ class ZenithPageserver(PgProtocol):
 
     Initializes the repository via `zenith init`.
     """
-    def __init__(self,
-                 env: ZenithEnv,
-                 port: PageserverPort,
-                 remote_storage: Optional[RemoteStorage] = None,
-                 config_override: Optional[str] = None):
+    def __init__(self, env: ZenithEnv, port: PageserverPort, config_override: Optional[str] = None):
         super().__init__(host='localhost', port=port.pg, user='zenith_admin')
         self.env = env
         self.running = False
         self.service_port = port
-        self.remote_storage = remote_storage
         self.config_override = config_override
 
     def start(self, overrides=()) -> 'ZenithPageserver':
@@ -1214,21 +1219,21 @@ class ZenithPageserver(PgProtocol):
 
 def append_pageserver_param_overrides(
     params_to_update: List[str],
-    pageserver_remote_storage: Optional[RemoteStorage],
+    remote_storage: Optional[RemoteStorage],
     pageserver_config_override: Optional[str] = None,
 ):
-    if pageserver_remote_storage is not None:
-        if isinstance(pageserver_remote_storage, LocalFsStorage):
-            pageserver_storage_override = f"local_path='{pageserver_remote_storage.root}'"
-        elif isinstance(pageserver_remote_storage, S3Storage):
-            pageserver_storage_override = f"bucket_name='{pageserver_remote_storage.bucket}',\
-                bucket_region='{pageserver_remote_storage.region}'"
+    if remote_storage is not None:
+        if isinstance(remote_storage, LocalFsStorage):
+            pageserver_storage_override = f"local_path='{remote_storage.root}'"
+        elif isinstance(remote_storage, S3Storage):
+            pageserver_storage_override = f"bucket_name='{remote_storage.bucket}',\
+                bucket_region='{remote_storage.region}'"
 
-            if pageserver_remote_storage.endpoint is not None:
-                pageserver_storage_override += f",endpoint='{pageserver_remote_storage.endpoint}'"
+            if remote_storage.endpoint is not None:
+                pageserver_storage_override += f",endpoint='{remote_storage.endpoint}'"
 
         else:
-            raise Exception(f'Unknown storage configuration {pageserver_remote_storage}')
+            raise Exception(f'Unknown storage configuration {remote_storage}')
         params_to_update.append(
             f'--pageserver-config-override=remote_storage={{{pageserver_storage_override}}}')
 
@@ -1850,7 +1855,11 @@ class Etcd:
         s.mount('http://', requests.adapters.HTTPAdapter(max_retries=1))  # do not retry
         s.get(f"{self.client_url()}/health").raise_for_status()
 
-    def start(self):
+    def try_start(self):
+        if self.handle is not None:
+            log.debug(f'etcd is already running on port {self.port}')
+            return
+
         pathlib.Path(self.datadir).mkdir(exist_ok=True)
 
         if not self.binary_path.is_file():


### PR DESCRIPTION
Part of https://github.com/neondatabase/neon/pull/1619

This is a PR that should create preliminary breakage before the main breakage is implemented.
* starts one safekeeper for every test 
I'm not sure if it uses that though, I should I also remove [this](https://github.com/neondatabase/neon/blob/ef40e404cf15cc335fbf6a226879e5358aa628eb/test_runner/fixtures/zenith_fixtures.py#L1543) line from fixtures? Anywhere else?
* starts an etcd for every test

Makes both pageserver and safekeeper binaries to require etcd broker endpoints specified for them in configs/startup args.

Without the endpoints, no etcd connection is possible.
Without etcd connection, no WAL streaming from Safekeeper to Pageserver is possible after the WIP PR mentioned above.