### PR TITLE
Share exponential backoff code and fix logic for delete task failure

### DIFF
--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -93,3 +93,56 @@ pub fn shutdown_pageserver(exit_code: i32) {
     info!("Shut down successfully completed");
     std::process::exit(exit_code);
 }
+
+const DEFAULT_BASE_BACKOFF_SECONDS: f64 = 0.1;
+const DEFAULT_MAX_BACKOFF_SECONDS: f64 = 3.0;
+
+async fn exponential_backoff(n: u32, base_increment: f64, max_seconds: f64) {
+    let backoff_duration_seconds =
+        exponential_backoff_duration_seconds(n, base_increment, max_seconds);
+    if backoff_duration_seconds > 0.0 {
+        info!(
+            "Backoff: waiting {backoff_duration_seconds} seconds before processing with the task",
+        );
+        tokio::time::sleep(std::time::Duration::from_secs_f64(backoff_duration_seconds)).await;
+    }
+}
+
+fn exponential_backoff_duration_seconds(n: u32, base_increment: f64, max_seconds: f64) -> f64 {
+    if n == 0 {
+        0.0
+    } else {
+        (1.0 + base_increment).powf(f64::from(n)).min(max_seconds)
+    }
+}
+
+#[cfg(test)]
+mod backoff_defaults_tests {
+    use super::*;
+
+    #[test]
+    fn backoff_defaults_produce_growing_backoff_sequence() {
+        let mut current_backoff_value = None;
+
+        for i in 0..10_000 {
+            let new_backoff_value = exponential_backoff_duration_seconds(
+                i,
+                DEFAULT_BASE_BACKOFF_SECONDS,
+                DEFAULT_MAX_BACKOFF_SECONDS,
+            );
+
+            if let Some(old_backoff_value) = current_backoff_value.replace(new_backoff_value) {
+                assert!(
+                    old_backoff_value <= new_backoff_value,
+                    "{i}th backoff value {new_backoff_value} is smaller than the previous one {old_backoff_value}"
+                )
+            }
+        }
+
+        assert_eq!(
+            current_backoff_value.expect("Should have produced backoff values to compare"),
+            DEFAULT_MAX_BACKOFF_SECONDS,
+            "Given big enough of retries, backoff should reach its allowed max value"
+        );
+    }
+}


### PR DESCRIPTION
Context: https://neondb.slack.com/archives/C033RQ5SPDH/p1659629771314369

* Fixes excessive `Skipping delete task due to failed upload tasks, reenqueuing` logs
* removes backoff on delete tasks when they are reenqueued due to failed upload task added in https://github.com/neondatabase/neon/pull/2190 
It is incorrect
* reuses the same `exponential_backoff` function in the storage_sync code

-------------------------

The error causing excessive logging was the logic, that rescheduled deletions even if there were no upload tasks run in the same batch.
This way, no timeouts were checked, since deletions were not actually started, instead instantly skipped due to no uploads in the task.

I have an ugly test for this, but @hlinnaka overhauls entire storage_sync.rs in https://github.com/neondatabase/neon/pull/2231 so I don't really want to commit it, since it needs even more ugliness to ensure it does not hang on error:

```rust
#[tokio::test]
async fn only_delete_layer_batch() -> anyhow::Result<()> {
    use crate::{
        repository::repo_harness::RepoHarness, storage_sync::test_utils::create_local_timeline,
    };
    use remote_storage::LocalFs;
    use tempfile::tempdir;

    let harness = RepoHarness::create("only_delete_layer_batch")?;
    let index = RemoteIndex::from_parts(harness.conf, HashMap::new())?;
    let sync_queue = SyncQueue::new(NonZeroUsize::new(100).unwrap());
    let sync_id = ZTenantTimelineId::new(harness.tenant_id, TIMELINE_ID);

    let layer_files = ["a", "b", "c", "d"];
    let storage = Arc::new(LocalFs::new(
        tempdir()?.path().to_path_buf(),
        harness.conf.workdir.clone(),
    )?);
    let current_retries = 3;
    let metadata = dummy_metadata(Lsn(0x30));
    let local_timeline_path = harness.timeline_path(&TIMELINE_ID);
    let timeline_upload =
        create_local_timeline(&harness, TIMELINE_ID, &layer_files, metadata.clone()).await?;
    for local_path in &timeline_upload.layers_to_upload {
        let remote_path = storage.remote_object_id(local_path)?;
        let remote_parent_dir = remote_path.parent().unwrap();
        if !remote_parent_dir.exists() {
            fs::create_dir_all(&remote_parent_dir).await?;
        }
        fs::copy(local_path, &remote_path).await?;
    }

    let delete = LayersDeletion {
        layers_to_delete: timeline_upload.layers_to_upload,
        deleted_layers: HashSet::new(),
        deletion_registered: false,
    };
    sync_queue.push(TEST_SYNC_ID, SyncTask::delete(delete.clone()));

    let (batch, queue_length) = sync_queue.next_task_batch();
    dbg!(queue_length);
    let (_, batch) = batch.into_iter().next().unwrap();

    let z = super::process_sync_task_batch(
        harness.conf,
        (storage, index, &sync_queue),
        NonZeroU32::new(10).unwrap(),
        sync_id,
        batch,
    )
    .await;

     // TODO this test now will hang if deletion processing works properly, since the next task batch is queried on an empty queue
    dbg!(z, sync_queue.next_task_batch());

    Ok(())
}
```

The test should pass on `main` since the deletion task gets rescheduled but should hang on this branch, since the deletion task does not get rescheduled and we query the batch on an empty queue.

I could have adjusted the test more, but it's quite big and would be deleted due to an overhaul so does not seem to be worth an effort.