### PR TITLE
Add failed case for RCU

### DIFF
--- a/libs/utils/src/simple_rcu.rs
+++ b/libs/utils/src/simple_rcu.rs
@@ -214,4 +214,24 @@ mod tests {
             &["one", "store two start", "release a", "store two done",]
         );
     }
+
+    #[test]
+    fn double_reader() {
+        let rcu = Rcu::new(5);
+        let reader1 = rcu.read();
+        let reader2 = rcu.read();
+
+        assert_eq!(5, *reader1);
+        assert_eq!(5, *reader2);
+    }
+
+    #[test]
+    fn double_writer() {
+        let rcu = Rcu::new(3);
+        let writer1 = rcu.write();
+        let writer2 = rcu.write();
+
+        assert_eq!(3, *writer1);
+        assert_eq!(3, *writer2);
+    }
 }


### PR DESCRIPTION
Hey @hlinnaka. I've seen your implementation of RCU. Look at the test case with two writers that are used as readers (it doesn't matter how the instances are used. It fails because of two writers at the same time). I've seen the panic with "rwlock write lock would result in deadlock". 

Was it designed for having only one writer instance? I didn't get it from comments, if it was so