### PR TITLE
do not ignore errors during downloading of tenant index parts

### DIFF
--- a/pageserver/src/storage_sync.rs
+++ b/pageserver/src/storage_sync.rs
@@ -1557,6 +1557,7 @@ fn schedule_first_sync_tasks(
     local_timeline_init_statuses
 }
 
+/// bool in return value stands for awaits_download
 fn compare_local_and_remote_timeline(
     new_sync_tasks: &mut VecDeque<(ZTenantTimelineId, SyncTask)>,
     sync_id: ZTenantTimelineId,
@@ -1566,14 +1567,6 @@ fn compare_local_and_remote_timeline(
 ) -> (LocalTimelineInitStatus, bool) {
     let remote_files = remote_entry.stored_files();
 
-    // TODO probably here we need more sophisticated logic,
-    //   if more data is available remotely can we just download what's there?
-    //   without trying to upload something. It may be tricky, needs further investigation.
-    //   For now looks strange that we can request upload
-    //   and download for the same timeline simultaneously.
-    //   (upload needs to be only for previously unsynced files, not whole timeline dir).
-    //   If one of the tasks fails they will be reordered in the queue which can lead
-    //   to timeline being stuck in evicted state
     let number_of_layers_to_download = remote_files.difference(&local_files).count();
     let (initial_timeline_status, awaits_download) = if number_of_layers_to_download > 0 {
         new_sync_tasks.push_back((

--- a/pageserver/src/storage_sync/index.rs
+++ b/pageserver/src/storage_sync/index.rs
@@ -97,8 +97,8 @@ impl RemoteIndex {
 
         for (tenant_id, index_parts) in index_parts {
             match index_parts {
-                // TODO: should we schedule a retry so it can be recovered? otherwise there is no way to revive it other restarting whole pageserver
-                TenantIndexParts::Poisoned(id) => warn!("skipping tenant_id set up for remote index because the index download has failed for timeline {id}"),
+                // TODO: should we schedule a retry so it can be recovered? otherwise we can revive it only through detach/attach or pageserver restart
+                TenantIndexParts::Poisoned { missing, ..} => warn!("skipping tenant_id set up for remote index because the index download has failed for timeline(s): {missing:?}"),
                 TenantIndexParts::Present(timelines) => {
                     for (timeline_id, index_part) in timelines {
                         let timeline_path = conf.timeline_path(&timeline_id, &tenant_id);


### PR DESCRIPTION
Instead of swallowing errors it catches them but this state is not recoverable other than through detach/attach sequence

Misses tests, I wonder should we have a Mock impl of remote storage trait that serves like a proxy to another implementation but randomly (or semi randomly) throws errors. WDYT @SomeoneToIgnore?