### PR TITLE
Fix zero timeline_start_lsn

### DIFF
--- a/safekeeper/src/control_file_upgrade.rs
+++ b/safekeeper/src/control_file_upgrade.rs
@@ -247,6 +247,7 @@ pub fn upgrade_control_file(buf: &[u8], version: u32) -> Result<SafeKeeperState>
         }
 
         // set special timeline_start_lsn because we don't know the real one
+        info!("setting timeline_start_lsn and local_start_lsn to Lsn(1)");
         oldstate.timeline_start_lsn = Lsn(1);
         oldstate.local_start_lsn = Lsn(1);
 

--- a/safekeeper/src/control_file_upgrade.rs
+++ b/safekeeper/src/control_file_upgrade.rs
@@ -239,6 +239,18 @@ pub fn upgrade_control_file(buf: &[u8], version: u32) -> Result<SafeKeeperState>
             remote_consistent_lsn: Lsn(0),
             peers: Peers(vec![]),
         });
+    } else if version == 5 {
+        info!("reading safekeeper control file version {}", version);
+        let mut oldstate = SafeKeeperState::des(&buf[..buf.len()])?;
+        if oldstate.timeline_start_lsn != Lsn(0) {
+            return Ok(oldstate);
+        }
+
+        // set special timeline_start_lsn because we don't know the real one
+        oldstate.timeline_start_lsn = Lsn(1);
+        oldstate.local_start_lsn = Lsn(1);
+
+        return Ok(oldstate);
     }
     bail!("unsupported safekeeper control file version {}", version)
 }

--- a/safekeeper/src/safekeeper.rs
+++ b/safekeeper/src/safekeeper.rs
@@ -28,7 +28,7 @@ use utils::{
 };
 
 pub const SK_MAGIC: u32 = 0xcafeceefu32;
-pub const SK_FORMAT_VERSION: u32 = 5;
+pub const SK_FORMAT_VERSION: u32 = 6;
 const SK_PROTOCOL_VERSION: u32 = 2;
 const UNKNOWN_SERVER_VERSION: u32 = 0;
 

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -625,8 +625,7 @@ impl GlobalTimelines {
         zttid: ZTenantTimelineId,
         create: bool,
     ) -> Result<Arc<Timeline>> {
-        let _enter =
-            info_span!("", timeline = %zttid.tenant_id).entered();
+        let _enter = info_span!("", timeline = %zttid.tenant_id).entered();
 
         let mut state = TIMELINES_STATE.lock().unwrap();
 

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -625,6 +625,9 @@ impl GlobalTimelines {
         zttid: ZTenantTimelineId,
         create: bool,
     ) -> Result<Arc<Timeline>> {
+        let _enter =
+            info_span!("", timeline = %zttid.tenant_id).entered();
+
         let mut state = TIMELINES_STATE.lock().unwrap();
 
         match state.timelines.get(&zttid) {


### PR DESCRIPTION
Currently there is a problem with old timelines, which are created before we introduced `timeline_start_lsn`. This problem is zero `timeline_start_lsn` and incorrect `local_start_lsn`. More specifically, we have the following code:

https://github.com/neondatabase/neon/blob/84b9fcbbd59d7cfaa4181f2f1b6869d248070be0/safekeeper/src/safekeeper.rs#L707-L717

This code updates `local_start_lsn` to proposer's start streaming at point. This is ok for new timelines, because `timeline_start_lsn` is not zero and we initialize everything only once. But this is working incorrectly for old timelines, because we don't know `timeline_start_lsn` and this `timeline_start_lsn` is always zero. That's why we change `local_start_lsn` every time, which is wrong.

Fix sets LSNs to Lsn(1), which is very hacky, but works for now and will allow us to fix this later.

Should fix #1980 