### PR TITLE
Add built files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test_output/
 
 *.key
 *.crt
+*.o
+*.so
+*.Po


### PR DESCRIPTION
`git status` after `make`:

```console
$ git st
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	pgxn/neon/.deps/
	pgxn/neon/inmem_smgr.o
	pgxn/neon/libpagestore.o
	pgxn/neon/libpqwalproposer.o
	pgxn/neon/neon.o
	pgxn/neon/neon.so
	pgxn/neon/pagestore_smgr.o
	pgxn/neon/relsize_cache.o
	pgxn/neon/walproposer.o
	pgxn/neon/walproposer_utils.o
	pgxn/neon_test_utils/.deps/
	pgxn/neon_test_utils/neon_test_utils.so
	pgxn/neon_test_utils/neontest.o
```

So lets not ttrack those to avoid having untracked files.