### PR TITLE
Tidy up CI configs slightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,6 @@ executors:
       - image: zimg/rust:1.58
 
 jobs:
-  check-codestyle-rust:
-    executor: neon-xlarge-executor
-    steps:
-      - checkout
-      - run:
-          name: rustfmt
-          when: always
-          command: cargo fmt --all -- --check
-
   # A job to build postgres
   build-postgres:
     executor: neon-xlarge-executor
@@ -740,7 +731,6 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - check-codestyle-rust
       - check-codestyle-python
       - build-postgres:
           name: build-postgres-<< matrix.build_type >>

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,12 +25,16 @@ jobs:
           submodules: true
           fetch-depth: 2
 
-      - name: install rust toolchain ${{ matrix.rust_toolchain }}
+      - name: Install rust toolchain ${{ matrix.rust_toolchain }}
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust_toolchain }}
+          components: rustfmt, clippy
           override: true
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
       - name: Install Ubuntu postgres dependencies
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,8 +1,10 @@
 name: Build and Test
 
 on:
-  pull_request:
   push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   regression-check:


### PR DESCRIPTION
Currently, the PRs are getting the same test run twice, example: https://github.com/neondatabase/neon/pull/1619
<img width="902" alt="image" src="https://user-images.githubusercontent.com/2690773/170346428-4a629f5f-827a-4eee-a46a-ea96c67fa0b2.png">

One alternative could be https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/2
another is to disable running these GH Actions on push entirely, running them on PRs only: those are basic `cargo fmt` and `clippy` runs, so every user can run them locally without the CI anyway.

Also unites `fmt` and `clippy` lints under one task, to follow up https://neondb.slack.com/archives/C036U0GRMRB/p1653309000932389