### PR TITLE
Split RcuWriteGuard::store() into two stages: store and wait.

### DIFF
--- a/pageserver/src/layered_repository/timeline.rs
+++ b/pageserver/src/layered_repository/timeline.rs
@@ -2046,14 +2046,14 @@ impl Timeline {
         //
         // The GC cutoff should only ever move forwards.
         {
-            let write_guard = self.latest_gc_cutoff_lsn.write();
+            let write_guard = self.latest_gc_cutoff_lsn.lock_for_write();
             ensure!(
                 *write_guard <= new_gc_cutoff,
                 "Cannot move GC cutoff LSN backwards (was {}, new {})",
                 *write_guard,
                 new_gc_cutoff
             );
-            write_guard.store(new_gc_cutoff);
+            write_guard.store_and_unlock(new_gc_cutoff).wait();
         }
 
         info!("GC starting");


### PR DESCRIPTION
This makes it easier to explain which stages allow concurrent readers and
writers. Expand the comments with examples, too.