### PR TITLE
run benchmarks conditionally, on main or if run-benchmarks label is set

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -218,6 +218,7 @@ jobs:
   benchmarks:
     runs-on: [ self-hosted, Linux, k8s-runner ]
     needs: [ build-neon ]
+    if: github.ref_name == 'main' || contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Benchmarking job takes around 35 minutes and for significant part of the PR's is not needed so this PR makes it configurable via run-benchmarks label

- [x] check it does not trigger without the label
- [x] check triggers with label
- [ ] check triggers on main 