### PR TITLE
tests: do not set num_safekeepers = 1, it's the default

### DIFF
--- a/test_runner/performance/test_perf_pgbench.py
+++ b/test_runner/performance/test_perf_pgbench.py
@@ -173,7 +173,6 @@ def test_pgbench(neon_with_baseline: PgCompare, scale: int, duration: int):
 @pytest.mark.parametrize("scale", get_scales_matrix())
 @pytest.mark.parametrize("duration", get_durations_matrix())
 def test_pgbench_flamegraph(zenbenchmark, pg_bin, neon_env_builder, scale: int, duration: int):
-    neon_env_builder.num_safekeepers = 1
     neon_env_builder.pageserver_config_override = """
 profiling="page_requests"
 """

--- a/test_runner/regress/test_auth.py
+++ b/test_runner/regress/test_auth.py
@@ -56,14 +56,12 @@ def test_pageserver_auth(neon_env_builder: NeonEnvBuilder):
         tenant_http_client.tenant_create()
 
 
-@pytest.mark.parametrize("with_safekeepers", [False, True])
-def test_compute_auth_to_pageserver(neon_env_builder: NeonEnvBuilder, with_safekeepers: bool):
+def test_compute_auth_to_pageserver(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.auth_enabled = True
-    if with_safekeepers:
-        neon_env_builder.num_safekeepers = 3
+    neon_env_builder.num_safekeepers = 3
     env = neon_env_builder.init_start()
 
-    branch = f"test_compute_auth_to_pageserver{with_safekeepers}"
+    branch = "test_compute_auth_to_pageserver"
     env.neon_cli.create_branch(branch)
     pg = env.postgres.create_start(branch)
 

--- a/test_runner/regress/test_branch_behind.py
+++ b/test_runner/regress/test_branch_behind.py
@@ -10,13 +10,6 @@ from fixtures.utils import print_gc_result, query_scalar
 # Create a couple of branches off the main branch, at a historical point in time.
 #
 def test_branch_behind(neon_env_builder: NeonEnvBuilder):
-
-    # Use safekeeper in this test to avoid a subtle race condition.
-    # Without safekeeper, walreceiver reconnection can stuck
-    # because of IO deadlock.
-    #
-    # See https://github.com/neondatabase/neon/issues/1068
-    neon_env_builder.num_safekeepers = 1
     # Disable pitr, because here we want to test branch creation after GC
     neon_env_builder.pageserver_config_override = "tenant_config={pitr_interval = '0 sec'}"
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_crafted_wal_end.py
+++ b/test_runner/regress/test_crafted_wal_end.py
@@ -17,7 +17,6 @@ from fixtures.neon_fixtures import NeonEnvBuilder, WalCraft
     ],
 )
 def test_crafted_wal_end(neon_env_builder: NeonEnvBuilder, wal_type: str):
-    neon_env_builder.num_safekeepers = 1
     env = neon_env_builder.init_start()
     env.neon_cli.create_branch("test_crafted_wal_end")
 

--- a/test_runner/regress/test_fullbackup.py
+++ b/test_runner/regress/test_fullbackup.py
@@ -18,8 +18,6 @@ num_rows = 1000
 def test_fullbackup(
     neon_env_builder: NeonEnvBuilder, pg_bin: PgBin, port_distributor: PortDistributor
 ):
-
-    neon_env_builder.num_safekeepers = 1
     env = neon_env_builder.init_start()
 
     env.neon_cli.create_branch("test_fullbackup")

--- a/test_runner/regress/test_import.py
+++ b/test_runner/regress/test_import.py
@@ -122,7 +122,6 @@ def test_import_from_vanilla(test_output_dir, pg_bin, vanilla_pg, neon_env_build
 
 @pytest.mark.timeout(600)
 def test_import_from_pageserver_small(pg_bin: PgBin, neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.num_safekeepers = 1
     neon_env_builder.enable_local_fs_remote_storage()
     env = neon_env_builder.init_start()
 
@@ -140,7 +139,6 @@ def test_import_from_pageserver_small(pg_bin: PgBin, neon_env_builder: NeonEnvBu
 # @pytest.mark.skipif(os.environ.get('BUILD_TYPE') == "debug", reason="only run with release build")
 @pytest.mark.skip("See https://github.com/neondatabase/neon/issues/2255")
 def test_import_from_pageserver_multisegment(pg_bin: PgBin, neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.num_safekeepers = 1
     neon_env_builder.enable_local_fs_remote_storage()
     env = neon_env_builder.init_start()
 

--- a/test_runner/regress/test_lsn_mapping.py
+++ b/test_runner/regress/test_lsn_mapping.py
@@ -9,7 +9,6 @@ from fixtures.utils import query_scalar
 # Test pageserver get_lsn_by_timestamp API
 #
 def test_lsn_mapping(neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.num_safekeepers = 1
     env = neon_env_builder.init_start()
 
     new_timeline_id = env.neon_cli.create_branch("test_lsn_mapping")

--- a/test_runner/regress/test_pitr_gc.py
+++ b/test_runner/regress/test_pitr_gc.py
@@ -12,8 +12,6 @@ from fixtures.utils import print_gc_result, query_scalar
 # Insert some data, run GC and create a branch in the past.
 #
 def test_pitr_gc(neon_env_builder: NeonEnvBuilder):
-
-    neon_env_builder.num_safekeepers = 1
     # Set pitr interval such that we need to keep the data
     neon_env_builder.pageserver_config_override = (
         "tenant_config={pitr_interval = '1 day', gc_horizon = 0}"

--- a/test_runner/regress/test_recovery.py
+++ b/test_runner/regress/test_recovery.py
@@ -10,7 +10,6 @@ from fixtures.neon_fixtures import NeonEnvBuilder
 # Test pageserver recovery after crash
 #
 def test_pageserver_recovery(neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.num_safekeepers = 1
     # Override default checkpointer settings to run it more often
     neon_env_builder.pageserver_config_override = "tenant_config={checkpoint_distance = 1048576}"
 

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -50,29 +50,23 @@ def test_tenant_creation_fails(neon_simple_env: NeonEnv):
     ), "pageserver should clean its temp tenant dirs on restart"
 
 
-@pytest.mark.parametrize("with_safekeepers", [False, True])
-def test_tenants_normal_work(neon_env_builder: NeonEnvBuilder, with_safekeepers: bool):
-    if with_safekeepers:
-        neon_env_builder.num_safekeepers = 3
+def test_tenants_normal_work(neon_env_builder: NeonEnvBuilder):
+    neon_env_builder.num_safekeepers = 3
 
     env = neon_env_builder.init_start()
     """Tests tenants with and without wal acceptors"""
     tenant_1, _ = env.neon_cli.create_tenant()
     tenant_2, _ = env.neon_cli.create_tenant()
 
-    env.neon_cli.create_timeline(
-        f"test_tenants_normal_work_with_safekeepers{with_safekeepers}", tenant_id=tenant_1
-    )
-    env.neon_cli.create_timeline(
-        f"test_tenants_normal_work_with_safekeepers{with_safekeepers}", tenant_id=tenant_2
-    )
+    env.neon_cli.create_timeline("test_tenants_normal_work", tenant_id=tenant_1)
+    env.neon_cli.create_timeline("test_tenants_normal_work", tenant_id=tenant_2)
 
     pg_tenant1 = env.postgres.create_start(
-        f"test_tenants_normal_work_with_safekeepers{with_safekeepers}",
+        "test_tenants_normal_work",
         tenant_id=tenant_1,
     )
     pg_tenant2 = env.postgres.create_start(
-        f"test_tenants_normal_work_with_safekeepers{with_safekeepers}",
+        "test_tenants_normal_work",
         tenant_id=tenant_2,
     )
 

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -1037,7 +1037,6 @@ def test_wal_deleted_after_broadcast(neon_env_builder: NeonEnvBuilder):
 
 @pytest.mark.parametrize("auth_enabled", [False, True])
 def test_delete_force(neon_env_builder: NeonEnvBuilder, auth_enabled: bool):
-    neon_env_builder.num_safekeepers = 1
     neon_env_builder.auth_enabled = auth_enabled
     env = neon_env_builder.init_start()
 


### PR DESCRIPTION
Also get rid if `with_safekeepers` parameter in tests. Its meaning has changed: `False` meant "no safekeepers" which is not supported anymore, so we assume it's always `True`.

See #1648 