### PR TITLE
Use more up-to-date disk_consistent_lsn when creating an empty timeline

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -154,8 +154,16 @@ impl Repository {
         // Create the timeline directory, and write initial metadata to file.
         crashsafe_dir::create_dir_all(timeline_path)?;
 
-        let new_metadata =
-            TimelineMetadata::new(Lsn(0), None, None, Lsn(0), initdb_lsn, initdb_lsn);
+        let disk_consistent_lsn = Lsn(initdb_lsn.0.saturating_sub(1));
+
+        let new_metadata = TimelineMetadata::new(
+            disk_consistent_lsn,
+            None,
+            None,
+            Lsn(0),
+            initdb_lsn,
+            initdb_lsn,
+        );
         save_metadata(
             self.conf,
             new_timeline_id,


### PR DESCRIPTION
During empty timeline creation, `initdb_lsn` is considered our next open layer point: `new_timeline.layers.write().unwrap().next_open_layer_at = Some(initdb_lsn);`, so makes sense to consider all before it as persisted.