### PR TITLE
github/workflows: run periodic benchmarks earlier

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -11,7 +11,7 @@ on:
     #          │ │ ┌───────────── day of the month (1 - 31)
     #          │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #          │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    - cron:  '36 7 * * *' # run once a day, timezone is utc
+    - cron:  '36 4 * * *' # run once a day, timezone is utc
 
   workflow_dispatch: # adds ability to run this manually
 


### PR DESCRIPTION
From time to time, we have failed periodic benchmark jobs because a new version is getting released on staging:
https://github.com/neondatabase/neon/actions/workflows/benchmarking.yml

Let's move the job from 7:36 UTC to 4:37 UTC (18:37 PDT, 07:37 EEST).