### PR TITLE
Use less generics, more GenericRemoteStorage in pageserver

### DIFF
--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -42,19 +42,13 @@ pub const DEFAULT_REMOTE_STORAGE_MAX_SYNC_ERRORS: u32 = 10;
 /// https://aws.amazon.com/premiumsupport/knowledge-center/s3-request-limit-avoid-throttling/
 pub const DEFAULT_REMOTE_STORAGE_S3_CONCURRENCY_LIMIT: usize = 100;
 
-pub trait RemoteObjectName {
-    // Needed to retrieve last component for RemoteObjectId.
-    // In other words a file name
-    fn object_name(&self) -> Option<&str>;
-}
-
 /// Storage (potentially remote) API to manage its state.
 /// This storage tries to be unaware of any layered repository context,
 /// providing basic CRUD operations for storage files.
 #[async_trait::async_trait]
 pub trait RemoteStorage: Send + Sync {
     /// A way to uniquely reference a file in the remote storage.
-    type RemoteObjectId: RemoteObjectName;
+    type RemoteObjectId;
 
     /// Attempts to derive the storage path out of the local path, if the latter is correct.
     fn remote_object_id(&self, local_path: &Path) -> anyhow::Result<Self::RemoteObjectId>;

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -71,7 +71,7 @@ pub trait RemoteStorage: Send + Sync {
     /// so this method doesnt need to.
     async fn list_prefixes(
         &self,
-        prefix: Option<Self::RemoteObjectId>,
+        prefix: Option<&Self::RemoteObjectId>,
     ) -> anyhow::Result<Vec<Self::RemoteObjectId>>;
 
     /// Streams the local file contents into remote into the remote storage entry.
@@ -161,6 +161,13 @@ impl GenericRemoteStorage {
                     s3_config.bucket_name, s3_config.bucket_region, s3_config.prefix_in_bucket, s3_config.endpoint);
                 S3Bucket::new(s3_config, working_directory).map(GenericRemoteStorage::S3)
             }
+        }
+    }
+
+    pub fn as_local(&self) -> Option<&LocalFs> {
+        match self {
+            Self::Local(local_fs) => Some(local_fs),
+            _ => None,
         }
     }
 }

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -17,15 +17,9 @@ use tokio::{
 };
 use tracing::*;
 
-use crate::{path_with_suffix_extension, Download, DownloadError, RemoteObjectName};
+use crate::{path_with_suffix_extension, Download, DownloadError};
 
 use super::{strip_path_prefix, RemoteStorage, StorageMetadata};
-
-impl RemoteObjectName for PathBuf {
-    fn object_name(&self) -> Option<&str> {
-        self.file_stem().and_then(|n| n.to_str())
-    }
-}
 
 pub struct LocalFs {
     working_directory: PathBuf,

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -5,7 +5,6 @@
 //! volume is mounted to the local FS.
 
 use std::{
-    borrow::Cow,
     future::Future,
     path::{Path, PathBuf},
     pin::Pin,
@@ -113,13 +112,10 @@ impl RemoteStorage for LocalFs {
 
     async fn list_prefixes(
         &self,
-        prefix: Option<Self::RemoteObjectId>,
+        prefix: Option<&Self::RemoteObjectId>,
     ) -> anyhow::Result<Vec<Self::RemoteObjectId>> {
-        let path = match prefix {
-            Some(prefix) => Cow::Owned(prefix),
-            None => Cow::Borrowed(&self.storage_root),
-        };
-        get_all_files(path.as_ref(), false).await
+        let path = prefix.unwrap_or(&self.storage_root);
+        get_all_files(path, false).await
     }
 
     async fn upload(

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -316,11 +316,11 @@ impl RemoteStorage for S3Bucket {
     /// Note: it wont include empty "directories"
     async fn list_prefixes(
         &self,
-        prefix: Option<Self::RemoteObjectId>,
+        prefix: Option<&Self::RemoteObjectId>,
     ) -> anyhow::Result<Vec<Self::RemoteObjectId>> {
         // get the passed prefix or if it is not set use prefix_in_bucket value
         let list_prefix = prefix
-            .map(|p| p.0)
+            .map(|p| p.0.clone())
             .or_else(|| self.prefix_in_bucket.clone())
             .map(|mut p| {
                 // required to end with a separator

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -19,9 +19,7 @@ use tokio::{io, sync::Semaphore};
 use tokio_util::io::ReaderStream;
 use tracing::debug;
 
-use crate::{
-    strip_path_prefix, Download, DownloadError, RemoteObjectName, RemoteStorage, S3Config,
-};
+use crate::{strip_path_prefix, Download, DownloadError, RemoteStorage, S3Config};
 
 use super::StorageMetadata;
 
@@ -96,6 +94,23 @@ const S3_PREFIX_SEPARATOR: char = '/';
 pub struct S3ObjectKey(String);
 
 impl S3ObjectKey {
+    /// Turn a/b/c or a/b/c/ into c
+    pub fn object_name(&self) -> Option<&str> {
+        // corner case, char::to_string is not const, thats why this is more verbose than it needs to be
+        // see https://github.com/rust-lang/rust/issues/88674
+        if self.0.len() == 1 && self.0.chars().next().unwrap() == S3_PREFIX_SEPARATOR {
+            return None;
+        }
+
+        if self.0.ends_with(S3_PREFIX_SEPARATOR) {
+            self.0.rsplit(S3_PREFIX_SEPARATOR).nth(1)
+        } else {
+            self.0
+                .rsplit_once(S3_PREFIX_SEPARATOR)
+                .map(|(_, last)| last)
+        }
+    }
+
     fn key(&self) -> &str {
         &self.0
     }
@@ -116,25 +131,6 @@ impl S3ObjectKey {
                 .split(S3_PREFIX_SEPARATOR)
                 .collect::<PathBuf>(),
         )
-    }
-}
-
-impl RemoteObjectName for S3ObjectKey {
-    /// Turn a/b/c or a/b/c/ into c
-    fn object_name(&self) -> Option<&str> {
-        // corner case, char::to_string is not const, thats why this is more verbose than it needs to be
-        // see https://github.com/rust-lang/rust/issues/88674
-        if self.0.len() == 1 && self.0.chars().next().unwrap() == S3_PREFIX_SEPARATOR {
-            return None;
-        }
-
-        if self.0.ends_with(S3_PREFIX_SEPARATOR) {
-            self.0.rsplit(S3_PREFIX_SEPARATOR).nth(1)
-        } else {
-            self.0
-                .rsplit_once(S3_PREFIX_SEPARATOR)
-                .map(|(_, last)| last)
-        }
     }
 }
 

--- a/pageserver/src/storage_sync.rs
+++ b/pageserver/src/storage_sync.rs
@@ -156,7 +156,7 @@ use std::{
 use anyhow::{anyhow, bail, Context};
 use futures::stream::{FuturesUnordered, StreamExt};
 use once_cell::sync::{Lazy, OnceCell};
-use remote_storage::{GenericRemoteStorage, RemoteStorage};
+use remote_storage::GenericRemoteStorage;
 use tokio::{
     fs,
     runtime::Runtime,
@@ -253,36 +253,20 @@ pub struct SyncStartupData {
 /// Along with that, scans tenant files local and remote (if the sync gets enabled) to check the initial timeline states.
 pub fn start_local_timeline_sync(
     config: &'static PageServerConf,
+    storage: Option<Arc<GenericRemoteStorage>>,
 ) -> anyhow::Result<SyncStartupData> {
     let local_timeline_files = local_tenant_timeline_files(config)
         .context("Failed to collect local tenant timeline files")?;
 
-    match config.remote_storage_config.as_ref() {
-        Some(storage_config) => {
-            match GenericRemoteStorage::new(config.workdir.clone(), storage_config)
-                .context("Failed to init the generic remote storage")?
-            {
-                GenericRemoteStorage::Local(local_fs_storage) => {
-                    storage_sync::spawn_storage_sync_thread(
-                        config,
-                        local_timeline_files,
-                        local_fs_storage,
-                        storage_config.max_concurrent_syncs,
-                        storage_config.max_sync_errors,
-                    )
-                }
-                GenericRemoteStorage::S3(s3_bucket_storage) => {
-                    storage_sync::spawn_storage_sync_thread(
-                        config,
-                        local_timeline_files,
-                        s3_bucket_storage,
-                        storage_config.max_concurrent_syncs,
-                        storage_config.max_sync_errors,
-                    )
-                }
-            }
-            .context("Failed to spawn the storage sync thread")
-        }
+    match storage.zip(config.remote_storage_config.as_ref()) {
+        Some((storage, storage_config)) => storage_sync::spawn_storage_sync_thread(
+            config,
+            local_timeline_files,
+            storage,
+            storage_config.max_concurrent_syncs,
+            storage_config.max_sync_errors,
+        )
+        .context("Failed to spawn the storage sync thread"),
         None => {
             info!("No remote storage configured, skipping storage sync, considering all local timelines with correct metadata files enabled");
             let mut local_timeline_init_statuses = LocalTimelineInitStatuses::new();
@@ -810,17 +794,13 @@ pub fn schedule_layer_download(tenant_id: ZTenantId, timeline_id: ZTimelineId) {
 
 /// Launch a thread to perform remote storage sync tasks.
 /// See module docs for loop step description.
-pub(super) fn spawn_storage_sync_thread<P, S>(
+pub(super) fn spawn_storage_sync_thread(
     conf: &'static PageServerConf,
     local_timeline_files: HashMap<ZTenantTimelineId, (TimelineMetadata, HashSet<PathBuf>)>,
-    storage: S,
+    storage: Arc<GenericRemoteStorage>,
     max_concurrent_timelines_sync: NonZeroUsize,
     max_sync_errors: NonZeroU32,
-) -> anyhow::Result<SyncStartupData>
-where
-    P: Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) -> anyhow::Result<SyncStartupData> {
     let sync_queue = SyncQueue::new(max_concurrent_timelines_sync);
     SYNC_QUEUE
         .set(sync_queue)
@@ -860,7 +840,7 @@ where
             storage_sync_loop(
                 runtime,
                 conf,
-                (Arc::new(storage), remote_index_clone, sync_queue),
+                (storage, remote_index_clone, sync_queue),
                 max_sync_errors,
             );
             Ok(())
@@ -873,15 +853,12 @@ where
     })
 }
 
-fn storage_sync_loop<P, S>(
+fn storage_sync_loop(
     runtime: Runtime,
     conf: &'static PageServerConf,
-    (storage, index, sync_queue): (Arc<S>, RemoteIndex, &SyncQueue),
+    (storage, index, sync_queue): (Arc<GenericRemoteStorage>, RemoteIndex, &SyncQueue),
     max_sync_errors: NonZeroU32,
-) where
-    P: Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) {
     info!("Starting remote storage sync loop");
     loop {
         let loop_storage = Arc::clone(&storage);
@@ -983,18 +960,14 @@ enum UploadStatus {
     Nothing,
 }
 
-async fn process_batches<P, S>(
+async fn process_batches(
     conf: &'static PageServerConf,
     max_sync_errors: NonZeroU32,
-    storage: Arc<S>,
+    storage: Arc<GenericRemoteStorage>,
     index: &RemoteIndex,
     batched_tasks: HashMap<ZTenantTimelineId, SyncTaskBatch>,
     sync_queue: &SyncQueue,
-) -> HashSet<ZTenantId>
-where
-    P: Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) -> HashSet<ZTenantId> {
     let mut sync_results = batched_tasks
         .into_iter()
         .map(|(sync_id, batch)| {
@@ -1030,17 +1003,13 @@ where
     downloaded_timelines
 }
 
-async fn process_sync_task_batch<P, S>(
+async fn process_sync_task_batch(
     conf: &'static PageServerConf,
-    (storage, index, sync_queue): (Arc<S>, RemoteIndex, &SyncQueue),
+    (storage, index, sync_queue): (Arc<GenericRemoteStorage>, RemoteIndex, &SyncQueue),
     max_sync_errors: NonZeroU32,
     sync_id: ZTenantTimelineId,
     batch: SyncTaskBatch,
-) -> DownloadStatus
-where
-    P: Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) -> DownloadStatus {
     let sync_start = Instant::now();
     let current_remote_timeline = { index.read().await.timeline_entry(&sync_id).cloned() };
 
@@ -1175,19 +1144,15 @@ where
     download_status
 }
 
-async fn download_timeline_data<P, S>(
+async fn download_timeline_data(
     conf: &'static PageServerConf,
-    (storage, index, sync_queue): (&S, &RemoteIndex, &SyncQueue),
+    (storage, index, sync_queue): (&GenericRemoteStorage, &RemoteIndex, &SyncQueue),
     current_remote_timeline: Option<&RemoteTimeline>,
     sync_id: ZTenantTimelineId,
     new_download_data: SyncData<LayersDownload>,
     sync_start: Instant,
     task_name: &str,
-) -> DownloadStatus
-where
-    P: Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) -> DownloadStatus {
     match download_timeline_layers(
         conf,
         storage,
@@ -1298,17 +1263,14 @@ async fn update_local_metadata(
     Ok(())
 }
 
-async fn delete_timeline_data<P, S>(
+async fn delete_timeline_data(
     conf: &'static PageServerConf,
-    (storage, index, sync_queue): (&S, &RemoteIndex, &SyncQueue),
+    (storage, index, sync_queue): (&GenericRemoteStorage, &RemoteIndex, &SyncQueue),
     sync_id: ZTenantTimelineId,
     mut new_delete_data: SyncData<LayersDeletion>,
     sync_start: Instant,
     task_name: &str,
-) where
-    P: Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) {
     let timeline_delete = &mut new_delete_data.data;
 
     if !timeline_delete.deletion_registered {
@@ -1343,19 +1305,15 @@ async fn read_metadata_file(metadata_path: &Path) -> anyhow::Result<TimelineMeta
     .context("Failed to parse metadata bytes")
 }
 
-async fn upload_timeline_data<P, S>(
+async fn upload_timeline_data(
     conf: &'static PageServerConf,
-    (storage, index, sync_queue): (&S, &RemoteIndex, &SyncQueue),
+    (storage, index, sync_queue): (&GenericRemoteStorage, &RemoteIndex, &SyncQueue),
     current_remote_timeline: Option<&RemoteTimeline>,
     sync_id: ZTenantTimelineId,
     new_upload_data: SyncData<LayersUpload>,
     sync_start: Instant,
     task_name: &str,
-) -> UploadStatus
-where
-    P: Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) -> UploadStatus {
     let mut uploaded_data = match upload_timeline_layers(
         storage,
         sync_queue,
@@ -1406,17 +1364,13 @@ enum RemoteDataUpdate<'a> {
     Delete(&'a HashSet<PathBuf>),
 }
 
-async fn update_remote_data<P, S>(
+async fn update_remote_data(
     conf: &'static PageServerConf,
-    storage: &S,
+    storage: &GenericRemoteStorage,
     index: &RemoteIndex,
     sync_id: ZTenantTimelineId,
     update: RemoteDataUpdate<'_>,
-) -> anyhow::Result<()>
-where
-    P: Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) -> anyhow::Result<()> {
     let updated_remote_timeline = {
         let mut index_accessor = index.write().await;
 

--- a/pageserver/src/storage_sync/delete.rs
+++ b/pageserver/src/storage_sync/delete.rs
@@ -1,27 +1,25 @@
 //! Timeline synchronization logic to delete a bulk of timeline's remote files from the remote storage.
 
+use std::path::Path;
+
 use anyhow::Context;
 use futures::stream::{FuturesUnordered, StreamExt};
 use tracing::{debug, error, info};
 
 use crate::storage_sync::{SyncQueue, SyncTask};
-use remote_storage::RemoteStorage;
+use remote_storage::{GenericRemoteStorage, RemoteStorage};
 use utils::zid::ZTenantTimelineId;
 
 use super::{LayersDeletion, SyncData};
 
 /// Attempts to remove the timleline layers from the remote storage.
 /// If the task had not adjusted the metadata before, the deletion will fail.
-pub(super) async fn delete_timeline_layers<'a, P, S>(
-    storage: &'a S,
+pub(super) async fn delete_timeline_layers<'a>(
+    storage: &'a GenericRemoteStorage,
     sync_queue: &SyncQueue,
     sync_id: ZTenantTimelineId,
     mut delete_data: SyncData<LayersDeletion>,
-) -> bool
-where
-    P: std::fmt::Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+) -> bool {
     if !delete_data.data.deletion_registered {
         error!("Cannot delete timeline layers before the deletion metadata is not registered, reenqueueing");
         delete_data.retries += 1;
@@ -45,25 +43,14 @@ where
     let mut delete_tasks = layers_to_delete
         .into_iter()
         .map(|local_layer_path| async {
-            let storage_path =
-                match storage
-                    .remote_object_id(&local_layer_path)
-                    .with_context(|| {
-                        format!(
-                            "Failed to get the layer storage path for local path '{}'",
-                            local_layer_path.display()
-                        )
-                    }) {
-                    Ok(path) => path,
-                    Err(e) => return Err((e, local_layer_path)),
-                };
-
-            match storage.delete(&storage_path).await.with_context(|| {
-                format!(
-                    "Failed to delete remote layer from storage at '{:?}'",
-                    storage_path
-                )
-            }) {
+            match match storage {
+                GenericRemoteStorage::Local(storage) => {
+                    remove_storage_object(storage, &local_layer_path).await
+                }
+                GenericRemoteStorage::S3(storage) => {
+                    remove_storage_object(storage, &local_layer_path).await
+                }
+            } {
                 Ok(()) => Ok(local_layer_path),
                 Err(e) => Err((e, local_layer_path)),
             }
@@ -101,6 +88,28 @@ where
     errored
 }
 
+async fn remove_storage_object<P, S>(storage: &S, local_layer_path: &Path) -> anyhow::Result<()>
+where
+    P: std::fmt::Debug + Send + Sync + 'static,
+    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
+{
+    let storage_path = storage
+        .remote_object_id(local_layer_path)
+        .with_context(|| {
+            format!(
+                "Failed to get the layer storage path for local path '{}'",
+                local_layer_path.display()
+            )
+        })?;
+
+    storage.delete(&storage_path).await.with_context(|| {
+        format!(
+            "Failed to delete remote layer from storage at '{:?}'",
+            storage_path
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::HashSet, num::NonZeroUsize};
@@ -114,7 +123,7 @@ mod tests {
         layered_repository::repo_harness::{RepoHarness, TIMELINE_ID},
         storage_sync::test_utils::{create_local_timeline, dummy_metadata},
     };
-    use remote_storage::LocalFs;
+    use remote_storage::{LocalFs, RemoteStorage};
 
     use super::*;
 
@@ -123,10 +132,10 @@ mod tests {
         let harness = RepoHarness::create("delete_timeline_negative")?;
         let sync_queue = SyncQueue::new(NonZeroUsize::new(100).unwrap());
         let sync_id = ZTenantTimelineId::new(harness.tenant_id, TIMELINE_ID);
-        let storage = LocalFs::new(
+        let storage = GenericRemoteStorage::Local(LocalFs::new(
             tempdir()?.path().to_path_buf(),
             harness.conf.workdir.clone(),
-        )?;
+        )?);
 
         let deleted = delete_timeline_layers(
             &storage,
@@ -158,17 +167,20 @@ mod tests {
 
         let sync_id = ZTenantTimelineId::new(harness.tenant_id, TIMELINE_ID);
         let layer_files = ["a", "b", "c", "d"];
-        let storage = LocalFs::new(
+        let storage = GenericRemoteStorage::Local(LocalFs::new(
             tempdir()?.path().to_path_buf(),
             harness.conf.workdir.clone(),
-        )?;
+        )?);
+
+        let local_storage = storage.as_local().unwrap();
+
         let current_retries = 3;
         let metadata = dummy_metadata(Lsn(0x30));
         let local_timeline_path = harness.timeline_path(&TIMELINE_ID);
         let timeline_upload =
             create_local_timeline(&harness, TIMELINE_ID, &layer_files, metadata.clone()).await?;
         for local_path in timeline_upload.layers_to_upload {
-            let remote_path = storage.remote_object_id(&local_path)?;
+            let remote_path = local_storage.remote_object_id(&local_path)?;
             let remote_parent_dir = remote_path.parent().unwrap();
             if !remote_parent_dir.exists() {
                 fs::create_dir_all(&remote_parent_dir).await?;
@@ -176,11 +188,11 @@ mod tests {
             fs::copy(&local_path, &remote_path).await?;
         }
         assert_eq!(
-            storage
+            local_storage
                 .list()
                 .await?
                 .into_iter()
-                .map(|remote_path| storage.local_path(&remote_path).unwrap())
+                .map(|remote_path| local_storage.local_path(&remote_path).unwrap())
                 .filter_map(|local_path| { Some(local_path.file_name()?.to_str()?.to_owned()) })
                 .sorted()
                 .collect::<Vec<_>>(),
@@ -213,11 +225,11 @@ mod tests {
         assert!(deleted, "Should be able to delete timeline files");
 
         assert_eq!(
-            storage
+            local_storage
                 .list()
                 .await?
                 .into_iter()
-                .map(|remote_path| storage.local_path(&remote_path).unwrap())
+                .map(|remote_path| local_storage.local_path(&remote_path).unwrap())
                 .filter_map(|local_path| { Some(local_path.file_name()?.to_str()?.to_owned()) })
                 .sorted()
                 .collect::<Vec<_>>(),


### PR DESCRIPTION
Adjusts pageserver's remote storage code to
* share single remote storage in http and storage_sync parts, thus using single semaphore to limit S3 requests
* pushes all `<P, S>` remote storage-related down to download/upload/delete.rs specific modules' functions, using `GenericRemoteStorage` everywhere else as a container to pass the storage dependency around