### PR TITLE
Refactor test_race_conditions

### DIFF
--- a/test_runner/batch_others/test_wal_acceptor_async.py
+++ b/test_runner/batch_others/test_wal_acceptor_async.py
@@ -496,12 +496,8 @@ async def run_race_conditions(env: NeonEnv, pg: Postgres):
     n_queries = 200
     expected_sum = 0
 
-    for i in range(1, n_iterations + 1):
-        # await for the end of the previous iteration
-        while data.iteration < i:
-            await asyncio.sleep(0.1)
-
-        for i in range((i - 1) * n_queries, i * n_queries):
+    while data.iteration < n_iterations:
+            await asyncio.sleep(0.01)
             await conn.execute(f"INSERT INTO t values ({i+1}, 'payload')")
             expected_sum += i + 1
 

--- a/test_runner/batch_others/test_wal_acceptor_async.py
+++ b/test_runner/batch_others/test_wal_acceptor_async.py
@@ -493,13 +493,16 @@ async def run_race_conditions(env: NeonEnv, pg: Postgres):
     bg_xmas = asyncio.create_task(xmas_garland(env.safekeepers, data))
 
     n_iterations = 5
-    n_queries = 200
     expected_sum = 0
+    i = 1
 
-    while data.iteration < n_iterations:
-            await asyncio.sleep(0.01)
-            await conn.execute(f"INSERT INTO t values ({i+1}, 'payload')")
-            expected_sum += i + 1
+    while data.iteration <= n_iterations:
+        await asyncio.sleep(0.005)
+        await conn.execute(f"INSERT INTO t values ({i}, 'payload')")
+        expected_sum += i
+        i += 1
+
+    log.info(f'Executed {i-1} queries')
 
     res = await conn.fetchval('SELECT sum(key) FROM t')
     assert res == expected_sum

--- a/test_runner/batch_others/test_wal_acceptor_async.py
+++ b/test_runner/batch_others/test_wal_acceptor_async.py
@@ -9,6 +9,7 @@ from fixtures.neon_fixtures import NeonEnv, NeonEnvBuilder, Postgres, Safekeeper
 from fixtures.log_helper import getLogger
 from fixtures.utils import lsn_from_hex, lsn_to_hex
 from typing import List, Optional
+from dataclasses import dataclass
 
 log = getLogger('root.safekeeper_async')
 
@@ -456,3 +457,68 @@ def test_unavailability(neon_env_builder: NeonEnvBuilder):
     pg = env.postgres.create_start('test_safekeepers_unavailability')
 
     asyncio.run(run_unavailability(env, pg))
+
+
+@dataclass
+class RaceConditionTest:
+    iteration: int
+    is_stopped: bool
+
+
+# shut down random subset of safekeeper, sleep, wake them up, rinse, repeat
+async def xmas_garland(safekeepers: List[Safekeeper], data: RaceConditionTest):
+    while not data.is_stopped:
+        data.iteration += 1
+        victims = []
+        for sk in safekeepers:
+            if random.random() >= 0.5:
+                victims.append(sk)
+        log.info(
+            f'Iteration {data.iteration}: stopping {list(map(lambda sk: sk.id, victims))} safekeepers'
+        )
+        for v in victims:
+            v.stop()
+        await asyncio.sleep(1)
+        for v in victims:
+            v.start()
+        log.info(f'Iteration {data.iteration} finished')
+        await asyncio.sleep(1)
+
+
+async def run_race_conditions(env: NeonEnv, pg: Postgres):
+    conn = await pg.connect_async()
+    await conn.execute('CREATE TABLE t(key int primary key, value text)')
+
+    data = RaceConditionTest(0, False)
+    bg_xmas = asyncio.create_task(xmas_garland(env.safekeepers, data))
+
+    n_iterations = 5
+    n_queries = 200
+    expected_sum = 0
+
+    for i in range(1, n_iterations + 1):
+        # await for the end of the previous iteration
+        while data.iteration < i:
+            await asyncio.sleep(0.1)
+
+        for i in range((i - 1) * n_queries, i * n_queries):
+            await conn.execute(f"INSERT INTO t values ({i+1}, 'payload')")
+            expected_sum += i + 1
+
+    res = await conn.fetchval('SELECT sum(key) FROM t')
+    assert res == expected_sum
+
+    data.is_stopped = True
+    await bg_xmas
+
+
+# do inserts while concurrently getting up/down subsets of acceptors
+def test_race_conditions(neon_env_builder: NeonEnvBuilder):
+
+    neon_env_builder.num_safekeepers = 3
+    env = neon_env_builder.init_start()
+
+    env.neon_cli.create_branch('test_safekeepers_race_conditions')
+    pg = env.postgres.create_start('test_safekeepers_race_conditions')
+
+    asyncio.run(run_race_conditions(env, pg))


### PR DESCRIPTION
This test failed in CI on `proc.join()`. Since it's hard to debug Process tests (output from subprocesses is missing), it's better to refactor this test to use python async.

```
test_runner/batch_others/test_wal_acceptor.py::test_race_conditions
reason: Timeout >300.0s
```