### PR TITLE
pass RemoteStorage as impl RemoteStorage instead of GenericRemoteStorage

### DIFF
--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -42,13 +42,19 @@ pub const DEFAULT_REMOTE_STORAGE_MAX_SYNC_ERRORS: u32 = 10;
 /// https://aws.amazon.com/premiumsupport/knowledge-center/s3-request-limit-avoid-throttling/
 pub const DEFAULT_REMOTE_STORAGE_S3_CONCURRENCY_LIMIT: usize = 100;
 
+pub trait RemoteObjectName {
+    // Needed to retrieve last component for RemoteObjectId.
+    // In other words a file name
+    fn object_name(&self) -> Option<&str>;
+}
+
 /// Storage (potentially remote) API to manage its state.
 /// This storage tries to be unaware of any layered repository context,
 /// providing basic CRUD operations for storage files.
 #[async_trait::async_trait]
-pub trait RemoteStorage: Send + Sync {
+pub trait RemoteStorage: Send + Sync + 'static {
     /// A way to uniquely reference a file in the remote storage.
-    type RemoteObjectId;
+    type RemoteObjectId: RemoteObjectName + Debug + Send + Sync;
 
     /// Attempts to derive the storage path out of the local path, if the latter is correct.
     fn remote_object_id(&self, local_path: &Path) -> anyhow::Result<Self::RemoteObjectId>;

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -17,9 +17,15 @@ use tokio::{
 };
 use tracing::*;
 
-use crate::{path_with_suffix_extension, Download, DownloadError};
+use crate::{path_with_suffix_extension, Download, DownloadError, RemoteObjectName};
 
 use super::{strip_path_prefix, RemoteStorage, StorageMetadata};
+
+impl RemoteObjectName for PathBuf {
+    fn object_name(&self) -> Option<&str> {
+        self.file_stem().and_then(|n| n.to_str())
+    }
+}
 
 pub struct LocalFs {
     working_directory: PathBuf,

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -12,7 +12,7 @@ use crate::thread_mgr::ThreadKind;
 use crate::walredo::PostgresRedoManager;
 use crate::{thread_mgr, timelines, walreceiver};
 use anyhow::Context;
-use remote_storage::GenericRemoteStorage;
+use remote_storage::RemoteStorage;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -134,10 +134,11 @@ impl fmt::Display for TenantState {
 /// are scheduled for download and added to the repository once download is completed.
 pub fn init_tenant_mgr(
     conf: &'static PageServerConf,
-    remote_storage: Option<Arc<GenericRemoteStorage>>,
+    remote_storage: Option<Arc<impl RemoteStorage>>,
 ) -> anyhow::Result<RemoteIndex> {
     let (timeline_updates_sender, timeline_updates_receiver) =
         mpsc::unbounded_channel::<LocalTimelineUpdate>();
+
     tenants_state::set_timeline_update_sender(timeline_updates_sender)?;
     walreceiver::init_wal_receiver_main_thread(conf, timeline_updates_receiver)?;
 


### PR DESCRIPTION
That brings back RemoteObjectName, and removes almost all generic bounds on remote storage methods by using only `impl RemoteStorage`

I didnt do any major rearrangements, changed only signatures of existing functions 

Remote storage parts look better to me, but `http::routes` module started to look uglier. Also this required hacky `Option::<LocalFs>::None` for the case when pageserver is launched without remote storage