### PR TITLE
Added project option in case SNI data is missing. Resolving issue #1745.

### DIFF
--- a/libs/utils/src/pq_proto.rs
+++ b/libs/utils/src/pq_proto.rs
@@ -269,11 +269,15 @@ impl FeStartupPacket {
                             .next()
                             .context("expected even number of params in StartupMessage")?;
                         if name == "options" {
-                            // deprecated way of passing params as cmd line args
-                            for cmdopt in value.split(' ') {
-                                let nameval: Vec<&str> = cmdopt.split('=').collect();
+                            //parsing options arguments "..&options=<var>:<val>,.."
+                            //extended example and set of options:
+                            //https://github.com/neondatabase/neon/blob/main/docs/rfcs/016-connection-routing.md#connection-url
+                            for cmdopt in value.split(',') {
+                                let nameval: Vec<&str> = cmdopt.split(':').collect();
                                 if nameval.len() == 2 {
                                     params.insert(nameval[0].to_string(), nameval[1].to_string());
+                                } else {
+                                    //todo: inform user / throw error message if options format is wrong.
                                 }
                             }
                         } else {

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -26,6 +26,10 @@ pub struct ClientCredentials {
     // New console API requires SNI info to determine the cluster name.
     // Other Auth backends don't need it.
     pub sni_data: Option<String>,
+
+    // cluster_option is passed as argument from options from url.
+    // To be used to determine cluster name in case sni_data is missing.
+    pub project_option: Option<String>,
 }
 
 impl ClientCredentials {
@@ -37,10 +41,10 @@ impl ClientCredentials {
 
 #[derive(Debug, Error)]
 pub enum ProjectNameError {
-    #[error("SNI is missing, please upgrade the postgres client library")]
+    #[error("SNI info is missing. EITHER please upgrade the postgres client library OR pass the project name as a parameter: '..&options=project:<project name>..'.")]
     Missing,
 
-    #[error("SNI is malformed")]
+    #[error("SNI is malformed.")]
     Bad,
 }
 
@@ -49,10 +53,17 @@ impl UserFacingError for ProjectNameError {}
 impl ClientCredentials {
     /// Determine project name from SNI.
     pub fn project_name(&self) -> Result<&str, ProjectNameError> {
-        // Currently project name is passed as a top level domain
-        let sni = self.sni_data.as_ref().ok_or(ProjectNameError::Missing)?;
-        let (first, _) = sni.split_once('.').ok_or(ProjectNameError::Bad)?;
-        Ok(first)
+        let ret = match &self.sni_data {
+            //if sni_data exists, use it to determine project name
+            Some(sni_data) => sni_data.split_once('.').ok_or(ProjectNameError::Bad)?.0,
+            //otherwise use project_option if it was manually set thought ..&options=project:<name> parameter
+            None => self
+                .project_option
+                .as_ref()
+                .ok_or(ProjectNameError::Missing)?
+                .as_str(),
+        };
+        Ok(ret)
     }
 }
 
@@ -68,11 +79,17 @@ impl TryFrom<HashMap<String, String>> for ClientCredentials {
 
         let user = get_param("user")?;
         let dbname = get_param("database")?;
+        let project = get_param("project");
+        let project_option = match project {
+            Ok(project) => Some(project),
+            Err(_) => None,
+        };
 
         Ok(Self {
             user,
             dbname,
             sni_data: None,
+            project_option,
         })
     }
 }


### PR DESCRIPTION
[Copying from #1813 with few changes.]

#### Summary

Added ability to pass project name as an option argument (..&options=project:<project name>..) in case SNI data is missing.
Resolving issue #1745 

#### Rationale

Since SNI is a recent postgres feature, some posgres clients might not be updated, and since our proxy relies on the SNI data for routing, we need to prove an alternative way for users to pass this information. For that purpose we are added logic to use the project parameter from options argument as the SNI data

#### Behavior

We first start the proxy
`./target/debug/proxy --auth-backend=console -c server.crt -k server.key`

Running (with sslsni=0)
`psql 'postgres://my-cluster-123.localtest.me:4432/main?sslmode=require&sslsni=0'`
results in (notice new error message)
> got message: StartupMessage { major_version: 3, minor_version: 0, params: {"": "", "user": "klimentserafimov", "application_name": "psql", "database": "main", "client_encoding": "UTF8"} }
error: SNI info is missing. EITHER please upgrade the postgres client library OR pass the project name as a parameter: '..&options=project:\<project name\>..'.

Running (with ..&options=project:my-cluster-123)
`psql 'postgres://my-cluster-123.localtest.me:4432/main?sslmode=require&sslsni=0&options=project:my-cluster-123'`
results in (notice cluster name in StartupMessage)

> got message: StartupMessage { major_version: 3, minor_version: 0, params: {"user": "klimentserafimov", "application_name": "psql", "database": "main", "client_encoding": "UTF8", "": "", "project": "my-cluster-123"} }
cplane request: http://localhost:3000/authenticate_proxy_request//proxy_get_role_secret?project=my-cluster-123&role=klimentserafimov
error: error sending request for url (http://localhost:3000/authenticate_proxy_request//proxy_get_role_secret?project=my-cluster-123&role=klimentserafimov): error trying to connect: tcp connect error: Connection refused (os error 61)

Which is exactly what we want, because when we run without sslsni=0 and without '..&options=project:my-cluster-123':
`psql 'postgres://my-cluster-123.localtest.me:4432/main?sslmode=require'`
results in

> got message: StartupMessage { major_version: 3, minor_version: 0, params: {"user": "klimentserafimov", "application_name": "psql", "client_encoding": "UTF8", "": "", "database": "main"} }
cplane request: http://localhost:3000/authenticate_proxy_request//proxy_get_role_secret?project=my-cluster-123&role=klimentserafimov
error: error sending request for url (http://localhost:3000/authenticate_proxy_request//proxy_get_role_secret?project=my-cluster-123&role=klimentserafimov): error trying to connect: tcp connect error: Connection refused (os error 61)

### Remaining todos

1. Throw error if options arguments are ill-formed. 
