### PR TITLE
Speed up test shutdown, by polling more frequently.

### DIFF
--- a/control_plane/src/safekeeper.rs
+++ b/control_plane/src/safekeeper.rs
@@ -247,7 +247,7 @@ impl SafekeeperNode {
         // Shutting down may take a long time,
         // if safekeeper flushes a lot of data
         let mut tcp_stopped = false;
-        for _ in 0..100 {
+        for i in 0..600 {
             if !tcp_stopped {
                 if let Err(err) = TcpStream::connect(&address) {
                     tcp_stopped = true;
@@ -272,9 +272,11 @@ impl SafekeeperNode {
                     }
                 }
             }
-            print!(".");
-            io::stdout().flush().unwrap();
-            thread::sleep(Duration::from_secs(1));
+            if i % 10 == 0 {
+                print!(".");
+                io::stdout().flush().unwrap();
+            }
+            thread::sleep(Duration::from_millis(100));
         }
 
         bail!("Failed to stop safekeeper with pid {}", pid);

--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -318,7 +318,7 @@ impl PageServerNode {
         // Shutting down may take a long time,
         // if pageserver checkpoints a lot of data
         let mut tcp_stopped = false;
-        for _ in 0..100 {
+        for i in 0..600 {
             if !tcp_stopped {
                 if let Err(err) = TcpStream::connect(&address) {
                     tcp_stopped = true;
@@ -344,9 +344,11 @@ impl PageServerNode {
                     }
                 }
             }
-            print!(".");
-            io::stdout().flush().unwrap();
-            thread::sleep(Duration::from_secs(1));
+            if i % 10 == 0 {
+                print!(".");
+                io::stdout().flush().unwrap();
+            }
+            thread::sleep(Duration::from_millis(100));
         }
 
         bail!("Failed to stop pageserver with pid {}", pid);


### PR DESCRIPTION
A fair amount of the time in our python tests is spent waiting for the
pageserver and safekeeper processes to shut down. It doesn't matter so
much when you're running a lot of tests in parallel, but it's quite
noticeable when running them sequentially.

A big part of the slowness is that is that after sending the SIGTERM
signal, we poll to see if the process is still running, and the
polling happened at 1 s interval. Reduce it to 0.1 s.