### PR TITLE
Follow-up for neondatabase/neon#2448

### DIFF
--- a/.github/helm-values/neon-stress.proxy.yaml
+++ b/.github/helm-values/neon-stress.proxy.yaml
@@ -1,6 +1,7 @@
 fullnameOverride: "neon-stress-proxy"
 
 settings:
+  authBackend: "link"
   authEndpoint: "https://console.dev.neon.tech/authenticate_proxy_request/"
   uri: "https://console.dev.neon.tech/psql_session/"
 

--- a/.github/helm-values/production.proxy.yaml
+++ b/.github/helm-values/production.proxy.yaml
@@ -1,4 +1,5 @@
 settings:
+  authBackend: "link"
   authEndpoint: "https://console.neon.tech/authenticate_proxy_request/"
   uri: "https://console.neon.tech/psql_session/"
 

--- a/.github/helm-values/staging.proxy.yaml
+++ b/.github/helm-values/staging.proxy.yaml
@@ -5,6 +5,7 @@ image:
   repository: neondatabase/neon
 
 settings:
+  authBackend: "link"
   authEndpoint: "https://console.stage.neon.tech/authenticate_proxy_request/"
   uri: "https://console.stage.neon.tech/psql_session/"
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -2,10 +2,8 @@
 
 Proxy binary accepts `--auth-backend` CLI option, which determines auth scheme and cluster routing method. Following backends are currently implemented:
 
-* legacy
-  old method, when username ends with `@zenith` it uses md5 auth dbname as the cluster name; otherwise, it sends a login link and waits for the console to call back
 * console
-  new SCRAM-based console API; uses SNI info to select the destination cluster
+  new SCRAM-based console API; uses SNI info to select the destination project (endpoint soon)
 * postgres
   uses postgres to select auth secrets of existing roles. Useful for local testing
 * link
@@ -13,21 +11,20 @@ Proxy binary accepts `--auth-backend` CLI option, which determines auth scheme a
 
 ## Using SNI-based routing on localhost
 
-Now proxy determines cluster name from the subdomain, request to the `my-cluster-42.somedomain.tld` will be routed to the cluster named `my-cluster-42`. Unfortunately `/etc/hosts` does not support domain wildcards, so I usually use `*.localtest.me` which resolves to `127.0.0.1`. Now we can create self-signed certificate and play with proxy:
+Now proxy determines project name from the subdomain, request to the `round-rice-566201.somedomain.tld` will be routed to the project named `round-rice-566201`. Unfortunately, `/etc/hosts` does not support domain wildcards, so I usually use `*.localtest.me` which resolves to `127.0.0.1`. Now we can create self-signed certificate and play with proxy:
 
-```
+```sh
 openssl req -new -x509 -days 365 -nodes -text -out server.crt -keyout server.key -subj "/CN=*.localtest.me"
-
 ```
 
-now you can start proxy:
+start proxy
 
-```
+```sh
 ./target/debug/proxy -c server.crt -k server.key
 ```
 
-and connect to it:
+and connect to it
 
-```
+```sh
 PGSSLROOTCERT=./server.crt psql 'postgres://my-cluster-42.localtest.me:1234?sslmode=verify-full'
 ```


### PR DESCRIPTION
* remove `legacy` mode from the proxy readme
* explicitly specify `authBackend` in the link auth proxy helm-values for all envs