### PR TITLE
Use regular agent for triggering e2e tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -412,7 +412,7 @@ jobs:
   trigger-e2e-tests:
     runs-on: dev
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init
     needs: [ build-neon ]
     steps:


### PR DESCRIPTION
e2e triggering is a bunch of `curl` calls on GH API + a few secrets, so could be done from any agent, not a special rust one.
