### PR TITLE
ignore record property warning to fix benchmarks

### DIFF
--- a/pageserver/src/storage_sync/download.rs
+++ b/pageserver/src/storage_sync/download.rs
@@ -202,8 +202,6 @@ where
         })
         .map_err(DownloadError::BadInput)?;
 
-    warn!("part_storage_path {:?}", part_storage_path);
-
     let mut index_part_download = storage.download(&part_storage_path).await?;
 
     let mut index_part_bytes = Vec::new();

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 filterwarnings =
     error::pytest.PytestUnhandledThreadExceptionWarning
     error::UserWarning
+    ignore:record_property is incompatible with junit_family:pytest.PytestWarning
 addopts =
     -m 'not remote_cluster'
 markers =

--- a/test_runner/batch_others/test_remote_storage.py
+++ b/test_runner/batch_others/test_remote_storage.py
@@ -110,7 +110,7 @@ def test_remote_storage_backup_and_restore(
     client.tenant_attach(UUID(tenant_id))
 
     log.info("waiting for timeline redownload")
-    wait_until(number_of_iterations=10,
+    wait_until(number_of_iterations=20,
                interval=1,
                func=lambda: assert_timeline_local(client, UUID(tenant_id), UUID(timeline_id)))
 

--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -350,7 +350,7 @@ def wait_segment_offload(tenant_id, timeline_id, live_sk, seg_end):
         if lsn_from_hex(tli_status.backup_lsn) >= lsn_from_hex(seg_end):
             break
         elapsed = time.time() - started_at
-        if elapsed > 20:
+        if elapsed > 30:
             raise RuntimeError(
                 f"timed out waiting {elapsed:.0f}s for segment ending at {seg_end} get offloaded")
         time.sleep(0.5)

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -299,7 +299,9 @@ class PgProtocol:
         # change it by calling "SET statement_timeout" after
         # connecting.
         options = result.get('options', '')
-        result['options'] = f'-cstatement_timeout=120s {options}'
+        if "statement_timeout" not in options:
+            options = f'-cstatement_timeout=120s {options}'
+        result['options'] = options
         return result
 
     # autocommit=True here by default because that's what we need most of the time

--- a/test_runner/performance/test_wal_backpressure.py
+++ b/test_runner/performance/test_wal_backpressure.py
@@ -155,7 +155,7 @@ def start_pgbench_intensive_initialization(env: PgCompare, scale: int):
             f'-s{scale}',
             '-i',
             '-Idtg',
-            env.pg.connstr(options='-cstatement_timeout=300s')
+            env.pg.connstr(options='-cstatement_timeout=360s')
         ])
 
 

--- a/test_runner/performance/test_wal_backpressure.py
+++ b/test_runner/performance/test_wal_backpressure.py
@@ -155,7 +155,7 @@ def start_pgbench_intensive_initialization(env: PgCompare, scale: int, done_even
             f'-s{scale}',
             '-i',
             '-Idtg',
-            env.pg.connstr(options='-cstatement_timeout=360s')
+            env.pg.connstr(options='-cstatement_timeout=600s')
         ])
 
     done_event.set()


### PR DESCRIPTION
We use it only to carry parameters from test run to report generation code and do not rely on it to be present in junit file

UPD: benchmark job failed so I added a fix to this PR as well (increased timeout for pgbench init)