### PR TITLE
Test new build image

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ jobs:
   build-neon:
     runs-on: dev
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:3036850941
       options: --init
     strategy:
       fail-fast: false
@@ -236,7 +236,7 @@ jobs:
   regress-tests:
     runs-on: dev
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:3036850941
       options: --init
     needs: [ build-neon ]
     strategy:
@@ -269,7 +269,7 @@ jobs:
   benchmarks:
     runs-on: dev
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:3036850941
       options: --init
     needs: [ build-neon ]
     if: github.ref_name == 'main' || contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
@@ -300,7 +300,7 @@ jobs:
   merge-allure-report:
     runs-on: dev
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:3036850941
       options: --init
     needs: [ regress-tests, benchmarks ]
     if: always()
@@ -340,7 +340,7 @@ jobs:
   coverage-report:
     runs-on: dev
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:3036850941
       options: --init
     needs: [ regress-tests ]
     strategy:
@@ -583,7 +583,7 @@ jobs:
         run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v14:latest compute-node-v14
 
       - name: Pull rust image from ECR
-        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned rust
+        run: crane pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:3036850941 rust
 
       - name: Configure docker login
         run: |
@@ -604,7 +604,7 @@ jobs:
         run: crane push compute-node-v14 neondatabase/compute-node-v14:${{needs.tag.outputs.build-tag}}
 
       - name: Push rust image to Docker Hub
-        run: crane push rust neondatabase/rust:pinned
+        run: crane push rust neondatabase/rust:3036850941
 
       - name: Add latest tag to images
         if: |


### PR DESCRIPTION
Tests new `build` image with rustc 1.60, using https://github.com/neondatabase/build/pull/18#issuecomment-1243521000 and https://github.com/neondatabase/build/runs/8304294667?check_suite_focus=true#step:5:2959