### PR TITLE
log: adding context to wal timeout errors

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -80,7 +80,12 @@ where
         let (backup_prev, backup_lsn) = if let Some(req_lsn) = req_lsn {
             // Backup was requested at a particular LSN. Wait for it to arrive.
             info!("waiting for {}", req_lsn);
-            timeline.wait_lsn(req_lsn)?;
+
+            let ctx = format!(
+                "Backup was already requested at lsn {}. Waiting for it to arrive.",
+                req_lsn
+            );
+            timeline.wait_lsn(req_lsn, &ctx)?;
 
             // If the requested point is the end of the timeline, we can
             // provide prev_lsn. (get_last_record_rlsn() might return it as

--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -418,7 +418,7 @@ impl Timeline for LayeredTimeline {
     }
 
     /// Wait until WAL has been received up to the given LSN.
-    fn wait_lsn(&self, lsn: Lsn) -> anyhow::Result<()> {
+    fn wait_lsn(&self, lsn: Lsn, ctx: &str) -> anyhow::Result<()> {
         // This should never be called from the WAL receiver thread, because that could lead
         // to a deadlock.
         ensure!(
@@ -431,8 +431,8 @@ impl Timeline for LayeredTimeline {
                 .wait_for_timeout(lsn, self.conf.wait_lsn_timeout)
                 .with_context(|| {
                     format!(
-                        "Timed out while waiting for WAL record at LSN {} to arrive, last_record_lsn {} disk consistent LSN={}",
-                        lsn, self.get_last_record_lsn(), self.get_disk_consistent_lsn()
+                        "Timed out while waiting for WAL record at LSN {} to arrive, last_record_lsn {} disk consistent LSN={} context={}",
+                        lsn, self.get_last_record_lsn(), self.get_disk_consistent_lsn(), ctx
                     )
                 }))?;
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -663,7 +663,11 @@ impl PageServerHandler {
             if lsn <= last_record_lsn {
                 lsn = last_record_lsn;
             } else {
-                timeline.wait_lsn(lsn)?;
+                let ctx = format!(
+                    "requested lsn: {} is ahead of last_record_lsn: {}",
+                    lsn, last_record_lsn
+                );
+                timeline.wait_lsn(lsn, &ctx)?;
                 // Since we waited for 'lsn' to arrive, that is now the last
                 // record LSN. (Or close enough for our purposes; the
                 // last-record LSN can advance immediately after we return
@@ -673,7 +677,8 @@ impl PageServerHandler {
             if lsn == Lsn(0) {
                 bail!("invalid LSN(0) in request");
             }
-            timeline.wait_lsn(lsn)?;
+            let ctx = format!("requesting lsn: {}. Latest page wasn't requested.", lsn);
+            timeline.wait_lsn(lsn, &ctx)?;
         }
         ensure!(
             lsn >= **latest_gc_cutoff_lsn,

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -316,7 +316,7 @@ pub trait Timeline: Send + Sync {
     /// You should call this before any of the other get_* or list_* functions. Calling
     /// those functions with an LSN that has been processed yet is an error.
     ///
-    fn wait_lsn(&self, lsn: Lsn) -> Result<()>;
+    fn wait_lsn(&self, lsn: Lsn, ctx: &str) -> Result<()>;
 
     /// Lock and get timeline's GC cuttof
     fn get_latest_gc_cutoff_lsn(&self) -> RwLockReadGuard<Lsn>;

--- a/pageserver/src/timelines.rs
+++ b/pageserver/src/timelines.rs
@@ -246,7 +246,9 @@ pub(crate) fn create_timeline(
                 // sizes etc. and that would get confused if the previous page versions
                 // are not in the repository yet.
                 *lsn = lsn.align();
-                ancestor_timeline.wait_lsn(*lsn)?;
+
+                let ctx = "waiting for the requested ancestor_start_lsn to complete";
+                ancestor_timeline.wait_lsn(*lsn, ctx)?;
 
                 let ancestor_ancestor_lsn = ancestor_timeline.get_ancestor_lsn();
                 if ancestor_ancestor_lsn > *lsn {


### PR DESCRIPTION
Extend the `wait_lsn()` to accept a `str` context.

This is simply helpful to quickly figure out, which operation
was exactly in progress when the timeout really happened.

fixes #2106