### PR TITLE
Add quick-start guide in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ still refer to "zenith", but we are in the process of renaming things.
 ## Quick start
 [Join the waitlist](https://neon.tech/) for our free tier and connect to it with your preferred postgres client (psql, dbeaver, etc)
 
+Alternatively, compile and run the project [locally](https://github.com/neondatabase/postgres).
+
 ## Architecture overview
 
 A Neon installation consists of compute nodes and Neon storage engine.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Neon is a serverless open source alternative to AWS Aurora Postgres. It separate
 The project used to be called "Zenith". Many of the commands and code comments
 still refer to "zenith", but we are in the process of renaming things.
 
+## Quick start
+[Join the waitlist](https://neon.tech/) for our free tier and connect to it with your preferred postgres client (psql, dbeaver, etc)
+
 ## Architecture overview
 
 A Neon installation consists of compute nodes and Neon storage engine.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ still refer to "zenith", but we are in the process of renaming things.
 ## Quick start
 [Join the waitlist](https://neon.tech/) for our free tier and connect to it with your preferred postgres client (psql, dbeaver, etc)
 
-Alternatively, compile and run the project [locally](https://github.com/neondatabase/postgres).
+Alternatively, compile and run the project [locally](#running-local-installation).
 
 ## Architecture overview
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The project used to be called "Zenith". Many of the commands and code comments
 still refer to "zenith", but we are in the process of renaming things.
 
 ## Quick start
-[Join the waitlist](https://neon.tech/) for our free tier and connect to it with your preferred postgres client (psql, dbeaver, etc)
+[Join the waitlist](https://neon.tech/) for our free tier to receive your serverless postgres instance. Then connect to it with your preferred postgres client (psql, dbeaver, etc) or use the online SQL editor.
 
 Alternatively, compile and run the project [locally](#running-local-installation).
 


### PR DESCRIPTION
Our current readme talks past users and gets straight to the "how it's made" part. Should our readme be more of a landing page? Feel free to comment.

