### PR TITLE
fixed listing profiling as feature, if enabled on pageserver

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -98,6 +98,8 @@ fn main() -> anyhow::Result<()> {
         let features: &[&str] = &[
             #[cfg(feature = "failpoints")]
             "failpoints",
+            #[cfg(feature = "profiling")]
+            "profiling",
         ];
         println!("{{\"features\": {features:?} }}");
         return Ok(());


### PR DESCRIPTION
fixed listing profiling as feature, if enabled on `pageserver --enabled-features` and [resolves issue](https://github.com/neondatabase/neon/issues/1627).

build with `profiling` flag enabled.
![CleanShot 2022-05-14 at 01 47 28](https://user-images.githubusercontent.com/86035/168383364-59d98c01-2197-4694-89cf-401de1a2d2fd.png)

build with `profiling` flag disabled.
![CleanShot 2022-05-14 at 01 53 23](https://user-images.githubusercontent.com/86035/168384137-dbf96d44-e886-490f-8532-98a8c95b01ea.png)

