### PR TITLE
Fix flaky `test_branch_creation_before_gc` test

### DIFF
--- a/test_runner/batch_others/test_branch_and_gc.py
+++ b/test_runner/batch_others/test_branch_and_gc.py
@@ -139,7 +139,7 @@ def test_branch_creation_before_gc(neon_simple_env: NeonEnv):
             'image_creation_threshold': '1',
 
             # set PITR interval to be small, so we can do GC
-            'pitr_interval': '1 s'
+            'pitr_interval': '0 s'
         })
 
     b0 = env.neon_cli.create_branch('b0', tenant_id=tenant)


### PR DESCRIPTION
Resolves #2140.

## Changes

Reduce `pitr_interval` in `test_branch_creation_before_gc` test from `1s` to `0s`

## Context

https://github.com/neondatabase/neon/commit/ed102f44d9cb101da57f6915afbbc96a14d23570 speeds up WAL processing performance, which makes the insertion transaction in the test runs in < '1s'. The test uses 'pitr_interval=1s', so it fails because GC cannot remove data as expected.