### PR TITLE
Rename 'wal_producer_connstr' to 'wal_source_connstr'.

### DIFF
--- a/pageserver/src/http/models.rs
+++ b/pageserver/src/http/models.rs
@@ -102,7 +102,7 @@ impl TenantConfigRequest {
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WalReceiverEntry {
-    pub wal_producer_connstr: Option<String>,
+    pub wal_source_connstr: Option<String>,
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub last_received_msg_lsn: Option<Lsn>,
     /// the timestamp (in microseconds) of the last received message

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -694,11 +694,11 @@ components:
       type: object
       required:
         - thread_id
-        - wal_producer_connstr
+        - wal_source_connstr
       properties:
         thread_id:
           type: integer
-        wal_producer_connstr:
+        wal_source_connstr:
           type: string
         last_received_msg_lsn:
           type: string

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -326,7 +326,7 @@ async fn wal_receiver_main_thread_loop_step<'a>(
                         WAL_RECEIVER_ENTRIES.write().await.insert(
                             id,
                             WalReceiverEntry {
-                                wal_producer_connstr: None,
+                                wal_source_connstr: None,
                                 last_received_msg_lsn: None,
                                 last_received_msg_ts: None,
                             },

--- a/test_runner/batch_others/test_pageserver_api.py
+++ b/test_runner/batch_others/test_pageserver_api.py
@@ -65,7 +65,7 @@ def test_pageserver_http_get_wal_receiver_not_found(neon_simple_env: NeonEnv):
 
     empty_response = client.wal_receiver_get(tenant_id, timeline_id)
 
-    assert empty_response.get('wal_producer_connstr') is None, 'Should not be able to connect to WAL streaming without PG compute node running'
+    assert empty_response.get('wal_source_connstr') is None, 'Should not be able to connect to WAL streaming without PG compute node running'
     assert empty_response.get('last_received_msg_lsn') is None, 'Should not be able to connect to WAL streaming without PG compute node running'
     assert empty_response.get('last_received_msg_ts') is None, 'Should not be able to connect to WAL streaming without PG compute node running'
 
@@ -82,7 +82,7 @@ def test_pageserver_http_get_wal_receiver_success(neon_simple_env: NeonEnv):
 
         # a successful `wal_receiver_get` response must contain the below fields
         assert list(res.keys()) == [
-            "wal_producer_connstr",
+            "wal_source_connstr",
             "last_received_msg_lsn",
             "last_received_msg_ts",
         ]


### PR DESCRIPTION
What the WAL receiver really connects to is the safekeeper. The
"producer" term is a bit misleading, as the safekeeper doesn't produce
the WAL, the compute node does.

This change also applies to the name of the field used in the mgmt API
in in the response of the
'/v1/tenant/:tenant_id/timeline/:timeline_id/wal_receiver' endpoint.
AFAICS that's not used anywhere else than one python test, so it
should be OK to change it.