### PR TITLE
Silence "Module already imported" warning in python tests

### DIFF
--- a/test_runner/conftest.py
+++ b/test_runner/conftest.py
@@ -1,5 +1,5 @@
 pytest_plugins = ("fixtures.neon_fixtures",
                   "fixtures.benchmark_fixture",
+                  "fixtures.pg_stats",
                   "fixtures.compare_fixtures",
-                  "fixtures.slow",
-                  "fixtures.pg_stats")
+                  "fixtures.slow")


### PR DESCRIPTION
We were getting a warning like this from the pg_regress tests:

    =================== warnings summary ===================
    /usr/lib/python3/dist-packages/_pytest/config/__init__.py:663
      /usr/lib/python3/dist-packages/_pytest/config/__init__.py:663: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: fixtures.pg_stats
        self.import_plugin(import_spec)

    -- Docs: https://docs.pytest.org/en/stable/warnings.html
    ------------------ Benchmark results -------------------

To fix, reorder the imports in conftest.py. I'm not sure what exactly
the problem was or why the order matters, but the warning is gone and
that's good enough for me.