### PR TITLE
Proposal: Introduce downcasting for GenericRemoteStorage instead of `as_local` implementation

### DIFF
--- a/pageserver/src/storage_sync/delete.rs
+++ b/pageserver/src/storage_sync/delete.rs
@@ -172,7 +172,7 @@ mod tests {
             harness.conf.workdir.clone(),
         )?);
 
-        let local_storage = storage.as_local().unwrap();
+        let local_storage: &LocalFs = (&storage).try_into().unwrap();
 
         let current_retries = 3;
         let metadata = dummy_metadata(Lsn(0x30));

--- a/pageserver/src/storage_sync/download.rs
+++ b/pageserver/src/storage_sync/download.rs
@@ -486,7 +486,7 @@ mod tests {
             tempdir()?.path().to_owned(),
             harness.conf.workdir.clone(),
         )?);
-        let local_storage = storage.as_local().unwrap();
+        let local_storage: &LocalFs = (&storage).try_into().unwrap();
         let current_retries = 3;
         let metadata = dummy_metadata(Lsn(0x30));
         let local_timeline_path = harness.timeline_path(&TIMELINE_ID);
@@ -643,7 +643,7 @@ mod tests {
             tempdir()?.path().to_owned(),
             harness.conf.workdir.clone(),
         )?);
-        let local_storage = storage.as_local().unwrap();
+        let local_storage: &LocalFs = (&storage).try_into().unwrap();
         let metadata = dummy_metadata(Lsn(0x30));
         let local_timeline_path = harness.timeline_path(&TIMELINE_ID);
 

--- a/pageserver/src/storage_sync/upload.rs
+++ b/pageserver/src/storage_sync/upload.rs
@@ -228,7 +228,7 @@ mod tests {
             tempdir()?.path().to_owned(),
             harness.conf.workdir.clone(),
         )?);
-        let local_storage = storage.as_local().unwrap();
+        let local_storage: &LocalFs = (&storage).try_into().unwrap();
         let current_retries = 3;
         let metadata = dummy_metadata(Lsn(0x30));
         let local_timeline_path = harness.timeline_path(&TIMELINE_ID);
@@ -316,7 +316,7 @@ mod tests {
             tempdir()?.path().to_owned(),
             harness.conf.workdir.clone(),
         )?);
-        let local_storage = storage.as_local().unwrap();
+        let local_storage: &LocalFs = (&storage).try_into().unwrap();
         let current_retries = 5;
         let metadata = dummy_metadata(Lsn(0x40));
 
@@ -409,7 +409,7 @@ mod tests {
             tempdir()?.path().to_owned(),
             harness.conf.workdir.clone(),
         )?);
-        let local_storage = storage.as_local().unwrap();
+        let local_storage: &LocalFs = (&storage).try_into().unwrap();
         let metadata = dummy_metadata(Lsn(0x40));
         let local_timeline_path = harness.timeline_path(&TIMELINE_ID);
 


### PR DESCRIPTION
Hey Neon!

I want to propose removing `as_local` implementation in favor of having the ability to convert between types. WDYT?