### PR TITLE
inventory file fix for neon-stress env

### DIFF
--- a/.circleci/ansible/neon-stress.hosts
+++ b/.circleci/ansible/neon-stress.hosts
@@ -12,6 +12,7 @@ pageservers
 safekeepers
 
 [storage:vars]
+env_name = neon-stress
 console_mgmt_base_url = http://neon-stress-console.local
 bucket_name           = neon-storage-ireland
 bucket_region         = eu-west-1


### PR DESCRIPTION
will fix this
```
TASK [upload systemd service definition] ***************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'env_name' is undefined
fatal: [neon-stress-sk-1]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'env_name' is undefined"}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'env_name' is undefined
fatal: [neon-stress-sk-3]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'env_name' is undefined"}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'env_name' is undefined
fatal: [neon-stress-sk-2]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'env_name' is undefined"}
```