### PR TITLE
replaced ztenantid with tenantid

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -15,7 +15,7 @@ use utils::{
     connstring::connection_host_port,
     lsn::Lsn,
     postgres_backend::AuthType,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 use crate::local_env::LocalEnv;
@@ -28,7 +28,7 @@ use crate::storage::PageServerNode;
 pub struct ComputeControlPlane {
     base_port: u16,
     pageserver: Arc<PageServerNode>,
-    pub nodes: BTreeMap<(ZTenantId, String), Arc<PostgresNode>>,
+    pub nodes: BTreeMap<(TenantId, String), Arc<PostgresNode>>,
     env: LocalEnv,
 }
 
@@ -76,7 +76,7 @@ impl ComputeControlPlane {
 
     pub fn new_node(
         &mut self,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         name: &str,
         timeline_id: ZTimelineId,
         lsn: Option<Lsn>,
@@ -116,7 +116,7 @@ pub struct PostgresNode {
     is_test: bool,
     pub timeline_id: ZTimelineId,
     pub lsn: Option<Lsn>, // if it's a read-only node. None for primary
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     uses_wal_proposer: bool,
 }
 
@@ -149,7 +149,7 @@ impl PostgresNode {
         let context = format!("in config file {}", cfg_path_str);
         let port: u16 = conf.parse_field("port", &context)?;
         let timeline_id: ZTimelineId = conf.parse_field("neon.timeline_id", &context)?;
-        let tenant_id: ZTenantId = conf.parse_field("neon.tenant_id", &context)?;
+        let tenant_id: TenantId = conf.parse_field("neon.tenant_id", &context)?;
         let uses_wal_proposer = conf.get("safekeepers").is_some();
 
         // parse recovery_target_lsn, if any

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -15,7 +15,7 @@ use std::process::{Command, Stdio};
 use utils::{
     auth::{encode_from_key_file, Claims, Scope},
     postgres_backend::AuthType,
-    zid::{NodeId, ZTenantId, ZTenantTimelineId, ZTimelineId},
+    zid::{NodeId, TenantId, ZTenantTimelineId, ZTimelineId},
 };
 
 use crate::safekeeper::SafekeeperNode;
@@ -54,7 +54,7 @@ pub struct LocalEnv {
     // --tenantid is not explicitly specified.
     #[serde(default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    pub default_tenant_id: Option<ZTenantId>,
+    pub default_tenant_id: Option<TenantId>,
 
     // used to issue tokens during e.g pg start
     #[serde(default)]
@@ -69,11 +69,11 @@ pub struct LocalEnv {
 
     /// Keep human-readable aliases in memory (and persist them to config), to hide ZId hex strings from the user.
     #[serde(default)]
-    // A `HashMap<String, HashMap<ZTenantId, ZTimelineId>>` would be more appropriate here,
+    // A `HashMap<String, HashMap<TenantId, ZTimelineId>>` would be more appropriate here,
     // but deserialization into a generic toml object as `toml::Value::try_from` fails with an error.
     // https://toml.io/en/v1.0.0 does not contain a concept of "a table inside another table".
     #[serde_as(as = "HashMap<_, Vec<(DisplayFromStr, DisplayFromStr)>>")]
-    branch_name_mappings: HashMap<String, Vec<(ZTenantId, ZTimelineId)>>,
+    branch_name_mappings: HashMap<String, Vec<(TenantId, ZTimelineId)>>,
 }
 
 /// Etcd broker config for cluster internal communication.
@@ -213,7 +213,7 @@ impl LocalEnv {
         self.base_data_dir.join("pgdatadirs").join("tenants")
     }
 
-    pub fn pg_data_dir(&self, tenantid: &ZTenantId, branch_name: &str) -> PathBuf {
+    pub fn pg_data_dir(&self, tenantid: &TenantId, branch_name: &str) -> PathBuf {
         self.pg_data_dirs_path()
             .join(tenantid.to_string())
             .join(branch_name)
@@ -231,7 +231,7 @@ impl LocalEnv {
     pub fn register_branch_mapping(
         &mut self,
         branch_name: String,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         timeline_id: ZTimelineId,
     ) -> anyhow::Result<()> {
         let existing_values = self
@@ -258,7 +258,7 @@ impl LocalEnv {
     pub fn get_branch_timeline_id(
         &self,
         branch_name: &str,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
     ) -> Option<ZTimelineId> {
         self.branch_name_mappings
             .get(branch_name)?
@@ -304,7 +304,7 @@ impl LocalEnv {
 
         // If no initial tenant ID was given, generate it.
         if env.default_tenant_id.is_none() {
-            env.default_tenant_id = Some(ZTenantId::generate());
+            env.default_tenant_id = Some(TenantId::generate());
         }
 
         env.base_data_dir = base_path();

--- a/control_plane/src/safekeeper.rs
+++ b/control_plane/src/safekeeper.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use utils::{
     connstring::connection_address,
     http::error::HttpErrorBody,
-    zid::{NodeId, ZTenantId, ZTimelineId},
+    zid::{NodeId, TenantId, ZTimelineId},
 };
 
 use crate::local_env::{LocalEnv, SafekeeperConf};
@@ -292,7 +292,7 @@ impl SafekeeperNode {
 
     pub fn timeline_create(
         &self,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         timeline_id: ZTimelineId,
         peer_ids: Vec<NodeId>,
     ) -> Result<()> {

--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -23,7 +23,7 @@ use utils::{
     http::error::HttpErrorBody,
     lsn::Lsn,
     postgres_backend::AuthType,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 use crate::local_env::LocalEnv;
@@ -109,7 +109,7 @@ impl PageServerNode {
 
     pub fn init(
         &self,
-        create_tenant: Option<ZTenantId>,
+        create_tenant: Option<TenantId>,
         initial_timeline_id: Option<ZTimelineId>,
         config_overrides: &[&str],
     ) -> anyhow::Result<ZTimelineId> {
@@ -387,9 +387,9 @@ impl PageServerNode {
 
     pub fn tenant_create(
         &self,
-        new_tenant_id: Option<ZTenantId>,
+        new_tenant_id: Option<TenantId>,
         settings: HashMap<&str, &str>,
-    ) -> anyhow::Result<Option<ZTenantId>> {
+    ) -> anyhow::Result<Option<TenantId>> {
         let tenant_id_string = self
             .http_request(Method::POST, format!("{}/tenant", self.http_base_url))
             .json(&TenantCreateRequest {
@@ -443,7 +443,7 @@ impl PageServerNode {
             .transpose()
     }
 
-    pub fn tenant_config(&self, tenant_id: ZTenantId, settings: HashMap<&str, &str>) -> Result<()> {
+    pub fn tenant_config(&self, tenant_id: TenantId, settings: HashMap<&str, &str>) -> Result<()> {
         self.http_request(Method::PUT, format!("{}/tenant/config", self.http_base_url))
             .json(&TenantConfigRequest {
                 tenant_id,
@@ -491,7 +491,7 @@ impl PageServerNode {
         Ok(())
     }
 
-    pub fn timeline_list(&self, tenant_id: &ZTenantId) -> anyhow::Result<Vec<TimelineInfo>> {
+    pub fn timeline_list(&self, tenant_id: &TenantId) -> anyhow::Result<Vec<TimelineInfo>> {
         let timeline_infos: Vec<TimelineInfo> = self
             .http_request(
                 Method::GET,
@@ -506,7 +506,7 @@ impl PageServerNode {
 
     pub fn timeline_create(
         &self,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         new_timeline_id: Option<ZTimelineId>,
         ancestor_start_lsn: Option<Lsn>,
         ancestor_timeline_id: Option<ZTimelineId>,

--- a/libs/etcd_broker/src/lib.rs
+++ b/libs/etcd_broker/src/lib.rs
@@ -17,7 +17,7 @@ use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::*;
 use utils::{
     lsn::Lsn,
-    zid::{NodeId, ZTenantId, ZTenantTimelineId},
+    zid::{NodeId, TenantId, ZTenantTimelineId},
 };
 
 /// Default value to use for prefixing to all etcd keys with.
@@ -123,7 +123,7 @@ impl SkTimelineSubscriptionKind {
         }
     }
 
-    pub fn tenant(broker_etcd_prefix: String, tenant: ZTenantId) -> Self {
+    pub fn tenant(broker_etcd_prefix: String, tenant: TenantId) -> Self {
         Self {
             broker_etcd_prefix,
             kind: SubscriptionKind::Tenant(tenant),
@@ -160,7 +160,7 @@ enum SubscriptionKind {
     /// Get every timeline update.
     All,
     /// Get certain tenant timelines' updates.
-    Tenant(ZTenantId),
+    Tenant(TenantId),
     /// Get certain timeline updates.
     Timeline(ZTenantTimelineId),
 }
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn typical_etcd_prefix_should_be_parsed() {
         let prefix = "neon";
-        let tenant_id = ZTenantId::generate();
+        let tenant_id = TenantId::generate();
         let timeline_id = ZTimelineId::generate();
         let all_subscription = SkTimelineSubscriptionKind {
             broker_etcd_prefix: prefix.to_string(),

--- a/libs/utils/src/auth.rs
+++ b/libs/utils/src/auth.rs
@@ -14,7 +14,7 @@ use jsonwebtoken::{
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
-use crate::zid::ZTenantId;
+use crate::zid::TenantId;
 
 const JWT_ALGORITHM: Algorithm = Algorithm::RS256;
 
@@ -30,17 +30,17 @@ pub enum Scope {
 pub struct Claims {
     #[serde(default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    pub tenant_id: Option<ZTenantId>,
+    pub tenant_id: Option<TenantId>,
     pub scope: Scope,
 }
 
 impl Claims {
-    pub fn new(tenant_id: Option<ZTenantId>, scope: Scope) -> Self {
+    pub fn new(tenant_id: Option<TenantId>, scope: Scope) -> Self {
         Self { tenant_id, scope }
     }
 }
 
-pub fn check_permission(claims: &Claims, tenantid: Option<ZTenantId>) -> Result<()> {
+pub fn check_permission(claims: &Claims, tenantid: Option<TenantId>) -> Result<()> {
     match (&claims.scope, tenantid) {
         (Scope::Tenant, None) => {
             bail!("Attempt to access management api with tenant scope. Permission denied")

--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -1,6 +1,6 @@
 use crate::auth::{self, Claims, JwtAuth};
 use crate::http::error;
-use crate::zid::ZTenantId;
+use crate::zid::TenantId;
 use anyhow::anyhow;
 use hyper::header::AUTHORIZATION;
 use hyper::{header::CONTENT_TYPE, Body, Request, Response, Server};
@@ -137,7 +137,7 @@ pub fn auth_middleware<B: hyper::body::HttpBody + Send + Sync + 'static>(
     })
 }
 
-pub fn check_permission(req: &Request<Body>, tenantid: Option<ZTenantId>) -> Result<(), ApiError> {
+pub fn check_permission(req: &Request<Body>, tenantid: Option<TenantId>) -> Result<(), ApiError> {
     match req.context::<Claims>() {
         Some(claims) => Ok(auth::check_permission(&claims, tenantid)
             .map_err(|err| ApiError::Forbidden(err.to_string()))?),

--- a/libs/utils/src/zid.rs
+++ b/libs/utils/src/zid.rs
@@ -188,19 +188,19 @@ zid_newtype!(ZTimelineId);
 /// like `[173,80,132,115,129,226,72,254,170,201,135,108,199,26,228,24]`.
 /// See [`ZId`] for alternative ways to serialize it.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
-pub struct ZTenantId(ZId);
+pub struct TenantId(ZId);
 
-zid_newtype!(ZTenantId);
+zid_newtype!(TenantId);
 
 // A pair uniquely identifying Zenith instance.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ZTenantTimelineId {
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     pub timeline_id: ZTimelineId,
 }
 
 impl ZTenantTimelineId {
-    pub fn new(tenant_id: ZTenantId, timeline_id: ZTimelineId) -> Self {
+    pub fn new(tenant_id: TenantId, timeline_id: ZTimelineId) -> Self {
         ZTenantTimelineId {
             tenant_id,
             timeline_id,
@@ -208,11 +208,11 @@ impl ZTenantTimelineId {
     }
 
     pub fn generate() -> Self {
-        Self::new(ZTenantId::generate(), ZTimelineId::generate())
+        Self::new(TenantId::generate(), ZTimelineId::generate())
     }
 
     pub fn empty() -> Self {
-        Self::new(ZTenantId::from([0u8; 16]), ZTimelineId::from([0u8; 16]))
+        Self::new(TenantId::from([0u8; 16]), ZTimelineId::from([0u8; 16]))
     }
 }
 

--- a/neon_local/src/main.rs
+++ b/neon_local/src/main.rs
@@ -22,7 +22,7 @@ use utils::{
     lsn::Lsn,
     postgres_backend::AuthType,
     project_git_version,
-    zid::{NodeId, ZTenantId, ZTenantTimelineId, ZTimelineId},
+    zid::{NodeId, TenantId, ZTenantTimelineId, ZTimelineId},
 };
 
 use pageserver::timelines::TimelineInfo;
@@ -432,7 +432,7 @@ fn print_timeline(
 /// Connects to the pageserver to query this information.
 fn get_timeline_infos(
     env: &local_env::LocalEnv,
-    tenant_id: &ZTenantId,
+    tenant_id: &TenantId,
 ) -> Result<HashMap<ZTimelineId, TimelineInfo>> {
     Ok(PageServerNode::from_env(env)
         .timeline_list(tenant_id)?
@@ -442,7 +442,7 @@ fn get_timeline_infos(
 }
 
 // Helper function to parse --tenant_id option, or get the default from config file
-fn get_tenant_id(sub_match: &ArgMatches, env: &local_env::LocalEnv) -> anyhow::Result<ZTenantId> {
+fn get_tenant_id(sub_match: &ArgMatches, env: &local_env::LocalEnv) -> anyhow::Result<TenantId> {
     if let Some(tenant_id_from_arguments) = parse_tenant_id(sub_match).transpose() {
         tenant_id_from_arguments
     } else if let Some(default_id) = env.default_tenant_id {
@@ -452,10 +452,10 @@ fn get_tenant_id(sub_match: &ArgMatches, env: &local_env::LocalEnv) -> anyhow::R
     }
 }
 
-fn parse_tenant_id(sub_match: &ArgMatches) -> anyhow::Result<Option<ZTenantId>> {
+fn parse_tenant_id(sub_match: &ArgMatches) -> anyhow::Result<Option<TenantId>> {
     sub_match
         .value_of("tenant-id")
-        .map(ZTenantId::from_str)
+        .map(TenantId::from_str)
         .transpose()
         .context("Failed to parse tenant id from the argument string")
 }

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -24,7 +24,7 @@ use utils::{
     shutdown::exit_now,
     signals::{self, Signal},
     tcp_listener,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 project_git_version!(GIT_VERSION);
@@ -113,7 +113,7 @@ fn main() -> anyhow::Result<()> {
     let init = arg_matches.is_present("init");
     let create_tenant = arg_matches
         .value_of("create-tenant")
-        .map(ZTenantId::from_str)
+        .map(TenantId::from_str)
         .transpose()
         .context("Failed to parse tenant id from the arguments")?;
     let initial_timeline_id = arg_matches

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -16,7 +16,7 @@ use toml_edit::{Document, Item};
 use url::Url;
 use utils::{
     postgres_backend::AuthType,
-    zid::{NodeId, ZTenantId, ZTimelineId},
+    zid::{NodeId, TenantId, ZTimelineId},
 };
 
 use crate::layered_repository::TIMELINES_SEGMENT_NAME;
@@ -341,15 +341,15 @@ impl PageServerConf {
         self.workdir.join("tenants")
     }
 
-    pub fn tenant_path(&self, tenantid: &ZTenantId) -> PathBuf {
+    pub fn tenant_path(&self, tenantid: &TenantId) -> PathBuf {
         self.tenants_path().join(tenantid.to_string())
     }
 
-    pub fn timelines_path(&self, tenantid: &ZTenantId) -> PathBuf {
+    pub fn timelines_path(&self, tenantid: &TenantId) -> PathBuf {
         self.tenant_path(tenantid).join(TIMELINES_SEGMENT_NAME)
     }
 
-    pub fn timeline_path(&self, timelineid: &ZTimelineId, tenantid: &ZTenantId) -> PathBuf {
+    pub fn timeline_path(&self, timelineid: &ZTimelineId, tenantid: &TenantId) -> PathBuf {
         self.timelines_path(tenantid).join(timelineid.to_string())
     }
 

--- a/pageserver/src/http/models.rs
+++ b/pageserver/src/http/models.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use utils::{
     lsn::Lsn,
-    zid::{NodeId, ZTenantId, ZTimelineId},
+    zid::{NodeId, TenantId, ZTimelineId},
 };
 
 #[serde_as]
@@ -26,7 +26,7 @@ pub struct TimelineCreateRequest {
 pub struct TenantCreateRequest {
     #[serde(default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
-    pub new_tenant_id: Option<ZTenantId>,
+    pub new_tenant_id: Option<TenantId>,
     pub checkpoint_distance: Option<u64>,
     pub compaction_target_size: Option<u64>,
     pub compaction_period: Option<String>,
@@ -43,7 +43,7 @@ pub struct TenantCreateRequest {
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct TenantCreateResponse(#[serde_as(as = "DisplayFromStr")] pub ZTenantId);
+pub struct TenantCreateResponse(#[serde_as(as = "DisplayFromStr")] pub TenantId);
 
 #[derive(Serialize)]
 pub struct StatusResponse {
@@ -51,7 +51,7 @@ pub struct StatusResponse {
 }
 
 impl TenantCreateRequest {
-    pub fn new(new_tenant_id: Option<ZTenantId>) -> TenantCreateRequest {
+    pub fn new(new_tenant_id: Option<TenantId>) -> TenantCreateRequest {
         TenantCreateRequest {
             new_tenant_id,
             ..Default::default()
@@ -62,7 +62,7 @@ impl TenantCreateRequest {
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct TenantConfigRequest {
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     #[serde(default)]
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub checkpoint_distance: Option<u64>,
@@ -79,7 +79,7 @@ pub struct TenantConfigRequest {
 }
 
 impl TenantConfigRequest {
-    pub fn new(tenant_id: ZTenantId) -> TenantConfigRequest {
+    pub fn new(tenant_id: TenantId) -> TenantConfigRequest {
         TenantConfigRequest {
             tenant_id,
             checkpoint_distance: None,

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -25,7 +25,7 @@ use utils::{
         request::parse_request_param,
         RequestExt, RouterBuilder,
     },
-    zid::{ZTenantId, ZTenantTimelineId, ZTimelineId},
+    zid::{TenantId, ZTenantTimelineId, ZTimelineId},
 };
 
 struct State {
@@ -85,7 +85,7 @@ async fn status_handler(request: Request<Body>) -> Result<Response<Body>, ApiErr
 }
 
 async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<Body>, ApiError> {
-    let tenant_id: ZTenantId = parse_request_param(&request, "tenant_id")?;
+    let tenant_id: TenantId = parse_request_param(&request, "tenant_id")?;
     let request_data: TimelineCreateRequest = json_request(&mut request).await?;
 
     check_permission(&request, Some(tenant_id))?;
@@ -110,7 +110,7 @@ async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<
 }
 
 async fn timeline_list_handler(request: Request<Body>) -> Result<Response<Body>, ApiError> {
-    let tenant_id: ZTenantId = parse_request_param(&request, "tenant_id")?;
+    let tenant_id: TenantId = parse_request_param(&request, "tenant_id")?;
     check_permission(&request, Some(tenant_id))?;
     let include_non_incremental_logical_size = get_include_non_incremental_logical_size(&request);
     let local_timeline_infos = tokio::task::spawn_blocking(move || {
@@ -160,7 +160,7 @@ fn get_include_non_incremental_logical_size(request: &Request<Body>) -> bool {
 }
 
 async fn timeline_detail_handler(request: Request<Body>) -> Result<Response<Body>, ApiError> {
-    let tenant_id: ZTenantId = parse_request_param(&request, "tenant_id")?;
+    let tenant_id: TenantId = parse_request_param(&request, "tenant_id")?;
     check_permission(&request, Some(tenant_id))?;
 
     let timeline_id: ZTimelineId = parse_request_param(&request, "timeline_id")?;
@@ -225,7 +225,7 @@ async fn timeline_detail_handler(request: Request<Body>) -> Result<Response<Body
 }
 
 async fn wal_receiver_get_handler(request: Request<Body>) -> Result<Response<Body>, ApiError> {
-    let tenant_id: ZTenantId = parse_request_param(&request, "tenant_id")?;
+    let tenant_id: TenantId = parse_request_param(&request, "tenant_id")?;
     check_permission(&request, Some(tenant_id))?;
 
     let timeline_id: ZTimelineId = parse_request_param(&request, "timeline_id")?;
@@ -242,7 +242,7 @@ async fn wal_receiver_get_handler(request: Request<Body>) -> Result<Response<Bod
 }
 
 async fn timeline_attach_handler(request: Request<Body>) -> Result<Response<Body>, ApiError> {
-    let tenant_id: ZTenantId = parse_request_param(&request, "tenant_id")?;
+    let tenant_id: TenantId = parse_request_param(&request, "tenant_id")?;
     check_permission(&request, Some(tenant_id))?;
 
     let timeline_id: ZTimelineId = parse_request_param(&request, "timeline_id")?;
@@ -343,7 +343,7 @@ async fn try_download_index_part_data(
 }
 
 async fn timeline_detach_handler(request: Request<Body>) -> Result<Response<Body>, ApiError> {
-    let tenant_id: ZTenantId = parse_request_param(&request, "tenant_id")?;
+    let tenant_id: TenantId = parse_request_param(&request, "tenant_id")?;
     check_permission(&request, Some(tenant_id))?;
 
     let timeline_id: ZTimelineId = parse_request_param(&request, "timeline_id")?;
@@ -419,8 +419,8 @@ async fn tenant_create_handler(mut request: Request<Body>) -> Result<Response<Bo
 
     let target_tenant_id = request_data
         .new_tenant_id
-        .map(ZTenantId::from)
-        .unwrap_or_else(ZTenantId::generate);
+        .map(TenantId::from)
+        .unwrap_or_else(TenantId::generate);
 
     let new_tenant_id = tokio::task::spawn_blocking(move || {
         let _enter = info_span!("tenant_create", tenant = ?target_tenant_id).entered();

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -59,7 +59,7 @@ use utils::{
     crashsafe_dir,
     lsn::{AtomicLsn, Lsn, RecordLsn},
     seqwait::SeqWait,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 mod blob_io;
@@ -164,7 +164,7 @@ pub struct LayeredRepository {
     // This is necessary to allow global config updates.
     tenant_conf: Arc<RwLock<TenantConfOpt>>,
 
-    tenant_id: ZTenantId,
+    tenant_id: TenantId,
     timelines: Mutex<HashMap<ZTimelineId, LayeredTimelineEntry>>,
     // This mutex prevents creation of new timelines during GC.
     // Adding yet another mutex (in addition to `timelines`) is needed because holding
@@ -679,7 +679,7 @@ impl LayeredRepository {
         conf: &'static PageServerConf,
         tenant_conf: TenantConfOpt,
         walredo_mgr: Arc<dyn WalRedoManager + Send + Sync>,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         remote_index: RemoteIndex,
         upload_layers: bool,
     ) -> LayeredRepository {
@@ -698,7 +698,7 @@ impl LayeredRepository {
     /// Locate and load config
     pub fn load_tenant_config(
         conf: &'static PageServerConf,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
     ) -> anyhow::Result<TenantConfOpt> {
         let target_config_path = TenantConf::path(conf, tenantid);
 
@@ -735,7 +735,7 @@ impl LayeredRepository {
 
     pub fn persist_tenant_config(
         conf: &'static PageServerConf,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         tenant_conf: TenantConfOpt,
     ) -> anyhow::Result<()> {
         let _enter = info_span!("saving tenantconf").entered();
@@ -764,7 +764,7 @@ impl LayeredRepository {
     pub fn save_metadata(
         conf: &'static PageServerConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         data: &TimelineMetadata,
         first_save: bool,
     ) -> Result<()> {
@@ -913,7 +913,7 @@ impl LayeredRepository {
         Ok(totals)
     }
 
-    pub fn tenant_id(&self) -> ZTenantId {
+    pub fn tenant_id(&self) -> TenantId {
         self.tenant_id
     }
 }
@@ -922,7 +922,7 @@ pub struct LayeredTimeline {
     conf: &'static PageServerConf,
     tenant_conf: Arc<RwLock<TenantConfOpt>>,
 
-    tenant_id: ZTenantId,
+    tenant_id: TenantId,
     timeline_id: ZTimelineId,
 
     layers: RwLock<LayerMap>,
@@ -1198,7 +1198,7 @@ impl LayeredTimeline {
         metadata: TimelineMetadata,
         ancestor: Option<LayeredTimelineEntry>,
         timeline_id: ZTimelineId,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         walredo_mgr: Arc<dyn WalRedoManager + Send + Sync>,
         upload_layers: bool,
     ) -> LayeredTimeline {
@@ -2541,7 +2541,7 @@ fn rename_to_backup(path: PathBuf) -> anyhow::Result<()> {
 pub fn load_metadata(
     conf: &'static PageServerConf,
     timeline_id: ZTimelineId,
-    tenant_id: ZTenantId,
+    tenant_id: TenantId,
 ) -> anyhow::Result<TimelineMetadata> {
     let metadata_path = metadata_path(conf, timeline_id, tenant_id);
     let metadata_bytes = std::fs::read(&metadata_path).with_context(|| {

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -51,7 +51,7 @@ use tracing::*;
 use utils::{
     bin_ser::BeSer,
     lsn::Lsn,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 ///
@@ -66,7 +66,7 @@ struct Summary {
     magic: u16,
     format_version: u16,
 
-    tenantid: ZTenantId,
+    tenantid: TenantId,
     timelineid: ZTimelineId,
     key_range: Range<Key>,
     lsn_range: Range<Lsn>,
@@ -175,7 +175,7 @@ impl DeltaKey {
 pub struct DeltaLayer {
     path_or_conf: PathOrConf,
 
-    pub tenantid: ZTenantId,
+    pub tenantid: TenantId,
     pub timelineid: ZTimelineId,
     pub key_range: Range<Key>,
     pub lsn_range: Range<Lsn>,
@@ -196,7 +196,7 @@ pub struct DeltaLayerInner {
 }
 
 impl Layer for DeltaLayer {
-    fn get_tenant_id(&self) -> ZTenantId {
+    fn get_tenant_id(&self) -> TenantId {
         self.tenantid
     }
 
@@ -410,7 +410,7 @@ impl DeltaLayer {
     fn path_for(
         path_or_conf: &PathOrConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         fname: &DeltaFileName,
     ) -> PathBuf {
         match path_or_conf {
@@ -424,7 +424,7 @@ impl DeltaLayer {
     fn temp_path_for(
         conf: &PageServerConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         key_start: Key,
         lsn_range: &Range<Lsn>,
     ) -> PathBuf {
@@ -525,7 +525,7 @@ impl DeltaLayer {
     pub fn new(
         conf: &'static PageServerConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         filename: &DeltaFileName,
     ) -> DeltaLayer {
         DeltaLayer {
@@ -603,7 +603,7 @@ pub struct DeltaLayerWriter {
     conf: &'static PageServerConf,
     path: PathBuf,
     timelineid: ZTimelineId,
-    tenantid: ZTenantId,
+    tenantid: TenantId,
 
     key_start: Key,
     lsn_range: Range<Lsn>,
@@ -620,7 +620,7 @@ impl DeltaLayerWriter {
     pub fn new(
         conf: &'static PageServerConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         key_start: Key,
         lsn_range: Range<Lsn>,
     ) -> Result<DeltaLayerWriter> {

--- a/pageserver/src/layered_repository/ephemeral_file.rs
+++ b/pageserver/src/layered_repository/ephemeral_file.rs
@@ -17,7 +17,7 @@ use std::ops::DerefMut;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tracing::*;
-use utils::zid::{ZTenantId, ZTimelineId};
+use utils::zid::{TenantId, ZTimelineId};
 
 use std::os::unix::fs::FileExt;
 
@@ -39,7 +39,7 @@ pub struct EphemeralFiles {
 
 pub struct EphemeralFile {
     file_id: u64,
-    _tenantid: ZTenantId,
+    _tenantid: TenantId,
     _timelineid: ZTimelineId,
     file: Arc<VirtualFile>,
 
@@ -49,7 +49,7 @@ pub struct EphemeralFile {
 impl EphemeralFile {
     pub fn create(
         conf: &PageServerConf,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         timelineid: ZTimelineId,
     ) -> Result<EphemeralFile, std::io::Error> {
         let mut l = EPHEMERAL_FILES.write().unwrap();
@@ -322,7 +322,7 @@ mod tests {
 
     fn repo_harness(
         test_name: &str,
-    ) -> Result<(&'static PageServerConf, ZTenantId, ZTimelineId), Error> {
+    ) -> Result<(&'static PageServerConf, TenantId, ZTimelineId), Error> {
         let repo_dir = PageServerConf::test_repo_dir(test_name);
         let _ = fs::remove_dir_all(&repo_dir);
         let conf = PageServerConf::dummy_conf(repo_dir);
@@ -330,7 +330,7 @@ mod tests {
         // OK in a test.
         let conf: &'static PageServerConf = Box::leak(Box::new(conf));
 
-        let tenantid = ZTenantId::from_str("11000000000000000000000000000000").unwrap();
+        let tenantid = TenantId::from_str("11000000000000000000000000000000").unwrap();
         let timelineid = ZTimelineId::from_str("22000000000000000000000000000000").unwrap();
         fs::create_dir_all(conf.timeline_path(&timelineid, &tenantid))?;
 

--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -47,7 +47,7 @@ use tracing::*;
 use utils::{
     bin_ser::BeSer,
     lsn::Lsn,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 ///
@@ -62,7 +62,7 @@ struct Summary {
     magic: u16,
     format_version: u16,
 
-    tenantid: ZTenantId,
+    tenantid: TenantId,
     timelineid: ZTimelineId,
     key_range: Range<Key>,
     lsn: Lsn,
@@ -99,7 +99,7 @@ impl From<&ImageLayer> for Summary {
 ///
 pub struct ImageLayer {
     path_or_conf: PathOrConf,
-    pub tenantid: ZTenantId,
+    pub tenantid: TenantId,
     pub timelineid: ZTimelineId,
     pub key_range: Range<Key>,
 
@@ -130,7 +130,7 @@ impl Layer for ImageLayer {
         Some(self.path())
     }
 
-    fn get_tenant_id(&self) -> ZTenantId {
+    fn get_tenant_id(&self) -> TenantId {
         self.tenantid
     }
 
@@ -231,7 +231,7 @@ impl ImageLayer {
     fn path_for(
         path_or_conf: &PathOrConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         fname: &ImageFileName,
     ) -> PathBuf {
         match path_or_conf {
@@ -245,7 +245,7 @@ impl ImageLayer {
     fn temp_path_for(
         conf: &PageServerConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         fname: &ImageFileName,
     ) -> PathBuf {
         let rand_string: String = rand::thread_rng()
@@ -339,7 +339,7 @@ impl ImageLayer {
     pub fn new(
         conf: &'static PageServerConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         filename: &ImageFileName,
     ) -> ImageLayer {
         ImageLayer {
@@ -417,7 +417,7 @@ pub struct ImageLayerWriter {
     conf: &'static PageServerConf,
     path: PathBuf,
     timelineid: ZTimelineId,
-    tenantid: ZTenantId,
+    tenantid: TenantId,
     key_range: Range<Key>,
     lsn: Lsn,
 
@@ -429,7 +429,7 @@ impl ImageLayerWriter {
     pub fn new(
         conf: &'static PageServerConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         key_range: &Range<Key>,
         lsn: Lsn,
     ) -> anyhow::Result<ImageLayerWriter> {

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -21,7 +21,7 @@ use utils::{
     bin_ser::BeSer,
     lsn::Lsn,
     vec_map::VecMap,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 // avoid binding to Write (conflicts with std::io::Write)
 // while being able to use std::fmt::Write's methods
@@ -32,7 +32,7 @@ use std::sync::RwLock;
 
 pub struct InMemoryLayer {
     conf: &'static PageServerConf,
-    tenantid: ZTenantId,
+    tenantid: TenantId,
     timelineid: ZTimelineId,
 
     ///
@@ -89,7 +89,7 @@ impl Layer for InMemoryLayer {
         None
     }
 
-    fn get_tenant_id(&self) -> ZTenantId {
+    fn get_tenant_id(&self) -> TenantId {
         self.tenantid
     }
 
@@ -239,7 +239,7 @@ impl InMemoryLayer {
     pub fn create(
         conf: &'static PageServerConf,
         timelineid: ZTimelineId,
-        tenantid: ZTenantId,
+        tenantid: TenantId,
         start_lsn: Lsn,
     ) -> Result<InMemoryLayer> {
         trace!(

--- a/pageserver/src/layered_repository/metadata.rs
+++ b/pageserver/src/layered_repository/metadata.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use utils::{
     bin_ser::BeSer,
     lsn::Lsn,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 use crate::config::PageServerConf;
@@ -70,7 +70,7 @@ struct TimelineMetadataBody {
 pub fn metadata_path(
     conf: &'static PageServerConf,
     timelineid: ZTimelineId,
-    tenantid: ZTenantId,
+    tenantid: TenantId,
 ) -> PathBuf {
     conf.timeline_path(&timelineid, &tenantid)
         .join(METADATA_FILE_NAME)

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use utils::{
     lsn::Lsn,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 pub fn range_overlaps<T>(a: &Range<T>, b: &Range<T>) -> bool
@@ -84,7 +84,7 @@ pub enum ValueReconstructResult {
 /// LSN
 ///
 pub trait Layer: Send + Sync {
-    fn get_tenant_id(&self) -> ZTenantId;
+    fn get_tenant_id(&self) -> TenantId;
 
     /// Identify the timeline this layer belongs to
     fn get_timeline_id(&self) -> ZTimelineId;

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -49,7 +49,7 @@ use once_cell::sync::OnceCell;
 use tracing::error;
 use utils::{
     lsn::Lsn,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 use crate::layered_repository::writeback_ephemeral_file;
@@ -108,7 +108,7 @@ enum CacheKey {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 struct MaterializedPageHashKey {
-    tenant_id: ZTenantId,
+    tenant_id: TenantId,
     timeline_id: ZTimelineId,
     key: Key,
 }
@@ -307,7 +307,7 @@ impl PageCache {
     /// returned page.
     pub fn lookup_materialized_page(
         &self,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         timeline_id: ZTimelineId,
         key: &Key,
         lsn: Lsn,
@@ -337,7 +337,7 @@ impl PageCache {
     ///
     pub fn memorize_materialized_page(
         &self,
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         timeline_id: ZTimelineId,
         key: Key,
         lsn: Lsn,

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -438,7 +438,7 @@ pub mod repo_harness {
     use super::*;
     use crate::tenant_config::{TenantConf, TenantConfOpt};
     use hex_literal::hex;
-    use utils::zid::ZTenantId;
+    use utils::zid::TenantId;
 
     pub const TIMELINE_ID: ZTimelineId =
         ZTimelineId::from_array(hex!("11223344556677881122334455667788"));
@@ -480,7 +480,7 @@ pub mod repo_harness {
     pub struct RepoHarness<'a> {
         pub conf: &'static PageServerConf,
         pub tenant_conf: TenantConf,
-        pub tenant_id: ZTenantId,
+        pub tenant_id: TenantId,
 
         pub lock_guard: (
             Option<RwLockReadGuard<'a, ()>>,
@@ -513,7 +513,7 @@ pub mod repo_harness {
 
             let tenant_conf = TenantConf::dummy_conf();
 
-            let tenant_id = ZTenantId::generate();
+            let tenant_id = TenantId::generate();
             fs::create_dir_all(conf.tenant_path(&tenant_id))?;
             fs::create_dir_all(conf.timelines_path(&tenant_id))?;
 

--- a/pageserver/src/storage_sync.rs
+++ b/pageserver/src/storage_sync.rs
@@ -967,10 +967,8 @@ where
         })
         .collect::<FuturesUnordered<_>>();
 
-    let mut new_timeline_states: HashMap<
-        TenantId,
-        HashMap<ZTimelineId, TimelineSyncStatusUpdate>,
-    > = HashMap::new();
+    let mut new_timeline_states: HashMap<TenantId, HashMap<ZTimelineId, TimelineSyncStatusUpdate>> =
+        HashMap::new();
 
     while let Some((sync_id, state_update)) = sync_results.next().await {
         debug!("Finished storage sync task for sync id {sync_id}");

--- a/pageserver/src/tenant_config.rs
+++ b/pageserver/src/tenant_config.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use std::time::Duration;
-use utils::zid::ZTenantId;
+use utils::zid::TenantId;
 
 pub const TENANT_CONFIG_NAME: &str = "config";
 
@@ -204,7 +204,7 @@ impl TenantConf {
 
     /// Points to a place in pageserver's local directory,
     /// where certain tenant's tenantconf file should be located.
-    pub fn path(conf: &'static PageServerConf, tenantid: ZTenantId) -> PathBuf {
+    pub fn path(conf: &'static PageServerConf, tenantid: TenantId) -> PathBuf {
         conf.tenant_path(&tenantid).join(TENANT_CONFIG_NAME)
     }
 

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -288,10 +288,7 @@ pub fn create_tenant_repository(
     }
 }
 
-pub fn update_tenant_config(
-    tenant_conf: TenantConfOpt,
-    tenant_id: TenantId,
-) -> anyhow::Result<()> {
+pub fn update_tenant_config(tenant_conf: TenantConfOpt, tenant_id: TenantId) -> anyhow::Result<()> {
     info!("configuring tenant {tenant_id}");
     let repo = get_repository_for_tenant(tenant_id)?;
 

--- a/pageserver/src/tenant_threads.rs
+++ b/pageserver/src/tenant_threads.rs
@@ -6,12 +6,12 @@ use crate::tenant_mgr::TenantState;
 use anyhow::Result;
 use std::time::Duration;
 use tracing::*;
-use utils::zid::ZTenantId;
+use utils::zid::TenantId;
 
 ///
 /// Compaction thread's main loop
 ///
-pub fn compact_loop(tenantid: ZTenantId) -> Result<()> {
+pub fn compact_loop(tenantid: TenantId) -> Result<()> {
     if let Err(err) = compact_loop_ext(tenantid) {
         error!("compact loop terminated with error: {:?}", err);
         Err(err)
@@ -20,7 +20,7 @@ pub fn compact_loop(tenantid: ZTenantId) -> Result<()> {
     }
 }
 
-fn compact_loop_ext(tenantid: ZTenantId) -> Result<()> {
+fn compact_loop_ext(tenantid: TenantId) -> Result<()> {
     loop {
         if tenant_mgr::get_tenant_state(tenantid) != Some(TenantState::Active) {
             break;
@@ -47,7 +47,7 @@ fn compact_loop_ext(tenantid: ZTenantId) -> Result<()> {
 ///
 /// GC thread's main loop
 ///
-pub fn gc_loop(tenantid: ZTenantId) -> Result<()> {
+pub fn gc_loop(tenantid: TenantId) -> Result<()> {
     loop {
         if tenant_mgr::get_tenant_state(tenantid) != Some(TenantState::Active) {
             break;

--- a/pageserver/src/thread_mgr.rs
+++ b/pageserver/src/thread_mgr.rs
@@ -47,7 +47,7 @@ use tracing::{debug, error, info, warn};
 
 use lazy_static::lazy_static;
 
-use utils::zid::{ZTenantId, ZTimelineId};
+use utils::zid::{TenantId, ZTimelineId};
 
 use crate::shutdown_pageserver;
 
@@ -110,7 +110,7 @@ pub enum ThreadKind {
 
 struct MutableThreadState {
     /// Tenant and timeline that this thread is associated with.
-    tenant_id: Option<ZTenantId>,
+    tenant_id: Option<TenantId>,
     timeline_id: Option<ZTimelineId>,
 
     /// Handle for waiting for the thread to exit. It can be None, if the
@@ -138,7 +138,7 @@ struct PageServerThread {
 ///   of the thread will lead to shutdown of entire process
 pub fn spawn<F>(
     kind: ThreadKind,
-    tenant_id: Option<ZTenantId>,
+    tenant_id: Option<TenantId>,
     timeline_id: Option<ZTimelineId>,
     name: &str,
     shutdown_process_on_error: bool,
@@ -266,7 +266,7 @@ fn thread_wrapper<F>(
 }
 
 // expected to be called from the thread of the given id.
-pub fn associate_with(tenant_id: Option<ZTenantId>, timeline_id: Option<ZTimelineId>) {
+pub fn associate_with(tenant_id: Option<TenantId>, timeline_id: Option<ZTimelineId>) {
     CURRENT_THREAD.with(|ct| {
         let borrowed = ct.borrow();
         let mut thread_mut = borrowed.as_ref().unwrap().mutable.lock().unwrap();
@@ -291,7 +291,7 @@ pub fn associate_with(tenant_id: Option<ZTenantId>, timeline_id: Option<ZTimelin
 ///
 pub fn shutdown_threads(
     kind: Option<ThreadKind>,
-    tenant_id: Option<ZTenantId>,
+    tenant_id: Option<TenantId>,
     timeline_id: Option<ZTimelineId>,
 ) {
     let mut victim_threads = Vec::new();

--- a/pageserver/src/timelines.rs
+++ b/pageserver/src/timelines.rs
@@ -17,7 +17,7 @@ use tracing::*;
 use utils::{
     crashsafe_dir, logging,
     lsn::Lsn,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 use crate::{
@@ -102,7 +102,7 @@ impl LocalTimelineInfo {
     }
 
     pub fn from_repo_timeline<T>(
-        tenant_id: ZTenantId,
+        tenant_id: TenantId,
         timeline_id: ZTimelineId,
         repo_timeline: &RepositoryTimeline<T>,
         include_non_incremental_logical_size: bool,
@@ -130,7 +130,7 @@ pub struct RemoteTimelineInfo {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TimelineInfo {
     #[serde_as(as = "DisplayFromStr")]
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     #[serde_as(as = "DisplayFromStr")]
     pub timeline_id: ZTimelineId,
     pub local: Option<LocalTimelineInfo>,
@@ -145,7 +145,7 @@ pub struct PointInTime {
 
 pub fn init_pageserver(
     conf: &'static PageServerConf,
-    create_tenant: Option<ZTenantId>,
+    create_tenant: Option<TenantId>,
     initial_timeline_id: Option<ZTimelineId>,
 ) -> anyhow::Result<()> {
     // Initialize logger
@@ -181,7 +181,7 @@ pub enum CreateRepo {
 pub fn create_repo(
     conf: &'static PageServerConf,
     tenant_conf: TenantConfOpt,
-    tenant_id: ZTenantId,
+    tenant_id: TenantId,
     create_repo: CreateRepo,
 ) -> Result<Arc<RepositoryImpl>> {
     let (wal_redo_manager, remote_index) = match create_repo {
@@ -279,7 +279,7 @@ fn run_initdb(conf: &'static PageServerConf, initdbpath: &Path) -> Result<()> {
 //
 fn bootstrap_timeline<R: Repository>(
     conf: &'static PageServerConf,
-    tenantid: ZTenantId,
+    tenantid: TenantId,
     tli: ZTimelineId,
     repo: &R,
 ) -> Result<()> {
@@ -320,7 +320,7 @@ fn bootstrap_timeline<R: Repository>(
 }
 
 pub(crate) fn get_local_timelines(
-    tenant_id: ZTenantId,
+    tenant_id: TenantId,
     include_non_incremental_logical_size: bool,
 ) -> Result<Vec<(ZTimelineId, LocalTimelineInfo)>> {
     let repo = tenant_mgr::get_repository_for_tenant(tenant_id)
@@ -344,7 +344,7 @@ pub(crate) fn get_local_timelines(
 
 pub(crate) fn create_timeline(
     conf: &'static PageServerConf,
-    tenant_id: ZTenantId,
+    tenant_id: TenantId,
     new_timeline_id: Option<ZTimelineId>,
     ancestor_timeline_id: Option<ZTimelineId>,
     ancestor_start_lsn: Option<Lsn>,

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -36,7 +36,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
 use tracing::*;
-use utils::{bin_ser::BeSer, lsn::Lsn, nonblock::set_nonblock, zid::ZTenantId};
+use utils::{bin_ser::BeSer, lsn::Lsn, nonblock::set_nonblock, zid::TenantId};
 
 use crate::config::PageServerConf;
 use crate::pgdatadir_mapping::{key_to_rel_block, key_to_slru_block};
@@ -129,7 +129,7 @@ lazy_static! {
 /// records.
 ///
 pub struct PostgresRedoManager {
-    tenantid: ZTenantId,
+    tenantid: TenantId,
     conf: &'static PageServerConf,
 
     process: Mutex<Option<PostgresRedoProcess>>,
@@ -229,7 +229,7 @@ impl PostgresRedoManager {
     ///
     /// Create a new PostgresRedoManager.
     ///
-    pub fn new(conf: &'static PageServerConf, tenantid: ZTenantId) -> PostgresRedoManager {
+    pub fn new(conf: &'static PageServerConf, tenantid: TenantId) -> PostgresRedoManager {
         // The actual process is launched lazily, on first request.
         PostgresRedoManager {
             tenantid,
@@ -603,7 +603,7 @@ impl PostgresRedoProcess {
     //
     // Start postgres binary in special WAL redo mode.
     //
-    fn launch(conf: &PageServerConf, tenantid: &ZTenantId) -> Result<PostgresRedoProcess, Error> {
+    fn launch(conf: &PageServerConf, tenantid: &TenantId) -> Result<PostgresRedoProcess, Error> {
         // FIXME: We need a dummy Postgres cluster to run the process in. Currently, we
         // just create one with constant name. That fails if you try to launch more than
         // one WAL redo manager concurrently.

--- a/safekeeper/src/control_file_upgrade.rs
+++ b/safekeeper/src/control_file_upgrade.rs
@@ -9,7 +9,7 @@ use utils::{
     bin_ser::LeSer,
     lsn::Lsn,
     pq_proto::SystemId,
-    zid::{ZTenantId, ZTimelineId},
+    zid::{TenantId, ZTimelineId},
 };
 
 /// Persistent consensus state of the acceptor.
@@ -45,7 +45,7 @@ pub struct ServerInfoV2 {
     /// Postgres server version
     pub pg_version: u32,
     pub system_id: SystemId,
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     /// Zenith timelineid
     pub ztli: ZTimelineId,
     pub wal_seg_size: u32,
@@ -76,7 +76,7 @@ pub struct ServerInfoV3 {
     pub pg_version: u32,
     pub system_id: SystemId,
     #[serde(with = "hex")]
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     /// Zenith timelineid
     #[serde(with = "hex")]
     pub timeline_id: ZTimelineId,
@@ -106,7 +106,7 @@ pub struct SafeKeeperStateV3 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SafeKeeperStateV4 {
     #[serde(with = "hex")]
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     /// Zenith timelineid
     #[serde(with = "hex")]
     pub timeline_id: ZTimelineId,
@@ -193,7 +193,7 @@ pub fn upgrade_control_file(buf: &[u8], version: u32) -> Result<SafeKeeperState>
             remote_consistent_lsn: Lsn(0),
             peers: Peers(vec![]),
         });
-    // migrate to moving ztenantid/ztli to the top and adding some lsns
+    // migrate to moving tenantid/ztli to the top and adding some lsns
     } else if version == 3 {
         info!("reading safekeeper control file version {}", version);
         let oldstate = SafeKeeperStateV3::des(&buf[..buf.len()])?;

--- a/safekeeper/src/handler.rs
+++ b/safekeeper/src/handler.rs
@@ -18,7 +18,7 @@ use utils::{
     lsn::Lsn,
     postgres_backend::{self, PostgresBackend},
     pq_proto::{BeMessage, FeStartupPacket, RowDescriptor, INT4_OID, TEXT_OID},
-    zid::{ZTenantId, ZTenantTimelineId, ZTimelineId},
+    zid::{TenantId, ZTenantTimelineId, ZTimelineId},
 };
 
 /// Safekeeper handler of postgres commands
@@ -26,7 +26,7 @@ pub struct SafekeeperPostgresHandler {
     pub conf: SafeKeeperConf,
     /// assigned application name
     pub appname: Option<String>,
-    pub ztenantid: Option<ZTenantId>,
+    pub tenantid: Option<TenantId>,
     pub ztimelineid: Option<ZTimelineId>,
     pub timeline: Option<Arc<Timeline>>,
 }
@@ -67,8 +67,8 @@ impl postgres_backend::Handler for SafekeeperPostgresHandler {
     // ztenant id and ztimeline id are passed in connection string params
     fn startup(&mut self, _pgb: &mut PostgresBackend, sm: &FeStartupPacket) -> Result<()> {
         if let FeStartupPacket::StartupMessage { params, .. } = sm {
-            self.ztenantid = match params.get("ztenantid") {
-                Some(z) => Some(ZTenantId::from_str(z)?), // just curious, can I do that from .map?
+            self.tenantid = match params.get("tenantid") {
+                Some(z) => Some(TenantId::from_str(z)?), // just curious, can I do that from .map?
                 _ => None,
             };
 
@@ -95,7 +95,7 @@ impl postgres_backend::Handler for SafekeeperPostgresHandler {
         let create = !(matches!(cmd, SafekeeperPostgresCommand::StartReplication { .. })
             || matches!(cmd, SafekeeperPostgresCommand::IdentifySystem));
 
-        let tenantid = self.ztenantid.context("tenantid is required")?;
+        let tenantid = self.tenantid.context("tenantid is required")?;
         let timelineid = self.ztimelineid.context("timelineid is required")?;
         if self.timeline.is_none() {
             self.timeline.set(
@@ -132,7 +132,7 @@ impl SafekeeperPostgresHandler {
         SafekeeperPostgresHandler {
             conf,
             appname: None,
-            ztenantid: None,
+            tenantid: None,
             ztimelineid: None,
             timeline: None,
         }

--- a/safekeeper/src/http/models.rs
+++ b/safekeeper/src/http/models.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use utils::zid::{NodeId, ZTenantId, ZTimelineId};
+use utils::zid::{NodeId, TenantId, ZTimelineId};
 
 #[derive(Serialize, Deserialize)]
 pub struct TimelineCreateRequest {
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     pub timeline_id: ZTimelineId,
     pub peer_ids: Vec<NodeId>,
 }

--- a/safekeeper/src/http/routes.rs
+++ b/safekeeper/src/http/routes.rs
@@ -20,7 +20,7 @@ use utils::{
         RequestExt, RouterBuilder,
     },
     lsn::Lsn,
-    zid::{NodeId, ZTenantId, ZTenantTimelineId, ZTimelineId},
+    zid::{NodeId, TenantId, ZTenantTimelineId, ZTimelineId},
 };
 
 use super::models::TimelineCreateRequest;
@@ -65,7 +65,7 @@ struct AcceptorStateStatus {
 #[derive(Debug, Serialize)]
 struct TimelineStatus {
     #[serde(serialize_with = "display_serialize")]
-    tenant_id: ZTenantId,
+    tenant_id: TenantId,
     #[serde(serialize_with = "display_serialize")]
     timeline_id: ZTimelineId,
     acceptor_state: AcceptorStateStatus,

--- a/safekeeper/src/json_ctrl.rs
+++ b/safekeeper/src/json_ctrl.rs
@@ -100,7 +100,7 @@ fn prepare_safekeeper(spg: &mut SafekeeperPostgresHandler) -> Result<()> {
         proposer_id: [0u8; 16],
         system_id: 0,
         ztli: spg.ztimelineid.unwrap(),
-        tenant_id: spg.ztenantid.unwrap(),
+        tenant_id: spg.tenantid.unwrap(),
         tli: 0,
         wal_seg_size: pg_constants::WAL_SEGMENT_SIZE as u32, // 16MB, default for tests
     });

--- a/safekeeper/src/lib.rs
+++ b/safekeeper/src/lib.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use url::Url;
 
-use utils::zid::{NodeId, ZTenantId, ZTenantTimelineId};
+use utils::zid::{NodeId, TenantId, ZTenantTimelineId};
 
 pub mod broker;
 pub mod control_file;
@@ -60,7 +60,7 @@ pub struct SafeKeeperConf {
 }
 
 impl SafeKeeperConf {
-    pub fn tenant_dir(&self, tenant_id: &ZTenantId) -> PathBuf {
+    pub fn tenant_dir(&self, tenant_id: &TenantId) -> PathBuf {
         self.workdir.join(tenant_id.to_string())
     }
 

--- a/safekeeper/src/safekeeper.rs
+++ b/safekeeper/src/safekeeper.rs
@@ -24,7 +24,7 @@ use utils::{
     bin_ser::LeSer,
     lsn::Lsn,
     pq_proto::{SystemId, ZenithFeedback},
-    zid::{NodeId, ZTenantId, ZTenantTimelineId, ZTimelineId},
+    zid::{NodeId, TenantId, ZTenantTimelineId, ZTimelineId},
 };
 
 pub const SK_MAGIC: u32 = 0xcafeceefu32;
@@ -169,7 +169,7 @@ pub struct Peers(pub Vec<(NodeId, PeerInfo)>);
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SafeKeeperState {
     #[serde(with = "hex")]
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     /// Zenith timelineid
     #[serde(with = "hex")]
     pub timeline_id: ZTimelineId,
@@ -265,7 +265,7 @@ pub struct ProposerGreeting {
     pub system_id: SystemId,
     /// Zenith timelineid
     pub ztli: ZTimelineId,
-    pub tenant_id: ZTenantId,
+    pub tenant_id: TenantId,
     pub tli: TimeLineID,
     pub wal_seg_size: u32,
 }

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -22,7 +22,7 @@ use tracing::*;
 use utils::{
     lsn::Lsn,
     pq_proto::ZenithFeedback,
-    zid::{NodeId, ZTenantId, ZTenantTimelineId},
+    zid::{NodeId, TenantId, ZTenantTimelineId},
 };
 
 use crate::control_file;
@@ -764,7 +764,7 @@ impl GlobalTimelines {
     /// There may be a race if new timelines are created simultaneously.
     pub async fn delete_force_all_for_tenant(
         conf: &SafeKeeperConf,
-        tenant_id: &ZTenantId,
+        tenant_id: &TenantId,
     ) -> Result<HashMap<ZTenantTimelineId, TimelineDeleteForceResult>> {
         info!("deleting all timelines for tenant {}", tenant_id);
         let mut to_delete = HashMap::new();

--- a/test_runner/batch_others/test_tenant_relocation.py
+++ b/test_runner/batch_others/test_tenant_relocation.py
@@ -207,8 +207,8 @@ def test_tenant_relocation(neon_env_builder: NeonEnvBuilder,
         # needs to be streamed to the new pageserver
         # TODO (rodionov) use attach to start replication
         with pg_cur(PgProtocol(host='localhost', port=new_pageserver_pg_port)) as cur:
-            # "callmemaybe {} {} host={} port={} options='-c ztimelineid={} ztenantid={}'"
-            safekeeper_connstring = f"host=localhost port={env.safekeepers[0].port.pg} options='-c ztimelineid={timeline} ztenantid={tenant} pageserver_connstr=postgresql://no_user:@localhost:{new_pageserver_pg_port}'"
+            # "callmemaybe {} {} host={} port={} options='-c ztimelineid={} tenantid={}'"
+            safekeeper_connstring = f"host=localhost port={env.safekeepers[0].port.pg} options='-c ztimelineid={timeline} tenantid={tenant} pageserver_connstr=postgresql://no_user:@localhost:{new_pageserver_pg_port}'"
             cur.execute("callmemaybe {} {} {}".format(tenant.hex,
                                                       timeline.hex,
                                                       safekeeper_connstring))

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1798,7 +1798,7 @@ class Safekeeper:
 
         # "replication=0" hacks psycopg not to send additional queries
         # on startup, see https://github.com/psycopg/psycopg2/pull/482
-        connstr = f"host=localhost port={self.port.pg} replication=0 options='-c ztimelineid={timeline_id.hex} ztenantid={tenant_id.hex}'"
+        connstr = f"host=localhost port={self.port.pg} replication=0 options='-c ztimelineid={timeline_id.hex} tenantid={tenant_id.hex}'"
 
         with closing(psycopg2.connect(connstr)) as conn:
             # server doesn't support transactions


### PR DESCRIPTION
this pull request is [part of renaming](https://github.com/neondatabase/neon/issues/1702) `zenith` references, and replacing them with `neon`. additional details,
- In this particular pull request, `ZTenantId` is replaced with `TenantId`.
- I plan to follow with a few more pull requests each replacing `ZTenantTimelineId`, `ZTimelineId` with `TenantTimelineId`, `TimelineId` respectively.



note: this pull-request depends on following -
- [ ] merging [change-set in neon/postgres](https://github.com/neondatabase/postgres/pull/168), 
- [ ] bump up `vendor/postgres` git sub-module to point to the `neon/postgres` main