### PR TITLE
github/workflows: Fix git dubious ownership

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -85,7 +85,7 @@ runs:
         PLATFORM: github-actions-selfhosted
         AWS_ACCESS_KEY_ID: ${{ inputs.real_s3_access_key_id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.real_s3_secret_access_key }}
-      shell: bash -euxo pipefail {0} {0}
+      shell: bash -euxo pipefail {0}
       run: |
         PERF_REPORT_DIR="$(realpath test_runner/perf-report-local)"
         rm -rf $PERF_REPORT_DIR

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,6 +35,16 @@ jobs:
       GIT_VERSION: ${{ github.sha }}
 
     steps:
+      - name: Fix git ownerwhip
+        run: |
+          # Workaround for `fatal: detected dubious ownership in repository at ...`
+          #
+          # Use both ${{ github.workspace }} and ${GITHUB_WORKSPACE} because they're different on host and in containers
+          #   Ref https://github.com/actions/checkout/issues/785
+          #
+          git config --global --add safe.directory ${{ github.workspace }}
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This should fix a problem with git dubious ownership:

```
++ git rev-parse HEAD:vendor/postgres
fatal: detected dubious ownership in repository at '/__w/neon/neon'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/neon/neon
+ echo ::set-output name=pg_rev::
```

https://github.com/neondatabase/neon/runs/7636477633?check_suite_focus=true#step:4:15