### PR TITLE
Parallelize performance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,7 +770,6 @@ workflows:
           context: PERF_TEST_RESULT_CONNSTR
           build_type: release
           test_selection: performance
-          run_in_parallel: false
           save_perf_report: true
           requires:
             - build-neon-release

--- a/test_runner/fixtures/benchmark_fixture.py
+++ b/test_runner/fixtures/benchmark_fixture.py
@@ -170,7 +170,7 @@ class NeonBenchmarker:
                 "name": metric_name,
                 "value": metric_value,
                 "unit": unit,
-                "report": report,
+                "report": str(report),
             },
         )
 

--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -156,8 +156,10 @@ class VanillaCompare(PgCompare):
     def __init__(self, zenbenchmark, vanilla_pg: VanillaPostgres):
         self._pg = vanilla_pg
         self._zenbenchmark = zenbenchmark
-        vanilla_pg.configure(
-            ['shared_buffers=1MB', 'synchronous_commit=off', f'port={vanilla_pg.port}'])
+        vanilla_pg.configure([
+            'shared_buffers=1MB',
+            'synchronous_commit=off',
+        ])
         vanilla_pg.start()
 
         # Long-lived cursor, useful for flushing

--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -156,10 +156,8 @@ class VanillaCompare(PgCompare):
     def __init__(self, zenbenchmark, vanilla_pg: VanillaPostgres):
         self._pg = vanilla_pg
         self._zenbenchmark = zenbenchmark
-        vanilla_pg.configure([
-            'shared_buffers=1MB',
-            'synchronous_commit=off',
-        ])
+        vanilla_pg.configure(
+            ['shared_buffers=1MB', 'synchronous_commit=off', f'port={vanilla_pg.port}'])
         vanilla_pg.start()
 
         # Long-lived cursor, useful for flushing

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1378,6 +1378,7 @@ class VanillaPostgres(PgProtocol):
         self.pgdatadir = pgdatadir
         self.pg_bin = pg_bin
         self.running = False
+        self.port = port
         self.pg_bin.run_capture(['initdb', '-D', pgdatadir])
 
     def configure(self, options: List[str]):
@@ -1413,10 +1414,13 @@ class VanillaPostgres(PgProtocol):
 
 
 @pytest.fixture(scope='function')
-def vanilla_pg(test_output_dir: str) -> Iterator[VanillaPostgres]:
+def vanilla_pg(test_output_dir: str,
+               port_distributor: PortDistributor) -> Iterator[VanillaPostgres]:
     pgdatadir = os.path.join(test_output_dir, "pgdata-vanilla")
     pg_bin = PgBin(test_output_dir)
-    with VanillaPostgres(pgdatadir, pg_bin, 5432) as vanilla_pg:
+    port = port_distributor.get_port()
+    log.info(f"Start vanilla PG on {port}")
+    with VanillaPostgres(pgdatadir, pg_bin, port) as vanilla_pg:
         yield vanilla_pg
 
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1382,7 +1382,7 @@ class VanillaPostgres(PgProtocol):
         self.pg_bin.run_capture(['initdb', '-D', pgdatadir])
 
         with open(os.path.join(self.pgdatadir, 'postgresql.conf'), 'a') as conf_file:
-            conf_file.write(f"port={self.port}")
+            conf_file.write(f"port={self.port}\n")
 
     def configure(self, options: List[str]):
         """Append lines into postgresql.conf file."""


### PR DESCRIPTION
This PR adds changes to allow running performance tests in parallel. Currently, our performance test workflow runs in under 20min, but as we [add more tests](https://github.com/neondatabase/neon/pull/1891), it will become significantly slower. Making them run in parallel will help reduce the wait time.

## Changes
- configure to run multiple vanilla PGs on different ports
  + fix proxy tests as a result of the above change
- update CI to allow performance tests run in parallel