### PR TITLE
Fix nightly benchmark reports

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -80,14 +80,14 @@ runs:
       env:
         NEON_BIN: /tmp/neon/bin
         TEST_OUTPUT: /tmp/test_output
-        # this variable will be embedded in perf test report
-        # and is needed to distinguish different environments
-        PLATFORM: github-actions-selfhosted
         BUILD_TYPE: ${{ inputs.build_type }}
         AWS_ACCESS_KEY_ID: ${{ inputs.real_s3_access_key_id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.real_s3_secret_access_key }}
       shell: bash -euxo pipefail {0}
       run: |
+        # PLATFORM will be embedded in the perf test report
+        # and it is needed to distinguish different environments
+        export PLATFORM=${PLATFORM:-github-actions-selfhosted}
         export POSTGRES_DISTRIB_DIR=${POSTGRES_DISTRIB_DIR:-/tmp/neon/pg_install}
 
         if [ "${BUILD_TYPE}" = "remote" ]; then
@@ -155,7 +155,7 @@ runs:
         if [[ "${{ inputs.save_perf_report }}" == "true" ]]; then
           if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             export REPORT_FROM="$PERF_REPORT_DIR"
-            export REPORT_TO=local
+            export REPORT_TO="$PLATFORM"
             scripts/generate_and_push_perf_report.sh
           fi
         fi


### PR DESCRIPTION
In https://github.com/neondatabase/neon/pull/2326 I've missed that we have hardcoded `PLATFORM` in `run-python-test-set` action. Now it's configurable along with `REPORT_TO` (which is set to `PLATFORM` value as well instead of `local`)