### PR TITLE
Handle uninitialized timelines on pageserver startup

### DIFF
--- a/pageserver/src/bin/update_metadata.rs
+++ b/pageserver/src/bin/update_metadata.rs
@@ -55,9 +55,15 @@ fn main() -> Result<()> {
     }
 
     if let Some(prev_lsn) = arg_matches.value_of("prev_lsn") {
+        let prev_record_lsn = if prev_lsn.is_empty() {
+            None
+        } else {
+            Some(Lsn::from_str(prev_lsn)?)
+        };
+
         meta = TimelineMetadata::new(
             meta.disk_consistent_lsn(),
-            Some(Lsn::from_str(prev_lsn)?),
+            prev_record_lsn,
             meta.ancestor_timeline(),
             meta.ancestor_lsn(),
             meta.latest_gc_cutoff_lsn(),

--- a/pageserver/src/timelines.rs
+++ b/pageserver/src/timelines.rs
@@ -285,7 +285,9 @@ fn bootstrap_timeline<R: Repository>(
 ) -> Result<()> {
     let _enter = info_span!("bootstrapping", timeline = %tli, tenant = %tenantid).entered();
 
-    let initdb_path = conf.tenant_path(&tenantid).join("tmp");
+    let initdb_path = conf
+        .tenant_path(&tenantid)
+        .join(format!("tmp-tenant-{}-timeline-{}", tenantid, tli));
 
     // Init temporarily repo to get bootstrap data
     run_initdb(conf, &initdb_path)?;

--- a/test_runner/batch_others/test_timeline_creation.py
+++ b/test_runner/batch_others/test_timeline_creation.py
@@ -1,0 +1,13 @@
+from fixtures.zenith_fixtures import ZenithEnv
+import concurrent.futures
+
+
+def test_create_multiple_timelines_parallel(zenith_simple_env: ZenithEnv):
+    env = zenith_simple_env
+
+    tenant_id, _ = env.zenith_cli.create_tenant()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(env.zenith_cli.create_timeline, f"test-timeline-{i}", tenant_id) for i in range(4)]
+        for future in futures:
+            future.result()

--- a/test_runner/batch_others/test_timeline_creation.py
+++ b/test_runner/batch_others/test_timeline_creation.py
@@ -1,5 +1,11 @@
-from fixtures.zenith_fixtures import ZenithEnv
+from typing import List
+from fixtures.zenith_fixtures import ZenithEnv, zenith_binpath
 import concurrent.futures
+import os
+from uuid import UUID
+import subprocess
+from fixtures.log_helper import log
+from contextlib import closing
 
 
 def test_create_multiple_timelines_parallel(zenith_simple_env: ZenithEnv):
@@ -8,6 +14,74 @@ def test_create_multiple_timelines_parallel(zenith_simple_env: ZenithEnv):
     tenant_id, _ = env.zenith_cli.create_tenant()
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-        futures = [executor.submit(env.zenith_cli.create_timeline, f"test-timeline-{i}", tenant_id) for i in range(4)]
+        futures = [
+            executor.submit(env.zenith_cli.create_timeline, f"test-timeline-{i}", tenant_id)
+            for i in range(4)
+        ]
         for future in futures:
             future.result()
+
+
+def update_timeline_metadata(env: ZenithEnv,
+                             tenant_id: UUID,
+                             timeline_id: UUID,
+                             args: List[str] = []):
+    bin_update_metadata = os.path.join(str(zenith_binpath), 'update_metadata')
+
+    metadata_path = f"{env.repo_dir}/tenants/{tenant_id.hex}/timelines/{timeline_id.hex}/metadata"
+
+    args = [bin_update_metadata, metadata_path] + args
+
+    # Run the `update_metadata` command
+    # The codes below are copied from `zenith_fixtures.ZenithCli.raw_cli` function.
+    log.info('Running command "{}"'.format(' '.join(args)))
+    log.info(f'Running in "{env.repo_dir}"')
+
+    try:
+        res = subprocess.run(args,
+                             check=True,
+                             universal_newlines=True,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        log.info(f"Run success: {res.stdout}")
+    except subprocess.CalledProcessError as exc:
+        # this way command output will be in recorded and shown in CI in failure message
+        msg = f"""\
+        Run failed: {exc}
+            stdout: {exc.stdout}
+            stderr: {exc.stderr}
+        """
+        log.info(msg)
+
+        raise Exception(msg) from exc
+
+
+def test_find_and_fix_unintialized_timelines(zenith_simple_env: ZenithEnv):
+    env = zenith_simple_env
+
+    tenant_id, _ = env.zenith_cli.create_tenant()
+
+    timeline_id = env.zenith_cli.create_timeline("test", tenant_id)
+
+    # Try to simulate an uninintialized timeline by
+    # - removing all layer files
+    # - update the `prev_record_lsn` and `disk_lsn` of the timeline's metadata
+    timeline_path = f"{env.repo_dir}/tenants/{tenant_id.hex}/timelines/{timeline_id.hex}"
+    for file in os.listdir(timeline_path):
+        print(file)
+        if file != "metadata":
+            os.remove(f"{timeline_path}/{file}")
+    update_timeline_metadata(env, tenant_id, timeline_id, ["--disk_lsn", "0/0", "--prev_lsn", ""])
+
+    env.zenith_cli.pageserver_stop(immediate=True)
+    env.zenith_cli.pageserver_start()
+
+    # Ensure that the tenant state is not broken and executing transactions
+    # on the new timeline should succeed without any errors.
+    pg = env.postgres.create_start("test", tenant_id=tenant_id)
+    with closing(pg.connect()) as conn:
+        with conn.cursor() as cur:
+            cur.execute("CREATE TABLE t(key int primary key, value text)")
+            cur.execute("INSERT INTO t SELECT generate_series(1,100), 'payload'")
+            cur.execute("SELECT COUNT(*) FROM t")
+            assert cur.fetchone()[0] == 100


### PR DESCRIPTION
Resolve #1663.

## Context and changes

This PR adds `timelines::find_and_fix_unintialized_timelines` function and related functions to "fix" uninitialized timelines on pageserver startup by re-initializing them.

A timeline can be uninitialized if the pageserver dies between creating a new timeline and populating it. Right now, there is no reliable way to create an uninitialized timeline without changing the underlying codes. This PR is implemented based on the assumption as described in the original issue (#1663).

This PR also fixes the issue when creating two timelines at the same time for the same tenant. See https://github.com/neondatabase/neon/issues/1663#issuecomment-1131850188.

## Testing
- added `test_create_multiple_timelines_parallel`, which tests the pageserver when creating multiple timelines in parallel
- added `test_find_and_fix_unintialized_timelines`, which simulates a uninitialized timeline by manually updating the timeline's metadata  and removing the layer files
   + this requires changing `update_metadata` binary to allow us to set `prev_record_lsn=None`  