### PR TITLE
Add 'push to docker hub' step for compute tools, and use tags more correctly

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -461,14 +461,48 @@ jobs:
         run:
           MANIFEST=$(aws ecr batch-get-image --repository-name ${{ matrix.name }} --image-ids imageTag=$GITHUB_RUN_ID --query 'images[].imageManifest' --output text) && aws ecr put-image --repository-name ${{ matrix.name }} --image-tag latest --image-manifest "$MANIFEST"
 
+  push-compute-tools-docker-hub:
+    runs-on: dev
+    needs: [ promote-image-compute-tools, tag ]
+    container: golang:1.19-bullseye
+
+    steps:
+      - name: Install Crane & ECR helper
+        run: |
+          go install github.com/google/go-containerregistry/cmd/crane@31786c6cbb82d6ec4fb8eb79cd9387905130534e # v0.11.0
+          go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@69c85dc22db6511932bbf119e1a0cc5c90c69a7f # v0.6.0
+      
+      - name: Configure ECR login
+        run: |
+          mkdir /github/home/.docker/
+          echo "{\"credsStore\":\"ecr-login\"}" > /github/home/.docker/config.json
+
+      - name: Pull compute tools image from ECR
+        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:$GITHUB_RUN_ID compute-tools
+
+      - name: Configure docker login
+        run: |
+          # ECR Credential Helper & Docker Hub don't work together in config, hence reset
+          echo "" > /github/home/.docker/config.json
+          crane auth login -u ${{ secrets.NEON_DOCKERHUB_USERNAME }} -p ${{ secrets.NEON_DOCKERHUB_PASSWORD }} index.docker.io
+
+      - name: Push compute tools image to Docker Hub
+        run: crane push compute-tools neondatabase/compute-tools:${{needs.tag.outputs.build-tag}}
+
+      - name: Add latest tag to image
+        if: |
+          (github.ref_name == 'main' || github.ref_name == 'release') &&
+          github.event_name != 'workflow_dispatch'
+        run: |
+          crane tag neondatabase/compute-tools:${{needs.tag.outputs.build-tag}} latest
+
   compute-node-image:
     runs-on: dev
     container: gcr.io/kaniko-project/executor:v1.9.0-debug
     # note: This image depends on neondatabase/compute-tools:latest (or :thisversion),
     # which isn't available until after the image is promoted.
     # Ergo, we must explicitly build and promote compute-tools separately.
-    needs:
-      - promote-image-compute-tools
+    needs: [ push-compute-tools-docker-hub, tag]
 
     steps:
       - name: Checkout
@@ -482,7 +516,15 @@ jobs:
 
       - name: Kaniko build compute node
         working-directory: ./vendor/postgres/
-        run: /kaniko/executor --snapshotMode=redo --cache=true --cache-repo 369495373322.dkr.ecr.eu-central-1.amazonaws.com/cache --snapshotMode=redo --context . --build-arg=COMPUTE_TOOLS_TAG=$GITHUB_RUN_ID --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node:$GITHUB_RUN_ID
+        run: >
+          /kaniko/executor
+          --snapshotMode=redo
+          --cache=true
+          --cache-repo 369495373322.dkr.ecr.eu-central-1.amazonaws.com/cache
+          --snapshotMode=redo
+          --context .
+          --build-arg=COMPUTE_TOOLS_TAG=${{needs.tag.outputs.build-tag}}
+          --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node:$GITHUB_RUN_ID
 
   promote-images:
     runs-on: dev
@@ -530,9 +572,6 @@ jobs:
       - name: Pull neon image from ECR
         run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:latest neon
 
-      - name: Pull compute tools image from ECR
-        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:latest compute-tools
-
       - name: Pull compute node image from ECR
         run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node:latest compute-node
 
@@ -545,9 +584,6 @@ jobs:
       - name: Push neon image to Docker Hub
         run: crane push neon neondatabase/neon:${{needs.tag.outputs.build-tag}}
 
-      - name: Push compute tools image to Docker Hub
-        run: crane push compute-tools neondatabase/compute-tools:${{needs.tag.outputs.build-tag}}
-
       - name: Push compute node image to Docker Hub
         run: crane push compute-node neondatabase/compute-node:${{needs.tag.outputs.build-tag}}
 
@@ -557,7 +593,6 @@ jobs:
           github.event_name != 'workflow_dispatch'
         run: |
           crane tag neondatabase/neon:${{needs.tag.outputs.build-tag}} latest
-          crane tag neondatabase/compute-tools:${{needs.tag.outputs.build-tag}} latest
           crane tag neondatabase/compute-node:${{needs.tag.outputs.build-tag}} latest
 
   calculate-deploy-targets:


### PR DESCRIPTION
This fixes a live issue in CI correctness, and should fix build issues in
the main branch by correctly ordering image uploads and depending on the
correct image tags.

Previously, I'd used the build id, as opposed to the tag number generated in the `tag` job (this job I hadn't realized was critical for generating these sequential tag numbers). Anyway, that should fix the issue we encounter here: https://github.com/neondatabase/neon/runs/7913544606