### PR TITLE
github/workflows: Create projects using API

### DIFF
--- a/.github/actions/neon-project-create/action.yml
+++ b/.github/actions/neon-project-create/action.yml
@@ -8,6 +8,9 @@ inputs:
   environment:
     desctiption: 'dev (aka captest) or stage'
     required: true
+  region_id:
+    desctiption: 'Region ID, if not set the project will be created in the default region'
+    required: false
 outputs:
   dsn:
     description: 'Created Project DSN (for main database)'
@@ -19,18 +22,18 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Parse enviroment
-      id: parse-environment
+    - name: Parse Input
+      id: parse-input
       shell: bash -euxo pipefail {0}
       run: |
         case "${ENVIRONMENT}" in
           dev)
             API_HOST=console.dev.neon.tech
-            REGION_ID=eu-west-1
+            REGION_ID=${REGION_ID:-eu-west-1}
             ;;
           staging)
             API_HOST=console.stage.neon.tech
-            REGION_ID=us-east-1
+            REGION_ID=${REGION_ID:-us-east-1}
             ;;
           *)
             echo 2>&1 "Unknown environment=${ENVIRONMENT}. Allowed 'dev' or 'staging' only"
@@ -42,6 +45,7 @@ runs:
         echo "::set-output name=region_id::${REGION_ID}"
       env:
         ENVIRONMENT: ${{ inputs.environment }}
+        REGION_ID: ${{ inputs.region_id }}
 
     - name: Create Neon Project
       id: create-neon-project
@@ -73,5 +77,5 @@ runs:
         echo "::set-output name=project_id::${project_id}"
       env:
         API_KEY: ${{ inputs.api_key }}
-        API_HOST: ${{ steps.parse-environment.outputs.api_host }}
-        REGION_ID: ${{ steps.parse-environment.outputs.region_id }}
+        API_HOST: ${{ steps.parse-input.outputs.api_host }}
+        REGION_ID: ${{ steps.parse-input.outputs.region_id }}

--- a/.github/actions/neon-project-create/action.yml
+++ b/.github/actions/neon-project-create/action.yml
@@ -1,0 +1,77 @@
+name: 'Create Neon Project'
+description: 'Create Neon Project using API'
+
+inputs:
+  api_key:
+    desctiption: 'Neon API key'
+    required: true
+  environment:
+    desctiption: 'dev (aka captest) or stage'
+    required: true
+outputs:
+  dsn:
+    description: 'Created Project DSN (for main database)'
+    value: ${{ steps.create-neon-project.outputs.dsn }}
+  project_id:
+    description: 'Created Project ID'
+    value: ${{ steps.create-neon-project.outputs.project_id }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Parse enviroment
+      id: parse-environment
+      shell: bash -euxo pipefail {0}
+      run: |
+        case "${ENVIRONMENT}" in
+          dev)
+            API_HOST=console.dev.neon.tech
+            REGION_ID=eu-west-1
+            ;;
+          staging)
+            API_HOST=console.stage.neon.tech
+            REGION_ID=us-east-1
+            ;;
+          *)
+            echo 2>&1 "Unknown environment=${ENVIRONMENT}. Allowed 'dev' or 'staging' only"
+            exit 1
+            ;;
+        esac
+
+        echo "::set-output name=api_host::${API_HOST}"
+        echo "::set-output name=region_id::${REGION_ID}"
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+
+    - name: Create Neon Project
+      id: create-neon-project
+      # A shell without `set -x` to not to expose password/dsn in logs
+      shell: bash -euo pipefail {0}
+      run: |
+        project=$(curl \
+          "https://${API_HOST}/api/v1/projects" \
+          --fail \
+          --header "Accept: application/json" \
+          --header "Content-Type: application/json" \
+          --header "Authorization: Bearer ${API_KEY}" \
+          --data "{
+            \"project\": {
+              \"platform_id\": \"serverless\",
+              \"region_id\": \"${REGION_ID}\",
+              \"settings\": { }
+            }
+          }")
+
+        # Mask password
+        echo "::add-mask::$(echo $project | jq --raw-output '.roles[] | select(.name != "web_access") | .password')"
+
+        dsn=$(echo $project | jq --raw-output '.roles[] | select(.name != "web_access") | .dsn')/main
+        echo "::add-mask::${dsn}"
+        echo "::set-output name=dsn::${dsn}"
+
+        project_id=$(echo $project | jq --raw-output '.id')
+        echo "::set-output name=project_id::${project_id}"
+      env:
+        API_KEY: ${{ inputs.api_key }}
+        API_HOST: ${{ steps.parse-environment.outputs.api_host }}
+        REGION_ID: ${{ steps.parse-environment.outputs.region_id }}

--- a/.github/actions/neon-project-delete/action.yml
+++ b/.github/actions/neon-project-delete/action.yml
@@ -15,18 +15,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Parse enviroment
-      id: parse-environment
+    - name: Parse Input
+      id: parse-input
       shell: bash -euxo pipefail {0}
       run: |
         case "${ENVIRONMENT}" in
           dev)
             API_HOST=console.dev.neon.tech
-            REGION_ID=eu-west-1
             ;;
           staging)
             API_HOST=console.stage.neon.tech
-            REGION_ID=us-east-1
             ;;
           *)
             echo 2>&1 "Unknown environment=${ENVIRONMENT}. Allowed 'dev' or 'staging' only"
@@ -35,7 +33,6 @@ runs:
         esac
 
         echo "::set-output name=api_host::${API_HOST}"
-        echo "::set-output name=region_id::${REGION_ID}"
       env:
         ENVIRONMENT: ${{ inputs.environment }}
 
@@ -54,4 +51,4 @@ runs:
       env:
         API_KEY: ${{ inputs.api_key }}
         PROJECT_ID: ${{ inputs.project_id }}
-        API_HOST: ${{ steps.parse-environment.outputs.api_host }}
+        API_HOST: ${{ steps.parse-input.outputs.api_host }}

--- a/.github/actions/neon-project-delete/action.yml
+++ b/.github/actions/neon-project-delete/action.yml
@@ -1,0 +1,57 @@
+name: 'Delete Neon Project'
+description: 'Delete Neon Project using API'
+
+inputs:
+  api_key:
+    desctiption: 'Neon API key'
+    required: true
+  environment:
+    desctiption: 'dev (aka captest) or stage'
+    required: true
+  project_id:
+    desctiption: 'ID of the Project to delete'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Parse enviroment
+      id: parse-environment
+      shell: bash -euxo pipefail {0}
+      run: |
+        case "${ENVIRONMENT}" in
+          dev)
+            API_HOST=console.dev.neon.tech
+            REGION_ID=eu-west-1
+            ;;
+          staging)
+            API_HOST=console.stage.neon.tech
+            REGION_ID=us-east-1
+            ;;
+          *)
+            echo 2>&1 "Unknown environment=${ENVIRONMENT}. Allowed 'dev' or 'staging' only"
+            exit 1
+            ;;
+        esac
+
+        echo "::set-output name=api_host::${API_HOST}"
+        echo "::set-output name=region_id::${REGION_ID}"
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+
+    - name: Delete Neon Project
+      shell: bash -euxo pipefail {0}
+      run: |
+        # Allow PROJECT_ID to be empty/null for cases when .github/actions/neon-project-create failed
+        if [ -n "${PROJECT_ID}" ]; then
+          curl -X "POST" \
+            "https://${API_HOST}/api/v1/projects/${PROJECT_ID}/delete" \
+            --fail \
+            --header "Accept: application/json" \
+            --header "Content-Type: application/json" \
+            --header "Authorization: Bearer ${API_KEY}"
+        fi
+      env:
+        API_KEY: ${{ inputs.api_key }}
+        PROJECT_ID: ${{ inputs.project_id }}
+        API_HOST: ${{ steps.parse-environment.outputs.api_host }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -131,11 +131,12 @@ jobs:
       POSTGRES_DISTRIB_DIR: /usr
       TEST_OUTPUT: /tmp/test_output
       BUILD_TYPE: remote
+      SAVE_PERF_REPORT: true
 
     strategy:
       fail-fast: false
       matrix:
-        connstr: [ BENCHMARK_CAPTEST_CONNSTR, BENCHMARK_RDS_CONNSTR ]
+        platform: [ neon-captest, rds-aurora ]
 
     runs-on: dev
     container:
@@ -147,26 +148,40 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Calculate platform
-      id: calculate-platform
-      env:
-        CONNSTR: ${{ matrix.connstr }}
-      run: |
-        if [ "${CONNSTR}" = "BENCHMARK_CAPTEST_CONNSTR" ]; then
-          PLATFORM=neon-captest
-        elif [ "${CONNSTR}" = "BENCHMARK_RDS_CONNSTR" ]; then
-          PLATFORM=rds-aurora
-        else
-          echo 2>&1 "Unknown CONNSTR=${CONNSTR}. Allowed are BENCHMARK_CAPTEST_CONNSTR, and BENCHMARK_RDS_CONNSTR only"
-          exit 1
-        fi
-
-        echo "::set-output name=PLATFORM::${PLATFORM}"
-
     - name: Install Deps
       run: |
         sudo apt -y update
         sudo apt install -y postgresql-14
+
+    - name: Create Neon Project
+      if: matrix.platform == 'neon-captest'
+      id: create-neon-project
+      uses: ./.github/actions/neon-project-create
+      with:
+        environment: dev
+        api_key: ${{ secrets.NEON_CAPTEST_API_KEY }}
+
+    - name: Set up Connection String
+      id: set-up-connstr
+      run: |
+        case "${PLATFORM}" in
+          neon-captest)
+            CONNSTR=${{ steps.create-neon-project.outputs.dsn }}
+            ;;
+          rds-aurora)
+            CONNSTR=${{ secrets.BENCHMARK_RDS_CONNSTR }}
+            ;;
+          *)
+            echo 2>&1 "Unknown PLATFORM=${PLATFORM}. Allowed only 'neon-captest' or 'rds-aurora'"
+            exit 1
+            ;;
+        esac
+
+        echo "::set-output name=connstr::${CONNSTR}"
+
+        psql ${CONNSTR} -c "SELECT version();"
+      env:
+        PLATFORM: ${{ matrix.platform }}
 
     - name: Benchmark init
       uses: ./.github/actions/run-python-test-set
@@ -174,11 +189,11 @@ jobs:
         build_type: ${{ env.BUILD_TYPE }}
         test_selection: performance
         run_in_parallel: false
-        save_perf_report: true
+        save_perf_report: ${{ env.SAVE_PERF_REPORT }}
         extra_params: -m remote_cluster --timeout 21600 -k test_pgbench_remote_init
       env:
-        PLATFORM: ${{ steps.calculate-platform.outputs.PLATFORM }}
-        BENCHMARK_CONNSTR: ${{ secrets[matrix.connstr] }}
+        PLATFORM: ${{ matrix.platform }}
+        BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
 
@@ -188,25 +203,25 @@ jobs:
         build_type: ${{ env.BUILD_TYPE }}
         test_selection: performance
         run_in_parallel: false
-        save_perf_report: true
+        save_perf_report: ${{ env.SAVE_PERF_REPORT }}
         extra_params: -m remote_cluster --timeout 21600 -k test_pgbench_remote_simple_update
       env:
-        PLATFORM: ${{ steps.calculate-platform.outputs.PLATFORM }}
-        BENCHMARK_CONNSTR: ${{ secrets[matrix.connstr] }}
+        PLATFORM: ${{ matrix.platform }}
+        BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
 
-    - name: Benchmark simple-update
+    - name: Benchmark select-only
       uses: ./.github/actions/run-python-test-set
       with:
         build_type: ${{ env.BUILD_TYPE }}
         test_selection: performance
         run_in_parallel: false
-        save_perf_report: true
+        save_perf_report: ${{ env.SAVE_PERF_REPORT }}
         extra_params: -m remote_cluster --timeout 21600 -k test_pgbench_remote_select_only
       env:
-        PLATFORM: ${{ steps.calculate-platform.outputs.PLATFORM }}
-        BENCHMARK_CONNSTR: ${{ secrets[matrix.connstr] }}
+        PLATFORM: ${{ matrix.platform }}
+        BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
 
@@ -215,6 +230,14 @@ jobs:
       with:
         action: generate
         build_type: ${{ env.BUILD_TYPE }}
+
+    - name: Delete Neon Project
+      if: ${{ matrix.platform == 'neon-captest' && always() }}
+      uses: ./.github/actions/neon-project-delete
+      with:
+        environment: dev
+        project_id: ${{ steps.create-neon-project.outputs.project_id }}
+        api_key: ${{ secrets.NEON_CAPTEST_API_KEY }}
 
     - name: Post to a Slack channel
       if: ${{ github.event.schedule && failure() }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -62,19 +62,12 @@ jobs:
         echo Pgbench
         $POSTGRES_DISTRIB_DIR/bin/pgbench --version
 
-    # FIXME cluster setup is skipped due to various changes in console API
-    # for now pre created cluster is used. When API gain some stability
-    # after massive changes dynamic cluster setup will be revived.
-    # So use pre created cluster. It needs to be started manually, but stop is automatic after 5 minutes of inactivity
-    - name: Setup cluster
-      env:
-        BENCHMARK_CONNSTR: "${{ secrets.BENCHMARK_STAGING_CONNSTR }}"
-      run: |
-        set -e
-
-        echo "Starting cluster"
-        # wake up the cluster
-        $POSTGRES_DISTRIB_DIR/bin/psql $BENCHMARK_CONNSTR -c "SELECT 1"
+    - name: Create Neon Project
+      id: create-neon-project
+      uses: ./.github/actions/neon-project-create
+      with:
+        environment: staging
+        api_key: ${{ secrets.NEON_STAGING_API_KEY }}
 
     - name: Run benchmark
       # pgbench is installed system wide from official repo
@@ -97,7 +90,7 @@ jobs:
         TEST_PG_BENCH_DURATIONS_MATRIX: "300"
         TEST_PG_BENCH_SCALES_MATRIX: "10,100"
         PLATFORM: "neon-staging"
-        BENCHMARK_CONNSTR: "${{ secrets.BENCHMARK_STAGING_CONNSTR }}"
+        BENCHMARK_CONNSTR: ${{ steps.create-neon-project.outputs.dsn }}
         REMOTE_ENV: "1" # indicate to test harness that we do not have zenith binaries locally
       run: |
         # just to be sure that no data was cached on self hosted runner
@@ -114,6 +107,14 @@ jobs:
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
       run: |
         REPORT_FROM=$(realpath perf-report-staging) REPORT_TO=staging scripts/generate_and_push_perf_report.sh
+
+    - name: Delete Neon Project
+      if: ${{ always() }}
+      uses: ./.github/actions/neon-project-delete
+      with:
+        environment: staging
+        project_id: ${{ steps.create-neon-project.outputs.project_id }}
+        api_key: ${{ secrets.NEON_STAGING_API_KEY }}
 
     - name: Post to a Slack channel
       if: ${{ github.event.schedule && failure() }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -14,6 +14,13 @@ on:
     - cron:  '36 4 * * *' # run once a day, timezone is utc
 
   workflow_dispatch: # adds ability to run this manually
+    inputs:
+      environment:
+        description: 'Environment to run remote tests on (dev or staging)'
+        required: false
+      region_id:
+        description: 'Use a particular region. If empty the default one will be used'
+        false: true
 
 defaults:
   run:
@@ -66,8 +73,8 @@ jobs:
       id: create-neon-project
       uses: ./.github/actions/neon-project-create
       with:
-        environment: staging
-        api_key: ${{ secrets.NEON_STAGING_API_KEY }}
+        environment: ${{ github.event.inputs.environment || 'staging' }}
+        api_key: ${{ ( github.event.inputs.environment || 'staging' ) == 'staging' && secrets.NEON_STAGING_API_KEY  || secrets.NEON_CAPTEST_API_KEY }}
 
     - name: Run benchmark
       # pgbench is installed system wide from official repo
@@ -159,8 +166,8 @@ jobs:
       id: create-neon-project
       uses: ./.github/actions/neon-project-create
       with:
-        environment: dev
-        api_key: ${{ secrets.NEON_CAPTEST_API_KEY }}
+        environment: ${{ github.event.inputs.environment || 'dev' }}
+        api_key: ${{ ( github.event.inputs.environment || 'dev' ) == 'staging' && secrets.NEON_STAGING_API_KEY  || secrets.NEON_CAPTEST_API_KEY }}
 
     - name: Set up Connection String
       id: set-up-connstr

--- a/.github/workflows/pg_clients.yml
+++ b/.github/workflows/pg_clients.yml
@@ -47,11 +47,17 @@ jobs:
       shell: bash -euxo pipefail {0}
       run: ./scripts/pysync
 
+    - name: Create Neon Project
+      id: create-neon-project
+      uses: ./.github/actions/neon-project-create
+      with:
+        environment: staging
+        api_key: ${{ secrets.NEON_STAGING_API_KEY }}
+
     - name: Run pytest
       env:
         REMOTE_ENV: 1
-        BENCHMARK_CONNSTR: "${{ secrets.BENCHMARK_STAGING_CONNSTR }}"
-
+        BENCHMARK_CONNSTR: ${{ steps.create-neon-project.outputs.dsn }}
         POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install/v14
       shell: bash -euxo pipefail {0}
       run: |
@@ -64,6 +70,14 @@ jobs:
           --verbose \
           -m "remote_cluster" \
           -rA "test_runner/pg_clients"
+
+    - name: Delete Neon Project
+      if: ${{ always() }}
+      uses: ./.github/actions/neon-project-delete
+      with:
+        environment: staging
+        project_id: ${{ steps.create-neon-project.outputs.project_id }}
+        api_key: ${{ secrets.NEON_STAGING_API_KEY }}
 
     # We use GitHub's action upload-artifact because `ubuntu-latest` doesn't have configured AWS CLI.
     # It will be fixed after switching to gen2 runner


### PR DESCRIPTION
Currently, in `benchmarking.yml` and `pg_clients.yml` we reuse pre-defined projects on staging and captest and pass a connection string from secrets to tests.

In this PR, I've added composite actions for creating/deleting projects using API (using API KEY from secrets). Ideally, these should be replaced with `neonctl` or with "native" actions with JS/TS neon API bindings.

Also, these changes should help with bloating timelines (a couple of examples from the private slack: [1](https://neondb.slack.com/archives/C033A2WE6BZ/p1661242409350029), [2](https://neondb.slack.com/archives/C033A2WE6BZ/p1660811826449959), [3](https://neondb.slack.com/archives/C033QLM5P7D/p1657480581083049?thread_ts=1657476997.715149&cid=C033QLM5P7D)) and it should help to avoid issues with polluted by previous run DB (like https://github.com/neondatabase/neon/pull/2135).

Possible drawbacks:
-  Reusing projects kind of imitates real usage and could highlight issues that are not reproducible for a freshly created environment. I'm aware only of one with timelines (mentioned above) that was found. If we want to catch such kinds of errors in the future, I believe we should have a separate test that will exercise existing projects instead of relying on the side effects of other tests.
- This change could (and probably will) affect our performance test statistics, which should be fine. 

Tests:
- Benchmarking bench https://github.com/neondatabase/neon/runs/8226271367
- Benchmarking pgbench-compare (with smaller DB): https://github.com/neondatabase/neon/actions/runs/3006253852
- Postgres clients: https://github.com/neondatabase/neon/runs/8225533371