### PR TITLE
Move relation size cache from WalIngest to DatadirTimeline

### DIFF
--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -8,7 +8,7 @@ use lazy_static::lazy_static;
 use tracing::*;
 
 use std::cmp::{max, min, Ordering};
-use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::Write;

--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -293,6 +293,11 @@ pub struct LayeredTimeline {
     /// Current logical size of the "datadir", at the last LSN.
     current_logical_size: AtomicIsize,
 
+    /// Information about the last processed message by the WAL receiver,
+    /// or None if WAL receiver has not received anything for this timeline
+    /// yet.
+    pub last_received_wal: Mutex<Option<WalReceiverInfo>>,
+
     /// Relation size cache
     rel_size_cache: RwLock<HashMap<RelTag, (Lsn, BlockNumber)>>,
 }
@@ -650,6 +655,7 @@ impl LayeredTimeline {
             partitioning: Mutex::new((KeyPartitioning::new(), Lsn(0))),
             repartition_threshold: 0,
 
+            last_received_wal: Mutex::new(None),
             rel_size_cache: RwLock::new(HashMap::new()),
         };
         result.repartition_threshold = result.get_checkpoint_distance() / 10;

--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -8,7 +8,7 @@ use lazy_static::lazy_static;
 use tracing::*;
 
 use std::cmp::{max, min, Ordering};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -38,7 +38,9 @@ use crate::layered_repository::{
 
 use crate::config::PageServerConf;
 use crate::keyspace::{KeyPartitioning, KeySpace};
+use crate::pgdatadir_mapping::BlockNumber;
 use crate::pgdatadir_mapping::LsnForTimestamp;
+use crate::reltag::RelTag;
 use crate::tenant_config::TenantConfOpt;
 use crate::DatadirTimeline;
 
@@ -291,10 +293,8 @@ pub struct LayeredTimeline {
     /// Current logical size of the "datadir", at the last LSN.
     current_logical_size: AtomicIsize,
 
-    /// Information about the last processed message by the WAL receiver,
-    /// or None if WAL receiver has not received anything for this timeline
-    /// yet.
-    pub last_received_wal: Mutex<Option<WalReceiverInfo>>,
+    /// Relation size cache
+    rel_size_cache: RwLock<HashMap<RelTag, (Lsn, BlockNumber)>>,
 }
 
 pub struct WalReceiverInfo {
@@ -306,7 +306,38 @@ pub struct WalReceiverInfo {
 /// Inherit all the functions from DatadirTimeline, to provide the
 /// functionality to store PostgreSQL relations, SLRUs, etc. in a
 /// LayeredTimeline.
-impl DatadirTimeline for LayeredTimeline {}
+impl DatadirTimeline for LayeredTimeline {
+    fn get_cached_rel_size(&self, tag: &RelTag, lsn: Lsn) -> Option<BlockNumber> {
+        let rel_size_cache = self.rel_size_cache.read().unwrap();
+        if let Some((cached_lsn, nblocks)) = rel_size_cache.get(tag) {
+            if lsn >= *cached_lsn {
+                return Some(*nblocks);
+            }
+        }
+        None
+    }
+
+    fn update_cached_rel_size(&self, tag: RelTag, lsn: Lsn, nblocks: BlockNumber) {
+        let mut rel_size_cache = self.rel_size_cache.write().unwrap();
+        if let Some((cached_lsn, _cached_nblocks)) = rel_size_cache.get(&tag) {
+            if lsn >= *cached_lsn {
+                rel_size_cache.insert(tag, (lsn, nblocks));
+            }
+        } else {
+            rel_size_cache.insert(tag, (lsn, nblocks));
+        }
+    }
+
+    fn set_cached_rel_size(&self, tag: RelTag, lsn: Lsn, nblocks: BlockNumber) {
+        let mut rel_size_cache = self.rel_size_cache.write().unwrap();
+        rel_size_cache.insert(tag, (lsn, nblocks));
+    }
+
+    fn remove_cached_rel_size(&self, tag: &RelTag) {
+        let mut rel_size_cache = self.rel_size_cache.write().unwrap();
+        rel_size_cache.remove(tag);
+    }
+}
 
 ///
 /// Information about how much history needs to be retained, needed by
@@ -617,7 +648,7 @@ impl LayeredTimeline {
             partitioning: Mutex::new((KeyPartitioning::new(), Lsn(0))),
             repartition_threshold: 0,
 
-            last_received_wal: Mutex::new(None),
+            rel_size_cache: RwLock::new(HashMap::new()),
         };
         result.repartition_threshold = result.get_checkpoint_distance() / 10;
         result

--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -412,8 +412,6 @@ impl Timeline for LayeredTimeline {
 
     /// Look up the value with the given a key
     fn get(&self, key: Key, lsn: Lsn) -> Result<Bytes> {
-        debug_assert!(lsn <= self.get_last_record_lsn());
-
         // Check the page cache. We will get back the most recent page with lsn <= `lsn`.
         // The cached image can be returned directly if there is no WAL between the cached image
         // and requested LSN. The cached image can also be used to reduce the amount of WAL needed

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -462,16 +462,16 @@ pub trait DatadirTimeline: Timeline {
         Ok(result.to_keyspace())
     }
 
-    /// Get cached size of relation if it nt updated fter speified LSN
+    /// Get cached size of relation if it not updated after specified LSN
     fn get_cached_rel_size(&self, tag: &RelTag, lsn: Lsn) -> Option<BlockNumber>;
 
     /// Update cached relation size if there is no more recent update
     fn update_cached_rel_size(&self, tag: RelTag, lsn: Lsn, nblocks: BlockNumber);
 
-    /// Store cached reltion size
+    /// Store cached relation size
     fn set_cached_rel_size(&self, tag: RelTag, lsn: Lsn, nblocks: BlockNumber);
 
-    /// Remove cached reltion size
+    /// Remove cached relation size
     fn remove_cached_rel_size(&self, tag: &RelTag);
 }
 

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -485,7 +485,7 @@ pub struct DatadirModification<'a, T: DatadirTimeline> {
     /// in the state in 'tline' yet.
     pub tline: &'a T,
 
-    /// Lsn assigned by create_modification
+    /// Lsn assigned by begin_modification
     pub lsn: Lsn,
 
     // The modifications are not applied directly to the underlying key-value store.

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -122,6 +122,7 @@ pub trait DatadirTimeline: Timeline {
 
         if let Some(nblocks) = self.get_cached_rel_size(&tag, lsn) {
             return Ok(nblocks);
+        }
 
         if (tag.forknum == pg_constants::FSM_FORKNUM
             || tag.forknum == pg_constants::VISIBILITYMAP_FORKNUM)

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -56,13 +56,16 @@ pub trait DatadirTimeline: Timeline {
     /// This provides a transaction-like interface to perform a bunch
     /// of modifications atomically.
     ///
-    /// To ingest a WAL record, call begin_modification() to get a
+    /// To ingest a WAL record, call begin_modification(lsn) to get a
     /// DatadirModification object. Use the functions in the object to
     /// modify the repository state, updating all the pages and metadata
-    /// that the WAL record affects. When you're done, call commit(lsn) to
-    /// commit the changes. All the changes will be stamped with the specified LSN.
+    /// that the WAL record affects. When you're done, call commit() to
+    /// commit the changes.
     ///
-    /// Calling commit(lsn) will flush all the changes and reset the state,
+    /// Lsn stored in modification is advanced by `ingest_record` and
+    /// is used by `commit()` to update `last_record_lsn`.
+    ///
+    /// Calling commit() will flush all the changes and reset the state,
     /// so the `DatadirModification` struct can be reused to perform the next modification.
     ///
     /// Note that any pending modifications you make through the

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -77,6 +77,7 @@ impl<'a, T: DatadirTimeline> WalIngest<'a, T> {
         modification: &mut DatadirModification<T>,
         decoded: &mut DecodedWALRecord,
     ) -> Result<()> {
+		modification.lsn = lsn;
         decode_wal_record(recdata, decoded).context("failed decoding wal record")?;
 
         let mut buf = decoded.record.clone();

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -942,7 +942,7 @@ impl<'a, T: DatadirTimeline> WalIngest<'a, T> {
         // Check if the relation exists. We implicitly create relations on first
         // record.
         // TODO: would be nice if to be more explicit about it
-        let last_lsn = self.timeline.get_last_record_lsn();
+        let last_lsn = modification.lsn;
         let old_nblocks = if !self.timeline.get_rel_exists(rel, last_lsn)? {
             // create it with 0 size initially, the logic below will extend it
             modification.put_rel_creation(rel, 0)?;

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -77,7 +77,7 @@ impl<'a, T: DatadirTimeline> WalIngest<'a, T> {
         modification: &mut DatadirModification<T>,
         decoded: &mut DecodedWALRecord,
     ) -> Result<()> {
-		modification.lsn = lsn;
+        modification.lsn = lsn;
         decode_wal_record(recdata, decoded).context("failed decoding wal record")?;
 
         let mut buf = decoded.record.clone();

--- a/pageserver/src/walreceiver/walreceiver_connection.rs
+++ b/pageserver/src/walreceiver/walreceiver_connection.rs
@@ -154,7 +154,7 @@ pub async fn handle_walreceiver_connection(
 
                 {
                     let mut decoded = DecodedWALRecord::default();
-                    let mut modification = timeline.begin_modification();
+                    let mut modification = timeline.begin_modification(endlsn);
                     while let Some((lsn, recdata)) = waldecoder.poll_decode()? {
                         // let _enter = info_span!("processing record", lsn = %lsn).entered();
 


### PR DESCRIPTION
We need relation size cache in timeline to speed up getting relation size without accessing storage.
It may be critical for creating new branch when logical size of new branch is calculated.
See discussion at https://app.slack.com/client/T026T3BRN0P/C036U0GRMRB/thread/C036U0GRMRB-1657747809.541039