### PR TITLE
Expose timeline logical size as a prometheus metric.

### DIFF
--- a/libs/postgres_ffi/src/nonrelfile_utils.rs
+++ b/libs/postgres_ffi/src/nonrelfile_utils.rs
@@ -1,8 +1,8 @@
 //!
 //! Common utilities for dealing with PostgreSQL non-relation files.
 //!
-use crate::transaction_id_precedes;
 use super::pg_constants;
+use crate::transaction_id_precedes;
 use bytes::BytesMut;
 use log::*;
 

--- a/libs/postgres_ffi/src/waldecoder.rs
+++ b/libs/postgres_ffi/src/waldecoder.rs
@@ -8,9 +8,9 @@
 //! to look deeper into the WAL records to also understand which blocks they modify, the code
 //! for that is in pageserver/src/walrecord.rs
 //!
+use super::bindings::{XLogLongPageHeaderData, XLogPageHeaderData, XLogRecord, XLOG_PAGE_MAGIC};
 use super::pg_constants;
 use super::xlog_utils::*;
-use super::bindings::{XLogLongPageHeaderData, XLogPageHeaderData, XLogRecord, XLOG_PAGE_MAGIC};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crc32c::*;
 use log::*;


### PR DESCRIPTION
Physical size was already exposed, and it'd be nice to show both
logical and physical size side by side in our graphana dashboards.