### PR TITLE
Add fork_at_current_lsn function which creates branch at current LSN

### DIFF
--- a/test_runner/batch_others/test_branching.py
+++ b/test_runner/batch_others/test_branching.py
@@ -5,7 +5,7 @@ from typing import List
 
 import pytest
 from fixtures.log_helper import log
-from fixtures.neon_fixtures import NeonEnv, PgBin, Postgres, fork_at_current_lsn
+from fixtures.neon_fixtures import NeonEnv, PgBin, Postgres
 from performance.test_perf_pgbench import get_scales_matrix
 
 
@@ -46,9 +46,7 @@ def test_branching_with_pgbench(
         pg_bin.run_capture(["pgbench", "-i", f"-s{scale}", connstr])
         pg_bin.run_capture(["pgbench", "-T15", connstr])
 
-    pg = env.postgres.create_start("main", tenant_id=tenant)
-    fork_at_current_lsn(env, pg, "b0", tenant_id=tenant)
-
+    env.neon_cli.create_branch("b0", tenant_id=tenant)
     pgs: List[Postgres] = []
     pgs.append(env.postgres.create_start("b0", tenant_id=tenant))
 
@@ -74,9 +72,9 @@ def test_branching_with_pgbench(
             threads = []
 
         if ty == "cascade":
-            fork_at_current_lsn(env, pg, "b{}".format(i + 1), "b{}".format(i), tenant_id=tenant)
+            env.neon_cli.create_branch("b{}".format(i + 1), "b{}".format(i), tenant_id=tenant)
         else:
-            fork_at_current_lsn(env, pg, "b{}".format(i + 1), "b0", tenant_id=tenant)
+            env.neon_cli.create_branch("b{}".format(i + 1), "b0", tenant_id=tenant)
 
         pgs.append(env.postgres.create_start("b{}".format(i + 1), tenant_id=tenant))
 

--- a/test_runner/batch_others/test_branching.py
+++ b/test_runner/batch_others/test_branching.py
@@ -5,7 +5,7 @@ from typing import List
 
 import pytest
 from fixtures.log_helper import log
-from fixtures.neon_fixtures import NeonEnv, PgBin, Postgres
+from fixtures.neon_fixtures import NeonEnv, PgBin, Postgres, fork_at_current_lsn
 from performance.test_perf_pgbench import get_scales_matrix
 
 
@@ -46,7 +46,9 @@ def test_branching_with_pgbench(
         pg_bin.run_capture(["pgbench", "-i", f"-s{scale}", connstr])
         pg_bin.run_capture(["pgbench", "-T15", connstr])
 
-    env.neon_cli.create_branch("b0", tenant_id=tenant)
+    pg = env.postgres.create_start("main", tenant_id=tenant)
+    fork_at_current_lsn(env, pg, "b0", tenant_id=tenant)
+
     pgs: List[Postgres] = []
     pgs.append(env.postgres.create_start("b0", tenant_id=tenant))
 
@@ -72,9 +74,9 @@ def test_branching_with_pgbench(
             threads = []
 
         if ty == "cascade":
-            env.neon_cli.create_branch("b{}".format(i + 1), "b{}".format(i), tenant_id=tenant)
+            fork_at_current_lsn(env, pg, "b{}".format(i + 1), "b{}".format(i), tenant_id=tenant)
         else:
-            env.neon_cli.create_branch("b{}".format(i + 1), "b0", tenant_id=tenant)
+            fork_at_current_lsn(env, pg, "b{}".format(i + 1), "b0", tenant_id=tenant)
 
         pgs.append(env.postgres.create_start("b{}".format(i + 1), tenant_id=tenant))
 

--- a/test_runner/batch_others/test_twophase.py
+++ b/test_runner/batch_others/test_twophase.py
@@ -1,7 +1,7 @@
 import os
 
 from fixtures.log_helper import log
-from fixtures.neon_fixtures import NeonEnv
+from fixtures.neon_fixtures import NeonEnv, fork_at_current_lsn
 
 
 #
@@ -55,7 +55,7 @@ def test_twophase(neon_simple_env: NeonEnv):
     assert len(twophase_files) == 2
 
     # Create a branch with the transaction in prepared state
-    env.neon_cli.create_branch("test_twophase_prepared", "test_twophase")
+    fork_at_current_lsn(env, pg, "test_twophase_prepared", "test_twophase")
 
     # Start compute on the new branch
     pg2 = env.postgres.create_start(

--- a/test_runner/batch_others/test_vm_bits.py
+++ b/test_runner/batch_others/test_vm_bits.py
@@ -1,5 +1,5 @@
 from fixtures.log_helper import log
-from fixtures.neon_fixtures import NeonEnv
+from fixtures.neon_fixtures import NeonEnv, fork_at_current_lsn
 
 
 #
@@ -33,7 +33,7 @@ def test_vm_bit_clear(neon_simple_env: NeonEnv):
     cur.execute("UPDATE vmtest_update SET id = 5000 WHERE id = 1")
 
     # Branch at this point, to test that later
-    env.neon_cli.create_branch("test_vm_bit_clear_new", "test_vm_bit_clear")
+    fork_at_current_lsn(env, pg, "test_vm_bit_clear_new", "test_vm_bit_clear")
 
     # Clear the buffer cache, to force the VM page to be re-fetched from
     # the page server

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2643,7 +2643,7 @@ def fork_at_current_lsn(
     env: NeonEnv,
     pg: Postgres,
     new_branch_name: str = DEFAULT_BRANCH_NAME,
-    ancestor_branch_name: Optional[str] = None,
+    ancestor_branch_name: str,
     tenant_id: Optional[uuid.UUID] = None,
 ) -> uuid.UUID:
     """

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2636,7 +2636,7 @@ def wait_for_last_record_lsn(
 def wait_for_last_flush_lsn(env: NeonEnv, pg: Postgres, tenant: uuid.UUID, timeline: uuid.UUID):
     """Wait for pageserver to catch up the latest flush LSN"""
     last_flush_lsn = lsn_from_hex(pg.safe_psql("SELECT pg_current_wal_flush_lsn()")[0][0])
-    return wait_for_last_record_lsn(env.pageserver.http_client(), tenant, timeline, last_flush_lsn)
+    wait_for_last_record_lsn(env.pageserver.http_client(), tenant, timeline, last_flush_lsn)
 
 
 def fork_at_current_lsn(
@@ -2648,4 +2648,4 @@ def fork_at_current_lsn(
 ) -> uuid.UUID:
     """Create new branch for current tenant/timeline on the last LSN. Before branch creation this function enforce that LSN is replayed by pagserver"""
     current_lsn = pg.safe_psql("SELECT pg_current_wal_lsn()")[0][0]
-    env.neon_cli.create_branch(new_branch_name, ancestor_branch_name, tenant_id, current_lsn)
+    return env.neon_cli.create_branch(new_branch_name, ancestor_branch_name, tenant_id, current_lsn)

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2637,3 +2637,15 @@ def wait_for_last_flush_lsn(env: NeonEnv, pg: Postgres, tenant: uuid.UUID, timel
     """Wait for pageserver to catch up the latest flush LSN"""
     last_flush_lsn = lsn_from_hex(pg.safe_psql("SELECT pg_current_wal_flush_lsn()")[0][0])
     wait_for_last_record_lsn(env.pageserver.http_client(), tenant, timeline, last_flush_lsn)
+
+
+def fork_at_current_lsn(
+    env: NeonEnv,
+    pg: Postgres,
+    new_branch_name: str = DEFAULT_BRANCH_NAME,
+    ancestor_branch_name: Optional[str] = None,
+    tenant_id: Optional[uuid.UUID] = None,
+) -> uuid.UUID:
+    """Create new branch for current tenant/timeline on the last LSN. Before branch creation this function enforce that LSN is replayed by pagserver"""
+    current_lsn = pg.safe_psql("SELECT pg_current_wal_lsn()")[0][0]
+    env.neon_cli.create_branch(new_branch_name, ancestor_branch_name, tenant_id, current_lsn)

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2636,7 +2636,7 @@ def wait_for_last_record_lsn(
 def wait_for_last_flush_lsn(env: NeonEnv, pg: Postgres, tenant: uuid.UUID, timeline: uuid.UUID):
     """Wait for pageserver to catch up the latest flush LSN"""
     last_flush_lsn = lsn_from_hex(pg.safe_psql("SELECT pg_current_wal_flush_lsn()")[0][0])
-    wait_for_last_record_lsn(env.pageserver.http_client(), tenant, timeline, last_flush_lsn)
+    return wait_for_last_record_lsn(env.pageserver.http_client(), tenant, timeline, last_flush_lsn)
 
 
 def fork_at_current_lsn(

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2646,6 +2646,10 @@ def fork_at_current_lsn(
     ancestor_branch_name: Optional[str] = None,
     tenant_id: Optional[uuid.UUID] = None,
 ) -> uuid.UUID:
-    """Create new branch for current tenant/timeline on the last LSN. Before branch creation this function enforce that LSN is replayed by pagserver"""
+    """
+    Create new branch at the last LSN of an existing branch.
+    The "last LSN" is taken from the given Postgres instance. The pageserver will wait for all the
+    the WAL up to that LSN to arrive in the pageserver before creating the branch.
+    """
     current_lsn = pg.safe_psql("SELECT pg_current_wal_lsn()")[0][0]
     return env.neon_cli.create_branch(new_branch_name, ancestor_branch_name, tenant_id, current_lsn)

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2642,7 +2642,7 @@ def wait_for_last_flush_lsn(env: NeonEnv, pg: Postgres, tenant: uuid.UUID, timel
 def fork_at_current_lsn(
     env: NeonEnv,
     pg: Postgres,
-    new_branch_name: str = DEFAULT_BRANCH_NAME,
+    new_branch_name: str,
     ancestor_branch_name: str,
     tenant_id: Optional[uuid.UUID] = None,
 ) -> uuid.UUID:


### PR DESCRIPTION
There are some test failures caused by wrong assumption that all changes made before `create_branch` are applied at server before branch creation and so included in the branch.

I added `fork_at_current_lsn` function which extracts current LSN and pass it to `create_branch` function.