### PR TITLE
Small fixes

### DIFF
--- a/pageserver/src/storage_sync/download.rs
+++ b/pageserver/src/storage_sync/download.rs
@@ -141,8 +141,7 @@ async fn download_index_part(
     sync_id: ZTenantTimelineId,
 ) -> Result<IndexPart, DownloadError> {
     let index_part_path = metadata_path(conf, sync_id.timeline_id, sync_id.tenant_id)
-        .with_file_name(IndexPart::FILE_NAME)
-        .with_extension(IndexPart::FILE_EXTENSION);
+        .with_file_name(IndexPart::FILE_NAME);
     let mut index_part_download = storage
         .download_storage_object(None, &index_part_path)
         .await?;
@@ -663,8 +662,7 @@ mod tests {
 
         let local_index_part_path =
             metadata_path(harness.conf, sync_id.timeline_id, sync_id.tenant_id)
-                .with_file_name(IndexPart::FILE_NAME)
-                .with_extension(IndexPart::FILE_EXTENSION);
+                .with_file_name(IndexPart::FILE_NAME);
         let storage_path = local_storage.remote_object_id(&local_index_part_path)?;
         fs::create_dir_all(storage_path.parent().unwrap()).await?;
         fs::write(&storage_path, serde_json::to_vec(&index_part)?).await?;

--- a/pageserver/src/storage_sync/index.rs
+++ b/pageserver/src/storage_sync/index.rs
@@ -278,8 +278,7 @@ pub struct IndexPart {
 }
 
 impl IndexPart {
-    pub const FILE_NAME: &'static str = "index_part";
-    pub const FILE_EXTENSION: &'static str = "json";
+    pub const FILE_NAME: &'static str = "index_part.json";
 
     #[cfg(test)]
     pub fn new(

--- a/pageserver/src/storage_sync/upload.rs
+++ b/pageserver/src/storage_sync/upload.rs
@@ -42,8 +42,7 @@ pub(super) async fn upload_index_part(
     let index_part_bytes = tokio::io::BufReader::new(std::io::Cursor::new(index_part_bytes));
 
     let index_part_path = metadata_path(conf, sync_id.timeline_id, sync_id.tenant_id)
-        .with_file_name(IndexPart::FILE_NAME)
-        .with_extension(IndexPart::FILE_EXTENSION);
+        .with_file_name(IndexPart::FILE_NAME);
     storage
         .upload_storage_object(index_part_bytes, index_part_size, &index_part_path)
         .await
@@ -442,16 +441,9 @@ mod tests {
 
         let index_part_path = storage_files.first().unwrap();
         assert_eq!(
-            index_part_path.file_stem().and_then(|name| name.to_str()),
+            index_part_path.file_name().and_then(|name| name.to_str()),
             Some(IndexPart::FILE_NAME),
             "Remote index part should have the correct name"
-        );
-        assert_eq!(
-            index_part_path
-                .extension()
-                .and_then(|extension| extension.to_str()),
-            Some(IndexPart::FILE_EXTENSION),
-            "Remote index part should have the correct extension"
         );
 
         let remote_index_part: IndexPart =

--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -112,10 +112,10 @@ class NeonCompare(PgCompare):
         return self._pg_bin
 
     def flush(self):
-        self.pscur.execute(f"do_gc {self.env.initial_tenant.hex} {self.timeline} 0")
+        self.pscur.execute(f"do_gc {self.env.initial_tenant} {self.timeline} 0")
 
     def compact(self):
-        self.pscur.execute(f"compact {self.env.initial_tenant.hex} {self.timeline}")
+        self.pscur.execute(f"compact {self.env.initial_tenant} {self.timeline}")
 
     def report_peak_memory_use(self) -> None:
         self.zenbenchmark.record(


### PR DESCRIPTION
Fixes 

* Benchmark Python test failure
https://github.com/neondatabase/neon/actions/runs/2977846982
https://neon-github-public-dev.s3.amazonaws.com/reports/main/release/2977846982/index.html#suites/792a596a01c566b9215997335bf18812/8185c7bf6360013c/

```
AttributeError: 'ZTenantId' object has no attribute 'hex'
test_runner/performance/test_bulk_insert.py:27: in test_bulk_insert
    env.flush()
test_runner/fixtures/compare_fixtures.py:115: in flush
    self.pscur.execute(f"do_gc {self.env.initial_tenant.hex} {self.timeline} 0")
E   AttributeError: 'ZTenantId' object has no attribute 'hex'
```

* Takes https://github.com/neondatabase/neon/pull/2368/files#r959375753 and again embeds it into another PR 🙂 