### PR TITLE
Remove extra type aliases

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -11,14 +11,13 @@ use super::models::{
     StatusResponse, TenantConfigRequest, TenantCreateRequest, TenantCreateResponse, TenantInfo,
     TimelineCreateRequest,
 };
-use crate::layered_repository::metadata::TimelineMetadata;
+use crate::layered_repository::{metadata::TimelineMetadata, LayeredTimeline};
 use crate::pgdatadir_mapping::DatadirTimeline;
 use crate::repository::{LocalTimelineState, RepositoryTimeline};
 use crate::repository::{Repository, Timeline};
 use crate::storage_sync;
 use crate::storage_sync::index::{RemoteIndex, RemoteTimeline};
 use crate::tenant_config::TenantConfOpt;
-use crate::TimelineImpl;
 use crate::{config::PageServerConf, tenant_mgr, timelines};
 use utils::{
     auth::JwtAuth,
@@ -86,7 +85,7 @@ fn get_config(request: &Request<Body>) -> &'static PageServerConf {
 // Helper functions to construct a LocalTimelineInfo struct for a timeline
 
 fn local_timeline_info_from_loaded_timeline(
-    timeline: &TimelineImpl,
+    timeline: &LayeredTimeline,
     include_non_incremental_logical_size: bool,
     include_non_incremental_physical_size: bool,
 ) -> anyhow::Result<LocalTimelineInfo> {
@@ -161,7 +160,7 @@ fn local_timeline_info_from_unloaded_timeline(metadata: &TimelineMetadata) -> Lo
 }
 
 fn local_timeline_info_from_repo_timeline(
-    repo_timeline: &RepositoryTimeline<TimelineImpl>,
+    repo_timeline: &RepositoryTimeline<LayeredTimeline>,
     include_non_incremental_logical_size: bool,
     include_non_incremental_physical_size: bool,
 ) -> anyhow::Result<LocalTimelineInfo> {

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -59,7 +59,9 @@ mod storage_layer;
 mod timeline;
 
 use storage_layer::Layer;
-use timeline::{LayeredTimeline, LayeredTimelineEntry};
+use timeline::LayeredTimelineEntry;
+
+pub use timeline::LayeredTimeline;
 
 // re-export this function so that page_cache.rs can use it.
 pub use crate::layered_repository::ephemeral_file::writeback as writeback_ephemeral_file;

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -28,7 +28,6 @@ use tracing::info;
 use crate::thread_mgr::ThreadKind;
 use metrics::{register_int_gauge_vec, IntGaugeVec};
 
-use layered_repository::LayeredRepository;
 use pgdatadir_mapping::DatadirTimeline;
 
 /// Current storage format version
@@ -61,9 +60,6 @@ pub enum CheckpointConfig {
     // Flush all in-memory data and reconstruct all page images
     Forced,
 }
-
-pub type RepositoryImpl = LayeredRepository;
-pub type TimelineImpl = <LayeredRepository as repository::Repository>::Timeline;
 
 pub fn shutdown_pageserver(exit_code: i32) {
     // Shut down the libpq endpoint thread. This prevents new connections from

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -412,7 +412,6 @@ pub mod repo_harness {
     use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
     use std::{fs, path::PathBuf};
 
-    use crate::RepositoryImpl;
     use crate::{
         config::PageServerConf,
         layered_repository::LayeredRepository,
@@ -508,11 +507,11 @@ pub mod repo_harness {
             })
         }
 
-        pub fn load(&self) -> RepositoryImpl {
+        pub fn load(&self) -> LayeredRepository {
             self.try_load().expect("failed to load test repo")
         }
 
-        pub fn try_load(&self) -> Result<RepositoryImpl> {
+        pub fn try_load(&self) -> Result<LayeredRepository> {
             let walredo_mgr = Arc::new(TestRedoManager);
 
             let repo = LayeredRepository::new(

--- a/pageserver/src/timelines.rs
+++ b/pageserver/src/timelines.rs
@@ -21,10 +21,13 @@ use utils::{
 use crate::tenant_mgr;
 use crate::{
     config::PageServerConf, repository::Repository, storage_sync::index::RemoteIndex,
-    tenant_config::TenantConfOpt, RepositoryImpl, TimelineImpl,
+    tenant_config::TenantConfOpt,
 };
 use crate::{import_datadir, LOG_FILE_NAME};
-use crate::{layered_repository::LayeredRepository, walredo::WalRedoManager};
+use crate::{
+    layered_repository::{LayeredRepository, LayeredTimeline},
+    walredo::WalRedoManager,
+};
 use crate::{repository::Timeline, CheckpointConfig};
 
 #[derive(Debug, Clone, Copy)]
@@ -73,7 +76,7 @@ pub fn create_repo(
     tenant_conf: TenantConfOpt,
     tenant_id: ZTenantId,
     create_repo: CreateRepo,
-) -> Result<Arc<RepositoryImpl>> {
+) -> Result<Arc<LayeredRepository>> {
     let (wal_redo_manager, remote_index) = match create_repo {
         CreateRepo::Real {
             wal_redo_manager,
@@ -223,7 +226,7 @@ pub(crate) fn create_timeline(
     new_timeline_id: Option<ZTimelineId>,
     ancestor_timeline_id: Option<ZTimelineId>,
     mut ancestor_start_lsn: Option<Lsn>,
-) -> Result<Option<(ZTimelineId, Arc<TimelineImpl>)>> {
+) -> Result<Option<(ZTimelineId, Arc<LayeredTimeline>)>> {
     let new_timeline_id = new_timeline_id.unwrap_or_else(ZTimelineId::generate);
     let repo = tenant_mgr::get_repository_for_tenant(tenant_id)?;
 


### PR DESCRIPTION
Follow-up of https://github.com/neondatabase/neon/pull/2231#discussion_r942313342

Removes both timeline-related type aliases, simplifying some type declarations:

Before: `local_timelines: HashMap<ZTimelineId, Arc<<RepositoryImpl as Repository>::Timeline>>,` 
After   : `local_timelines: HashMap<ZTimelineId, Arc<LayeredTimeline>>,`