### PR TITLE
Use more restrictive .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,18 @@
-**/.git/
-**/__pycache__
-**/.pytest_cache
+*
 
-.git
-.github
-target
-tmp_check
-tmp_install
-tmp_check_cli
-test_output
-.vscode
-.neon
-integration_tests/.neon
-.mypy_cache
+!Cargo.toml
+!Cargo.lock
+!Makefile
 
-Dockerfile
-.dockerignore
-
+!.cargo/
+!.config/
+!control_plane/
+!compute_tools/
+!libs/
+!pageserver/
+!pgxn/
+!proxy/
+!safekeeper/
+!vendor/postgres/
+!workspace_hack/
+!neon_local/


### PR DESCRIPTION
Avoids new directories like https://github.com/neondatabase/neon/pull/2342/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R6 to appear in the docker context by default.