### PR TITLE
Don't swallow panics when the pageserver is build with failpoints.

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -183,13 +183,8 @@ fn main() -> anyhow::Result<()> {
     // as a ref.
     let conf: &'static PageServerConf = Box::leak(Box::new(conf));
 
-    // If failpoints are used, terminate the whole pageserver process if they are hit.
+    // Initialize up failpoints support
     let scenario = FailScenario::setup();
-    if fail::has_failpoints() {
-        std::panic::set_hook(Box::new(|_| {
-            std::process::exit(1);
-        }));
-    }
 
     // Basic initialization of things that don't change after startup
     virtual_file::init(conf.max_file_descriptors);

--- a/test_runner/batch_others/test_recovery.py
+++ b/test_runner/batch_others/test_recovery.py
@@ -45,14 +45,14 @@ def test_pageserver_recovery(zenith_env_builder: ZenithEnvBuilder):
 
                     # Configure failpoints
                     pscur.execute(
-                        "failpoints checkpoint-before-sync=sleep(2000);checkpoint-after-sync=panic")
+                        "failpoints checkpoint-before-sync=sleep(2000);checkpoint-after-sync=exit")
 
                     # Do some updates until pageserver is crashed
                     try:
                         while True:
                             cur.execute("update foo set x=x+1")
                     except Exception as err:
-                        log.info(f"Excepted server crash {err}")
+                        log.info(f"Expected server crash {err}")
 
     log.info("Wait before server restart")
     env.pageserver.stop()


### PR DESCRIPTION
It's very confusing, and because you don't get a stack trace and error
message in the logs, makes debugging very hard.