### PR TITLE
Refactor build system to prepare for building multiple Postgres versions.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,9 +3,9 @@
 **/.pytest_cache
 
 .git
+pg_install
 target
 tmp_check
-tmp_install
 tmp_check_cli
 test_output
 .vscode

--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -78,7 +78,7 @@ runs:
     - name: Run pytest
       env:
         NEON_BIN: /tmp/neon/bin
-        POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install
+        POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install/v14
         TEST_OUTPUT: /tmp/test_output
         # this variable will be embedded in perf test report
         # and is needed to distinguish different environments

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,8 +78,8 @@ jobs:
           fetch-depth: 1
 
       - name: Set pg revision for caching
-        id: pg_ver
-        run: echo ::set-output name=pg_rev::$(git rev-parse HEAD:vendor/postgres)
+        id: pg_v14_rev
+        run: echo ::set-output name=pg_rev::$(git rev-parse HEAD:vendor/postgres-v14)
         shell: bash -euxo pipefail {0}
 
       # Set some environment variables used by all the steps.
@@ -124,12 +124,12 @@ jobs:
             v6-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-${{ hashFiles('Cargo.lock') }}
             v6-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-
 
-      - name: Cache postgres build
+      - name: Cache postgres v14 build
         id: cache_pg
         uses: actions/cache@v3
         with:
-          path: tmp_install/
-          key: v1-${{ runner.os }}-${{ matrix.build_type }}-pg-${{ steps.pg_ver.outputs.pg_rev }}-${{ hashFiles('Makefile') }}
+          path: pg_install/v14
+          key: v1-${{ runner.os }}-${{ matrix.build_type }}-pg-${{ steps.pg_v14_rev.outputs.pg_rev }}-${{ hashFiles('Makefile') }}
 
       - name: Build postgres
         if: steps.cache_pg.outputs.cache-hit != 'true'
@@ -188,7 +188,7 @@ jobs:
         shell: bash -euxo pipefail {0}
 
       - name: Install postgres binaries
-        run: cp -a tmp_install /tmp/neon/pg_install
+        run: cp -a pg_install /tmp/neon/pg_install
         shell: bash -euxo pipefail {0}
 
       - name: Upload Neon artifact
@@ -432,7 +432,7 @@ jobs:
           files: |
             Dockerfile
             Dockerfile.compute-tools
-            ./vendor/postgres/Dockerfile
+            ./vendor/postgres-14/Dockerfile
 
   neon-image:
     # force building for all 3 images
@@ -490,7 +490,7 @@ jobs:
         run: echo "{\"credsStore\":\"ecr-login\"}" > /kaniko/.docker/config.json
 
       - name: Kaniko build console
-        working-directory: ./vendor/postgres/
+        working-directory: ./vendor/postgres-14/
         run: /kaniko/executor --snapshotMode=redo --cache=true --cache-repo 369495373322.dkr.ecr.eu-central-1.amazonaws.com/cache --snapshotMode=redo --context . --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node:$GITHUB_RUN_ID
 
   promote-images:
@@ -519,7 +519,7 @@ jobs:
         run: |
           go install github.com/google/go-containerregistry/cmd/crane@31786c6cbb82d6ec4fb8eb79cd9387905130534e # v0.11.0
           go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@69c85dc22db6511932bbf119e1a0cc5c90c69a7f # v0.6.0
-          
+
 #      - name: Get build tag
 #        run: |
 #          if [[ "$GITHUB_REF_NAME" == "main" ]]; then

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            tmp_install/
+            pg_install/
           key: ${{ runner.os }}-pg-${{ steps.pg_ver.outputs.pg_rev }}
 
       - name: Set extra env for macOS
@@ -87,10 +87,10 @@ jobs:
         if: failure()
         continue-on-error: true
         run: |
-          echo '' && echo '=== config.log ===' && echo ''
-          cat tmp_install/build/config.log
-          echo '' && echo '=== configure.log ===' && echo ''
-          cat tmp_install/build/configure.log
+          echo '' && echo '=== Postgres v14 config.log ===' && echo ''
+          cat pg_install/build/v14/config.log
+          echo '' && echo '=== Postgres v14 configure.log ===' && echo ''
+          cat pg_install/build/v14/configure.log
 
       - name: Cache cargo deps
         id: cache_cargo

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -27,6 +27,8 @@ jobs:
         # Rust toolchains (e.g. nightly or 1.37.0), add them here.
         rust_toolchain: [1.58]
         os: [ubuntu-latest, macos-latest]
+        # To support several Postgres versions, add them here.
+        postgres_version: [v14]
     timeout-minutes: 60
     name: check codestyle rust and postgres
     runs-on: ${{ matrix.os }}
@@ -61,14 +63,14 @@ jobs:
 
       - name: Set pg revision for caching
         id: pg_ver
-        run: echo ::set-output name=pg_rev::$(git rev-parse HEAD:vendor/postgres)
+        run: echo ::set-output name=pg_rev::$(git rev-parse HEAD:vendor/postgres-${{matrix.postgres_version}})
 
-      - name: Cache postgres build
+      - name: Cache postgres ${{matrix.postgres_version}} build
         id: cache_pg
         uses: actions/cache@v2
         with:
           path: |
-            pg_install/
+            pg_install/${{matrix.postgres_version}}
           key: ${{ runner.os }}-pg-${{ steps.pg_ver.outputs.pg_rev }}
 
       - name: Set extra env for macOS
@@ -87,10 +89,10 @@ jobs:
         if: failure()
         continue-on-error: true
         run: |
-          echo '' && echo '=== Postgres v14 config.log ===' && echo ''
-          cat pg_install/build/v14/config.log
-          echo '' && echo '=== Postgres v14 configure.log ===' && echo ''
-          cat pg_install/build/v14/configure.log
+          echo '' && echo '=== Postgres ${{matrix.postgres_version}} config.log ===' && echo ''
+          cat pg_install/build/${{matrix.postgres_version}}/config.log
+          echo '' && echo '=== Postgres ${{matrix.postgres_version}} configure.log ===' && echo ''
+          cat pg_install/build/${{matrix.postgres_version}}/configure.log
 
       - name: Cache cargo deps
         id: cache_cargo

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -28,7 +28,7 @@ jobs:
         rust_toolchain: [1.58]
         os: [ubuntu-latest, macos-latest]
         # To support several Postgres versions, add them here.
-        postgres_version: [v14]
+        postgres_version: [v14, v15]
     timeout-minutes: 60
     name: check codestyle rust and postgres
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -28,7 +28,7 @@ jobs:
         rust_toolchain: [1.58]
         os: [ubuntu-latest, macos-latest]
     timeout-minutes: 60
-    name: run regression test suite
+    name: check codestyle rust and postgres
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/pg_clients.yml
+++ b/.github/workflows/pg_clients.yml
@@ -52,7 +52,7 @@ jobs:
         REMOTE_ENV: 1
         BENCHMARK_CONNSTR: "${{ secrets.BENCHMARK_STAGING_CONNSTR }}"
 
-        POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install
+        POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install/v14
       shell: bash -euxo pipefail {0}
       run: |
         # Test framework expects we have psql binary;

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
+/pg_install
 /target
 /tmp_check
-/tmp_install
 /tmp_check_cli
 __pycache__/
 test_output/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "vendor/postgres"]
-	path = vendor/postgres
+[submodule "vendor/postgres-v14"]
+	path = vendor/postgres-v14
 	url = https://github.com/zenithdb/postgres
 	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = vendor/postgres-v14
 	url = https://github.com/zenithdb/postgres
 	branch = main
+[submodule "vendor/postgres-v15"]
+	path = vendor/postgres-v15
+	url = https://github.com/neondatabase/postgres.git
+	branch = REL_15_STABLE_neon

--- a/.yapfignore
+++ b/.yapfignore
@@ -3,7 +3,7 @@
 # See source code for the exact file format: https://github.com/google/yapf/blob/c6077954245bc3add82dafd853a1c7305a6ebd20/yapf/yapflib/file_resources.py#L40-L43
 vendor/
 target/
-tmp_install/
+pg_install/
 __pycache__/
 test_output/
 .neon/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY Makefile Makefile
 ENV BUILD_TYPE release
 RUN set -e \
     && mold -run make -j $(nproc) -s postgres \
-    && rm -rf tmp_install/build \
-    && tar -C tmp_install -czf /postgres_install.tar.gz .
+    && rm -rf pg_install/build \
+    && tar -C pg_install -czf /postgres_install.tar.gz .
 
 # Build zenith binaries
 FROM neondatabase/rust:1.58 AS build
@@ -25,7 +25,7 @@ ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
 
-COPY --from=pg-build /pg/tmp_install/include/postgresql/server tmp_install/include/postgresql/server
+COPY --from=pg-build /pg/pg_install/include/postgresql/server pg_install/include/postgresql/server
 COPY . .
 
 # Show build caching stats to check if it was used in the end.
@@ -54,7 +54,7 @@ COPY --from=build --chown=zenith:zenith /home/runner/target/release/pageserver /
 COPY --from=build --chown=zenith:zenith /home/runner/target/release/safekeeper /usr/local/bin
 COPY --from=build --chown=zenith:zenith /home/runner/target/release/proxy      /usr/local/bin
 
-COPY --from=pg-build /pg/tmp_install/         /usr/local/
+COPY --from=pg-build /pg/pg_install/         /usr/local/
 COPY --from=pg-build /postgres_install.tar.gz /data/
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,7 @@
 ROOT_PROJECT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-# Where to install Postgres, default is ./tmp_install, maybe useful for package managers
-POSTGRES_INSTALL_DIR ?= $(ROOT_PROJECT_DIR)/tmp_install
-
-# Seccomp BPF is only available for Linux
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Linux)
-	SECCOMP = --with-libseccomp
-else
-	SECCOMP =
-endif
+# Where to install Postgres, default is ./pg_install, maybe useful for package managers
+POSTGRES_INSTALL_DIR ?= $(ROOT_PROJECT_DIR)/pg_install/
 
 #
 # We differentiate between release / debug build types using the BUILD_TYPE
@@ -27,6 +19,13 @@ else ifeq ($(BUILD_TYPE),debug)
 else
 	$(error Bad build type '$(BUILD_TYPE)', see Makefile for options)
 endif
+
+# Seccomp BPF is only available for Linux
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	PG_CONFIGURE_OPTS += --with-libseccomp
+endif
+
 
 # macOS with brew-installed openssl requires explicit paths
 # It can be configured with OPENSSL_PREFIX variable
@@ -62,49 +61,50 @@ neon: postgres-headers
 	$(CARGO_CMD_PREFIX) cargo build $(CARGO_BUILD_FLAGS)
 
 ### PostgreSQL parts
-$(POSTGRES_INSTALL_DIR)/build/config.status:
-	+@echo "Configuring postgres build"
-	mkdir -p $(POSTGRES_INSTALL_DIR)/build
-	(cd $(POSTGRES_INSTALL_DIR)/build && \
-	$(ROOT_PROJECT_DIR)/vendor/postgres/configure CFLAGS='$(PG_CFLAGS)' \
+$(POSTGRES_INSTALL_DIR)/build/v14/config.status:
+	+@echo "Configuring Postgres v14 build"
+	mkdir -p $(POSTGRES_INSTALL_DIR)/build/v14
+	(cd $(POSTGRES_INSTALL_DIR)/build/v14 && \
+	$(ROOT_PROJECT_DIR)/vendor/postgres-v14/configure CFLAGS='$(PG_CFLAGS)' \
 		$(PG_CONFIGURE_OPTS) \
-		$(SECCOMP) \
-		--prefix=$(abspath $(POSTGRES_INSTALL_DIR)) > configure.log)
+		--prefix=$(abspath $(POSTGRES_INSTALL_DIR))/v14 > configure.log)
 
-# nicer alias for running 'configure'
-.PHONY: postgres-configure
-postgres-configure: $(POSTGRES_INSTALL_DIR)/build/config.status
+# nicer alias to run 'configure'
+.PHONY: postgres-v14-configure
+postgres-v14-configure: $(POSTGRES_INSTALL_DIR)/build/v14/config.status
 
-# Install the PostgreSQL header files into $(POSTGRES_INSTALL_DIR)/include
-.PHONY: postgres-headers
-postgres-headers: postgres-configure
-	+@echo "Installing PostgreSQL headers"
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/src/include MAKELEVEL=0 install
+
+# Install the PostgreSQL header files into $(POSTGRES_INSTALL_DIR)/<version>/include
+.PHONY: postgres-v14-headers
+postgres-v14-headers: postgres-v14-configure
+	+@echo "Installing PostgreSQL v14 headers"
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/src/include MAKELEVEL=0 install
 
 # Compile and install PostgreSQL and contrib/neon
-.PHONY: postgres
-postgres: postgres-configure \
-		  postgres-headers # to prevent `make install` conflicts with neon's `postgres-headers`
+.PHONY: postgres-v14
+postgres-v14: postgres-v14-configure \
+		  postgres-v14-headers # to prevent `make install` conflicts with neon's `postgres-headers`
 	+@echo "Compiling PostgreSQL"
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build MAKELEVEL=0 install
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14 MAKELEVEL=0 install
 	+@echo "Compiling contrib/neon"
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/contrib/neon install
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/neon install
 	+@echo "Compiling contrib/neon_test_utils"
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/contrib/neon_test_utils install
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/neon_test_utils install
 	+@echo "Compiling pg_buffercache"
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/contrib/pg_buffercache install
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/pg_buffercache install
 	+@echo "Compiling pageinspect"
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/contrib/pageinspect install
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/pageinspect install
 
+# shorthand to build all Postgres versions
+postgres: postgres-v14
 
-.PHONY: postgres-clean
-postgres-clean:
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build MAKELEVEL=0 clean
+postgres-headers: postgres-v14-headers
+
 
 # This doesn't remove the effects of 'configure'.
 .PHONY: clean
 clean:
-	cd $(POSTGRES_INSTALL_DIR)/build && $(MAKE) clean
+	cd $(POSTGRES_INSTALL_DIR)/build/v14 && $(MAKE) clean
 	$(CARGO_CMD_PREFIX) cargo clean
 
 # This removes everything

--- a/Makefile
+++ b/Makefile
@@ -48,17 +48,17 @@ CARGO_CMD_PREFIX += $(if $(filter n,$(MAKEFLAGS)),,+)
 CARGO_CMD_PREFIX += CARGO_TERM_PROGRESS_WHEN=never CI=1
 
 #
-# Top level Makefile to build Zenith and PostgreSQL
+# Top level Makefile to build Neon and PostgreSQL
 #
 .PHONY: all
-all: zenith postgres
+all: neon postgres
 
-### Zenith Rust bits
+### Neon Rust bits
 #
 # The 'postgres_ffi' depends on the Postgres headers.
-.PHONY: zenith
-zenith: postgres-headers
-	+@echo "Compiling Zenith"
+.PHONY: neon
+neon: postgres-headers
+	+@echo "Compiling Neon"
 	$(CARGO_CMD_PREFIX) cargo build $(CARGO_BUILD_FLAGS)
 
 ### PostgreSQL parts
@@ -84,7 +84,7 @@ postgres-headers: postgres-configure
 # Compile and install PostgreSQL and contrib/neon
 .PHONY: postgres
 postgres: postgres-configure \
-		  postgres-headers # to prevent `make install` conflicts with zenith's `postgres-headers`
+		  postgres-headers # to prevent `make install` conflicts with neon's `postgres-headers`
 	+@echo "Compiling PostgreSQL"
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build MAKELEVEL=0 install
 	+@echo "Compiling contrib/neon"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Pageserver consists of:
 - WAL receiver - service that receives WAL from WAL service and stores it in the repository.
 - Page service - service that communicates with compute nodes and responds with pages from the repository.
 - WAL redo - service that builds pages from base images and WAL records on Page service request
+
 ## Running local installation
 
 
@@ -101,7 +102,7 @@ make -j`sysctl -n hw.logicalcpu`
 ```
 
 #### Dependency installation notes
-To run the `psql` client, install the `postgresql-client` package or modify `PATH` and `LD_LIBRARY_PATH` to include `tmp_install/bin` and `tmp_install/lib`, respectively.
+To run the `psql` client, install the `postgresql-client` package or modify `PATH` and `LD_LIBRARY_PATH` to include `pg_install/bin` and `pg_install/lib`, respectively.
 
 To run the integration tests or Python scripts (not required to use the code), install
 Python (3.9 or higher), and install python3 packages using `./scripts/pysync` (requires [poetry](https://python-poetry.org/)) in the project directory.
@@ -208,7 +209,7 @@ Ensure your dependencies are installed as described [here](https://github.com/ne
 
 ```sh
 git clone --recursive https://github.com/neondatabase/neon.git
-make # builds also postgres and installs it to ./tmp_install
+make # builds also postgres and installs it to ./pg_install
 ./scripts/pytest
 ```
 

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -289,13 +289,13 @@ impl LocalEnv {
         let mut env: LocalEnv = toml::from_str(toml)?;
 
         // Find postgres binaries.
-        // Follow POSTGRES_DISTRIB_DIR if set, otherwise look in "tmp_install".
+        // Follow POSTGRES_DISTRIB_DIR if set, otherwise look in "pg_install/v14".
         if env.pg_distrib_dir == Path::new("") {
             if let Some(postgres_bin) = env::var_os("POSTGRES_DISTRIB_DIR") {
                 env.pg_distrib_dir = postgres_bin.into();
             } else {
                 let cwd = env::current_dir()?;
-                env.pg_distrib_dir = cwd.join("tmp_install")
+                env.pg_distrib_dir = cwd.join("pg_install/v14")
             }
         }
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -157,7 +157,7 @@ for other files and for sockets for incoming connections.
 A directory with Postgres installation to use during pageserver activities.
 Inside that dir, a `bin/postgres` binary should be present.
 
-The default distrib dir is `./tmp_install/`.
+The default distrib dir is `./pg_install/`.
 
 #### workdir (-D)
 

--- a/libs/postgres_ffi/build.rs
+++ b/libs/postgres_ffi/build.rs
@@ -47,14 +47,17 @@ fn main() {
     println!("cargo:rerun-if-changed=bindgen_deps.h");
 
     // Finding the location of C headers for the Postgres server:
-    // - if POSTGRES_INSTALL_DIR is set look into it, otherwise look into `<project_root>/tmp_install`
-    // - if there's a `bin/pg_config` file use it for getting include server, otherwise use `<project_root>/tmp_install/include/postgresql/server`
+    // - if POSTGRES_INSTALL_DIR is set look into it, otherwise look into `<project_root>/pg_install`
+    // - if there's a `bin/pg_config` file use it for getting include server, otherwise use `<project_root>/pg_install/v14/include/postgresql/server`
     let mut pg_install_dir = if let Some(postgres_install_dir) = env::var_os("POSTGRES_INSTALL_DIR")
     {
         postgres_install_dir.into()
     } else {
-        PathBuf::from("tmp_install")
+        PathBuf::from("pg_install")
     };
+    // Currently, we only expect to find PostgreSQL v14 sources, in "pg_install/v14". In the
+    // future, we will run this for all supported PostgreSQL versions.
+    pg_install_dir.push("v14");
 
     if pg_install_dir.is_relative() {
         let cwd = env::current_dir().unwrap();

--- a/libs/postgres_ffi/src/xlog_utils.rs
+++ b/libs/postgres_ffi/src/xlog_utils.rs
@@ -371,7 +371,7 @@ mod tests {
             .join("..")
             .join("..");
         let cfg = Conf {
-            pg_distrib_dir: top_path.join("tmp_install"),
+            pg_distrib_dir: top_path.join("pg_install/v14"),
             datadir: top_path.join(format!("test_output/{}", test_name)),
         };
         if cfg.datadir.exists() {

--- a/libs/postgres_ffi/wal_craft/src/bin/wal_craft.rs
+++ b/libs/postgres_ffi/wal_craft/src/bin/wal_craft.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
                     Arg::new("pg-distrib-dir")
                         .long("pg-distrib-dir")
                         .takes_value(true)
-                        .help("Directory with Postgres distribution (bin and lib directories, e.g. tmp_install)")
+                        .help("Directory with Postgres distribution (bin and lib directories, e.g. pg_install/v14)")
                         .default_value("/usr/local")
                 )
         )

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -205,7 +205,7 @@ impl Default for PageServerConfigBuilder {
             workdir: Set(PathBuf::new()),
             pg_distrib_dir: Set(env::current_dir()
                 .expect("cannot access current directory")
-                .join("tmp_install")),
+                .join("pg_install/v14")),
             auth_type: Set(AuthType::Trust),
             auth_validation_public_key_path: Set(None),
             remote_storage_config: Set(None),

--- a/test_runner/batch_pg_regress/test_isolation.py
+++ b/test_runner/batch_pg_regress/test_isolation.py
@@ -21,8 +21,8 @@ def test_isolation(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, caps
     (runpath / 'testtablespace').mkdir(parents=True)
 
     # Compute all the file locations that pg_isolation_regress will need.
-    build_path = os.path.join(pg_distrib_dir, 'build/src/test/isolation')
-    src_path = os.path.join(base_dir, 'vendor/postgres/src/test/isolation')
+    build_path = os.path.join(pg_distrib_dir, '../build/v14/src/test/isolation')
+    src_path = os.path.join(base_dir, 'vendor/postgres-v14/src/test/isolation')
     bindir = os.path.join(pg_distrib_dir, 'bin')
     schedule = os.path.join(src_path, 'isolation_schedule')
     pg_isolation_regress = os.path.join(build_path, 'pg_isolation_regress')

--- a/test_runner/batch_pg_regress/test_neon_regress.py
+++ b/test_runner/batch_pg_regress/test_neon_regress.py
@@ -22,7 +22,7 @@ def test_neon_regress(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, c
 
     # Compute all the file locations that pg_regress will need.
     # This test runs neon specific tests
-    build_path = os.path.join(pg_distrib_dir, 'build/src/test/regress')
+    build_path = os.path.join(pg_distrib_dir, '../build/v14/src/test/regress')
     src_path = os.path.join(base_dir, 'test_runner/neon_regress')
     bindir = os.path.join(pg_distrib_dir, 'bin')
     schedule = os.path.join(src_path, 'parallel_schedule')

--- a/test_runner/batch_pg_regress/test_pg_regress.py
+++ b/test_runner/batch_pg_regress/test_pg_regress.py
@@ -20,8 +20,8 @@ def test_pg_regress(neon_simple_env: NeonEnv, test_output_dir: pathlib.Path, pg_
     (runpath / 'testtablespace').mkdir(parents=True)
 
     # Compute all the file locations that pg_regress will need.
-    build_path = os.path.join(pg_distrib_dir, 'build/src/test/regress')
-    src_path = os.path.join(base_dir, 'vendor/postgres/src/test/regress')
+    build_path = os.path.join(pg_distrib_dir, '../build/v14/src/test/regress')
+    src_path = os.path.join(base_dir, 'vendor/postgres-v14/src/test/regress')
     bindir = os.path.join(pg_distrib_dir, 'bin')
     schedule = os.path.join(src_path, 'parallel_schedule')
     pg_regress = os.path.join(build_path, 'pg_regress')

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -61,7 +61,7 @@ Env = Dict[str, str]
 Fn = TypeVar('Fn', bound=Callable[..., Any])
 
 DEFAULT_OUTPUT_DIR = 'test_output'
-DEFAULT_POSTGRES_DIR = 'tmp_install'
+DEFAULT_POSTGRES_DIR = 'pg_install/v14'
 DEFAULT_BRANCH_NAME = 'main'
 
 BASE_PORT = 15000


### PR DESCRIPTION
Rename "vendor/postgres" to "vendor/postgres-v14"

Change Postgres build and install directory paths to be version-specific:

- tmp_install/build -> pg_install/build/14
- tmp_install/* -> pg_install/14/*

And Makefile targets:

- "make postgres" -> "make postgres-v14"
- "make postgres-headers" -> "make postgres-v14-headers"
- etc.
    
Add Makefile aliases:

- "make postgres" to build "postgres-v14" and in future, "postgres-v15"
- similarly for "make postgres-headers"
