### PR TITLE
Turn GenericRemoteStorage into just an alias for 'Box<dyn RemoteStorage>'

### DIFF
--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     ffi::OsStr,
-    fmt::Debug,
+    fmt::{Debug, Display},
     num::{NonZeroU32, NonZeroUsize},
     ops::Deref,
     path::{Path, PathBuf},
@@ -46,12 +46,6 @@ const REMOTE_STORAGE_PREFIX_SEPARATOR: char = '/';
 #[derive(Clone, PartialEq, Eq)]
 pub struct RemoteObjectId(String);
 
-impl From<RemoteObjectId> for String {
-    fn from(id: RemoteObjectId) -> Self {
-        id.0
-    }
-}
-
 ///
 /// A key that refers to an object in remote storage. It works much like a Path,
 /// but it's a separate datatype so that you don't accidentally mix local paths
@@ -80,7 +74,13 @@ impl RemoteObjectId {
 
 impl Debug for RemoteObjectId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        self.0.fmt(fmt)
+        Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl Display for RemoteObjectId {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, fmt)
     }
 }
 

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -34,7 +34,7 @@ struct State {
     auth: Option<Arc<JwtAuth>>,
     remote_index: RemoteIndex,
     allowlist_routes: Vec<Uri>,
-    remote_storage: Option<Arc<GenericRemoteStorage>>,
+    remote_storage: Option<GenericRemoteStorage>,
 }
 
 impl State {
@@ -42,7 +42,7 @@ impl State {
         conf: &'static PageServerConf,
         auth: Option<Arc<JwtAuth>>,
         remote_index: RemoteIndex,
-        remote_storage: Option<Arc<GenericRemoteStorage>>,
+        remote_storage: Option<GenericRemoteStorage>,
     ) -> anyhow::Result<Self> {
         let allowlist_routes = ["/v1/status", "/v1/doc", "/swagger.yml"]
             .iter()
@@ -659,7 +659,7 @@ pub fn make_router(
     conf: &'static PageServerConf,
     auth: Option<Arc<JwtAuth>>,
     remote_index: RemoteIndex,
-    remote_storage: Option<Arc<GenericRemoteStorage>>,
+    remote_storage: Option<GenericRemoteStorage>,
 ) -> anyhow::Result<RouterBuilder<hyper::Body, ApiError>> {
     let spec = include_bytes!("openapi_spec.yml");
     let mut router = attach_openapi_ui(endpoint::make_router(), spec, "/swagger.yml", "/v1/doc");

--- a/pageserver/src/storage_sync/delete.rs
+++ b/pageserver/src/storage_sync/delete.rs
@@ -7,15 +7,15 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tracing::{debug, error, info};
 
 use crate::storage_sync::{SyncQueue, SyncTask};
-use remote_storage::{GenericRemoteStorage, RemoteStorage};
+use remote_storage::GenericRemoteStorage;
 use utils::zid::ZTenantTimelineId;
 
 use super::{LayersDeletion, SyncData};
 
 /// Attempts to remove the timleline layers from the remote storage.
 /// If the task had not adjusted the metadata before, the deletion will fail.
-pub(super) async fn delete_timeline_layers<'a>(
-    storage: &'a GenericRemoteStorage,
+pub(super) async fn delete_timeline_layers(
+    storage: &GenericRemoteStorage,
     sync_queue: &SyncQueue,
     sync_id: ZTenantTimelineId,
     mut delete_data: SyncData<LayersDeletion>,
@@ -43,14 +43,7 @@ pub(super) async fn delete_timeline_layers<'a>(
     let mut delete_tasks = layers_to_delete
         .into_iter()
         .map(|local_layer_path| async {
-            match match storage {
-                GenericRemoteStorage::Local(storage) => {
-                    remove_storage_object(storage, &local_layer_path).await
-                }
-                GenericRemoteStorage::S3(storage) => {
-                    remove_storage_object(storage, &local_layer_path).await
-                }
-            } {
+            match remove_storage_object(storage, &local_layer_path).await {
                 Ok(()) => Ok(local_layer_path),
                 Err(e) => Err((e, local_layer_path)),
             }
@@ -88,11 +81,10 @@ pub(super) async fn delete_timeline_layers<'a>(
     errored
 }
 
-async fn remove_storage_object<P, S>(storage: &S, local_layer_path: &Path) -> anyhow::Result<()>
-where
-    P: std::fmt::Debug + Send + Sync + 'static,
-    S: RemoteStorage<RemoteObjectId = P> + Send + Sync + 'static,
-{
+async fn remove_storage_object(
+    storage: &GenericRemoteStorage,
+    local_layer_path: &Path,
+) -> anyhow::Result<()> {
     let storage_path = storage
         .remote_object_id(local_layer_path)
         .with_context(|| {
@@ -132,7 +124,7 @@ mod tests {
         let harness = RepoHarness::create("delete_timeline_negative")?;
         let sync_queue = SyncQueue::new(NonZeroUsize::new(100).unwrap());
         let sync_id = ZTenantTimelineId::new(harness.tenant_id, TIMELINE_ID);
-        let storage = GenericRemoteStorage::Local(LocalFs::new(
+        let storage = GenericRemoteStorage::new(LocalFs::new(
             tempdir()?.path().to_path_buf(),
             harness.conf.workdir.clone(),
         )?);
@@ -167,7 +159,7 @@ mod tests {
 
         let sync_id = ZTenantTimelineId::new(harness.tenant_id, TIMELINE_ID);
         let layer_files = ["a", "b", "c", "d"];
-        let storage = GenericRemoteStorage::Local(LocalFs::new(
+        let storage = GenericRemoteStorage::new(LocalFs::new(
             tempdir()?.path().to_path_buf(),
             harness.conf.workdir.clone(),
         )?);
@@ -180,7 +172,8 @@ mod tests {
         let timeline_upload =
             create_local_timeline(&harness, TIMELINE_ID, &layer_files, metadata.clone()).await?;
         for local_path in timeline_upload.layers_to_upload {
-            let remote_path = local_storage.remote_object_id(&local_path)?;
+            let remote_path =
+                local_storage.resolve_in_storage(&local_storage.remote_object_id(&local_path)?)?;
             let remote_parent_dir = remote_path.parent().unwrap();
             if !remote_parent_dir.exists() {
                 fs::create_dir_all(&remote_parent_dir).await?;

--- a/pageserver/src/storage_sync/download.rs
+++ b/pageserver/src/storage_sync/download.rs
@@ -625,7 +625,7 @@ mod tests {
             metadata_path(harness.conf, sync_id.timeline_id, sync_id.tenant_id)
                 .with_file_name(IndexPart::FILE_NAME);
         let index_part_remote_id = local_storage.remote_object_id(&local_index_part_path)?;
-        let index_part_local_path = PathBuf::from(String::from(index_part_remote_id));
+        let index_part_local_path = PathBuf::from(index_part_remote_id.to_string());
         fs::create_dir_all(index_part_local_path.parent().unwrap()).await?;
         fs::write(&index_part_local_path, serde_json::to_vec(&index_part)?).await?;
 

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -134,7 +134,7 @@ impl fmt::Display for TenantState {
 /// are scheduled for download and added to the repository once download is completed.
 pub fn init_tenant_mgr(
     conf: &'static PageServerConf,
-    remote_storage: Option<Arc<GenericRemoteStorage>>,
+    remote_storage: Option<GenericRemoteStorage>,
 ) -> anyhow::Result<RemoteIndex> {
     let (timeline_updates_sender, timeline_updates_receiver) =
         mpsc::unbounded_channel::<LocalTimelineUpdate>();


### PR DESCRIPTION
We had a pattern like this:

    match remote_storage {
        GenericRemoteStorage::Local(storage) => {
            let source = storage.remote_object_id(&file_path)?;
            ...
            storage
                .function(&source, ...)
                .await
       },
       GenericRemoteStorage::S3(storage) => {
	    ... exact same code as for the Local case ...
       },

This removes the code duplication, by allowing you to call the functions
directly on GenericRemoteStorage.

Also change RemoveObjectId to be just a type alias for String. Now that
the callers of GenericRemoteStorage functions don't know whether they're
dealing with the LocalFs or S3 implementation, RemoveObjectId must be the
same type for both.
