### PR TITLE
Add _total suffix to metrics name

### DIFF
--- a/libs/metrics/src/lib.rs
+++ b/libs/metrics/src/lib.rs
@@ -28,7 +28,7 @@ pub fn gather() -> Vec<prometheus::proto::MetricFamily> {
 
 lazy_static! {
     static ref DISK_IO_BYTES: IntGaugeVec = register_int_gauge_vec!(
-        "libmetrics_disk_io_bytes",
+        "libmetrics_disk_io_bytes_total",
         "Bytes written and read from disk, grouped by the operation (read|write)",
         &["io_operation"]
     )

--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -18,7 +18,7 @@ use super::error::ApiError;
 
 lazy_static! {
     static ref SERVE_METRICS_COUNT: IntCounter = register_int_counter!(
-        "libmetrics_serve_metrics_count",
+        "libmetrics_metric_handler_requests_total",
         "Number of metric requests made"
     )
     .expect("failed to define a metric");

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -15,17 +15,17 @@ const ERR_PROTO_VIOLATION: &str = "protocol violation";
 
 lazy_static! {
     static ref NUM_CONNECTIONS_ACCEPTED_COUNTER: IntCounter = register_int_counter!(
-        "proxy_accepted_connections",
+        "proxy_accepted_connections_total",
         "Number of TCP client connections accepted."
     )
     .unwrap();
     static ref NUM_CONNECTIONS_CLOSED_COUNTER: IntCounter = register_int_counter!(
-        "proxy_closed_connections",
+        "proxy_closed_connections_total",
         "Number of TCP client connections closed."
     )
     .unwrap();
     static ref NUM_BYTES_PROXIED_COUNTER: IntCounter = register_int_counter!(
-        "proxy_io_bytes",
+        "proxy_io_bytes_total",
         "Number of bytes sent/received between any client and backend."
     )
     .unwrap();

--- a/test_runner/fixtures/benchmark_fixture.py
+++ b/test_runner/fixtures/benchmark_fixture.py
@@ -236,7 +236,7 @@ class ZenithBenchmarker:
         """
         Fetch the "cumulative # of bytes written" metric from the pageserver
         """
-        metric_name = r'libmetrics_disk_io_bytes{io_operation="write"}'
+        metric_name = r'libmetrics_disk_io_bytes_total{io_operation="write"}'
         return self.get_int_counter_value(pageserver, metric_name)
 
     def get_peak_mem(self, pageserver) -> int:


### PR DESCRIPTION
Quick fix, forgot to add `_total` suffix to some accumulating metrics in https://github.com/neondatabase/neon/pull/1722, remembered only when I was playing with them in Grafana. 