### PR TITLE
Disable unexpected XLP_FIRST_IS_CONTRECORD bit check.

### DIFF
--- a/libs/postgres_ffi/src/waldecoder.rs
+++ b/libs/postgres_ffi/src/waldecoder.rs
@@ -84,11 +84,14 @@ impl WalStreamDecoder {
             }
             match self.state {
                 State::WaitingForRecord => {
-                    if hdr.xlp_info & XLP_FIRST_IS_CONTRECORD != 0 {
-                        return Err(
-                            "invalid xlog page header: unexpected XLP_FIRST_IS_CONTRECORD".into(),
-                        );
-                    }
+                    // TODO: uncomment once all WAL with redundant bit reaches
+                    // pageserver(s) on prod/staging. Stamping redundant bit was
+                    // removed in 49015ce98f550d postgres commit.
+                    // if hdr.xlp_info & XLP_FIRST_IS_CONTRECORD != 0 {
+                    //     return Err(
+                    //         "invalid xlog page header: unexpected XLP_FIRST_IS_CONTRECORD".into(),
+                    //     );
+                    // }
                     if hdr.xlp_rem_len != 0 {
                         return Err(format!(
                             "invalid xlog page header: xlp_rem_len={}, but it's not a contrecord",


### PR DESCRIPTION
We created a bunch of inappropriate bits in the past; let's remove the check for
some time to let WAL go through instead of doing binary acrobatics on prod WAL
files.