### PR TITLE
Don't include unnecessary copies of final binaries in rust cache.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,23 +66,27 @@ jobs:
           echo "CARGO_FEATURES=${CARGO_FEATURES}" >> $GITHUB_ENV
           echo "CARGO_FLAGS=${CARGO_FLAGS}" >> $GITHUB_ENV
 
-      # Don't include the ~/.cargo/registry/src directory. It contains just
-      # uncompressed versions of the crates in ~/.cargo/registry/cache
-      # directory, and it's faster to let 'cargo' to rebuild it from the
-      # compressed crates.
       - name: Cache cargo deps
         id: cache_cargo
         uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry/
+            # Don't include the ~/.cargo/registry/src directory. It contains just
+            # uncompressed versions of the crates in ~/.cargo/registry/cache
+            # directory, and it's faster to let 'cargo' to rebuild it from the
+            # compressed crates.
             !~/.cargo/registry/src
             ~/.cargo/git/
-            target/
+            # Don't include files in 'target' itself. They are the final binaries, and they
+            # are very large. Copies of the final binaries are also in the 'deps' directory,
+            # so it only takes "cargo build" a second to copy them back, if there have been
+            # no changes.
+            target/*/
           # Fall back to older versions of the key, if no cache for current Cargo.lock was found
           key: |
-            v3-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-${{ hashFiles('Cargo.lock') }}
-            v3-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-
+            v4-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-${{ hashFiles('Cargo.lock') }}
+            v4-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-
 
       - name: Cache postgres build
         id: cache_pg
@@ -268,7 +272,7 @@ jobs:
             !~/.cargo/registry/src
             ~/.cargo/git/
             target/
-          key: v3-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-${{ hashFiles('Cargo.lock') }}
+          key: v4-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Get Neon artifact for restoration
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Should speed up the build, by reducing the amount of data that needs to
be downloaded and re-uploaded on every build.