### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ make -j5
 ```
 
 #### building on OSX (12.3.1)
-1. Install XCode 
+1. Install XCode and dependencies
 ```
 xcode-select --install
+brew install protobuf etcd
 ```
 
 2. [Install Rust](https://www.rust-lang.org/tools/install)


### PR DESCRIPTION
Added "brew install protobuf etcd" to OSX installation instructions.
Added "sudo apt install libprotobuf-dev etcd" to Linux installation instructions.
Without these, cargo build complains. 
Figured out in collaboration with Bojan.