### PR TITLE
Adjust walreceiver backoff parameters

### DIFF
--- a/pageserver/src/walreceiver/connection_manager.rs
+++ b/pageserver/src/walreceiver/connection_manager.rs
@@ -230,8 +230,8 @@ async fn subscribe_for_timeline_updates(
     }
 }
 
-const DEFAULT_BASE_BACKOFF_SECONDS: f64 = 2.0;
-const DEFAULT_MAX_BACKOFF_SECONDS: f64 = 60.0;
+const DEFAULT_BASE_BACKOFF_SECONDS: f64 = 0.1;
+const DEFAULT_MAX_BACKOFF_SECONDS: f64 = 3.0;
 
 async fn exponential_backoff(n: u32, base: f64, max_seconds: f64) {
     if n == 0 {


### PR DESCRIPTION
Closes https://github.com/neondatabase/neon/issues/2160

The root cause of the issue seems to be a logic mismatch in two separate tasks:
* one task starts to open the walreceiver connection, but used to do a back off in case the SK node currently connected to had some connection issues before. We never erase the error count if there are etcd events coming from that node yet no successful connection was established

* we continue receiving etcd events meanwhile, checking if other nodes are better candidates for WAL streaming. In particular, we check for "no WAL timeout" threshold and reconnect, if it's exceeded for a currently selected node.

The issue in question was caused by some (networking?) issues that bumped the error count for _all_ SK nodes enough for the backoff time to become big enough (max value is 60 seconds and it's already in the logs in the issue) and the no WAL timeout threshold is 10 seconds.

So, now every SK node gets its walreceiver task spawned, that task checks the connection count and sees big numbers, starts to wait 60 seconds before opening a connection.
Meanwhile, etcd events are pouring (since SK nodes now work) and we eventually react on 10 seconds of no WAL threshold, by cancelling the current, backed-off, waiting connection and start another one that also waits.

Removing the backoff before opening a walreceiver connection seems to be appropriate with the current model the SK nodes are selected for connection: it's a sort of a round robin, where every time we consider new SK nodes for reconnection, we take only the ones with minimal errors.
E.g. if all SK nodes have 1 failed attempt to connect, the selection will be among all of them. If one of those nodes gets 2 failed connect attempts, first all other nodes with 1 failed attempt are connected to and only if all of them fail, the initial node with 2 failed connect attempts will be considered among others again.

------------

I'm thinking on how to write tests on these and the only thing coming to my mind are fallpoints with a Python test.
That could take some time, so I'll create the fix PR first to ensure the env is fixed fast.