### PR TITLE
Add python types to represent LSNs, tenant IDs and timeline IDs.

### DIFF
--- a/test_runner/fixtures/benchmark_fixture.py
+++ b/test_runner/fixtures/benchmark_fixture.py
@@ -5,7 +5,6 @@ import json
 import os
 import re
 import timeit
-import uuid
 import warnings
 from contextlib import contextmanager
 from datetime import datetime
@@ -17,6 +16,7 @@ from typing import Iterator, Optional
 import pytest
 from _pytest.config import Config
 from _pytest.terminal import TerminalReporter
+from fixtures.types import ZTenantId, ZTimelineId
 
 """
 This file contains fixtures for micro-benchmarks.
@@ -365,11 +365,11 @@ class NeonBenchmarker:
         assert matches
         return int(round(float(matches.group(1))))
 
-    def get_timeline_size(self, repo_dir: Path, tenantid: uuid.UUID, timelineid: str):
+    def get_timeline_size(self, repo_dir: Path, tenantid: ZTenantId, timelineid: ZTimelineId):
         """
         Calculate the on-disk size of a timeline
         """
-        path = "{}/tenants/{}/timelines/{}".format(repo_dir, tenantid.hex, timelineid)
+        path = "{}/tenants/{}/timelines/{}".format(repo_dir, tenantid, timelineid)
 
         totalbytes = 0
         for root, dirs, files in os.walk(path):

--- a/test_runner/fixtures/types.py
+++ b/test_runner/fixtures/types.py
@@ -1,0 +1,89 @@
+import random
+from functools import total_ordering
+from typing import Union
+
+
+@total_ordering
+class Lsn:
+    """
+    Datatype for an LSN. Internally it is a 64-bit integer, but the string
+    representation is like "1/123abcd". See also pg_lsn datatype in Postgres
+    """
+
+    def __init__(self, x: Union[int, str]):
+        if isinstance(x, int):
+            self.lsn_int = x
+        else:
+            """Convert lsn from hex notation to int."""
+            l, r = x.split("/")
+            self.lsn_int = (int(l, 16) << 32) + int(r, 16)
+            # FIXME: error if it doesn't look like a valid LSN
+
+    def __str__(self):
+        """Convert lsn from int to standard hex notation."""
+        return "{:X}/{:X}".format(self.lsn_int >> 32, self.lsn_int & 0xFFFFFFFF)
+
+    def __repr__(self):
+        return 'Lsn("{:X}/{:X}")'.format(self.lsn_int >> 32, self.lsn_int & 0xFFFFFFFF)
+
+    def __int__(self):
+        return self.lsn_int
+
+    def __lt__(self, other: "Lsn") -> bool:
+        return self.lsn_int < other.lsn_int
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Lsn):
+            return NotImplemented
+        return self.lsn_int == other.lsn_int
+
+    # Returns the difference between two Lsns, in bytes
+    def __sub__(self, other: "Lsn") -> int:
+        return self.lsn_int - other.lsn_int
+
+    def __hash__(self):
+        return hash(self.lsn_int)
+
+
+@total_ordering
+class ZId:
+    """
+    Datatype for a Neon tenant and timeline IDs. Internally it's a 16-byte array, and
+    the string representation is in hex. This corresponds to the ZId / ZTenantId /
+    ZTimelineIds in in the Rust code.
+    """
+
+    def __init__(self, x: str):
+        self.id = bytearray.fromhex(x)
+        assert len(self.id) == 16
+
+    def __str__(self):
+        return self.id.hex()
+
+    def __lt__(self, other) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.id < other.id
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.id == other.id
+
+    def __hash__(self):
+        return hash(str(self.id))
+
+    @classmethod
+    def generate(cls):
+        """Generate a random ID"""
+        return cls(random.randbytes(16).hex())
+
+
+class ZTenantId(ZId):
+    def __repr__(self):
+        return f'ZTenantId("{self.id.hex()}")'
+
+
+class ZTimelineId(ZId):
+    def __repr__(self):
+        return f'ZTimelineId("{self.id.hex()}")'

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -61,17 +61,6 @@ def global_counter() -> int:
     return _global_counter
 
 
-def lsn_to_hex(num: int) -> str:
-    """Convert lsn from int to standard hex notation."""
-    return "{:X}/{:X}".format(num >> 32, num & 0xFFFFFFFF)
-
-
-def lsn_from_hex(lsn_hex: str) -> int:
-    """Convert lsn from hex notation to int."""
-    l, r = lsn_hex.split("/")
-    return (int(l, 16) << 32) + int(r, 16)
-
-
 def print_gc_result(row):
     log.info("GC duration {elapsed} ms".format_map(row))
     log.info(

--- a/test_runner/performance/test_wal_backpressure.py
+++ b/test_runner/performance/test_wal_backpressure.py
@@ -9,7 +9,7 @@ from fixtures.benchmark_fixture import MetricReport, NeonBenchmarker
 from fixtures.compare_fixtures import NeonCompare, PgCompare, VanillaCompare
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import DEFAULT_BRANCH_NAME, NeonEnvBuilder, PgBin
-from fixtures.utils import lsn_from_hex
+from fixtures.types import Lsn
 from performance.test_perf_pgbench import get_durations_matrix, get_scales_matrix
 
 
@@ -198,8 +198,8 @@ def record_lsn_write_lag(env: PgCompare, run_cond: Callable[[], bool], pool_inte
         return
 
     lsn_write_lags = []
-    last_received_lsn = 0
-    last_pg_flush_lsn = 0
+    last_received_lsn = Lsn(0)
+    last_pg_flush_lsn = Lsn(0)
 
     with env.pg.connect().cursor() as cur:
         cur.execute("CREATE EXTENSION neon")
@@ -218,11 +218,11 @@ def record_lsn_write_lag(env: PgCompare, run_cond: Callable[[], bool], pool_inte
             res = cur.fetchone()
             lsn_write_lags.append(res[0])
 
-            curr_received_lsn = lsn_from_hex(res[3])
+            curr_received_lsn = Lsn(res[3])
             lsn_process_speed = (curr_received_lsn - last_received_lsn) / (1024**2)
             last_received_lsn = curr_received_lsn
 
-            curr_pg_flush_lsn = lsn_from_hex(res[2])
+            curr_pg_flush_lsn = Lsn(res[2])
             lsn_produce_speed = (curr_pg_flush_lsn - last_pg_flush_lsn) / (1024**2)
             last_pg_flush_lsn = curr_pg_flush_lsn
 

--- a/test_runner/regress/test_ancestor_branch.py
+++ b/test_runner/regress/test_ancestor_branch.py
@@ -1,5 +1,6 @@
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnvBuilder
+from fixtures.types import ZTimelineId
 from fixtures.utils import query_scalar
 
 
@@ -26,7 +27,7 @@ def test_ancestor_branch(neon_env_builder: NeonEnvBuilder):
 
     pg_branch0 = env.postgres.create_start("main", tenant_id=tenant)
     branch0_cur = pg_branch0.connect().cursor()
-    branch0_timeline = query_scalar(branch0_cur, "SHOW neon.timeline_id")
+    branch0_timeline = ZTimelineId(query_scalar(branch0_cur, "SHOW neon.timeline_id"))
     log.info(f"b0 timeline {branch0_timeline}")
 
     # Create table, and insert 100k rows.
@@ -50,7 +51,7 @@ def test_ancestor_branch(neon_env_builder: NeonEnvBuilder):
     log.info("postgres is running on 'branch1' branch")
 
     branch1_cur = pg_branch1.connect().cursor()
-    branch1_timeline = query_scalar(branch1_cur, "SHOW neon.timeline_id")
+    branch1_timeline = ZTimelineId(query_scalar(branch1_cur, "SHOW neon.timeline_id"))
     log.info(f"b1 timeline {branch1_timeline}")
 
     branch1_lsn = query_scalar(branch1_cur, "SELECT pg_current_wal_insert_lsn()")
@@ -73,7 +74,7 @@ def test_ancestor_branch(neon_env_builder: NeonEnvBuilder):
     log.info("postgres is running on 'branch2' branch")
     branch2_cur = pg_branch2.connect().cursor()
 
-    branch2_timeline = query_scalar(branch2_cur, "SHOW neon.timeline_id")
+    branch2_timeline = ZTimelineId(query_scalar(branch2_cur, "SHOW neon.timeline_id"))
     log.info(f"b2 timeline {branch2_timeline}")
 
     branch2_lsn = query_scalar(branch2_cur, "SELECT pg_current_wal_insert_lsn()")
@@ -91,7 +92,7 @@ def test_ancestor_branch(neon_env_builder: NeonEnvBuilder):
     log.info(f"LSN after 300k rows: {lsn_300}")
 
     # Run compaction on branch1.
-    compact = f"compact {tenant.hex} {branch1_timeline} {lsn_200}"
+    compact = f"compact {tenant} {branch1_timeline} {lsn_200}"
     log.info(compact)
     env.pageserver.safe_psql(compact)
 

--- a/test_runner/regress/test_auth.py
+++ b/test_runner/regress/test_auth.py
@@ -1,8 +1,8 @@
 from contextlib import closing
-from uuid import uuid4
 
 import pytest
 from fixtures.neon_fixtures import NeonEnvBuilder, NeonPageserverApiException
+from fixtures.types import ZTenantId
 
 
 def test_pageserver_auth(neon_env_builder: NeonEnvBuilder):
@@ -11,9 +11,9 @@ def test_pageserver_auth(neon_env_builder: NeonEnvBuilder):
 
     ps = env.pageserver
 
-    tenant_token = env.auth_keys.generate_tenant_token(env.initial_tenant.hex)
+    tenant_token = env.auth_keys.generate_tenant_token(env.initial_tenant)
     tenant_http_client = env.pageserver.http_client(tenant_token)
-    invalid_tenant_token = env.auth_keys.generate_tenant_token(uuid4().hex)
+    invalid_tenant_token = env.auth_keys.generate_tenant_token(ZTenantId.generate())
     invalid_tenant_http_client = env.pageserver.http_client(invalid_tenant_token)
 
     management_token = env.auth_keys.generate_management_token()

--- a/test_runner/regress/test_branch_and_gc.py
+++ b/test_runner/regress/test_branch_and_gc.py
@@ -4,7 +4,8 @@ import time
 import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv
-from fixtures.utils import lsn_from_hex, query_scalar
+from fixtures.types import Lsn
+from fixtures.utils import query_scalar
 
 
 # Test the GC implementation when running with branching.
@@ -74,18 +75,16 @@ def test_branch_and_gc(neon_simple_env: NeonEnv):
         "CREATE TABLE foo(key serial primary key, t text default 'foooooooooooooooooooooooooooooooooooooooooooooooooooo')"
     )
     main_cur.execute("INSERT INTO foo SELECT FROM generate_series(1, 100000)")
-    lsn1 = query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()")
+    lsn1 = Lsn(query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()"))
     log.info(f"LSN1: {lsn1}")
 
     main_cur.execute("INSERT INTO foo SELECT FROM generate_series(1, 100000)")
-    lsn2 = query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()")
+    lsn2 = Lsn(query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()"))
     log.info(f"LSN2: {lsn2}")
 
     # Set the GC horizon so that lsn1 is inside the horizon, which means
     # we can create a new branch starting from lsn1.
-    env.pageserver.safe_psql(
-        f"do_gc {tenant.hex} {timeline_main.hex} {lsn_from_hex(lsn2) - lsn_from_hex(lsn1) + 1024}"
-    )
+    env.pageserver.safe_psql(f"do_gc {tenant} {timeline_main} {lsn2 - lsn1 + 1024}")
 
     env.neon_cli.create_branch(
         "test_branch", "test_main", tenant_id=tenant, ancestor_start_lsn=lsn1
@@ -143,7 +142,7 @@ def test_branch_creation_before_gc(neon_simple_env: NeonEnv):
             "INSERT INTO t SELECT FROM generate_series(1, 100000)",
         ]
     )
-    lsn = res[2][0][0]
+    lsn = Lsn(res[2][0][0])
 
     # Use `failpoint=sleep` and `threading` to make the GC iteration triggers *before* the
     # branch creation task but the individual timeline GC iteration happens *after*
@@ -151,7 +150,7 @@ def test_branch_creation_before_gc(neon_simple_env: NeonEnv):
     env.pageserver.safe_psql("failpoints before-timeline-gc=sleep(2000)")
 
     def do_gc():
-        env.pageserver.safe_psql(f"do_gc {tenant.hex} {b0.hex} 0")
+        env.pageserver.safe_psql(f"do_gc {tenant} {b0} 0")
 
     thread = threading.Thread(target=do_gc, daemon=True)
     thread.start()

--- a/test_runner/regress/test_branch_behind.py
+++ b/test_runner/regress/test_branch_behind.py
@@ -2,6 +2,7 @@ import psycopg2.extras
 import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnvBuilder
+from fixtures.types import Lsn, ZTimelineId
 from fixtures.utils import print_gc_result, query_scalar
 
 
@@ -27,13 +28,13 @@ def test_branch_behind(neon_env_builder: NeonEnvBuilder):
 
     main_cur = pgmain.connect().cursor()
 
-    timeline = query_scalar(main_cur, "SHOW neon.timeline_id")
+    timeline = ZTimelineId(query_scalar(main_cur, "SHOW neon.timeline_id"))
 
     # Create table, and insert the first 100 rows
     main_cur.execute("CREATE TABLE foo (t text)")
 
     # keep some early lsn to test branch creation on out of date lsn
-    gced_lsn = query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()")
+    gced_lsn = Lsn(query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()"))
 
     main_cur.execute(
         """
@@ -42,7 +43,7 @@ def test_branch_behind(neon_env_builder: NeonEnvBuilder):
             FROM generate_series(1, 100) g
     """
     )
-    lsn_a = query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()")
+    lsn_a = Lsn(query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()"))
     log.info(f"LSN after 100 rows: {lsn_a}")
 
     # Insert some more rows. (This generates enough WAL to fill a few segments.)
@@ -53,7 +54,7 @@ def test_branch_behind(neon_env_builder: NeonEnvBuilder):
             FROM generate_series(1, 200000) g
     """
     )
-    lsn_b = query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()")
+    lsn_b = Lsn(query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()"))
     log.info(f"LSN after 200100 rows: {lsn_b}")
 
     # Branch at the point where only 100 rows were inserted
@@ -69,7 +70,7 @@ def test_branch_behind(neon_env_builder: NeonEnvBuilder):
             FROM generate_series(1, 200000) g
     """
     )
-    lsn_c = query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()")
+    lsn_c = Lsn(query_scalar(main_cur, "SELECT pg_current_wal_insert_lsn()"))
 
     log.info(f"LSN after 400100 rows: {lsn_c}")
 
@@ -96,25 +97,25 @@ def test_branch_behind(neon_env_builder: NeonEnvBuilder):
 
     # branch at segment boundary
     env.neon_cli.create_branch(
-        "test_branch_segment_boundary", "test_branch_behind", ancestor_start_lsn="0/3000000"
+        "test_branch_segment_boundary", "test_branch_behind", ancestor_start_lsn=Lsn("0/3000000")
     )
     pg = env.postgres.create_start("test_branch_segment_boundary")
     assert pg.safe_psql("SELECT 1")[0][0] == 1
 
     # branch at pre-initdb lsn
     with pytest.raises(Exception, match="invalid branch start lsn"):
-        env.neon_cli.create_branch("test_branch_preinitdb", ancestor_start_lsn="0/42")
+        env.neon_cli.create_branch("test_branch_preinitdb", ancestor_start_lsn=Lsn("0/42"))
 
     # branch at pre-ancestor lsn
     with pytest.raises(Exception, match="less than timeline ancestor lsn"):
         env.neon_cli.create_branch(
-            "test_branch_preinitdb", "test_branch_behind", ancestor_start_lsn="0/42"
+            "test_branch_preinitdb", "test_branch_behind", ancestor_start_lsn=Lsn("0/42")
         )
 
     # check that we cannot create branch based on garbage collected data
     with env.pageserver.cursor(cursor_factory=psycopg2.extras.DictCursor) as pscur:
         # call gc to advace latest_gc_cutoff_lsn
-        pscur.execute(f"do_gc {env.initial_tenant.hex} {timeline} 0")
+        pscur.execute(f"do_gc {env.initial_tenant} {timeline} 0")
         row = pscur.fetchone()
         print_gc_result(row)
 

--- a/test_runner/regress/test_lsn_mapping.py
+++ b/test_runner/regress/test_lsn_mapping.py
@@ -41,7 +41,7 @@ def test_lsn_mapping(neon_env_builder: NeonEnvBuilder):
     probe_timestamp = tbl[-1][1] + timedelta(hours=1)
     result = query_scalar(
         ps_cur,
-        f"get_lsn_by_timestamp {env.initial_tenant.hex} {new_timeline_id.hex} '{probe_timestamp.isoformat()}Z'",
+        f"get_lsn_by_timestamp {env.initial_tenant} {new_timeline_id} '{probe_timestamp.isoformat()}Z'",
     )
     assert result == "future"
 
@@ -49,7 +49,7 @@ def test_lsn_mapping(neon_env_builder: NeonEnvBuilder):
     probe_timestamp = tbl[0][1] - timedelta(hours=10)
     result = query_scalar(
         ps_cur,
-        f"get_lsn_by_timestamp {env.initial_tenant.hex} {new_timeline_id.hex} '{probe_timestamp.isoformat()}Z'",
+        f"get_lsn_by_timestamp {env.initial_tenant} {new_timeline_id} '{probe_timestamp.isoformat()}Z'",
     )
     assert result == "past"
 
@@ -60,7 +60,7 @@ def test_lsn_mapping(neon_env_builder: NeonEnvBuilder):
         # Call get_lsn_by_timestamp to get the LSN
         lsn = query_scalar(
             ps_cur,
-            f"get_lsn_by_timestamp {env.initial_tenant.hex} {new_timeline_id.hex} '{probe_timestamp.isoformat()}Z'",
+            f"get_lsn_by_timestamp {env.initial_tenant} {new_timeline_id} '{probe_timestamp.isoformat()}Z'",
         )
 
         # Launch a new read-only node at that LSN, and check that only the rows

--- a/test_runner/regress/test_neon_cli.py
+++ b/test_runner/regress/test_neon_cli.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import cast
 
 import requests
@@ -8,10 +7,11 @@ from fixtures.neon_fixtures import (
     NeonEnvBuilder,
     NeonPageserverHttpClient,
 )
+from fixtures.types import ZTenantId, ZTimelineId
 
 
 def helper_compare_timeline_list(
-    pageserver_http_client: NeonPageserverHttpClient, env: NeonEnv, initial_tenant: uuid.UUID
+    pageserver_http_client: NeonPageserverHttpClient, env: NeonEnv, initial_tenant: ZTenantId
 ):
     """
     Compare timelines list returned by CLI and directly via API.
@@ -20,7 +20,7 @@ def helper_compare_timeline_list(
 
     timelines_api = sorted(
         map(
-            lambda t: cast(str, t["timeline_id"]),
+            lambda t: ZTimelineId(t["timeline_id"]),
             pageserver_http_client.timeline_list(initial_tenant),
         )
     )
@@ -52,8 +52,8 @@ def test_cli_timeline_list(neon_simple_env: NeonEnv):
     # Check that all new branches are visible via CLI
     timelines_cli = [timeline_id for (_, timeline_id) in env.neon_cli.list_timelines()]
 
-    assert main_timeline_id.hex in timelines_cli
-    assert nested_timeline_id.hex in timelines_cli
+    assert main_timeline_id in timelines_cli
+    assert nested_timeline_id in timelines_cli
 
 
 def helper_compare_tenant_list(pageserver_http_client: NeonPageserverHttpClient, env: NeonEnv):
@@ -85,11 +85,11 @@ def test_cli_tenant_list(neon_simple_env: NeonEnv):
     helper_compare_tenant_list(pageserver_http_client, env)
 
     res = env.neon_cli.list_tenants()
-    tenants = sorted(map(lambda t: t.split()[0], res.stdout.splitlines()))
+    tenants = sorted(map(lambda t: ZTenantId(t.split()[0]), res.stdout.splitlines()))
 
-    assert env.initial_tenant.hex in tenants
-    assert tenant1.hex in tenants
-    assert tenant2.hex in tenants
+    assert env.initial_tenant in tenants
+    assert tenant1 in tenants
+    assert tenant2 in tenants
 
 
 def test_cli_tenant_create(neon_simple_env: NeonEnv):

--- a/test_runner/regress/test_readonly_node.py
+++ b/test_runner/regress/test_readonly_node.py
@@ -1,6 +1,7 @@
 import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv
+from fixtures.types import Lsn
 from fixtures.utils import query_scalar
 
 
@@ -84,7 +85,9 @@ def test_readonly_node(neon_simple_env: NeonEnv):
 
     # Check creating a node at segment boundary
     pg = env.postgres.create_start(
-        branch_name="test_readonly_node", node_name="test_branch_segment_boundary", lsn="0/3000000"
+        branch_name="test_readonly_node",
+        node_name="test_branch_segment_boundary",
+        lsn=Lsn("0/3000000"),
     )
     cur = pg.connect().cursor()
     cur.execute("SELECT 1")
@@ -94,5 +97,7 @@ def test_readonly_node(neon_simple_env: NeonEnv):
     with pytest.raises(Exception, match="invalid basebackup lsn"):
         # compute node startup with invalid LSN should fail
         env.postgres.create_start(
-            branch_name="test_readonly_node", node_name="test_readonly_node_preinitdb", lsn="0/42"
+            branch_name="test_readonly_node",
+            node_name="test_readonly_node_preinitdb",
+            lsn=Lsn("0/42"),
         )

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import time
 from pathlib import Path
-from uuid import UUID
 
 import pytest
 from fixtures.log_helper import log
@@ -18,7 +17,8 @@ from fixtures.neon_fixtures import (
     wait_for_upload,
     wait_until,
 )
-from fixtures.utils import lsn_from_hex, query_scalar
+from fixtures.types import Lsn, ZTenantId, ZTimelineId
+from fixtures.utils import query_scalar
 
 
 #
@@ -61,8 +61,8 @@ def test_remote_storage_backup_and_restore(
 
     client = env.pageserver.http_client()
 
-    tenant_id = pg.safe_psql("show neon.tenant_id")[0][0]
-    timeline_id = pg.safe_psql("show neon.timeline_id")[0][0]
+    tenant_id = ZTenantId(pg.safe_psql("show neon.tenant_id")[0][0])
+    timeline_id = ZTimelineId(pg.safe_psql("show neon.timeline_id")[0][0])
 
     checkpoint_numbers = range(1, 3)
 
@@ -74,17 +74,17 @@ def test_remote_storage_backup_and_restore(
                 INSERT INTO t{checkpoint_number} VALUES ({data_id}, '{data_secret}|{checkpoint_number}');
             """
             )
-            current_lsn = lsn_from_hex(query_scalar(cur, "SELECT pg_current_wal_flush_lsn()"))
+            current_lsn = Lsn(query_scalar(cur, "SELECT pg_current_wal_flush_lsn()"))
 
         # wait until pageserver receives that data
-        wait_for_last_record_lsn(client, UUID(tenant_id), UUID(timeline_id), current_lsn)
+        wait_for_last_record_lsn(client, tenant_id, timeline_id, current_lsn)
 
         # run checkpoint manually to be sure that data landed in remote storage
         env.pageserver.safe_psql(f"checkpoint {tenant_id} {timeline_id}")
 
         log.info(f"waiting for checkpoint {checkpoint_number} upload")
         # wait until pageserver successfully uploaded a checkpoint to remote storage
-        wait_for_upload(client, UUID(tenant_id), UUID(timeline_id), current_lsn)
+        wait_for_upload(client, tenant_id, timeline_id, current_lsn)
         log.info(f"upload of checkpoint {checkpoint_number} is done")
 
     ##### Stop the first pageserver instance, erase all its data
@@ -101,16 +101,16 @@ def test_remote_storage_backup_and_restore(
     # Introduce failpoint in download
     env.pageserver.safe_psql("failpoints remote-storage-download-pre-rename=return")
 
-    client.tenant_attach(UUID(tenant_id))
+    client.tenant_attach(tenant_id)
 
     # is there a better way to assert that failpoint triggered?
     time.sleep(10)
 
     # assert cannot attach timeline that is scheduled for download
     with pytest.raises(Exception, match="Conflict: Tenant download is already in progress"):
-        client.tenant_attach(UUID(tenant_id))
+        client.tenant_attach(tenant_id)
 
-    detail = client.timeline_detail(UUID(tenant_id), UUID(timeline_id))
+    detail = client.timeline_detail(tenant_id, timeline_id)
     log.info("Timeline detail with active failpoint: %s", detail)
     assert detail["local"] is None
     assert detail["remote"]["awaits_download"]
@@ -119,20 +119,20 @@ def test_remote_storage_backup_and_restore(
     env.pageserver.stop()
     env.pageserver.start()
 
-    client.tenant_attach(UUID(tenant_id))
+    client.tenant_attach(tenant_id)
 
     log.info("waiting for timeline redownload")
     wait_until(
         number_of_iterations=20,
         interval=1,
-        func=lambda: assert_timeline_local(client, UUID(tenant_id), UUID(timeline_id)),
+        func=lambda: assert_timeline_local(client, tenant_id, timeline_id),
     )
 
-    detail = client.timeline_detail(UUID(tenant_id), UUID(timeline_id))
+    detail = client.timeline_detail(tenant_id, timeline_id)
     assert detail["local"] is not None
     log.info("Timeline detail after attach completed: %s", detail)
     assert (
-        lsn_from_hex(detail["local"]["last_record_lsn"]) >= current_lsn
+        Lsn(detail["local"]["last_record_lsn"]) >= current_lsn
     ), "current db Lsn should should not be less than the one stored on remote storage"
     assert not detail["remote"]["awaits_download"]
 

--- a/test_runner/regress/test_tenant_conf.py
+++ b/test_runner/regress/test_tenant_conf.py
@@ -32,8 +32,8 @@ tenant_config={checkpoint_distance = 10000, compaction_target_size = 1048576}"""
     # it should match global configuration
     with closing(env.pageserver.connect()) as psconn:
         with psconn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as pscur:
-            log.info(f"show {env.initial_tenant.hex}")
-            pscur.execute(f"show {env.initial_tenant.hex}")
+            log.info(f"show {env.initial_tenant}")
+            pscur.execute(f"show {env.initial_tenant}")
             res = pscur.fetchone()
             assert all(
                 i in res.items()
@@ -52,7 +52,7 @@ tenant_config={checkpoint_distance = 10000, compaction_target_size = 1048576}"""
     # check the configuration of the new tenant
     with closing(env.pageserver.connect()) as psconn:
         with psconn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as pscur:
-            pscur.execute(f"show {tenant.hex}")
+            pscur.execute(f"show {tenant}")
             res = pscur.fetchone()
             log.info(f"res: {res}")
             assert all(
@@ -80,7 +80,7 @@ tenant_config={checkpoint_distance = 10000, compaction_target_size = 1048576}"""
 
     with closing(env.pageserver.connect()) as psconn:
         with psconn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as pscur:
-            pscur.execute(f"show {tenant.hex}")
+            pscur.execute(f"show {tenant}")
             res = pscur.fetchone()
             log.info(f"after config res: {res}")
             assert all(
@@ -103,7 +103,7 @@ tenant_config={checkpoint_distance = 10000, compaction_target_size = 1048576}"""
 
     with closing(env.pageserver.connect()) as psconn:
         with psconn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as pscur:
-            pscur.execute(f"show {tenant.hex}")
+            pscur.execute(f"show {tenant}")
             res = pscur.fetchone()
             log.info(f"after restart res: {res}")
             assert all(

--- a/test_runner/regress/test_tenant_tasks.py
+++ b/test_runner/regress/test_tenant_tasks.py
@@ -1,6 +1,5 @@
-from uuid import UUID
-
 from fixtures.neon_fixtures import NeonEnvBuilder, wait_until
+from fixtures.types import ZTenantId, ZTimelineId
 
 
 def get_only_element(l):  # noqa: E741
@@ -23,7 +22,7 @@ def test_tenant_tasks(neon_env_builder: NeonEnvBuilder):
 
     def get_state(tenant):
         all_states = client.tenant_list()
-        matching = [t for t in all_states if t["id"] == tenant.hex]
+        matching = [t for t in all_states if ZTenantId(t["id"]) == tenant]
         return get_only_element(matching)["state"]
 
     def get_metric_value(name):
@@ -35,8 +34,8 @@ def test_tenant_tasks(neon_env_builder: NeonEnvBuilder):
         value = line.lstrip(name).strip()
         return int(value)
 
-    def delete_all_timelines(tenant):
-        timelines = [UUID(t["timeline_id"]) for t in client.timeline_list(tenant)]
+    def delete_all_timelines(tenant: ZTenantId):
+        timelines = [ZTimelineId(t["timeline_id"]) for t in client.timeline_list(tenant)]
         for t in timelines:
             client.timeline_delete(tenant, t)
 
@@ -55,7 +54,7 @@ def test_tenant_tasks(neon_env_builder: NeonEnvBuilder):
     # Detach all tenants and wait for them to go idle
     # TODO they should be already idle since there are no active computes
     for tenant_info in client.tenant_list():
-        tenant_id = UUID(tenant_info["id"])
+        tenant_id = ZTenantId(tenant_info["id"])
         delete_all_timelines(tenant_id)
         wait_until(10, 0.2, lambda: assert_idle(tenant_id))
 

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -1,7 +1,6 @@
-from uuid import uuid4
-
 import pytest
 from fixtures.neon_fixtures import NeonEnv, NeonPageserverApiException, wait_until
+from fixtures.types import ZTenantId, ZTimelineId
 
 
 def test_timeline_delete(neon_simple_env: NeonEnv):
@@ -11,15 +10,15 @@ def test_timeline_delete(neon_simple_env: NeonEnv):
 
     # first try to delete non existing timeline
     # for existing tenant:
-    invalid_timeline_id = uuid4()
+    invalid_timeline_id = ZTimelineId.generate()
     with pytest.raises(NeonPageserverApiException, match="timeline not found"):
         ps_http.timeline_delete(tenant_id=env.initial_tenant, timeline_id=invalid_timeline_id)
 
     # for non existing tenant:
-    invalid_tenant_id = uuid4()
+    invalid_tenant_id = ZTenantId.generate()
     with pytest.raises(
         NeonPageserverApiException,
-        match=f"Tenant {invalid_tenant_id.hex} not found in local tenant state",
+        match=f"Tenant {invalid_tenant_id} not found in local tenant state",
     ):
         ps_http.timeline_delete(tenant_id=invalid_tenant_id, timeline_id=invalid_timeline_id)
 
@@ -37,7 +36,11 @@ def test_timeline_delete(neon_simple_env: NeonEnv):
     ):
 
         timeline_path = (
-            env.repo_dir / "tenants" / env.initial_tenant.hex / "timelines" / parent_timeline_id.hex
+            env.repo_dir
+            / "tenants"
+            / str(env.initial_tenant)
+            / "timelines"
+            / str(parent_timeline_id)
         )
         assert timeline_path.exists()
 
@@ -46,7 +49,7 @@ def test_timeline_delete(neon_simple_env: NeonEnv):
         assert not timeline_path.exists()
 
     timeline_path = (
-        env.repo_dir / "tenants" / env.initial_tenant.hex / "timelines" / leaf_timeline_id.hex
+        env.repo_dir / "tenants" / str(env.initial_tenant) / "timelines" / str(leaf_timeline_id)
     )
     assert timeline_path.exists()
 

--- a/test_runner/regress/test_wal_restore.py
+++ b/test_runner/regress/test_wal_restore.py
@@ -9,6 +9,7 @@ from fixtures.neon_fixtures import (
     base_dir,
     pg_distrib_dir,
 )
+from fixtures.types import ZTenantId
 
 
 def test_wal_restore(
@@ -21,7 +22,7 @@ def test_wal_restore(
     env.neon_cli.create_branch("test_wal_restore")
     pg = env.postgres.create_start("test_wal_restore")
     pg.safe_psql("create table t as select generate_series(1,300000)")
-    tenant_id = pg.safe_psql("show neon.tenant_id")[0][0]
+    tenant_id = ZTenantId(pg.safe_psql("show neon.tenant_id")[0][0])
     env.neon_cli.pageserver_stop()
     port = port_distributor.get_port()
     data_dir = test_output_dir / "pgsql.restored"


### PR DESCRIPTION
For better ergonomics. I always found it weird that we used UUID to
actually mean a tenant or timeline ID. It worked because it happened
to have the same length, 16 bytes, but it was hacky.