### PR TITLE
Ensure all temporary and empty directories and files are cleansed on pageserver startup

### DIFF
--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -344,6 +344,8 @@ impl Debug for S3Config {
     }
 }
 
+/// Adds a suffix to the file(directory) name, either appending the suffux to the end of its extension,
+/// or if there's no extension, creates one and puts a suffix there.
 pub fn path_with_suffix_extension(original_path: impl AsRef<Path>, suffix: &str) -> PathBuf {
     let new_extension = match original_path
         .as_ref()
@@ -467,6 +469,11 @@ mod tests {
         assert_eq!(
             &path_with_suffix_extension(&p, ".temp").to_string_lossy(),
             "/foo/bar.baz..temp"
+        );
+        let p = PathBuf::from("/foo/bar/dir/");
+        assert_eq!(
+            &path_with_suffix_extension(&p, ".temp").to_string_lossy(),
+            "/foo/bar/dir..temp"
         );
     }
 

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -21,6 +21,8 @@ use crate::{path_with_suffix_extension, Download, DownloadError, RemoteObjectId}
 
 use super::{strip_path_prefix, RemoteStorage, StorageMetadata};
 
+const LOCAL_FS_TEMP_FILE_SUFFIX: &str = "___temp";
+
 /// Convert a Path in the remote storage into a RemoteObjectId
 fn remote_object_id_from_path(path: &Path) -> anyhow::Result<RemoteObjectId> {
     Ok(RemoteObjectId(
@@ -143,7 +145,8 @@ impl RemoteStorage for LocalFs {
         // We need this dance with sort of durable rename (without fsyncs)
         // to prevent partial uploads. This was really hit when pageserver shutdown
         // cancelled the upload and partial file was left on the fs
-        let temp_file_path = path_with_suffix_extension(&target_file_path, "temp");
+        let temp_file_path =
+            path_with_suffix_extension(&target_file_path, LOCAL_FS_TEMP_FILE_SUFFIX);
         let mut destination = io::BufWriter::new(
             fs::OpenOptions::new()
                 .write(true)

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -470,7 +470,7 @@ async fn tenant_list_handler(request: Request<Body>) -> Result<Response<Body>, A
 
     let response_data = tokio::task::spawn_blocking(move || {
         let _enter = info_span!("tenant_list").entered();
-        crate::tenant_mgr::list_tenants(&remote_index)
+        crate::tenant_mgr::list_tenant_info(&remote_index)
     })
     .await
     .map_err(ApiError::from_err)?;
@@ -640,7 +640,8 @@ async fn tenant_config_handler(mut request: Request<Body>) -> Result<Response<Bo
     tokio::task::spawn_blocking(move || {
         let _enter = info_span!("tenant_config", tenant = ?tenant_id).entered();
 
-        tenant_mgr::update_tenant_config(tenant_conf, tenant_id)
+        let state = get_state(&request);
+        tenant_mgr::update_tenant_config(state.conf, tenant_conf, tenant_id)
     })
     .await
     .map_err(ApiError::from_err)??;

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -34,7 +34,7 @@ use crate::layered_repository::storage_layer::{
 use crate::page_cache::{PageReadGuard, PAGE_SZ};
 use crate::repository::{Key, Value, KEY_SIZE};
 use crate::virtual_file::VirtualFile;
-use crate::walrecord;
+use crate::{walrecord, TEMP_FILE_SUFFIX};
 use crate::{DELTA_FILE_MAGIC, STORAGE_FORMAT_VERSION};
 use anyhow::{bail, ensure, Context, Result};
 use rand::{distributions::Alphanumeric, Rng};
@@ -447,11 +447,12 @@ impl DeltaLayer {
             .collect();
 
         conf.timeline_path(&timelineid, &tenantid).join(format!(
-            "{}-XXX__{:016X}-{:016X}.{}.temp",
+            "{}-XXX__{:016X}-{:016X}.{}.{}",
             key_start,
             u64::from(lsn_range.start),
             u64::from(lsn_range.end),
-            rand_string
+            rand_string,
+            TEMP_FILE_SUFFIX,
         ))
     }
 

--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -30,7 +30,7 @@ use crate::layered_repository::storage_layer::{
 use crate::page_cache::PAGE_SZ;
 use crate::repository::{Key, Value, KEY_SIZE};
 use crate::virtual_file::VirtualFile;
-use crate::{IMAGE_FILE_MAGIC, STORAGE_FORMAT_VERSION};
+use crate::{IMAGE_FILE_MAGIC, STORAGE_FORMAT_VERSION, TEMP_FILE_SUFFIX};
 use anyhow::{bail, ensure, Context, Result};
 use bytes::Bytes;
 use hex;
@@ -255,7 +255,7 @@ impl ImageLayer {
             .collect();
 
         conf.timeline_path(&timelineid, &tenantid)
-            .join(format!("{}.{}.temp", fname, rand_string))
+            .join(format!("{fname}.{rand_string}.{TEMP_FILE_SUFFIX}"))
     }
 
     ///

--- a/pageserver/src/storage_sync/download.rs
+++ b/pageserver/src/storage_sync/download.rs
@@ -18,6 +18,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     config::PageServerConf, layered_repository::metadata::metadata_path, storage_sync::SyncTask,
+    TEMP_FILE_SUFFIX,
 };
 use utils::zid::{ZTenantId, ZTenantTimelineId, ZTimelineId};
 
@@ -25,8 +26,6 @@ use super::{
     index::{IndexPart, RemoteTimeline},
     LayersDownload, SyncData, SyncQueue,
 };
-
-pub const TEMP_DOWNLOAD_EXTENSION: &str = "temp_download";
 
 // We collect timelines remotely available for each tenant
 // in case we failed to gather all index parts (due to an error)
@@ -251,7 +250,7 @@ pub(super) async fn download_timeline_layers<'a>(
                 // https://www.postgresql.org/message-id/56583BDD.9060302@2ndquadrant.com
                 // If pageserver crashes the temp file will be deleted on startup and re-downloaded.
                 let temp_file_path =
-                    path_with_suffix_extension(&layer_destination_path, TEMP_DOWNLOAD_EXTENSION);
+                    path_with_suffix_extension(&layer_destination_path, TEMP_FILE_SUFFIX);
 
                 let mut destination_file =
                     fs::File::create(&temp_file_path).await.with_context(|| {

--- a/pageserver/src/tenant_tasks.rs
+++ b/pageserver/src/tenant_tasks.rs
@@ -34,11 +34,6 @@ async fn compaction_loop(tenantid: ZTenantId, mut cancel: watch::Receiver<()>) {
 
             // Break if we're not allowed to write to disk
             let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
-            // TODO do this inside repo.compaction_iteration instead.
-            let _guard = match repo.file_lock.try_read() {
-                Ok(g) => g,
-                Err(_) => return Ok(ControlFlow::Break(())),
-            };
 
             // Run compaction
             let compaction_period = repo.get_compaction_period();
@@ -233,11 +228,6 @@ async fn gc_loop(tenantid: ZTenantId, mut cancel: watch::Receiver<()>) {
 
             // Break if we're not allowed to write to disk
             let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
-            // TODO do this inside repo.gc_iteration instead.
-            let _guard = match repo.file_lock.try_read() {
-                Ok(g) => g,
-                Err(_) => return Ok(ControlFlow::Break(())),
-            };
 
             // Run gc
             let gc_period = repo.get_gc_period();

--- a/test_runner/regress/test_broken_timeline.py
+++ b/test_runner/regress/test_broken_timeline.py
@@ -32,33 +32,34 @@ def test_broken_timeline(neon_env_builder: NeonEnvBuilder):
 
     # Leave the first timeline alone, but corrupt the others in different ways
     (tenant0, timeline0, pg0) = tenant_timelines[0]
+    log.info(f"Timeline {tenant0}/{timeline0} is left intact")
 
-    # Corrupt metadata file on timeline 1
     (tenant1, timeline1, pg1) = tenant_timelines[1]
-    metadata_path = "{}/tenants/{}/timelines/{}/metadata".format(env.repo_dir, tenant1, timeline1)
-    print(f"overwriting metadata file at {metadata_path}")
+    metadata_path = f"{env.repo_dir}/tenants/{tenant1}/timelines/{timeline1}/metadata"
     f = open(metadata_path, "w")
     f.write("overwritten with garbage!")
     f.close()
+    log.info(f"Timeline {tenant1}/{timeline1} got its metadata spoiled")
 
-    # Missing layer files file on timeline 2. (This would actually work
-    # if we had Cloud Storage enabled in this test.)
     (tenant2, timeline2, pg2) = tenant_timelines[2]
-    timeline_path = "{}/tenants/{}/timelines/{}/".format(env.repo_dir, tenant2, timeline2)
+    timeline_path = f"{env.repo_dir}/tenants/{tenant2}/timelines/{timeline2}/"
     for filename in os.listdir(timeline_path):
         if filename.startswith("00000"):
             # Looks like a layer file. Remove it
             os.remove(f"{timeline_path}/{filename}")
+    log.info(
+        f"Timeline {tenant2}/{timeline2} got its layer files removed (no remote storage enabled)"
+    )
 
-    # Corrupt layer files file on timeline 3
     (tenant3, timeline3, pg3) = tenant_timelines[3]
-    timeline_path = "{}/tenants/{}/timelines/{}/".format(env.repo_dir, tenant3, timeline3)
+    timeline_path = f"{env.repo_dir}/tenants/{tenant3}/timelines/{timeline3}/"
     for filename in os.listdir(timeline_path):
         if filename.startswith("00000"):
             # Looks like a layer file. Corrupt it
             f = open(f"{timeline_path}/{filename}", "w")
             f.write("overwritten with garbage!")
             f.close()
+    log.info(f"Timeline {tenant3}/{timeline3} got its layer files spoiled")
 
     env.pageserver.start()
 
@@ -69,20 +70,28 @@ def test_broken_timeline(neon_env_builder: NeonEnvBuilder):
     # But all others are broken
 
     # First timeline would not get loaded into pageserver due to corrupt metadata file
-    (_tenant, _timeline, pg) = tenant_timelines[1]
     with pytest.raises(
         Exception, match=f"Could not get timeline {timeline1} in tenant {tenant1}"
     ) as err:
-        pg.start()
+        pg1.start()
+    log.info(f"compute startup failed eagerly for timeline with corrupt metadata: {err}")
+
+    # Second timeline has no ancestors, only the metadata file and no layer files
+    # We don't have the remote storage enabled, which means timeline is in an incorrect state,
+    # it's not loaded at all
+    with pytest.raises(
+        Exception, match=f"Could not get timeline {timeline2} in tenant {tenant2}"
+    ) as err:
+        pg2.start()
     log.info(f"compute startup failed eagerly for timeline with corrupt metadata: {err}")
 
     # Yet other timelines will fail when their layers will be queried during basebackup: we don't check layer file contents on startup, when loading the timeline
-    for n in range(2, 4):
-        (_tenant, _timeline, pg) = tenant_timelines[n]
+    for n in range(3, 4):
+        (bad_tenant, bad_timeline, pg) = tenant_timelines[n]
         with pytest.raises(Exception, match="extracting base backup failed") as err:
             pg.start()
         log.info(
-            f"compute startup failed lazily for timeline with corrupt layers, during basebackup preparation: {err}"
+            f"compute startup failed lazily for timeline {bad_tenant}/{bad_timeline} with corrupt layers, during basebackup preparation: {err}"
         )
 
 
@@ -107,6 +116,8 @@ def test_fix_broken_timelines_on_startup(neon_simple_env: NeonEnv):
 
     tenant_id, _ = env.neon_cli.create_tenant()
 
+    old_tenant_timelines = env.neon_cli.list_timelines(tenant_id)
+
     # Introduce failpoint when creating a new timeline
     env.pageserver.safe_psql("failpoints before-checkpoint-new-timeline=return")
     with pytest.raises(Exception, match="before-checkpoint-new-timeline"):
@@ -116,6 +127,8 @@ def test_fix_broken_timelines_on_startup(neon_simple_env: NeonEnv):
     env.neon_cli.pageserver_stop(immediate=True)
     env.neon_cli.pageserver_start()
 
-    # Check that tenant with "broken" timeline is not loaded.
-    with pytest.raises(Exception, match=f"Failed to get repo for tenant {tenant_id}"):
-        env.neon_cli.list_timelines(tenant_id)
+    # Creating the timeline didn't finish. The other timelines on tenant should still be present and work normally.
+    new_tenant_timelines = env.neon_cli.list_timelines(tenant_id)
+    assert (
+        new_tenant_timelines == old_tenant_timelines
+    ), f"Pageserver after restart should ignore non-initialized timelines for tenant {tenant_id}"


### PR DESCRIPTION
Extracted from https://github.com/neondatabase/neon/pull/2395

In order to ensure that the on-demand infrastructure is ready for timelines and tenants with errors and keeps such entities in memory (to show statistics later and not to error with cryptic errors as in https://github.com/neondatabase/neon/pull/2352), first we need to ensure that we create and clean up tmp directories uniformly.