### PR TITLE
Don't run codestyle checks separately for Postgres v14 and v15.

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -30,8 +30,6 @@ jobs:
         # this is all we need to install our toolchain later via rust-toolchain.toml
         # so don't install any toolchain explicitly.
         os: [ubuntu-latest, macos-latest]
-        # To support several Postgres versions, add them here.
-        postgres_version: [v14, v15]
     timeout-minutes: 60
     name: check codestyle rust and postgres
     runs-on: ${{ matrix.os }}
@@ -56,17 +54,29 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install flex bison openssl
 
-      - name: Set pg revision for caching
-        id: pg_ver
-        run: echo ::set-output name=pg_rev::$(git rev-parse HEAD:vendor/postgres-${{matrix.postgres_version}})
+      - name: Set pg 14 revision for caching
+        id: pg_v14_rev
+        run: echo ::set-output name=pg_rev::$(git rev-parse HEAD:vendor/postgres-v14)
+        shell: bash -euxo pipefail {0}
 
-      - name: Cache postgres ${{matrix.postgres_version}} build
-        id: cache_pg
+      - name: Set pg 15 revision for caching
+        id: pg_v15_rev
+        run: echo ::set-output name=pg_rev::$(git rev-parse HEAD:vendor/postgres-v15)
+        shell: bash -euxo pipefail {0}
+
+      - name: Cache postgres v14 build
+        id: cache_pg_14
         uses: actions/cache@v3
         with:
-          path: |
-            pg_install/${{matrix.postgres_version}}
-          key: ${{ runner.os }}-pg-${{ steps.pg_ver.outputs.pg_rev }}
+          path: pg_install/v14
+          key: v1-${{ runner.os }}-${{ matrix.build_type }}-pg-${{ steps.pg_v14_rev.outputs.pg_rev }}-${{ hashFiles('Makefile') }}
+
+      - name: Cache postgres v15 build
+        id: cache_pg_15
+        uses: actions/cache@v3
+        with:
+          path: pg_install/v15
+          key: v1-${{ runner.os }}-${{ matrix.build_type }}-pg-${{ steps.pg_v15_rev.outputs.pg_rev }}-${{ hashFiles('Makefile') }}
 
       - name: Set extra env for macOS
         if: matrix.os == 'macos-latest'
@@ -74,23 +84,18 @@ jobs:
           echo 'LDFLAGS=-L/usr/local/opt/openssl@3/lib' >> $GITHUB_ENV
           echo 'CPPFLAGS=-I/usr/local/opt/openssl@3/include' >> $GITHUB_ENV
 
-      - name: Build postgres
-        if: steps.cache_pg.outputs.cache-hit != 'true'
-        run: make postgres
+      - name: Build postgres v14
+        if: steps.cache_pg_14.outputs.cache-hit != 'true'
+        run: make postgres-v14
+        shell: bash -euxo pipefail {0}
+
+      - name: Build postgres v15
+        if: steps.cache_pg_15.outputs.cache-hit != 'true'
+        run: make postgres-v15
+        shell: bash -euxo pipefail {0}
 
       - name: Build neon extensions
         run: make neon-pg-ext
-
-      # Plain configure output can contain weird errors like 'error: C compiler cannot create executables'
-      # and the real cause will be inside config.log
-      - name: Print configure logs in case of failure
-        if: failure()
-        continue-on-error: true
-        run: |
-          echo '' && echo '=== Postgres ${{matrix.postgres_version}} config.log ===' && echo ''
-          cat pg_install/build/${{matrix.postgres_version}}/config.log
-          echo '' && echo '=== Postgres ${{matrix.postgres_version}} configure.log ===' && echo ''
-          cat pg_install/build/${{matrix.postgres_version}}/configure.log
 
       - name: Cache cargo deps
         id: cache_cargo


### PR DESCRIPTION
Previously, we compiled neon separately for Postgres v14 and v15, for the codestyle checks. But that was bogus; we actually just ran "make postgres", which always compiled both versions. The version really only affected the caching.

Fix that, by copying the build steps from the main build_and_test.yml workflow.