### PR TITLE
Explicitly error on cache issues during I/O

### DIFF
--- a/pageserver/src/layered_repository/block_io.rs
+++ b/pageserver/src/layered_repository/block_io.rs
@@ -157,7 +157,14 @@ where
         // Look up the right page
         let cache = page_cache::get();
         loop {
-            match cache.read_immutable_buf(self.file_id, blknum) {
+            match cache
+                .read_immutable_buf(self.file_id, blknum)
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("Failed to read immutable buf: {e:#}"),
+                    )
+                })? {
                 ReadBufResult::Found(guard) => break Ok(guard),
                 ReadBufResult::NotFound(mut write_guard) => {
                     // Read the page from disk into the buffer

--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -2117,7 +2117,7 @@ impl LayeredTimeline {
         key: Key,
         request_lsn: Lsn,
         mut data: ValueReconstructState,
-    ) -> Result<Bytes> {
+    ) -> anyhow::Result<Bytes> {
         // Perform WAL redo if needed
         data.records.reverse();
 
@@ -2167,13 +2167,15 @@ impl LayeredTimeline {
 
                 if img.len() == page_cache::PAGE_SZ {
                     let cache = page_cache::get();
-                    cache.memorize_materialized_page(
-                        self.tenant_id,
-                        self.timeline_id,
-                        key,
-                        last_rec_lsn,
-                        &img,
-                    );
+                    cache
+                        .memorize_materialized_page(
+                            self.tenant_id,
+                            self.timeline_id,
+                            key,
+                            last_rec_lsn,
+                            &img,
+                        )
+                        .context("Materialized page memoization failed")?;
                 }
 
                 Ok(img)


### PR DESCRIPTION
Context: https://neondb.slack.com/archives/C033A2WE6BZ/p1660815372124669?thread_ts=1660811826.449959&cid=C033A2WE6BZ

GC panics on out of disk errors, one of the sources was found in the logs as 

```
2022-08-17T16:53:49.594216Z ERROR gc iteration{tenant=0f64cffb9a8a48b2cfcc8c1ba97493df timeline=None}: writeback of buffer EphemeralPage { file_id: 7, blkno: 8019 } failed: failed to write back to ephemeral file at /storage/pageserver/data/tenants/0d3d204617651d10e4e1b6adac554419/timelines/436d7c005a9d2f3e24c2494c392d4c9a/ephemeral-7 error: No space left on device (os error 28)
thread 'tenant-task-worker' panicked at 'could not find a victim buffer to evict', 2022-08-17T16:53:49.594232Z ERROR gc iteration{tenant=bc7a5b7a93a7a8392d87173348d3e95e timeline=None}: writeback of buffer EphemeralPage { file_id: 7, blkno: 2886 } failed: failed to write back to ephemeral file at /storage/pageserver/data/tenants/0d3d204617651d10e4e1b6adac554419/timelines/436d7c005a9d2f3e24c2494c392d4c9a/ephemeral-7 error: No space left on device (os error 28)
pageserver/src/page_cache.rs:780:292022-08-17T16:53:49.594246Z ERROR gc iteration{tenant=47910a4336a82dc994d787363a1aad41 timeline=None}: writeback of buffer EphemeralPage { file_id: 7, blkno: 5335 } failed: failed to write back to ephemeral file at /storage/pageserver/data/tenants/0d3d204617651d10e4e1b6adac554419/timelines/436d7c005a9d2f3e24c2494c392d4c9a/ephemeral-7 error: No space left on device (os error 28)
stack backtrace:
```

The PR replaces `panic!` with `anyhow::bail!` and makes the method users to handle the error.