### PR TITLE
Add more buckets to pageserver latency metrics

### DIFF
--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -67,7 +67,7 @@ fn get_buckets_for_critical_operations() -> Vec<f64> {
     // adding this bucket we'll never know.
     let mut buckets = vec![];
     for exp in -12..=4 {
-        buckets.push((10 as f64).powf(exp as f64 / 2.0))
+        buckets.push(10_f64.powf(exp as f64 / 2.0))
     }
     buckets
 }

--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -62,17 +62,12 @@ use crate::{page_cache, storage_sync};
 /// latencies in the microsecond range but also extend far enough up to capture
 /// all latencies.
 fn get_buckets_for_critical_operations() -> Vec<f64> {
+    // Generate exponential buckets from 1 microsecond to ~5 minutes, sqrt(10) apart
     let mut buckets = vec![];
     for exp in -12..=4 {
         buckets.push((10 as f64).powf(exp as f64 / 2.0))
     }
     buckets
-}
-
-#[test]
-fn feature() {
-    let foo = get_buckets_for_critical_operations();
-    dbg!(foo);
 }
 
 // Metrics collected on operations on the storage repository.

--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -62,7 +62,9 @@ use crate::{page_cache, storage_sync};
 /// latencies in the microsecond range but also extend far enough up to capture
 /// all latencies.
 fn get_buckets_for_critical_operations() -> Vec<f64> {
-    // Generate exponential buckets from 1 microsecond to ~5 minutes, sqrt(10) apart
+    // Generate exponential buckets from 1 microsecond to ~5 minutes, sqrt(10) apart.
+    // Hopefully no critical operation will last 5 minutes. But without explicitly
+    // adding this bucket we'll never know.
     let mut buckets = vec![];
     for exp in -12..=4 {
         buckets.push((10 as f64).powf(exp as f64 / 2.0))


### PR DESCRIPTION
Our top bucket is currently non-empty, so we should add more buckets.