### PR TITLE
Explicitly enable cachepot in Docker builds only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN set -e \
 FROM neondatabase/rust:1.58 AS build
 ARG GIT_VERSION=local
 
+# Enable https://github.com/paritytech/cachepot to cache Rust crates' compilation results in Docker builds.
+# Set up cachepot to use an AWS S3 bucket for cache results, to reuse it between `docker build` invocations.
+# cachepot falls back to local filesystem if S3 is misconfigured, not failing the build.
+ARG RUSTC_WRAPPER=cachepot
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY

--- a/Dockerfile.compute-tools
+++ b/Dockerfile.compute-tools
@@ -2,6 +2,10 @@
 # NB: keep in sync with rust image version in .circle/config.yml
 FROM neondatabase/rust:1.58 AS rust-build
 
+# Enable https://github.com/paritytech/cachepot to cache Rust crates' compilation results in Docker builds.
+# Set up cachepot to use an AWS S3 bucket for cache results, to reuse it between `docker build` invocations.
+# cachepot falls back to local filesystem if S3 is misconfigured, not failing the build.
+ARG RUSTC_WRAPPER=cachepot
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Closes https://github.com/neondatabase/neon/issues/2130

Context: https://neondb.slack.com/archives/C033RQ5SPDH/p1658317905796069?thread_ts=1658317040.726839&cid=C033RQ5SPDH

Related: https://github.com/neondatabase/docker-images/pull/13

Adjust the build system to not to use `cachepot` anywhere, unless explicitly specified with `RUSTC_WRAPPER` env variable.