### PR TITLE
git-upload: pass committer to 'git rebase' (fix #1749)

### DIFF
--- a/scripts/git-upload
+++ b/scripts/git-upload
@@ -80,12 +80,14 @@ class GitRepo:
                 print('No changes detected, quitting')
                 return
 
-            run([
+            git_with_user = [
                 'git',
                 '-c',
                 'user.name=vipvap',
                 '-c',
                 'user.email=vipvap@zenith.tech',
+            ]
+            run(git_with_user + [
                 'commit',
                 '--author="vipvap <vipvap@zenith.tech>"',
                 f'--message={message}',
@@ -94,7 +96,7 @@ class GitRepo:
             for _ in range(5):
                 try:
                     run(['git', 'fetch', 'origin', branch])
-                    run(['git', 'rebase', f'origin/{branch}'])
+                    run(git_with_user + ['rebase', f'origin/{branch}'])
                     run(['git', 'push', 'origin', branch])
                     return
 


### PR DESCRIPTION
No committer was specified, which resulted in failing `git rebase` if the branch is not up-to-date.

Fixes #1749 