### PR TITLE
performance/test_dup_key: cleanup tables before test

### DIFF
--- a/test_runner/performance/test_dup_key.py
+++ b/test_runner/performance/test_dup_key.py
@@ -17,6 +17,8 @@ def test_dup_key(env: PgCompare):
 
     with closing(env.pg.connect()) as conn:
         with conn.cursor() as cur:
+            cur.execute('drop table if exists t, f;')
+
             cur.execute("SET synchronous_commit=off")
             cur.execute("SET statement_timeout=0")
 


### PR DESCRIPTION
For remote env, we use a preexisting database.

Ref https://github.com/neondatabase/neon/runs/7442734950?check_suite_focus=true
```
>                   cur.execute("create table t (i integer, filler text);")
E                   psycopg2.errors.DuplicateTable: relation "t" already exists
```