### PR TITLE
Disable failpoints by default

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,15 +94,17 @@ jobs:
       # CARGO_FEATURES is passed to "cargo metadata". It is separate from CARGO_FLAGS,
       #   because "cargo metadata" doesn't accept --release or --debug options
       #
+      # We run tests with addtional features, that are turned off by default (e.g. in release builds), see
+      # corresponding Cargo.toml files for their descriptions.
       - name: Set env variables
         run: |
           if [[ $BUILD_TYPE == "debug" ]]; then
             cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
-            CARGO_FEATURES=""
+            CARGO_FEATURES="--features failpoints"
             CARGO_FLAGS="--locked --timings"
           elif [[ $BUILD_TYPE == "release" ]]; then
             cov_prefix=""
-            CARGO_FEATURES="--features profiling"
+            CARGO_FEATURES="--features failpoints,profiling"
             CARGO_FLAGS="--locked --timings --release $CARGO_FEATURES"
           fi
           echo "cov_prefix=${cov_prefix}" >> $GITHUB_ENV

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-# It is simpler infra-wise to have failpoints enabled by default
-# It shouldn't affect performance in any way because failpoints
-# are not placed in hot code paths
-default = ["failpoints"]
-profiling = ["pprof"]
+default = []
+
+# Feature that enables a special API, fail_point! macro (adds some runtime cost)
+# to run tests on outage conditions
 failpoints = ["fail/failpoints"]
+profiling = ["pprof"]
 
 [dependencies]
 async-stream = "0.3"

--- a/test_runner/README.md
+++ b/test_runner/README.md
@@ -6,6 +6,7 @@ Prerequisites:
 - Correctly configured Python, see [`/docs/sourcetree.md`](/docs/sourcetree.md#using-python)
 - Neon and Postgres binaries
     - See the root [README.md](/README.md) for build directions
+      If you want to test tests with failpoints, you would need to add `--features failpoints` to Rust code build commands.
     - Tests can be run from the git tree; or see the environment variables
       below to run from other directories.
 - The neon git repo, including the postgres submodule


### PR DESCRIPTION
Right now, release builds are done using Dockerfiles, where our binaries are built with default features.
With the `default = ["failpoints"]` that meant, we shipped release binaries that had extra, peculiar features enabled.

It seems more safe to disable feature that might impact performance and adds an extra endpoint for breaking internal logic, the CI changes are quite small.

Yet, this makes local testing harder since all failpoints need a special flag to be used during `cargo build` to work locally.
https://github.com/rust-lang/cargo/issues/4829 hints it's impossible to set cargo features via env vars, so there seems to be no good way to get around it with cargo config file.
To me, seems like a better option, compared to exposing the failpoints API, I can add a test binaries build script, if it helps.