### PR TITLE
Move code style checks in CI to be part of the main build job.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -117,7 +117,15 @@ jobs:
             CARGO_FLAGS="--release --features profiling"
           fi
 
-          "${cov_prefix[@]}" mold -run cargo build $CARGO_FLAGS --features failpoints --bins --tests
+          "${cov_prefix[@]}" mold -run cargo build $CARGO_FLAGS --features failpoints --all --all-targets
+
+      - name: Check formatting
+        if: matrix.build_type == 'debug'
+        run: cargo fmt --all -- --check
+
+      - name: Run cargo clippy
+        if: matrix.build_type == 'debug'
+        run: ./run_clippy.sh
 
       - name: Run cargo test
         run: |
@@ -195,6 +203,30 @@ jobs:
         if: matrix.build_type == 'debug'
         uses: ./.github/actions/save-coverage-data
 
+  check-codestyle-python:
+    runs-on: [ self-hosted, Linux, k8s-runner ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - name: Cache poetry deps
+        id: cache_poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: v1-codestyle-python-deps-${{ hashFiles('poetry.lock') }}
+
+      - name: Install Python deps
+        run: ./scripts/pysync
+
+      - name: Run yapf to ensure code format
+        run: poetry run yapf --recursive --diff .
+
+      - name: Run mypy to check types
+        run: poetry run mypy .
 
   pg_regress-tests:
     runs-on: [ self-hosted, Linux, k8s-runner ]

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -19,6 +19,10 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  # This is a stripped down version of the 'build-neon' job in build_and_test.yml
+  # to run "cargo build" and codestyle checks on macOS. On other platforms,
+  # the 'build-neon' job does those checks too, but we don't run the full build
+  # on macOS
   check-codestyle-rust:
     strategy:
       fail-fast: false
@@ -26,7 +30,7 @@ jobs:
         # If we want to duplicate this job for different
         # Rust toolchains (e.g. nightly or 1.37.0), add them here.
         rust_toolchain: [1.58]
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
     timeout-minutes: 50
     runs-on: ${{ matrix.os }}
 
@@ -48,14 +52,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Install Ubuntu postgres dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt update
-          sudo apt install build-essential libreadline-dev zlib1g-dev flex bison libseccomp-dev libssl-dev
-
       - name: Install macOS postgres dependencies
-        if: matrix.os == 'macos-latest'
         run: brew install flex bison openssl
 
       - name: Set pg revision for caching
@@ -70,15 +67,11 @@ jobs:
             tmp_install/
           key: ${{ runner.os }}-pg-${{ steps.pg_ver.outputs.pg_rev }}
 
-      - name: Set extra env for macOS
-        if: matrix.os == 'macos-latest'
+      - name: Build Postgres header files
         run: |
           echo 'LDFLAGS=-L/usr/local/opt/openssl@3/lib' >> $GITHUB_ENV
           echo 'CPPFLAGS=-I/usr/local/opt/openssl@3/include' >> $GITHUB_ENV
-
-      - name: Build postgres
-        if: steps.cache_pg.outputs.cache-hit != 'true'
-        run: make postgres
+          make postgres-headers
 
       # Plain configure output can contain weird errors like 'error: C compiler cannot create executables'
       # and the real cause will be inside config.log
@@ -106,28 +99,3 @@ jobs:
 
       - name: Ensure all project builds
         run: cargo build --all --all-targets
-
-  check-codestyle-python:
-    runs-on: [ self-hosted, Linux, k8s-runner ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: false
-          fetch-depth: 1
-
-      - name: Cache poetry deps
-        id: cache_poetry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: v1-codestyle-python-deps-${{ hashFiles('poetry.lock') }}
-
-      - name: Install Python deps
-        run: ./scripts/pysync
-
-      - name: Run yapf to ensure code format
-        run: poetry run yapf --recursive --diff .
-
-      - name: Run mypy to check types
-        run: poetry run mypy .

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -28,7 +28,6 @@ jobs:
         rust_toolchain: [1.58]
         os: [ubuntu-latest, macos-latest]
     timeout-minutes: 50
-    name: run regression test suite
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
The old codestyle.yml workflow is kept just for macOS, renamed
to build_macos.yml.

Only run the codestyle checks in debug mode. Seems pointless to repeat
them in release mode, and furthermore, it's nice to continue with the
testing even when there are cosmetic issues. (I'm not 100% if github will
actually continue with the release-mode tests if the debug-mode build
fails, but we'll find out soon)
