### PR TITLE
Added paths to openssl includes and libraries for OSX in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ else
 $(error Bad build type `$(BUILD_TYPE)', see Makefile for options)
 endif
 
+# macOS with brew-installed openssl requires explicit paths
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    PG_CONFIGURE_OPTS += --with-includes=/usr/local/opt/openssl/include --with-libraries=/usr/local/opt/openssl/lib
+endif
+
 # Choose whether we should be silent or verbose
 CARGO_BUILD_FLAGS += --$(if $(filter s,$(MAKEFLAGS)),quiet,verbose)
 # Fix for a corner case when make doesn't pass a jobserver


### PR DESCRIPTION
I tried installing repo on OSX, but make complained that it can't locate one of openssl's dependencies

> kliments-mbp:neon klimentserafimov$ make -j16
Configuring postgres build
mkdir -p tmp_install/build
(cd tmp_install/build && \
	../../vendor/postgres/configure CFLAGS='-O0 -g3 ' \
		--enable-debug --with-openssl --enable-cassert --enable-depend \
		 \
		--prefix=/Users/klimentserafimov/neon/tmp_install > configure.log)
configure: error: library 'crypto' is required for OpenSSL
make: *** [tmp_install/build/config.status] Error 1

Googling the issue yielded this post: https://stackoverflow.com/questions/68088385/why-is-libcrypto-not-being-installed-when-i-install-openssl-from-source-on-macos

I escalated the issue to Stas. He recreated the issue on his machine and found this example of how to branch in the makefile based on os type: https://gist.github.com/sighingnow/deee806603ec9274fd47

And provided this code: 

> \# macOS with brew-installed openssl requires explicit paths
> UNAME_S := $(shell uname -s)
> ifeq ($(UNAME_S),Darwin)
>     PG_CONFIGURE_OPTS += --with-includes=/usr/local/opt/openssl/include --with-libraries=/usr/local/opt/openssl/lib
> endif

Which I copy-pasted in the makefile. Rerunning make worked without errors and the build completed.

Then I submitted this pull request. 
This is my first pull request at Neon and my first ever pull request.