### PR TITLE
Make local mypy behave like CI mypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,10 @@ exclude = ^vendor/
 # some tests don't typecheck when this flag is set
 check_untyped_defs = false
 
+# Help mypy find imports when running against list of individual files.
+# Without this line it would behave differently when executed on the entire project.
+mypy_path = $MYPY_CONFIG_FILE_DIR:$MYPY_CONFIG_FILE_DIR/test_runner
+
 disallow_incomplete_defs = false
 disallow_untyped_calls = false
 disallow_untyped_decorators = false


### PR DESCRIPTION
Running `make fmt` sometimes returns error locally, but runs fine on CI.

To narrow down the problem, running mypy on an individual file returns errors that are not found when running mypy on the project. The `make fmt` script runs mypy on individual files, but ci runs `poetry run mypy .`

Example, running on main branch:
```
$ poetry run mypy test_runner/batch_others/test_pageserver_restart.py
test_runner/batch_others/test_pageserver_restart.py:1: error: Cannot find implementation or library stub for module named "fixtures.neon_fixtures"
test_runner/batch_others/test_pageserver_restart.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
test_runner/batch_others/test_pageserver_restart.py:2: error: Cannot find implementation or library stub for module named "fixtures.log_helper"
```

My solution is to explicitly tell mypy where to look for imports.
