### PR TITLE
Control rustc version from storage repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 
+!rust-toolchain.toml
 !Cargo.toml
 !Cargo.lock
 !Makefile

--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -5,9 +5,6 @@ inputs:
   build_type:
     description: 'Type of Rust (neon) and C (postgres) builds. Must be "release" or "debug", or "remote" for the remote cluster'
     required: true
-  rust_toolchain:
-    description: 'Rust toolchain version to fetch the caches'
-    required: false
   test_selection:
     description: 'A python test suite to run'
     required: true
@@ -55,7 +52,7 @@ runs:
       if: inputs.build_type != 'remote'
       uses: ./.github/actions/download
       with:
-        name: neon-${{ runner.os }}-${{ inputs.build_type }}-${{ inputs.rust_toolchain }}-artifact
+        name: neon-${{ runner.os }}-${{ inputs.build_type }}-artifact
         path: /tmp/neon
 
     - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,7 +54,11 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ debug, release ]
-        rust_toolchain: [ 1.58 ]
+        # TODO this version is currently needed to make build statuses more informative
+        # and to clear cargo caches in a more transparent way.
+        # We should rather read this value from the file in the root of the repo, `rust-toolchain.toml` since it's
+        # truly setting what version of compiler the sources are built with
+        rust_toolchain: [ '1.60' ]
 
     env:
       BUILD_TYPE: ${{ matrix.build_type }}
@@ -100,11 +104,11 @@ jobs:
           if [[ $BUILD_TYPE == "debug" ]]; then
             cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
             CARGO_FEATURES=""
-            CARGO_FLAGS="--locked"
+            CARGO_FLAGS="--locked --timings"
           elif [[ $BUILD_TYPE == "release" ]]; then
             cov_prefix=""
             CARGO_FEATURES="--features profiling"
-            CARGO_FLAGS="--locked --release $CARGO_FEATURES"
+            CARGO_FLAGS="--locked --timings --release $CARGO_FEATURES"
           fi
           echo "cov_prefix=${cov_prefix}" >> $GITHUB_ENV
           echo "CARGO_FEATURES=${CARGO_FEATURES}" >> $GITHUB_ENV
@@ -218,6 +222,17 @@ jobs:
           name: neon-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.rust_toolchain }}-artifact
           path: /tmp/neon
 
+      - name: Prepare cargo build timing stats for storing
+        run: |
+          mkdir -p "/tmp/neon/cargo-timings/$BUILD_TYPE/"
+          cp -r ./target/cargo-timings/* "/tmp/neon/cargo-timings/$BUILD_TYPE/"
+        shell: bash -euxo pipefail {0}
+      - name: Upload cargo build stats
+        uses: ./.github/actions/upload
+        with:
+          name: neon-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.rust_toolchain }}-build-stats
+          path: /tmp/neon/cargo-timings/
+
       # XXX: keep this after the binaries.list is formed, so the coverage can properly work later
       - name: Merge and upload coverage data
         if: matrix.build_type == 'debug'
@@ -233,7 +248,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ debug, release ]
-        rust_toolchain: [ 1.58 ]
+        rust_toolchain: [ '1.60' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -269,7 +284,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ release ]
-        rust_toolchain: [ 1.58 ]
+        rust_toolchain: [ '1.60' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -341,7 +356,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ debug ]
-        rust_toolchain: [ 1.58 ]
+        rust_toolchain: [ '1.60' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,11 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ debug, release ]
-        # TODO this version is currently needed to make build statuses more informative
-        # and to clear cargo caches in a more transparent way.
-        # We should rather read this value from the file in the root of the repo, `rust-toolchain.toml` since it's
-        # truly setting what version of compiler the sources are built with
-        rust_toolchain: [ '1.60' ]
 
     env:
       BUILD_TYPE: ${{ matrix.build_type }}
@@ -130,8 +125,8 @@ jobs:
             target/
           # Fall back to older versions of the key, if no cache for current Cargo.lock was found
           key: |
-            v7-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-${{ hashFiles('Cargo.lock') }}
-            v7-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-
+            v8-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ hashFiles('Cargo.lock') }}
+            v8-${{ runner.os }}-${{ matrix.build_type }}-cargo-
 
       - name: Cache postgres v14 build
         id: cache_pg_14
@@ -219,7 +214,7 @@ jobs:
       - name: Upload Neon artifact
         uses: ./.github/actions/upload
         with:
-          name: neon-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.rust_toolchain }}-artifact
+          name: neon-${{ runner.os }}-${{ matrix.build_type }}-artifact
           path: /tmp/neon
 
       - name: Prepare cargo build timing stats for storing
@@ -230,7 +225,7 @@ jobs:
       - name: Upload cargo build stats
         uses: ./.github/actions/upload
         with:
-          name: neon-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.rust_toolchain }}-build-stats
+          name: neon-${{ runner.os }}-${{ matrix.build_type }}-build-stats
           path: /tmp/neon/cargo-timings/
 
       # XXX: keep this after the binaries.list is formed, so the coverage can properly work later
@@ -248,7 +243,6 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ debug, release ]
-        rust_toolchain: [ '1.60' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -260,7 +254,6 @@ jobs:
         uses: ./.github/actions/run-python-test-set
         with:
           build_type: ${{ matrix.build_type }}
-          rust_toolchain: ${{ matrix.rust_toolchain }}
           test_selection: regress
           needs_postgres_source: true
           run_with_real_s3: true
@@ -284,7 +277,6 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ release ]
-        rust_toolchain: [ '1.60' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -296,7 +288,6 @@ jobs:
         uses: ./.github/actions/run-python-test-set
         with:
           build_type: ${{ matrix.build_type }}
-          rust_toolchain: ${{ matrix.rust_toolchain }}
           test_selection: performance
           run_in_parallel: false
           save_perf_report: true
@@ -356,7 +347,6 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ debug ]
-        rust_toolchain: [ '1.60' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -373,12 +363,12 @@ jobs:
             !~/.cargo/registry/src
             ~/.cargo/git/
             target/
-          key: v7-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ matrix.rust_toolchain }}-${{ hashFiles('Cargo.lock') }}
+          key: v8-${{ runner.os }}-${{ matrix.build_type }}-cargo-${{ hashFiles('Cargo.lock') }}
 
       - name: Get Neon artifact
         uses: ./.github/actions/download
         with:
-          name: neon-${{ runner.os }}-${{ matrix.build_type }}-${{ matrix.rust_toolchain }}-artifact
+          name: neon-${{ runner.os }}-${{ matrix.build_type }}-artifact
           path: /tmp/neon
 
       - name: Get coverage artifact

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -24,9 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # If we want to duplicate this job for different
-        # Rust toolchains (e.g. nightly or 1.37.0), add them here.
-        rust_toolchain: [1.58]
+        # TODO read from `rust-toolchain.toml` and do the same in the build and test workflow too.
+        rust_toolchain: ['1.60']
         os: [ubuntu-latest, macos-latest]
         # To support several Postgres versions, add them here.
         postgres_version: [v14, v15]

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -24,8 +24,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO read from `rust-toolchain.toml` and do the same in the build and test workflow too.
-        rust_toolchain: ['1.60']
+        # XXX: both OSes have rustup
+        #   * https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#rust-tools
+        #   * https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#rust-tools
+        # this is all we need to install our toolchain later via rust-toolchain.toml
+        # so don't install any toolchain explicitly.
         os: [ubuntu-latest, macos-latest]
         # To support several Postgres versions, add them here.
         postgres_version: [v14, v15]
@@ -39,14 +42,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 2
-
-      - name: Install rust toolchain ${{ matrix.rust_toolchain }}
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust_toolchain }}
-          components: rustfmt, clippy
-          override: true
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -106,7 +101,7 @@ jobs:
             !~/.cargo/registry/src
             ~/.cargo/git
             target
-          key: v3-${{ runner.os }}-cargo-${{ hashFiles('./Cargo.lock') }}-rust-${{ matrix.rust_toolchain }}
+          key: v4-${{ runner.os }}-cargo-${{ hashFiles('./Cargo.lock') }}-rust
 
       - name: Run cargo clippy
         run: ./run_clippy.sh

--- a/Dockerfile.compute-node.legacy
+++ b/Dockerfile.compute-node.legacy
@@ -22,7 +22,7 @@ FROM $REPOSITORY/$IMAGE:$TAG AS compute-deps
 #
 # Image with Postgres build deps
 #
-FROM debian:buster-slim AS build-deps
+FROM debian:bullseye-slim AS build-deps
 
 RUN apt-get update && apt-get -yq install automake libtool build-essential bison flex libreadline-dev zlib1g-dev libxml2-dev \
                                           libcurl4-openssl-dev libossp-uuid-dev
@@ -59,7 +59,7 @@ WORKDIR /pg
 #
 # Final compute node image to be exported
 #
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # libreadline-dev is required to run psql
 RUN apt-get update && apt-get -yq install libreadline-dev libossp-uuid-dev

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This file is automatically picked up by [`rustup`](https://rust-lang.github.io/r
 rustup users who want to build with another toolchain can use [`rustup override`](https://rust-lang.github.io/rustup/overrides.html#directory-overrides) command to set a specific toolchain for the project's directory.
 
 non-rustup users most probably are not getting the same toolchain automatically from the file, so are responsible to manually verify their toolchain matches the version in the file.
-Never rustc versions most probably will work fine, yet older ones might not be supported due to some new features used by the project or the crates.
+Newer rustc versions most probably will work fine, yet older ones might not be supported due to some new features used by the project or the crates.
 
 #### Building on Linux
 
@@ -90,8 +90,8 @@ git clone --recursive https://github.com/neondatabase/neon.git
 cd neon
 
 # The preferred and default is to make a debug build. This will create a
-# demonstrably slower build than a release build. If you want to use a release
-# build, utilize "BUILD_TYPE=release make -j`nproc`"
+# demonstrably slower build than a release build. For a release build,
+# use "BUILD_TYPE=release make -j`nproc`"
 
 make -j`nproc`
 ```
@@ -106,8 +106,8 @@ git clone --recursive https://github.com/neondatabase/neon.git
 cd neon
 
 # The preferred and default is to make a debug build. This will create a
-# demonstrably slower build than a release build. If you want to use a release
-# build, utilize "BUILD_TYPE=release make -j`sysctl -n hw.logicalcpu`"
+# demonstrably slower build than a release build. For a release build,
+# use "BUILD_TYPE=release make -j`sysctl -n hw.logicalcpu`"
 
 make -j`sysctl -n hw.logicalcpu`
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ brew install libpq
 brew link --force libpq
 ```
 
+#### Rustc version
+
+The project uses [rust toolchain file](./rust-toolchain.toml) to define the version it's built with in CI for testing and local builds.
+
+This file is automatically picked up by [`rustup`](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) that installs (if absent) and uses the toolchain version pinned in the file.
+
+rustup users who want to build with another toolchain can use [`rustup override`](https://rust-lang.github.io/rustup/overrides.html#directory-overrides) command to set a specific toolchain for the project's directory.
+
+non-rustup users most probably are not getting the same toolchain automatically from the file, so are responsible to manually verify their toolchain matches the version in the file.
+Never rustc versions most probably will work fine, yet older ones might not be supported due to some new features used by the project or the crates.
+
 #### Building on Linux
 
 1. Build neon and patched postgres
@@ -78,9 +89,9 @@ brew link --force libpq
 git clone --recursive https://github.com/neondatabase/neon.git
 cd neon
 
-# The preferred and default is to make a debug build. This will create a 
+# The preferred and default is to make a debug build. This will create a
 # demonstrably slower build than a release build. If you want to use a release
-# build, utilize "BUILD_TYPE=release make -j`nproc`" 
+# build, utilize "BUILD_TYPE=release make -j`nproc`"
 
 make -j`nproc`
 ```
@@ -94,9 +105,9 @@ make -j`nproc`
 git clone --recursive https://github.com/neondatabase/neon.git
 cd neon
 
-# The preferred and default is to make a debug build. This will create a 
+# The preferred and default is to make a debug build. This will create a
 # demonstrably slower build than a release build. If you want to use a release
-# build, utilize "BUILD_TYPE=release make -j`sysctl -n hw.logicalcpu`" 
+# build, utilize "BUILD_TYPE=release make -j`sysctl -n hw.logicalcpu`"
 
 make -j`sysctl -n hw.logicalcpu`
 ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+channel = "1.60"
+profile = "default"
+# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
+# https://rust-lang.github.io/rustup/concepts/profiles.html
+# but we also need `llvm-tools-preview` for coverage data merges on CI
+components = ["llvm-tools-preview", "rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # 'testing' or even 'unstable', which is a bit more cutting-edge than we'd like. Hopefully the 1.60 packages reach
 # 'testing' soon (and similarly for the other distributions).
 # See https://tracker.debian.org/pkg/rustc for more details on Debian rustc package.
-channel = "1.60" # do update CI matrix values when updating this
+channel = "1.60" # do update GitHub CI cache values for rust builds, when changing this value
 profile = "default"
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,11 @@
 [toolchain]
-channel = "1.60"
+# We try to stick to a toolchain version that is widely available on popular distributions, so that most people
+# can use the toolchain that comes with their operating system. But if there's a feature we miss badly from a later
+# version, we can consider updating. As of this writing, 1.60 is available on Debian 'experimental' but not yet on
+# 'testing' or even 'unstable', which is a bit more cutting-edge than we'd like. Hopefully the 1.60 packages reach
+# 'testing' soon (and similarly for the other distributions).
+# See https://tracker.debian.org/pkg/rustc for more details on Debian rustc package.
+channel = "1.60" # do update CI matrix values when updating this
 profile = "default"
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -155,7 +155,7 @@ def get_scale_for_db(size_mb: int) -> int:
 
 
 ATTACHMENT_NAME_REGEX = re.compile(
-    r".+\.log|.+\.stderr|.+\.stdout|.+\.filediff|.+\.metrics|flamegraph\.svg|regression\.diffs"
+    r".+\.log|.+\.stderr|.+\.stdout|.+\.filediff|.+\.metrics|flamegraph\.svg|regression\.diffs|.+\.html"
 )
 
 
@@ -180,6 +180,9 @@ def allure_attach_from_dir(dir: Path):
             elif source.endswith(".svg"):
                 attachment_type = "image/svg+xml"
                 extension = "svg"
+            elif source.endswith(".html"):
+                attachment_type = "text/html"
+                extension = "html"
             else:
                 attachment_type = "text/plain"
                 extension = attachment.suffix.removeprefix(".")


### PR DESCRIPTION
Adds `rust-toolchain.toml` file and makes all our CI to install that rustc version instead to build the project.

Also bumps rustc version to 1.60 and adds cargo build times report with `--timings` that became available on 1.60 to ensure that we've updated the version everywhere.