### PR TITLE
Fix wal reconnects

### DIFF
--- a/pageserver/src/tenant_config.rs
+++ b/pageserver/src/tenant_config.rs
@@ -37,7 +37,7 @@ pub mod defaults {
     pub const DEFAULT_PITR_INTERVAL: &str = "30 days";
     pub const DEFAULT_WALRECEIVER_CONNECT_TIMEOUT: &str = "2 seconds";
     pub const DEFAULT_WALRECEIVER_LAGGING_WAL_TIMEOUT: &str = "10 seconds";
-    pub const DEFAULT_MAX_WALRECEIVER_LSN_WAL_LAG: u64 = 10_000;
+    pub const DEFAULT_MAX_WALRECEIVER_LSN_WAL_LAG: u64 = 10 * 1024 * 1024;
 }
 
 /// Per-tenant configuration options


### PR DESCRIPTION
Closes https://github.com/neondatabase/neon/issues/1985

* make `TaskHandle` to detect when its inner tokio task handle finishes
* fix the connection attempts increment logic
* lower priority for SK nodes with numerous unsuccessful connection attempts 

Does not address the high-level etcd subscription tasks' premature finish: now, there's nothing to check if such task had panicked and restart it. Either some channels (that detect that the other pard had been dropped) or `FuturesUnordered` that contain all handles should be introduced, but both of them require some extra code for case of cancelling all tasks and waiting on them to finish. 
In order to fix the CI issue first, a small PR with the fix is created instead.