### PR TITLE
Added invariant check for project name.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ff05a702273012438132f449575dbc804e27b2f3cbe3069aa237d26c98fa33"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.9",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,12 +752,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
 name = "debugid"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "der-parser"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -760,6 +819,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1732,6 +1802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e20717fa0541f39bd146692035c37bedfa532b3e5071b35761082407546b2a"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,6 +2328,7 @@ dependencies = [
  "url",
  "utils",
  "workspace_hack",
+ "x509-parser",
 ]
 
 [[package]]
@@ -2618,6 +2698,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -3058,6 +3147,18 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
 
 [[package]]
 name = "tar"
@@ -3919,6 +4020,24 @@ dependencies = [
  "tokio-util 0.7.0",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
+dependencies = [
+ "asn1-rs",
+ "base64",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.9",
 ]
 
 [[package]]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -39,6 +39,9 @@ utils = { path = "../libs/utils" }
 metrics = { path = "../libs/metrics" }
 workspace_hack = { version = "0.1", path = "../workspace_hack" }
 
+x509-parser = "0.13.2"
+substring = "1.4.5"
+
 [dev-dependencies]
 rcgen = "0.8.14"
 rstest = "0.12"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -40,7 +40,6 @@ metrics = { path = "../libs/metrics" }
 workspace_hack = { version = "0.1", path = "../workspace_hack" }
 
 x509-parser = "0.13.2"
-substring = "1.4.5"
 
 [dev-dependencies]
 rcgen = "0.8.14"

--- a/proxy/src/auth/backend/console.rs
+++ b/proxy/src/auth/backend/console.rs
@@ -74,8 +74,6 @@ pub enum AuthInfo {
 pub(super) struct Api<'a> {
     endpoint: &'a ApiUrl,
     creds: &'a ClientCredentials,
-    /// Cache project name, since we'll need it several times.
-    project: &'a str,
 }
 
 impl<'a> Api<'a> {
@@ -84,7 +82,6 @@ impl<'a> Api<'a> {
         Ok(Self {
             endpoint,
             creds,
-            project: creds.project_name.as_str(),
         })
     }
 
@@ -100,7 +97,7 @@ impl<'a> Api<'a> {
         let mut url = self.endpoint.clone();
         url.path_segments_mut().push("proxy_get_role_secret");
         url.query_pairs_mut()
-            .append_pair("project", self.project)
+            .append_pair("project", self.creds.project_name.as_str())
             .append_pair("role", &self.creds.user);
 
         // TODO: use a proper logger
@@ -123,7 +120,7 @@ impl<'a> Api<'a> {
     async fn wake_compute(&self) -> Result<DatabaseInfo> {
         let mut url = self.endpoint.clone();
         url.path_segments_mut().push("proxy_wake_compute");
-        url.query_pairs_mut().append_pair("project", self.project);
+        url.query_pairs_mut().append_pair("project", self.creds.project_name.as_str());
 
         // TODO: use a proper logger
         println!("cplane request: {url}");

--- a/proxy/src/auth/backend/console.rs
+++ b/proxy/src/auth/backend/console.rs
@@ -19,7 +19,7 @@ pub type Result<T> = std::result::Result<T, ConsoleAuthError>;
 #[derive(Debug, Error)]
 pub enum ConsoleAuthError {
     #[error(transparent)]
-    BadProjectName(#[from] auth::credentials::ProjectNameError),
+    BadProjectName(#[from] auth::credentials::ClientCredsParseError),
 
     // We shouldn't include the actual secret here.
     #[error("Bad authentication secret")]
@@ -84,7 +84,7 @@ impl<'a> Api<'a> {
         Ok(Self {
             endpoint,
             creds,
-            project: creds.project_name()?,
+            project: creds.project_name.as_str(),
         })
     }
 

--- a/proxy/src/auth/backend/console.rs
+++ b/proxy/src/auth/backend/console.rs
@@ -94,7 +94,7 @@ impl<'a> Api<'a> {
         let mut url = self.endpoint.clone();
         url.path_segments_mut().push("proxy_get_role_secret");
         url.query_pairs_mut()
-            .append_pair("project", self.creds.project_name.as_str())
+            .append_pair("project", &self.creds.project_name)
             .append_pair("role", &self.creds.user);
 
         // TODO: use a proper logger
@@ -118,7 +118,7 @@ impl<'a> Api<'a> {
         let mut url = self.endpoint.clone();
         url.path_segments_mut().push("proxy_wake_compute");
         url.query_pairs_mut()
-            .append_pair("project", self.creds.project_name.as_str());
+            .append_pair("project", &self.creds.project_name);
 
         // TODO: use a proper logger
         println!("cplane request: {url}");

--- a/proxy/src/auth/backend/console.rs
+++ b/proxy/src/auth/backend/console.rs
@@ -79,10 +79,7 @@ pub(super) struct Api<'a> {
 impl<'a> Api<'a> {
     /// Construct an API object containing the auth parameters.
     pub(super) fn new(endpoint: &'a ApiUrl, creds: &'a ClientCredentials) -> Result<Self> {
-        Ok(Self {
-            endpoint,
-            creds,
-        })
+        Ok(Self { endpoint, creds })
     }
 
     /// Authenticate the existing user or throw an error.
@@ -120,7 +117,8 @@ impl<'a> Api<'a> {
     async fn wake_compute(&self) -> Result<DatabaseInfo> {
         let mut url = self.endpoint.clone();
         url.path_segments_mut().push("proxy_wake_compute");
-        url.query_pairs_mut().append_pair("project", self.creds.project_name.as_str());
+        url.query_pairs_mut()
+            .append_pair("project", self.creds.project_name.as_str());
 
         // TODO: use a proper logger
         println!("cplane request: {url}");

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -114,7 +114,7 @@ mod tests_for_project_name_from_sni_data {
         let common_name = "localtest.me";
         let sni_data = format!("{target_project_name}.{common_name}");
         assert_eq!(
-            project_name_from_sni_data(sni_data.as_str(), common_name).ok(),
+            project_name_from_sni_data(&sni_data, common_name).ok(),
             Some(target_project_name.to_string())
         );
     }
@@ -128,7 +128,7 @@ mod tests_for_project_name_from_sni_data {
         let wrong_common_name = format!("wrong{wrong_suffix}");
         let sni_data = format!("{target_project_name}.{wrong_common_name}");
         assert_eq!(
-            project_name_from_sni_data(sni_data.as_str(), common_name).err(),
+            project_name_from_sni_data(&sni_data, common_name).err(),
             Some(ClientCredsParseError::InconsistentCommonNameAndSNI(
                 common_name.to_string(),
                 sni_data
@@ -238,7 +238,7 @@ mod tests_for_project_name_only {
                     let target_project_name =
                         format!("{project_name_prefix}{illegal_char}{project_name_suffix}");
                     assert_eq!(
-                        get_project_name(None, common_name, Some(target_project_name.as_str()))
+                        get_project_name(None, common_name, Some(&target_project_name))
                             .err(),
                         Some(ClientCredsParseError::ProjectNameContainsIllegalChars(
                             target_project_name

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -117,8 +117,8 @@ mod tests_for_project_name_from_sni_data {
         let common_name = "localtest.me";
         let sni_data = format!("{target_project_name}.{common_name}");
         assert_eq!(
-            project_name_from_sni_data(&sni_data, common_name).ok(),
-            Some(target_project_name.to_string())
+            project_name_from_sni_data(&sni_data, common_name),
+            Ok(target_project_name.to_string())
         );
     }
 
@@ -131,8 +131,8 @@ mod tests_for_project_name_from_sni_data {
         let wrong_common_name = format!("wrong{wrong_suffix}");
         let sni_data = format!("{target_project_name}.{wrong_common_name}");
         assert_eq!(
-            project_name_from_sni_data(&sni_data, common_name).err(),
-            Some(ClientCredsParseError::InconsistentCommonNameAndSNI(
+            project_name_from_sni_data(&sni_data, common_name),
+            Err(ClientCredsParseError::InconsistentCommonNameAndSNI(
                 common_name.to_string(),
                 sni_data
             ))
@@ -185,8 +185,8 @@ mod tests_for_project_name_only {
         let common_name = "localtest.me";
         let sni_data = format!("{target_project_name}.{common_name}");
         assert_eq!(
-            get_project_name(Some(&sni_data), Some(common_name), None).ok(),
-            Some(target_project_name.to_string())
+            get_project_name(Some(&sni_data), Some(common_name), None),
+            Ok(target_project_name.to_string())
         );
     }
 
@@ -205,8 +205,8 @@ mod tests_for_project_name_only {
                     format!("{project_name_prefix}{illegal_char}{project_name_suffix}");
                 let sni_data = format!("{target_project_name}.{common_name}");
                 assert_eq!(
-                    get_project_name(Some(&sni_data), Some(common_name), None).err(),
-                    Some(ClientCredsParseError::ProjectNameContainsIllegalChars(
+                    get_project_name(Some(&sni_data), Some(common_name), None),
+                    Err(ClientCredsParseError::ProjectNameContainsIllegalChars(
                         target_project_name
                     ))
                 );
@@ -220,8 +220,8 @@ mod tests_for_project_name_only {
         let common_names = [Some("localtest.me"), None];
         for common_name in common_names {
             assert_eq!(
-                get_project_name(None, common_name, Some(target_project_name)).ok(),
-                Some(target_project_name.to_string())
+                get_project_name(None, common_name, Some(target_project_name)),
+                Ok(target_project_name.to_string())
             );
         }
     }
@@ -241,8 +241,8 @@ mod tests_for_project_name_only {
                     let target_project_name =
                         format!("{project_name_prefix}{illegal_char}{project_name_suffix}");
                     assert_eq!(
-                        get_project_name(None, common_name, Some(&target_project_name)).err(),
-                        Some(ClientCredsParseError::ProjectNameContainsIllegalChars(
+                        get_project_name(None, common_name, Some(&target_project_name)),
+                        Err(ClientCredsParseError::ProjectNameContainsIllegalChars(
                             target_project_name
                         ))
                     );
@@ -261,9 +261,8 @@ mod tests_for_project_name_only {
                 Some(&sni_data),
                 Some(common_name),
                 Some(target_project_name)
-            )
-            .ok(),
-            Some(target_project_name.to_string())
+            ),
+            Ok(target_project_name.to_string())
         );
     }
 
@@ -274,8 +273,8 @@ mod tests_for_project_name_only {
         let common_name = "localtest.me";
         let sni_data = format!("{wrong_project_name}.{common_name}");
         assert_eq!(
-            get_project_name(Some(&sni_data), Some(common_name), Some(project_name_param)).err(),
-            Some(ClientCredsParseError::InconsistentProjectNameAndSNI(
+            get_project_name(Some(&sni_data), Some(common_name), Some(project_name_param)),
+            Err(ClientCredsParseError::InconsistentProjectNameAndSNI(
                 wrong_project_name.to_string(),
                 project_name_param.to_string()
             ))
@@ -295,8 +294,8 @@ mod tests_for_project_name_only {
         for sni_data in sni_datas {
             for project_name_param in project_names {
                 assert_eq!(
-                    get_project_name(sni_data.as_deref(), None, project_name_param).err(),
-                    Some(ClientCredsParseError::CommonNameNotSet)
+                    get_project_name(sni_data.as_deref(), None, project_name_param),
+                    Err(ClientCredsParseError::CommonNameNotSet)
                 );
             }
         }
@@ -318,9 +317,8 @@ mod tests_for_project_name_only {
         for project_name_param in project_names {
             for sni_data in &sni_datas {
                 assert_eq!(
-                    get_project_name(sni_data.as_deref(), Some(common_name), project_name_param)
-                        .err(),
-                    Some(ClientCredsParseError::InconsistentCommonNameAndSNI(
+                    get_project_name(sni_data.as_deref(), Some(common_name), project_name_param),
+                    Err(ClientCredsParseError::InconsistentCommonNameAndSNI(
                         common_name.to_string(),
                         sni_data.clone().unwrap().to_string()
                     ))

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -44,18 +44,19 @@ impl ClientCredentials {
 }
 
 #[derive(Debug, Error)]
+#[derive(PartialEq)]
 pub enum ProjectNameError {
     #[error("SNI is missing. EITHER please upgrade the postgres client library OR pass the project name as a parameter: '...&options=project%3D<project-name>...'.")]
     Missing,
 
-    #[error("Inconsistent project name inferred from SNI and project option. String from SNI: '{0}', String from project option: '{1}'")]
+    #[error("Inconsistent project name inferred from SNI and project option. Project name from SNI: '{0}', Project name from project option: '{1}'")]
     InconsistentProjectNameAndSNI(String, String),
 
     #[error("Common name is not set.")]
     CommonNameNotSet,
 
-    #[error("Inconsistent common name and SNI suffix. Expected common name: '{0}', SNI: '{1}'")]
-    InconsistentCommonNameAndSNI(String, String),
+    #[error("Inconsistent common name and SNI suffix. Common name: '{0}', SNI: '{1}', SNI suffix: '{2}'")]
+    InconsistentCommonNameAndSNI(String, String, String),
 
     #[error("Project name must contain only alphanumeric characters and hyphens ('-'). Project name: '{0}'.")]
     ProjectNameContainsIllegalChars(String),
@@ -64,6 +65,10 @@ pub enum ProjectNameError {
 impl UserFacingError for ProjectNameError {}
 
 /// Inferring project name from sni_data.
+/// If common_name is None, throws an CommonNameNotSet error,
+/// otherwise checks if common_name is suffix to sni_data.
+/// if common_name is not suffix to sni_data throws InconsistentCommonNameAndSNI error,
+/// otherwise returns the prefix of sni_data without the common_name suffix.
 fn project_name_from_sni_data<'sni>(
     sni_data: &'sni str,
     common_name: &Option<String>,
@@ -81,6 +86,7 @@ fn project_name_from_sni_data<'sni>(
         return Err(ProjectNameError::InconsistentCommonNameAndSNI(
             common_name.to_string(),
             sni_data.to_string(),
+            sni_suffix.to_string(),
         ));
     }
 
@@ -88,45 +94,199 @@ fn project_name_from_sni_data<'sni>(
     Ok(sni_data.substring(0, sni_data.len() - common_name.len()))
 }
 
-impl ClientCredentials {
-    /// Determine project name from SNI or from project_name parameter from options argument.
-    pub fn project_name(&self) -> Result<&str, ProjectNameError> {
-        // Checking that if both sni_data and project_name are set, then they should match
-        // otherwise, throws a ProjectNameError::Inconsistent error.
-        if let Some(sni_data) = &self.sni_data {
-            let project_name_from_sni_data =
-                project_name_from_sni_data(sni_data, &self.common_name)?;
-            if let Some(project_name_from_options) = &self.project_name {
-                if !project_name_from_options.eq(project_name_from_sni_data) {
-                    return Err(ProjectNameError::InconsistentProjectNameAndSNI(
-                        project_name_from_sni_data.to_string(),
-                        project_name_from_options.to_string(),
+#[cfg(test)]
+mod tests_for_project_name_from_sni_data {
+    use super::*;
+
+    #[test]
+    fn passing() {
+        let target_project_name = "my-project-123";
+        let common_name = String::from(".localtest.me");
+        let sni_data = target_project_name.to_string() + common_name.as_str();
+        assert_eq!(project_name_from_sni_data(sni_data.as_str(), &Some(common_name)).ok(), Some(target_project_name));
+    }
+
+    #[test]
+    fn throws_common_name_not_set() {
+        let target_project_name = "my-project-123";
+        let common_name = String::from(".localtest.me");
+        let sni_data = target_project_name.to_string() + common_name.as_str();
+        assert_eq!(project_name_from_sni_data(sni_data.as_str(), &None).err(), Some(ProjectNameError::CommonNameNotSet));
+    }
+
+    #[test]
+    fn throws_inconsistent_common_name_and_sni_data()  {
+        let target_project_name = "my-project-123";
+        let common_name = String::from(".localtest.me");
+        let wrong_suffix = "_localtest.me";
+        assert_eq!(common_name.len(), wrong_suffix.len());
+        let wrong_common_name = ".wrong".to_string() + wrong_suffix;
+        let sni_data = target_project_name.to_string() + wrong_common_name.as_str();
+        assert_eq!(
+            project_name_from_sni_data(sni_data.as_str(), &Some(common_name.clone())).err(),
+            Some(ProjectNameError::InconsistentCommonNameAndSNI(common_name, sni_data, wrong_suffix.to_string())));
+    }
+}
+
+/// Determine project name from SNI or from project_name parameter from options argument.
+fn project_name<'ret>(sni_data : &'ret Option<String>, common_name : &Option<String>, project_name : &'ret Option<String>) -> Result<&'ret str, ProjectNameError>
+{
+    // Checking that if both sni_data and project_name are set, then they should match
+    // otherwise, throws a ProjectNameError::Inconsistent error.
+    if let Some(sni_data) = sni_data {
+        let project_name_from_sni_data =
+            project_name_from_sni_data(sni_data, common_name)?;
+        if let Some(project_name_from_options) = &project_name {
+            if !project_name_from_options.eq(project_name_from_sni_data) {
+                return Err(ProjectNameError::InconsistentProjectNameAndSNI(
+                    project_name_from_sni_data.to_string(),
+                    project_name_from_options.to_string(),
+                ));
+            }
+        }
+    }
+
+    // determine the project name from self.sni_data if it exists, otherwise from self.project_name.
+    let ret = match &sni_data {
+        // if sni_data exists, use it to determine project name
+        Some(sni_data) => project_name_from_sni_data(sni_data, &common_name)?,
+        // otherwise use project_option if it was manually set thought options parameter.
+        None => project_name
+            .as_ref()
+            .ok_or(ProjectNameError::Missing)?
+            .as_str(),
+    };
+
+    // checking that formatting invariant holds.
+    // project name must contain only alphanumeric characters and hyphens.
+    if !ret.chars().all(|x: char| x.is_alphanumeric() || x == '-') {
+        return Err(ProjectNameError::ProjectNameContainsIllegalChars(
+            ret.to_string(),
+        ));
+    }
+
+    Ok(ret)
+}
+
+#[cfg(test)]
+mod tests_for_project_name_only {
+    use super::*;
+
+    #[test]
+    fn passing_from_sni_data_only() {
+        let target_project_name = "my-project-123";
+        let common_name = String::from(".localtest.me");
+        let sni_data = target_project_name.to_string() + common_name.as_str();
+        assert_eq!(project_name(&Some(sni_data), &Some(common_name), &None).ok(), Some(target_project_name));
+    }
+
+    #[test]
+    fn throws_project_name_contains_illegal_chars_from_sni_data_only() {
+        let project_name_prefix = "my-project";
+        let project_name_suffix = "123";
+        let common_name = String::from(".localtest.me");
+
+        for illegal_char_id in 0..256 {
+            let illegal_char : char = char::from_u32(illegal_char_id).unwrap();
+            if !(illegal_char.is_alphanumeric() || illegal_char == '-') && illegal_char.to_string().len() == 1 {
+                let target_project_name = format!("{}{}{}", project_name_prefix.to_string(), illegal_char, project_name_suffix);
+                let sni_data = target_project_name.to_string() + common_name.as_str();
+                assert_eq!(project_name(&Some(sni_data), &Some(common_name.clone()), &None).err(), Some(
+                    ProjectNameError::ProjectNameContainsIllegalChars(target_project_name)
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn passing_from_project_name_only() {
+        let target_project_name = "my-project-123";
+        let common_names = [Some(String::from(".localtest.me")), None];
+        for common_name in common_names {
+            assert_eq!(project_name(&None, &common_name, &Some(target_project_name.to_string())).ok(), Some(target_project_name));
+        }
+    }
+
+    #[test]
+    fn throws_project_name_contains_illegal_chars_from_project_name_only() {
+        let project_name_prefix = "my-project";
+        let project_name_suffix = "123";
+        let common_names = [Some(String::from(".localtest.me")), None];
+
+        for common_name in common_names {
+            for illegal_char_id in 0..256 {
+                let illegal_char: char = char::from_u32(illegal_char_id).unwrap();
+                if !(illegal_char.is_alphanumeric() || illegal_char == '-') && illegal_char.to_string().len() == 1 {
+                    let target_project_name = format!("{}{}{}", project_name_prefix.to_string(), illegal_char, project_name_suffix);
+                    assert_eq!(project_name(&None, &common_name, &Some(target_project_name.to_string())).err(), Some(
+                        ProjectNameError::ProjectNameContainsIllegalChars(target_project_name)
                     ));
                 }
             }
         }
+    }
 
-        // determine the project name from self.sni_data if it exists, otherwise from self.project_name.
-        let ret = match &self.sni_data {
-            // if sni_data exists, use it to determine project name
-            Some(sni_data) => project_name_from_sni_data(sni_data, &self.common_name)?,
-            // otherwise use project_option if it was manually set thought options parameter.
-            None => self
-                .project_name
-                .as_ref()
-                .ok_or(ProjectNameError::Missing)?
-                .as_str(),
-        };
+    #[test]
+    fn passing_from_sni_data_and_project_name() {
+        let target_project_name = "my-project-123";
+        let common_name = String::from(".localtest.me");
+        let sni_data = target_project_name.to_string() + common_name.as_str();
+        assert_eq!(project_name(&Some(sni_data), &Some(common_name), &Some(target_project_name.to_string())).ok(), Some(target_project_name));
+    }
 
-        // checking that formatting invariant holds.
-        // project name must contain only alphanumeric characters and hyphens.
-        if !ret.chars().all(|x: char| x.is_alphanumeric() || x == '-') {
-            return Err(ProjectNameError::ProjectNameContainsIllegalChars(
-                ret.to_string(),
-            ));
+    #[test]
+    fn throws_inconsistent_project_name_and_sni() {
+        let project_name_param = "my-project-123";
+        let wrong_project_name = "not-my-project-123";
+        let common_name = String::from(".localtest.me");
+        let sni_data = wrong_project_name.to_string() + common_name.as_str();
+        assert_eq!(project_name(&Some(sni_data.clone()), &Some(common_name), &Some(project_name_param.to_string())).err(),
+                   Some(ProjectNameError::InconsistentProjectNameAndSNI(wrong_project_name.to_string(), project_name_param.to_string())));
+    }
+
+    #[test]
+    fn throws_common_name_not_set() {
+        let target_project_name = "my-project-123";
+        let wrong_project_name = "not-my-project-123";
+        let common_name = String::from(".localtest.me");
+        let sni_datas = [
+            Some(wrong_project_name.to_string() + common_name.as_str()),
+            Some(target_project_name.to_string() + common_name.as_str())];
+        let project_names = [None, Some(target_project_name.to_string())];
+        for sni_data in sni_datas {
+            for project_name_param in &project_names {
+                assert_eq!(project_name(&sni_data, &None, &project_name_param).err(),
+                           Some(ProjectNameError::CommonNameNotSet));
+            }
         }
+    }
 
-        Ok(ret)
+    #[test]
+    fn throws_inconsistent_common_name_and_sni_data()  {
+        let target_project_name = "my-project-123";
+        let wrong_project_name = "not-my-project-123";
+        let common_name = String::from(".localtest.me");
+        let wrong_suffix = "_localtest.me";
+        assert_eq!(common_name.len(), wrong_suffix.len());
+        let wrong_common_name = ".wrong".to_string() + wrong_suffix;
+        let sni_datas = [
+            Some(wrong_project_name.to_string() + wrong_common_name.as_str()),
+            Some(target_project_name.to_string() + wrong_common_name.as_str())];
+        let project_names = [None, Some(target_project_name.to_string())];
+        for sni_data in sni_datas {
+            for project_name_param in &project_names {
+                assert_eq!(
+                    project_name(&sni_data.clone(), &Some(common_name.clone()), &project_name_param).err(),
+                    Some(ProjectNameError::InconsistentCommonNameAndSNI(common_name.to_string(), sni_data.clone().unwrap(), wrong_suffix.to_string())));
+            }
+        }
+    }
+}
+
+impl ClientCredentials {
+    /// Determine project name from SNI or from project_name parameter from options argument.
+    pub fn project_name(&self) -> Result<&str, ProjectNameError> {
+        return project_name(&self.sni_data, &self.common_name, &self.project_name);
     }
 }
 

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -69,19 +69,23 @@ impl ClientCredentials {
 
 #[derive(Debug, Error, PartialEq)]
 pub enum ProjectNameError {
-    #[error("SNI is missing. EITHER please upgrade the postgres client library OR pass the project name as a parameter: '...&options=project%3D<project-name>...'.")]
+    #[error(
+        "Project name is not specified. \
+        EITHER please upgrade the postgres client library (libpq) for SNI support \
+        OR pass the project name as a parameter: '&options=project%3D<project-name>'."
+    )]
     Missing,
 
-    #[error("Inconsistent project name inferred from SNI and project option. Project name from SNI: '{0}', Project name from project option: '{1}'")]
+    #[error("Inconsistent project name inferred from SNI ('{0}') and project option ('{1}').")]
     InconsistentProjectNameAndSNI(String, String),
 
     #[error("Common name is not set.")]
     CommonNameNotSet,
 
-    #[error("Inconsistent common name and SNI suffix. Common name: '{0}', SNI: '{1}'")]
+    #[error("Inconsistent common name ('{0}') and SNI suffix (SNI: '{1}').")]
     InconsistentCommonNameAndSNI(&'static str, String),
 
-    #[error("Project name must contain only alphanumeric characters and hyphens ('-'). Project name: '{0}'.")]
+    #[error("Project name ('{0}') must contain only alphanumeric characters and hyphens ('-').")]
     ProjectNameContainsIllegalChars(String),
 }
 

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -65,7 +65,7 @@ impl UserFacingError for ProjectNameError {}
 
 /// Inferring project name from sni_data.
 fn project_name_from_sni_data<'sni>(
-    sni_data: &'sni String,
+    sni_data: &'sni str,
     common_name: &Option<String>,
 ) -> Result<&'sni str, ProjectNameError> {
     // extract common name. If unset, throw a CommonNameNotSet error.

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -64,9 +64,10 @@ pub enum ProjectNameError {
 impl UserFacingError for ProjectNameError {}
 
 /// Inferring project name from sni_data.
-/// Used in ClientCredentials::project_name(...).
-fn project_name_from_sni_data<'a>(sni_data : &'a String, common_name : &Option<String>) -> Result<&'a str, ProjectNameError>
-{
+fn project_name_from_sni_data<'sni>(
+    sni_data: &'sni String,
+    common_name: &Option<String>,
+) -> Result<&'sni str, ProjectNameError> {
     // extract common name. If unset, throw a CommonNameNotSet error.
     let common_name = match &common_name {
         Some(common_name) => common_name,
@@ -75,15 +76,16 @@ fn project_name_from_sni_data<'a>(sni_data : &'a String, common_name : &Option<S
 
     // check that the common name passed from common_name is the actual suffix in sni_data.
     use substring::Substring;
-    let sni_suffix = sni_data.substring(
-        sni_data.len()-common_name.len(), sni_data.len());
+    let sni_suffix = sni_data.substring(sni_data.len() - common_name.len(), sni_data.len());
     if !sni_suffix.eq(common_name) {
         return Err(ProjectNameError::InconsistentCommonNameAndSNI(
-            common_name.to_string(), sni_data.to_string()));
+            common_name.to_string(),
+            sni_data.to_string(),
+        ));
     }
 
     // return sni_data without the common name suffix.
-    Ok(sni_data.substring(0, sni_data.len()-common_name.len()))
+    Ok(sni_data.substring(0, sni_data.len() - common_name.len()))
 }
 
 impl ClientCredentials {
@@ -118,8 +120,10 @@ impl ClientCredentials {
 
         // checking that formatting invariant holds.
         // project name must contain only alphanumeric characters and hyphens.
-        if !ret.chars().all(|x : char| x.is_alphanumeric() || x == '-') {
-            return Err(ProjectNameError::ProjectNameContainsIllegalChars(ret.to_string()));
+        if !ret.chars().all(|x: char| x.is_alphanumeric() || x == '-') {
+            return Err(ProjectNameError::ProjectNameContainsIllegalChars(
+                ret.to_string(),
+            ));
         }
 
         Ok(ret)
@@ -145,7 +149,7 @@ impl TryFrom<HashMap<String, String>> for ClientCredentials {
             dbname,
             sni_data: None,
             project_name,
-            common_name : None,
+            common_name: None,
         })
     }
 }

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -26,7 +26,10 @@ pub enum ClientCredsParseError {
     #[error("Common name is not set.")]
     CommonNameNotSet,
 
-    #[error("SNI ('{1}') inconsistently formatted with respect to common name ('{0}'). SNI should be formatted as '<project-name>.<common-name>'.")]
+    #[error(
+        "SNI ('{1}') inconsistently formatted with respect to common name ('{0}'). \
+        SNI should be formatted as '<project-name>.<common-name>'."
+    )]
     InconsistentCommonNameAndSNI(String, String),
 
     #[error("Project name ('{0}') must contain only alphanumeric characters and hyphens ('-').")]
@@ -238,8 +241,7 @@ mod tests_for_project_name_only {
                     let target_project_name =
                         format!("{project_name_prefix}{illegal_char}{project_name_suffix}");
                     assert_eq!(
-                        get_project_name(None, common_name, Some(&target_project_name))
-                            .err(),
+                        get_project_name(None, common_name, Some(&target_project_name)).err(),
                         Some(ClientCredsParseError::ProjectNameContainsIllegalChars(
                             target_project_name
                         ))

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -31,6 +31,9 @@ pub struct ClientCredentials {
     // In case sni_data is missing: project_name is used to determine cluster name.
     // In case sni_data is available: project_name and sni_data should match (otherwise throws an error).
     pub project_name: Option<String>,
+
+    // common name is extracted from server.crt and used as help to determine project name from SNI.
+    pub common_name: Option<String>,
 }
 
 impl ClientCredentials {
@@ -45,14 +48,43 @@ pub enum ProjectNameError {
     #[error("SNI is missing. EITHER please upgrade the postgres client library OR pass the project name as a parameter: '...&options=project%3D<project-name>...'.")]
     Missing,
 
-    #[error("SNI is malformed.")]
-    Bad,
-
     #[error("Inconsistent project name inferred from SNI and project option. String from SNI: '{0}', String from project option: '{1}'")]
-    Inconsistent(String, String),
+    InconsistentProjectNameAndSNI(String, String),
+
+    #[error("Common name is not set.")]
+    CommonNameNotSet,
+
+    #[error("Inconsistent common name and SNI suffix. Expected common name: '{0}', SNI: '{1}'")]
+    InconsistentCommonNameAndSNI(String, String),
+
+    #[error("Project name must contain only alphanumeric characters and hyphens ('-'). Project name: '{0}'.")]
+    ProjectNameContainsIllegalChars(String),
 }
 
 impl UserFacingError for ProjectNameError {}
+
+/// Inferring project name from sni_data.
+/// Used in ClientCredentials::project_name(...).
+fn project_name_from_sni_data<'a>(sni_data : &'a String, common_name : &Option<String>) -> Result<&'a str, ProjectNameError>
+{
+    // extract common name. If unset, throw a CommonNameNotSet error.
+    let common_name = match &common_name {
+        Some(common_name) => common_name,
+        None => return Err(ProjectNameError::CommonNameNotSet),
+    };
+
+    // check that the common name passed from common_name is the actual suffix in sni_data.
+    use substring::Substring;
+    let sni_suffix = sni_data.substring(
+        sni_data.len()-common_name.len(), sni_data.len());
+    if !sni_suffix.eq(common_name) {
+        return Err(ProjectNameError::InconsistentCommonNameAndSNI(
+            common_name.to_string(), sni_data.to_string()));
+    }
+
+    // return sni_data without the common name suffix.
+    Ok(sni_data.substring(0, sni_data.len()-common_name.len()))
+}
 
 impl ClientCredentials {
     /// Determine project name from SNI or from project_name parameter from options argument.
@@ -61,20 +93,21 @@ impl ClientCredentials {
         // otherwise, throws a ProjectNameError::Inconsistent error.
         if let Some(sni_data) = &self.sni_data {
             let project_name_from_sni_data =
-                sni_data.split_once('.').ok_or(ProjectNameError::Bad)?.0;
+                project_name_from_sni_data(sni_data, &self.common_name)?;
             if let Some(project_name_from_options) = &self.project_name {
                 if !project_name_from_options.eq(project_name_from_sni_data) {
-                    return Err(ProjectNameError::Inconsistent(
+                    return Err(ProjectNameError::InconsistentProjectNameAndSNI(
                         project_name_from_sni_data.to_string(),
                         project_name_from_options.to_string(),
                     ));
                 }
             }
         }
+
         // determine the project name from self.sni_data if it exists, otherwise from self.project_name.
         let ret = match &self.sni_data {
             // if sni_data exists, use it to determine project name
-            Some(sni_data) => sni_data.split_once('.').ok_or(ProjectNameError::Bad)?.0,
+            Some(sni_data) => project_name_from_sni_data(sni_data, &self.common_name)?,
             // otherwise use project_option if it was manually set thought options parameter.
             None => self
                 .project_name
@@ -82,6 +115,13 @@ impl ClientCredentials {
                 .ok_or(ProjectNameError::Missing)?
                 .as_str(),
         };
+
+        // checking that formatting invariant holds.
+        // project name must contain only alphanumeric characters and hyphens.
+        if !ret.chars().all(|x : char| x.is_alphanumeric() || x == '-') {
+            return Err(ProjectNameError::ProjectNameContainsIllegalChars(ret.to_string()));
+        }
+
         Ok(ret)
     }
 }
@@ -105,6 +145,7 @@ impl TryFrom<HashMap<String, String>> for ClientCredentials {
             dbname,
             sni_data: None,
             project_name,
+            common_name : None,
         })
     }
 }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -2,7 +2,6 @@ use crate::url::ApiUrl;
 use anyhow::{bail, ensure, Context};
 use std::{str::FromStr, sync::Arc};
 
-
 #[derive(Debug)]
 pub enum AuthBackendType {
     /// Legacy Cloud API (V1).

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -43,13 +43,6 @@ pub struct TlsConfig {
 }
 
 impl TlsConfig {
-    #[cfg(test)]
-    pub fn new(tls_config: Arc<rustls::ServerConfig>) -> TlsConfig {
-        TlsConfig {
-            tls_config,
-            common_name: None,
-        }
-    }
     pub fn get_tls_config(self) -> Arc<rustls::ServerConfig> {
         self.tls_config
     }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -60,10 +60,11 @@ pub fn configure_tls(key_path: &str, cert_path: &str) -> anyhow::Result<TlsConfi
     };
 
     // read PEM file at cert_path.
-    let pem_file = std::fs::File::open(cert_path)?;
-    let pem_buffer_reader = std::io::BufReader::new(pem_file);
-    let pem = x509_parser::pem::Pem::read(pem_buffer_reader)
-        .context("TLS cert file")?
+    let cert_file = std::fs::File::open(cert_path)
+        .context("Failed to open TLS cert file at '{cert_path}.'")?;
+    let buffer_reader = std::io::BufReader::new(cert_file);
+    let pem = x509_parser::pem::Pem::read(buffer_reader)
+        .context("Failed to read from buffer reader of cert file at '{cert_path'}")?
         .0;
     let cert_chain = {
         let cert_chain_bytes = &pem.contents;

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -38,13 +38,13 @@ pub struct ProxyConfig {
 
 #[derive(Clone)]
 pub struct TlsConfig {
-    pub tls_config: Arc<rustls::ServerConfig>,
-    pub common_name: Option<&'static str>,
+    pub config: Arc<rustls::ServerConfig>,
+    pub common_name: Option<String>,
 }
 
 impl TlsConfig {
-    pub fn get_tls_config(self) -> Arc<rustls::ServerConfig> {
-        self.tls_config
+    pub fn to_server_config(&self) -> Arc<rustls::ServerConfig> {
+        self.config.clone()
     }
 }
 
@@ -90,8 +90,7 @@ pub fn configure_tls(key_path: &str, cert_path: &str) -> anyhow::Result<TlsConfi
         let option_common_name = almost_common_name.strip_prefix(expected_prefix);
         let common_name = match option_common_name {
             Some(common_name) => {
-                let leaked_str: &'static str =
-                    Box::<str>::leak(common_name.to_string().into_boxed_str());
+                let leaked_str = common_name.to_string();
                 Some(leaked_str)
             }
             None => None,
@@ -100,7 +99,7 @@ pub fn configure_tls(key_path: &str, cert_path: &str) -> anyhow::Result<TlsConfi
     };
 
     Ok(TlsConfig {
-        tls_config: config.into(),
+        config: config.into(),
         common_name,
     })
 }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -93,11 +93,12 @@ pub fn configure_tls(key_path: &str, cert_path: &str) -> anyhow::Result<TlsConfi
             .subject
             .to_string();
         let expected_prefix = "CN=*.";
-        let common_name = almost_common_name
-            .strip_prefix(expected_prefix)
-            .unwrap_or("Expected {expected_prefix} prefix before the common name.")
-            .to_string();
-        common_name
+        let option_common_name = almost_common_name.strip_prefix(expected_prefix);
+        let common_name = match option_common_name {
+            Some(common_name) => common_name,
+            None => panic!("Expected {expected_prefix} prefix before the common name."),
+        };
+        common_name.to_string()
     };
     Ok(TlsConfig {
         tls_config: config.into(),

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -60,8 +60,8 @@ pub fn configure_tls(key_path: &str, cert_path: &str) -> anyhow::Result<TlsConfi
     };
 
     // read PEM file at cert_path.
-    let cert_file = std::fs::File::open(cert_path)
-        .context("Failed to open TLS cert file at '{cert_path}.'")?;
+    let cert_file =
+        std::fs::File::open(cert_path).context("Failed to open TLS cert file at '{cert_path}.'")?;
     let buffer_reader = std::io::BufReader::new(cert_file);
     let pem = x509_parser::pem::Pem::read(buffer_reader)
         .context("Failed to read from buffer reader of cert file at '{cert_path'}")?

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -87,15 +87,8 @@ pub fn configure_tls(key_path: &str, cert_path: &str) -> anyhow::Result<TlsConfi
     let common_name = {
         let almost_common_name = pem.parse_x509()?.tbs_certificate.subject.to_string();
         let expected_prefix = "CN=*.";
-        let option_common_name = almost_common_name.strip_prefix(expected_prefix);
-        let common_name = match option_common_name {
-            Some(common_name) => {
-                let leaked_str = common_name.to_string();
-                Some(leaked_str)
-            }
-            None => None,
-        };
-        common_name
+        let common_name = almost_common_name.strip_prefix(expected_prefix);
+        common_name.map(str::to_string)
     };
 
     Ok(TlsConfig {

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -2,6 +2,7 @@ use crate::url::ApiUrl;
 use anyhow::{bail, ensure, Context};
 use std::{str::FromStr, sync::Arc};
 
+
 #[derive(Debug)]
 pub enum AuthBackendType {
     /// Legacy Cloud API (V1).
@@ -34,6 +35,9 @@ pub struct ProxyConfig {
     pub auth_backend: AuthBackendType,
     pub auth_endpoint: ApiUrl,
     pub auth_link_uri: ApiUrl,
+
+    // common name is extracted from server.crt and used as help to determine project name from SNI.
+    pub common_name: Option<String>,
 }
 
 pub type TlsConfig = Arc<rustls::ServerConfig>;

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -36,7 +36,6 @@ pub struct ProxyConfig {
     pub auth_link_uri: ApiUrl,
 }
 
-#[derive(Clone)]
 pub struct TlsConfig {
     pub config: Arc<rustls::ServerConfig>,
     pub common_name: Option<String>,
@@ -77,7 +76,8 @@ pub fn configure_tls(key_path: &str, cert_path: &str) -> anyhow::Result<TlsConfi
         // allow TLS 1.2 to be compatible with older client libraries
         .with_protocol_versions(&[&rustls::version::TLS13, &rustls::version::TLS12])?
         .with_no_client_auth()
-        .with_single_cert(cert_chain, key)?;
+        .with_single_cert(cert_chain, key)?
+        .into();
 
     // determine common name from tls-cert (-c server.crt param).
     // used in asserting project name formatting invariant.
@@ -94,7 +94,7 @@ pub fn configure_tls(key_path: &str, cert_path: &str) -> anyhow::Result<TlsConfi
     };
 
     Ok(TlsConfig {
-        config: config.into(),
+        config,
         common_name,
     })
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -118,33 +118,11 @@ async fn main() -> anyhow::Result<()> {
     let mgmt_address: SocketAddr = arg_matches.value_of("mgmt").unwrap().parse()?;
     let http_address: SocketAddr = arg_matches.value_of("http").unwrap().parse()?;
 
-    // determine common name from tls-cert (-c server.crt param).
-    // used in asserting project name formatting invariant.
-    let common_name = match arg_matches.value_of("tls-cert") {
-        Some(cert_path) => {
-            let file = std::fs::File::open(cert_path)?;
-            let almost_common_name = x509_parser::pem::Pem::read(std::io::BufReader::new(file))?
-                .0
-                .parse_x509()?
-                .tbs_certificate
-                .subject
-                .to_string();
-            let expected_prefix = "CN=*";
-            let common_name = almost_common_name
-                .strip_prefix(expected_prefix)
-                .unwrap_or("Expected 'CN=*' prefix before the common name.")
-                .to_string();
-            Some(common_name)
-        }
-        None => None,
-    };
-
     let config: &ProxyConfig = Box::leak(Box::new(ProxyConfig {
         tls_config,
         auth_backend: arg_matches.value_of("auth-backend").unwrap().parse()?,
         auth_endpoint: arg_matches.value_of("auth-endpoint").unwrap().parse()?,
         auth_link_uri: arg_matches.value_of("uri").unwrap().parse()?,
-        common_name,
     }));
 
     println!("Version: {GIT_VERSION}");

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -24,9 +24,9 @@ use clap::{App, Arg};
 use config::ProxyConfig;
 use futures::FutureExt;
 use std::{future::Future, net::SocketAddr};
+use substring::Substring;
 use tokio::{net::TcpListener, task::JoinError};
 use utils::project_git_version;
-use substring::Substring;
 
 project_git_version!(GIT_VERSION);
 
@@ -125,13 +125,18 @@ async fn main() -> anyhow::Result<()> {
         Some(cert_path) => {
             let file = std::fs::File::open(cert_path).unwrap();
             let almost_common_name = x509_parser::pem::Pem::read(std::io::BufReader::new(file))
-                .unwrap().0
-                .parse_x509().unwrap()
-                .tbs_certificate.subject.to_string();
+                .unwrap()
+                .0
+                .parse_x509()
+                .unwrap()
+                .tbs_certificate
+                .subject
+                .to_string();
             let prefix = "CN=*";
             // making sure formatting is as expected: almost_common_name = "'CN=*'[<common name>]"
             assert_eq!(almost_common_name.substring(0, prefix.len()), prefix);
-            Some(almost_common_name.substring(prefix.len(), almost_common_name.len()).to_string())
+            let common_name = almost_common_name.substring(prefix.len(), almost_common_name.len());
+            Some(common_name.to_string())
         }
         None => None,
     };

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -24,7 +24,6 @@ use clap::{App, Arg};
 use config::ProxyConfig;
 use futures::FutureExt;
 use std::{future::Future, net::SocketAddr};
-use substring::Substring;
 use tokio::{net::TcpListener, task::JoinError};
 use utils::project_git_version;
 
@@ -130,11 +129,12 @@ async fn main() -> anyhow::Result<()> {
                 .tbs_certificate
                 .subject
                 .to_string();
-            let prefix = "CN=*";
-            // making sure formatting is as expected: almost_common_name = "'CN=*'[<common name>]"
-            assert_eq!(almost_common_name.substring(0, prefix.len()), prefix);
-            let common_name = almost_common_name.substring(prefix.len(), almost_common_name.len());
-            Some(common_name.to_string())
+            let expected_prefix = "CN=*";
+            let common_name = almost_common_name
+                .strip_prefix(expected_prefix)
+                .unwrap_or("Expected 'CN=*' prefix before the common name.")
+                .to_string();
+            Some(common_name)
         }
         None => None,
     };

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -123,7 +123,7 @@ async fn main() -> anyhow::Result<()> {
     // used in asserting project name formatting invariant.
     let common_name = match arg_matches.value_of("tls-cert") {
         Some(cert_path) => {
-            let file = std::fs::File::open(cert_path).unwrap();
+            let file = std::fs::File::open(cert_path)?;
             let almost_common_name = x509_parser::pem::Pem::read(std::io::BufReader::new(file))
                 .unwrap()
                 .0

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -124,11 +124,9 @@ async fn main() -> anyhow::Result<()> {
     let common_name = match arg_matches.value_of("tls-cert") {
         Some(cert_path) => {
             let file = std::fs::File::open(cert_path)?;
-            let almost_common_name = x509_parser::pem::Pem::read(std::io::BufReader::new(file))
-                .unwrap()
+            let almost_common_name = x509_parser::pem::Pem::read(std::io::BufReader::new(file))?
                 .0
-                .parse_x509()
-                .unwrap()
+                .parse_x509()?
                 .tbs_certificate
                 .subject
                 .to_string();

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -352,7 +352,6 @@ mod tests {
         let cancel_map = CancelMap::default();
         let (mut stream, _creds) = handshake(client, tls, &cancel_map, &None)
             .await?
-
             .context("handshake failed")?;
 
         auth.authenticate(&mut stream).await?;

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -271,10 +271,12 @@ mod tests {
     }
 
     /// Generate TLS certificates and build rustls configs for client and server.
-    fn generate_tls_config(hostname: &str) -> anyhow::Result<(ClientConfig<'_>, TlsConfig)> {
+    fn generate_tls_config(
+        hostname: &'static str,
+    ) -> anyhow::Result<(ClientConfig<'_>, TlsConfig)> {
         let (ca, cert, key) = generate_certs(hostname)?;
 
-        let server_config = {
+        let tls_config = {
             let config = rustls::ServerConfig::builder()
                 .with_safe_defaults()
                 .with_no_client_auth()
@@ -296,7 +298,13 @@ mod tests {
             ClientConfig { config, hostname }
         };
 
-        Ok((client_config, TlsConfig::new(server_config)))
+        Ok((
+            client_config,
+            TlsConfig {
+                tls_config,
+                common_name: Some(hostname),
+            },
+        ))
     }
 
     #[async_trait]

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -33,8 +33,8 @@ lazy_static! {
 
 /// A small combinator for pluggable error logging.
 async fn log_error<R, F>(future: F) -> F::Output
-    where
-        F: std::future::Future<Output = anyhow::Result<R>>,
+where
+    F: std::future::Future<Output = anyhow::Result<R>>,
 {
     future.await.map_err(|err| {
         println!("error: {}", err);

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -81,8 +81,8 @@ async fn handle_client(
         NUM_CONNECTIONS_CLOSED_COUNTER.inc();
     }
 
-    let tls_config = config.tls_config.clone();
-    let (stream, creds) = match handshake(stream, tls_config, cancel_map).await? {
+    let tls = config.tls_config.clone();
+    let (stream, creds) = match handshake(stream, tls, cancel_map).await? {
         Some(x) => x,
         None => return Ok(()), // it's a cancellation request
     };

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -155,7 +155,7 @@ async fn handshake<S: AsyncRead + AsyncWrite + Unpin>(
 
                 // Construct credentials
                 let creds =
-                    auth::ClientCredentials::parse(params, sni_data.as_deref(), common_name.as_deref());
+                    auth::ClientCredentials::parse(params, sni_data.as_deref(), common_name);
                 let creds = async { creds }.or_else(|e| stream.throw_error(e)).await?;
 
                 break Ok(Some((stream, creds)));

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -380,7 +380,7 @@ mod tests {
         let (client, server) = tokio::io::duplex(1024);
 
         let (_, server_config) =
-            generate_tls_config("handshake-tls-is-enforced-by-proxy.localhost", "localhost")?;
+            generate_tls_config("generic-project-name.localhost", "localhost")?;
         let proxy = tokio::spawn(dummy_proxy(client, Some(server_config), NoAuth));
 
         let client_err = tokio_postgres::Config::new()
@@ -409,7 +409,7 @@ mod tests {
         let (client, server) = tokio::io::duplex(1024);
 
         let (client_config, server_config) =
-            generate_tls_config("handshake-tls.localhost", "localhost")?;
+            generate_tls_config("generic-project-name.localhost", "localhost")?;
         let proxy = tokio::spawn(dummy_proxy(client, Some(server_config), NoAuth));
 
         let (_client, _conn) = tokio_postgres::Config::new()
@@ -431,7 +431,7 @@ mod tests {
         let (_client, _conn) = tokio_postgres::Config::new()
             .user("john_doe")
             .dbname("earth")
-            .options("project=handshake-raw")
+            .options("project=generic-project-name")
             .ssl_mode(SslMode::Prefer)
             .connect_raw(server, NoTls)
             .await?;
@@ -494,7 +494,7 @@ mod tests {
         let (client, server) = tokio::io::duplex(1024);
 
         let (client_config, server_config) =
-            generate_tls_config("scram-auth-good.localhost", "localhost")?;
+            generate_tls_config("generic-project-name.localhost", "localhost")?;
         let proxy = tokio::spawn(dummy_proxy(
             client,
             Some(server_config),
@@ -517,7 +517,7 @@ mod tests {
         let (client, server) = tokio::io::duplex(1024);
 
         let (client_config, server_config) =
-            generate_tls_config("scram-auth-mock.localhost", "localhost")?;
+            generate_tls_config("generic-project-name.localhost", "localhost")?;
         let proxy = tokio::spawn(dummy_proxy(
             client,
             Some(server_config),

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -157,7 +157,8 @@ async fn handshake<S: AsyncRead + AsyncWrite + Unpin>(
                 };
 
                 // Construct credentials
-                let creds = auth::ClientCredentials::parse(params, sni_data, common_name);
+                let creds =
+                    auth::ClientCredentials::parse(params, sni_data.as_deref(), common_name);
                 let creds = async { creds }.or_else(|e| stream.throw_error(e)).await?;
 
                 break Ok(Some((stream, creds)));

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -269,10 +269,10 @@ mod tests {
     }
 
     /// Generate TLS certificates and build rustls configs for client and server.
-    fn generate_tls_config(
-        hostname: &'static str,
-        common_name: &'static str,
-    ) -> anyhow::Result<(ClientConfig<'static>, TlsConfig)> {
+    fn generate_tls_config<'a>(
+        hostname: &'a str,
+        common_name: &'a str,
+    ) -> anyhow::Result<(ClientConfig<'a>, TlsConfig)> {
         let (ca, cert, key) = generate_certs(hostname)?;
 
         let tls_config = {
@@ -297,13 +297,12 @@ mod tests {
             ClientConfig { config, hostname }
         };
 
-        Ok((
-            client_config,
-            TlsConfig {
-                config: tls_config,
-                common_name: Some(common_name.to_string()),
-            },
-        ))
+        let tls_config = TlsConfig {
+            config: tls_config,
+            common_name: Some(common_name.to_string()),
+        };
+
+        Ok((client_config, tls_config))
     }
 
     #[async_trait]

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -350,8 +350,9 @@ mod tests {
         auth: impl TestAuth + Send,
     ) -> anyhow::Result<()> {
         let cancel_map = CancelMap::default();
-        let (mut stream, _creds) = handshake(client, tls, &cancel_map)
+        let (mut stream, _creds) = handshake(client, tls, &cancel_map, &None)
             .await?
+
             .context("handshake failed")?;
 
         auth.authenticate(&mut stream).await?;

--- a/test_runner/batch_others/test_proxy.py
+++ b/test_runner/batch_others/test_proxy.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def test_proxy_select_1(static_proxy):
-    static_proxy.safe_psql("select 1;")
+    static_proxy.safe_psql("select 1;", options="project=test-proxy-select-1")
 
 
 # Pass extra options to the server.

--- a/test_runner/batch_others/test_proxy.py
+++ b/test_runner/batch_others/test_proxy.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def test_proxy_select_1(static_proxy):
-    static_proxy.safe_psql("select 1;", options="project=test-proxy-select-1")
+    static_proxy.safe_psql("select 1;", options="project=generic-project-name")
 
 
 # Pass extra options to the server.


### PR DESCRIPTION
Resolving issue #1805 

### Summary
Added invariant check that throws an error if the inferred project name contains a character outside the set {alphanumeric U '-'}.

#### Note
Used common name from server.crt to determine project name from SNI (the common name is the suffix).

### Behavior

Start the proxy with 

> ./target/debug/proxy -c server.crt -k server.key --auth-backend=console

In another terminal, if you start a postgres instance without the correct name formatting, it throws an error:

> Kliments-MBP:neon klimentserafimov$ psql 'postgres://my_cluster_123.localtest.me:4432/main?sslmode=require'
psql: error: connection to server at "my_cluster_123.localtest.me" (127.0.0.1), port 4432 failed: ERROR:  Project name must contain only alphanumeric characters and hyphens ('-'). Project name: 'my_cluster_123'.

Here, underscores ('_') are not allowed.

Otherwise, it works as expected.

#### Untested behavior:
This functionality requires the common name to be set, otherwise it throws a "Common name is not set." error.