### PR TITLE
Fix `test_pageserver_http_get_wal_receiver_success` flaky test.

### DIFF
--- a/test_runner/batch_others/test_pageserver_api.py
+++ b/test_runner/batch_others/test_pageserver_api.py
@@ -90,7 +90,7 @@ def test_pageserver_http_get_wal_receiver_success(zenith_simple_env: ZenithEnv):
         assert res["last_received_msg_lsn"] is not None, "the last received message's LSN is empty"
 
         last_msg_lsn = lsn_from_hex(res["last_received_msg_lsn"])
-        assert prev_msg_lsn is not None and prev_msg_lsn >= last_msg_lsn, \
+        assert prev_msg_lsn is None or prev_msg_lsn < last_msg_lsn, \
             f"the last received message's LSN {last_msg_lsn} hasn't been updated \
             compared to the previous message's LSN {prev_msg_lsn}"
 


### PR DESCRIPTION
Fixes #1768.

## Context

Previously, to test `get_wal_receiver` API, we make run some DB transactions then call the API to check the latest message's LSN from the WAL receiver. However, this test won't work because it's not guaranteed that the WAL receiver will get the latest WAL from the postgres/safekeeper at the time of making the API call. 

This PR resolves the above issue by adding a "poll and wait" code that waits to retrieve the latest data from the WAL receiver. 

This PR also fixes a bug that tries to compare two hex LSNs, should convert to number before the comparison. See: https://github.com/neondatabase/neon/issues/1768#issuecomment-1133752122.