### PR TITLE
Disable tenant relocation python test

### DIFF
--- a/test_runner/batch_others/test_tenant_relocation.py
+++ b/test_runner/batch_others/test_tenant_relocation.py
@@ -95,6 +95,10 @@ def load(pg: Postgres, stop_event: threading.Event, load_ok_event: threading.Eve
     log.info('load thread stopped')
 
 
+@pytest.mark.skip(
+    reason=
+    "needs to replace callmemaybe call with better idea how to migrate timelines between pageservers"
+)
 @pytest.mark.parametrize('with_load', ['with_load', 'without_load'])
 def test_tenant_relocation(zenith_env_builder: ZenithEnvBuilder,
                            port_distributor: PortDistributor,


### PR DESCRIPTION
This test is flacky now and gets tracked in https://github.com/neondatabase/neon/issues/1667
Moreover, in https://github.com/neondatabase/neon/pull/1619 callmemaybe should be gone (as agreed before), hence the test should be worked anyway.

Suppressing it with a comment due to these reasons.