### PR TITLE
Use better defaults for pageserver Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+### Creates a storage Docker image with postgres, pageserver, safekeeper and proxy binaries.
+### The image itself is mainly used as a container for the binaries and for starting e2e tests with custom parameters.
+### By default, the binaries inside the image have some mock parameters and can start, but are not intended to be used
+### inside this image in the real deployments.
+
 # Build Postgres
 FROM 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned AS pg-build
 WORKDIR /home/nonroot
@@ -58,7 +63,18 @@ COPY --from=build --chown=zenith:zenith /home/nonroot/target/release/proxy      
 COPY --from=pg-build /home/nonroot/tmp_install/ /usr/local/
 COPY --from=pg-build /home/nonroot/postgres_install.tar.gz /data/
 
+# By default, pageserver uses `.neon/` working directory in WORKDIR, so create one and fill it with the dummy config.
+# Now, when `docker run ... pageserver` is run, it can start without errors, yet will have some default dummy values.
+RUN mkdir -p /data/.neon/ && chown -R zenith:zenith /data/.neon/ \
+    && /usr/local/bin/pageserver -D /data/.neon/ --init \
+       -c "id=1234" \
+       -c "broker_endpoints=['http://etcd:2379']" \
+       -c "pg_distrib_dir='/usr/local'" \
+       -c "listen_pg_addr='0.0.0.0:6400'" \
+       -c "listen_http_addr='0.0.0.0:9898'"
+
 VOLUME ["/data"]
 USER zenith
 EXPOSE 6400
-CMD ["pageserver"]
+EXPOSE 9898
+CMD ["/bin/bash"]


### PR DESCRIPTION
Follow-up of https://github.com/neondatabase/neon/pull/2272 and https://neondb.slack.com/archives/C039YKBRZB4/p1660811291662979?thread_ts=1660773828.605099&cid=C039YKBRZB4

`init` overhaul [removed](https://github.com/neondatabase/neon/pull/2272/files#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038a) the entrypoint that improved pageserver's usability inside the Docker container: it was able to start without errors and pretend to work.
PR recreates similar situation, but without an entrypoint.