### PR TITLE
WIP upgrade Neon to work with Postgres 15.

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -268,12 +268,12 @@ where
         };
 
         if spcnode == pg_constants::GLOBALTABLESPACE_OID {
-            let version_bytes = pg_constants::PG_MAJORVERSION.as_bytes();
+            let version_bytes = self.timeline.get_pg_version(self.lsn)?;
             let header = new_tar_header("PG_VERSION", version_bytes.len() as u64)?;
-            self.ar.append(&header, version_bytes)?;
+            self.ar.append(&header, &version_bytes[..])?;
 
             let header = new_tar_header("global/PG_VERSION", version_bytes.len() as u64)?;
-            self.ar.append(&header, version_bytes)?;
+            self.ar.append(&header, &version_bytes[..])?;
 
             if let Some(img) = relmap_img {
                 // filenode map for global tablespace
@@ -311,9 +311,9 @@ where
 
             if let Some(img) = relmap_img {
                 let dst_path = format!("base/{}/PG_VERSION", dbnode);
-                let version_bytes = pg_constants::PG_MAJORVERSION.as_bytes();
+                let version_bytes = self.timeline.get_pg_version(self.lsn)?;
                 let header = new_tar_header(&dst_path, version_bytes.len() as u64)?;
-                self.ar.append(&header, version_bytes)?;
+                self.ar.append(&header, &version_bytes[..])?;
 
                 let relmap_path = format!("base/{}/pg_filenode.map", dbnode);
                 let header = new_tar_header(&relmap_path, img.len() as u64)?;

--- a/pageserver/src/import_datadir.rs
+++ b/pageserver/src/import_datadir.rs
@@ -97,7 +97,7 @@ fn import_rel<T: DatadirTimeline, Reader: Read>(
     len: usize,
 ) -> anyhow::Result<()> {
     // Does it look like a relation file?
-    trace!("importing rel file {}", path.display());
+    info!("importing rel file {}", path.display());
 
     let filename = &path
         .file_name()
@@ -127,7 +127,7 @@ fn import_rel<T: DatadirTimeline, Reader: Read>(
     // ignore "relation already exists" error
     if let Err(e) = modification.put_rel_creation(rel, nblocks as u32) {
         if e.to_string().contains("already exists") {
-            debug!("relation {} already exists. we must be extending it", rel);
+            info!("relation {} already exists. we must be extending it", rel);
         } else {
             return Err(e);
         }
@@ -161,6 +161,7 @@ fn import_rel<T: DatadirTimeline, Reader: Read>(
     //
     // If we process rel segments out of order,
     // put_rel_extend will skip the update.
+    info!("updating rel {} size to {}", rel, blknum);
     modification.put_rel_extend(rel, blknum)?;
 
     Ok(())
@@ -455,7 +456,10 @@ pub fn import_file<T: DatadirTimeline, Reader: Read>(
                 debug!("imported relmap file")
             }
             "PG_VERSION" => {
-                debug!("ignored");
+                let version_bytes = read_all_bytes(reader)?;
+                modification.put_pg_version(version_bytes.clone())?;
+
+                debug!("imported PG_VERSION file");
             }
             _ => {
                 import_rel(modification, file_path, spcnode, dbnode, reader, len)?;
@@ -483,7 +487,10 @@ pub fn import_file<T: DatadirTimeline, Reader: Read>(
                 debug!("imported relmap file")
             }
             "PG_VERSION" => {
-                debug!("ignored");
+                let version_bytes = read_all_bytes(reader)?;
+                modification.put_pg_version(version_bytes.clone())?;
+
+                debug!("imported PG_VERSION file");
             }
             _ => {
                 import_rel(modification, file_path, spcnode, dbnode, reader, len)?;

--- a/pageserver/src/import_datadir.rs
+++ b/pageserver/src/import_datadir.rs
@@ -455,7 +455,7 @@ pub fn import_file<T: DatadirTimeline, Reader: Read>(
             }
             "PG_VERSION" => {
                 let version_bytes = read_all_bytes(reader)?;
-                modification.put_pg_version(version_bytes.clone())?;
+                modification.put_pg_version(version_bytes)?;
 
                 debug!("imported PG_VERSION file");
             }
@@ -486,7 +486,7 @@ pub fn import_file<T: DatadirTimeline, Reader: Read>(
             }
             "PG_VERSION" => {
                 let version_bytes = read_all_bytes(reader)?;
-                modification.put_pg_version(version_bytes.clone())?;
+                modification.put_pg_version(version_bytes)?;
 
                 debug!("imported PG_VERSION file");
             }

--- a/pageserver/src/import_datadir.rs
+++ b/pageserver/src/import_datadir.rs
@@ -97,7 +97,6 @@ fn import_rel<T: DatadirTimeline, Reader: Read>(
     len: usize,
 ) -> anyhow::Result<()> {
     // Does it look like a relation file?
-    info!("importing rel file {}", path.display());
 
     let filename = &path
         .file_name()
@@ -127,7 +126,7 @@ fn import_rel<T: DatadirTimeline, Reader: Read>(
     // ignore "relation already exists" error
     if let Err(e) = modification.put_rel_creation(rel, nblocks as u32) {
         if e.to_string().contains("already exists") {
-            info!("relation {} already exists. we must be extending it", rel);
+            debug!("relation {} already exists. we must be extending it", rel);
         } else {
             return Err(e);
         }
@@ -161,7 +160,6 @@ fn import_rel<T: DatadirTimeline, Reader: Read>(
     //
     // If we process rel segments out of order,
     // put_rel_extend will skip the update.
-    info!("updating rel {} size to {}", rel, blknum);
     modification.put_rel_extend(rel, blknum)?;
 
     Ok(())

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -362,8 +362,8 @@ pub trait DatadirTimeline: Timeline {
         self.get(CHECKPOINT_KEY, lsn)
     }
 
-    pub fn get_pg_version(&self, lsn: Lsn) -> Result<Bytes> {
-        self.tline.get(PG_VERSION_KEY, lsn)
+    fn get_pg_version(&self, lsn: Lsn) -> Result<Bytes> {
+        self.get(PG_VERSION_KEY, lsn)
     }
 
     /// Does the same as get_current_logical_size but counted on demand.

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -362,6 +362,10 @@ pub trait DatadirTimeline: Timeline {
         self.get(CHECKPOINT_KEY, lsn)
     }
 
+    pub fn get_pg_version(&self, lsn: Lsn) -> Result<Bytes> {
+        self.tline.get(PG_VERSION_KEY, lsn)
+    }
+
     /// Does the same as get_current_logical_size but counted on demand.
     /// Used to initialize the logical size tracking on startup.
     ///
@@ -458,6 +462,7 @@ pub trait DatadirTimeline: Timeline {
 
         result.add_key(CONTROLFILE_KEY);
         result.add_key(CHECKPOINT_KEY);
+        result.add_key(PG_VERSION_KEY);
 
         Ok(result.to_keyspace())
     }
@@ -630,6 +635,11 @@ impl<'a, T: DatadirTimeline> DatadirModification<'a, T> {
 
     pub fn put_checkpoint(&mut self, img: Bytes) -> Result<()> {
         self.put(CHECKPOINT_KEY, Value::Image(img));
+        Ok(())
+    }
+
+    pub fn put_pg_version(&mut self, version: Bytes) -> Result<()> {
+        self.put(PG_VERSION_KEY, Value::Image(version));
         Ok(())
     }
 
@@ -1053,6 +1063,7 @@ static ZERO_PAGE: Bytes = Bytes::from_static(&[0u8; pg_constants::BLCKSZ as usiz
 // 03 misc
 //    controlfile
 //    checkpoint
+//    pg_version
 //
 // Below is a full list of the keyspace allocation:
 //
@@ -1091,7 +1102,9 @@ static ZERO_PAGE: Bytes = Bytes::from_static(&[0u8; pg_constants::BLCKSZ as usiz
 //
 // Checkpoint:
 // 03 00000000 00000000 00000000 00   00000001
-
+//
+// PG_VERSION:
+// 03 00000000 00000000 00000000 00   00000002
 //-- Section 01: relation data and metadata
 
 const DBDIR_KEY: Key = Key {
@@ -1313,6 +1326,15 @@ const CHECKPOINT_KEY: Key = Key {
     field4: 0,
     field5: 0,
     field6: 1,
+};
+
+const PG_VERSION_KEY: Key = Key {
+    field1: 0x03,
+    field2: 0,
+    field3: 0,
+    field4: 0,
+    field5: 0,
+    field6: 2,
 };
 
 // Reverse mappings for a few Keys.

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -116,7 +116,7 @@ impl<'a, T: DatadirTimeline> WalIngest<'a, T> {
             let truncate = XlSmgrTruncate::decode(&mut buf);
             self.ingest_xlog_smgr_truncate(modification, &truncate)?;
         } else if decoded.xl_rmid == pg_constants::RM_DBASE_ID {
-            info!(
+            debug!(
                 "handle RM_DBASE_ID for Postgres version {:?}",
                 self.pg_version
             );
@@ -125,7 +125,7 @@ impl<'a, T: DatadirTimeline> WalIngest<'a, T> {
                     == pg_constants::XLOG_DBASE_CREATE_v14
                 {
                     let createdb = XlCreateDatabase::decode(&mut buf);
-                    info!("XLOG_DBASE_CREATE_v14");
+                    debug!("XLOG_DBASE_CREATE_v14");
 
                     self.ingest_xlog_dbase_create(modification, &createdb)?;
                 } else if (decoded.xl_info & pg_constants::XLR_RMGR_INFO_MASK)
@@ -141,14 +141,14 @@ impl<'a, T: DatadirTimeline> WalIngest<'a, T> {
                 if (decoded.xl_info & pg_constants::XLR_RMGR_INFO_MASK)
                     == pg_constants::XLOG_DBASE_CREATE_WAL_LOG_v15
                 {
-                    info!("XLOG_DBASE_CREATE_WAL_LOG_v15: noop");
+                    debug!("XLOG_DBASE_CREATE_WAL_LOG_v15: noop");
                 } else if (decoded.xl_info & pg_constants::XLR_RMGR_INFO_MASK)
                     == pg_constants::XLOG_DBASE_CREATE_FILE_COPY_v15
                 {
                     // The XLOG record was renamed between v14 and v15,
                     // but the record format is the same.
                     // So we can reuse XlCreateDatabase here.
-                    info!("XLOG_DBASE_CREATE_FILE_COPY_v15");
+                    debug!("XLOG_DBASE_CREATE_FILE_COPY_v15");
                     let createdb = XlCreateDatabase::decode(&mut buf);
                     self.ingest_xlog_dbase_create(modification, &createdb)?;
                 } else if (decoded.xl_info & pg_constants::XLR_RMGR_INFO_MASK)

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1090,6 +1090,7 @@ mod tests {
         let mut m = tline.begin_modification(Lsn(0x10));
         m.put_checkpoint(ZERO_CHECKPOINT.clone())?;
         m.put_relmap_file(0, 111, Bytes::from(""))?; // dummy relmapper file
+        m.put_pg_version(Bytes::from("15"))?; // dummy pg_version file
         m.commit()?;
         let walingest = WalIngest::new(tline, Lsn(0x10))?;
 

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -384,6 +384,7 @@ impl XlXactParsedRecord {
         if xinfo & pg_constants::XACT_XINFO_HAS_INVALS != 0 {
             let nmsgs = buf.get_i32_le();
             for _i in 0..nmsgs {
+                //FIXME: what does this code do?
                 let sizeof_shared_invalidation_message = 0;
                 buf.advance(sizeof_shared_invalidation_message);
             }
@@ -393,12 +394,12 @@ impl XlXactParsedRecord {
             trace!("XLOG_XACT_COMMIT-XACT_XINFO_HAS_TWOPHASE");
         }
         if xinfo & pg_constants::XACT_XINFO_HAS_DROPPED_STATS != 0 {
-            info!("XLOG_XACT_COMMIT-XACT_XINFO_HAS_DROPPED_STATS");
-            //FIXME: do we need to handle dropped stats here?
-
             let nitems = buf.get_i32_le();
-            let sizeof_xl_xact_stats_item = 12 as usize;
-            buf.advance((nitems as usize) * sizeof_xl_xact_stats_item);
+            debug!(
+                "XLOG_XACT_COMMIT-XACT_XINFO_HAS_DROPPED_STAT nitems {}",
+                nitems
+            );
+            //FIXME: do we need to handle dropped stats here?
         }
 
         XlXactParsedRecord {


### PR DESCRIPTION
Update neon to work with v15.
Corresponding postgres PR: https://github.com/neondatabase/postgres/pull/185

- Store pg_version in the timeline instead of using hard coded constant.
- Handle WAL format changes in v15:
   -  lz4 and zstd methods of FPW compression are added. Adjust BKPIMAGE_* flags.
   - new XACT_XINFO_HAS_DROPPED_STATS flag, handle it
   -  WAL record XLOG_DBASE_CREATE turned into XLOG_DBASE_CREATE_WAL_LOG and XLOG_DBASE_CREATE_FILE_COPY records in v15.

TODO:

- [ ] fix tests from batch others