### PR TITLE
Better storage sync logs

### DIFF
--- a/pageserver/src/storage_sync/delete.rs
+++ b/pageserver/src/storage_sync/delete.rs
@@ -95,6 +95,8 @@ where
         debug!("Reenqueuing failed delete task for timeline {sync_id}");
         delete_data.retries += 1;
         sync_queue.push(sync_id, SyncTask::Delete(delete_data));
+    } else {
+        info!("Successfully deleted all layers");
     }
     errored
 }


### PR DESCRIPTION
Have tried to follow-up https://github.com/neondatabase/neon/pull/2252#issuecomment-1212456075 with a GC and remote storage test, but turns out we need to add more metadata/methods to know that we've actually finished a download task: it does not update any data, visible to any APIs currently.

Since the storage sync gets changed massively in https://github.com/neondatabase/neon/pull/2231, I've decided to not to add any metadata and instead add more logging to better display the log flood issue, if it reappears after the fixes.

<details> 
  <summary>GC + remote storage test </summary>

   ```python
from contextlib import closing
from fixtures.utils import print_gc_result
import psycopg2.extras
import random

#
# Tests that a single delete task works correctly and removes data from remote storage.
# Generates a lot of data,
@pytest.mark.parametrize('remote_storatge_kind', available_remote_storages())
def test_remote_storage_removals(
    neon_env_builder: NeonEnvBuilder,
    remote_storatge_kind: RemoteStorageKind,
):
    # Disable pitr, because here we want to test branch creation after GC and set layer size to 20 MiB
    neon_env_builder.pageserver_config_override = "tenant_config={pitr_interval = '0 sec', checkpoint_distance = 10971520, compaction_threshold = 1, image_creation_threshold = 1}"
    # neon_env_builder.rust_log_override = 'debug'

    neon_env_builder.enable_remote_storage(
        remote_storage_kind=remote_storatge_kind,
        test_name='test_remote_storage_removals',
    )

    ##### First start, insert a lot data and upload it to the remote storage
    env = neon_env_builder.init_start()
    pg = env.postgres.create_start('main')

    client = env.pageserver.http_client()

    tenant_id = pg.safe_psql("show neon.tenant_id")[0][0]
    timeline_id = pg.safe_psql("show neon.timeline_id")[0][0]

    num_rows = 200_000
    updates_to_perform = 20_000
    updates_performed = 0

    with pg.cursor() as cur:
        log.info(f'creating the data')
        cur.execute('CREATE TABLE foo (id int, counter int, t text)')
        cur.execute(f'''
            INSERT INTO foo
                SELECT g, 0, 'long string to consume some spacelong string to consume some spacelong string to consume some spacelong string to consume some spacelong string to consume some spacelong string to consume some space' || g
                FROM generate_series(1, {num_rows}) g
        ''')
        cur.execute('CREATE INDEX ON foo(id)')

        log.info(f'updating the data')
        while updates_performed < updates_to_perform:
            updates_performed += 1
            id = random.randrange(1, num_rows)
            cur.execute(f'UPDATE foo SET counter = counter + 1 WHERE id = {id}')

        current_lsn = lsn_from_hex(query_scalar(cur, "SELECT pg_current_wal_flush_lsn()"))

    # wait until pageserver receives that data
    wait_for_last_record_lsn(client, UUID(tenant_id), UUID(timeline_id), current_lsn)

    # run checkpoint manually to be sure that data landed in remote storage
    env.pageserver.safe_psql(f"checkpoint {tenant_id} {timeline_id}")
    log.info(f'waiting for checkpoint upload')
    wait_for_upload(client, UUID(tenant_id), UUID(timeline_id), current_lsn)
    log.info(f'upload of checkpoint is done')

    # run GC
    with closing(env.pageserver.connect()) as psconn:
        with psconn.cursor(cursor_factory=psycopg2.extras.DictCursor) as pscur:
            pscur.execute(f"compact {env.initial_tenant.hex} {timeline_id}")
            # perform aggressive GC. Data still should be kept because of the PITR setting.
            pscur.execute(f"do_gc {env.initial_tenant.hex} {timeline_id} 0")
            row = pscur.fetchone()
            print_gc_result(row)


    # TODO kb how to wait for the deletion cleverer?
    time.sleep(200)

```

</details>

