### PR TITLE
Nightly Benchmarks: perform tests on both pre-created and fresh projects

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ neon-captest, rds-aurora ]
+        platform: [ neon-captest, neon-captest-new, rds-aurora ]
 
     runs-on: dev
     container:
@@ -162,7 +162,7 @@ jobs:
         sudo apt install -y postgresql-14
 
     - name: Create Neon Project
-      if: matrix.platform == 'neon-captest'
+      if: matrix.platform == 'neon-captest-new'
       id: create-neon-project
       uses: ./.github/actions/neon-project-create
       with:
@@ -174,6 +174,9 @@ jobs:
       run: |
         case "${PLATFORM}" in
           neon-captest)
+            CONNSTR=${{ secrets.BENCHMARK_CAPTEST_CONNSTR }}
+            ;;
+          neon-captest-new)
             CONNSTR=${{ steps.create-neon-project.outputs.dsn }}
             ;;
           rds-aurora)
@@ -240,7 +243,7 @@ jobs:
         build_type: ${{ env.BUILD_TYPE }}
 
     - name: Delete Neon Project
-      if: ${{ matrix.platform == 'neon-captest' && always() }}
+      if: ${{ matrix.platform == 'neon-captest-new' && always() }}
       uses: ./.github/actions/neon-project-delete
       with:
         environment: dev
@@ -252,6 +255,6 @@ jobs:
       uses: slackapi/slack-github-action@v1
       with:
         channel-id: "C033QLM5P7D" # dev-staging-stream
-        slack-message: "Periodic perf testing: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        slack-message: "Periodic perf testing ${{ matrix.platform }}: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -144,6 +144,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # neon-captest: Run pgbench, reusing existing project
+        # neon-captest-new: Same, but on a freshly created project
         platform: [ neon-captest, neon-captest-new, rds-aurora ]
 
     runs-on: dev
@@ -183,7 +185,7 @@ jobs:
             CONNSTR=${{ secrets.BENCHMARK_RDS_CONNSTR }}
             ;;
           *)
-            echo 2>&1 "Unknown PLATFORM=${PLATFORM}. Allowed only 'neon-captest' or 'rds-aurora'"
+            echo 2>&1 "Unknown PLATFORM=${PLATFORM}. Allowed only 'neon-captest', 'neon-captest-new' or 'rds-aurora'"
             exit 1
             ;;
         esac


### PR DESCRIPTION
The difference between a newly created project and reusing a pre-created project could be significant. Let's collect results for both of them as `neon-captest` and `neon-captest-new` to confirm or disconfirm it.
Naming suggestions are welcome!