### PR TITLE
Check for entire range during sasl validation

### DIFF
--- a/proxy/src/scram/messages.rs
+++ b/proxy/src/scram/messages.rs
@@ -14,7 +14,7 @@ pub const SCRAM_RAW_NONCE_LEN: usize = 18;
 fn validate_sasl_extensions<'a>(parts: impl Iterator<Item = &'a str>) -> Option<()> {
     for mut chars in parts.map(|s| s.chars()) {
         let attr = chars.next()?;
-        if !('a'..'z').contains(&attr) && !('A'..'Z').contains(&attr) {
+        if !('a'..='z').contains(&attr) && !('A'..='Z').contains(&attr) {
             return None;
         }
         let eq = chars.next()?;


### PR DESCRIPTION
1.63 clippy pointed out an interesting pattern in the code, I've decided to separate it from the rest of the clippy fixes to ensure it's the right thing to do.