### PR TITLE
Improve pageserver/safekeepeer HTTP API errors

### DIFF
--- a/libs/utils/src/http/error.rs
+++ b/libs/utils/src/http/error.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use hyper::{header, Body, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -25,18 +24,6 @@ pub enum ApiError {
 }
 
 impl ApiError {
-    pub fn from_internal_err<E: Into<anyhow::Error>>(err: E) -> Self {
-        Self::InternalServerError(anyhow!(err))
-    }
-
-    /// Creates an `ApiError::BadRequest` by converting it into an `anyhow::Error`
-    ///
-    /// If the type is already an `anyhow::Error`, directly using `BadRequest` enum variant should
-    /// be preferred.
-    pub fn from_bad_request<E: Into<anyhow::Error>>(err: E) -> Self {
-        Self::BadRequest(err.into())
-    }
-
     pub fn into_response(self) -> Response<Body> {
         match self {
             ApiError::BadRequest(err) => HttpErrorBody::response_from_msg_and_status(

--- a/libs/utils/src/http/error.rs
+++ b/libs/utils/src/http/error.rs
@@ -25,7 +25,7 @@ pub enum ApiError {
 }
 
 impl ApiError {
-    pub fn from_err<E: Into<anyhow::Error>>(err: E) -> Self {
+    pub fn from_internal_err<E: Into<anyhow::Error>>(err: E) -> Self {
         Self::InternalServerError(anyhow!(err))
     }
 

--- a/libs/utils/src/http/error.rs
+++ b/libs/utils/src/http/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
-    #[error("Bad request: {0:?}")]
+    #[error("Bad request: {0:#?}")]
     BadRequest(anyhow::Error),
 
     #[error("Forbidden: {0}")]

--- a/libs/utils/src/http/json.rs
+++ b/libs/utils/src/http/json.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use bytes::Buf;
 use hyper::{header, Body, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -9,16 +10,20 @@ pub async fn json_request<T: for<'de> Deserialize<'de>>(
 ) -> Result<T, ApiError> {
     let whole_body = hyper::body::aggregate(request.body_mut())
         .await
-        .map_err(ApiError::from_internal_err)?;
+        .context("Failed to read request body")
+        .map_err(ApiError::BadRequest)?;
     serde_json::from_reader(whole_body.reader())
-        .map_err(|err| ApiError::BadRequest(format!("Failed to parse json request {}", err)))
+        .context("Failed to parse json request")
+        .map_err(ApiError::BadRequest)
 }
 
 pub fn json_response<T: Serialize>(
     status: StatusCode,
     data: T,
 ) -> Result<Response<Body>, ApiError> {
-    let json = serde_json::to_string(&data).map_err(ApiError::from_internal_err)?;
+    let json = serde_json::to_string(&data)
+        .context("Failed to serialize JSON response")
+        .map_err(ApiError::from_internal_err)?;
     let response = Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, "application/json")

--- a/libs/utils/src/http/json.rs
+++ b/libs/utils/src/http/json.rs
@@ -9,7 +9,7 @@ pub async fn json_request<T: for<'de> Deserialize<'de>>(
 ) -> Result<T, ApiError> {
     let whole_body = hyper::body::aggregate(request.body_mut())
         .await
-        .map_err(ApiError::from_err)?;
+        .map_err(ApiError::from_internal_err)?;
     serde_json::from_reader(whole_body.reader())
         .map_err(|err| ApiError::BadRequest(format!("Failed to parse json request {}", err)))
 }
@@ -18,11 +18,11 @@ pub fn json_response<T: Serialize>(
     status: StatusCode,
     data: T,
 ) -> Result<Response<Body>, ApiError> {
-    let json = serde_json::to_string(&data).map_err(ApiError::from_err)?;
+    let json = serde_json::to_string(&data).map_err(ApiError::from_internal_err)?;
     let response = Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(json))
-        .map_err(ApiError::from_err)?;
+        .map_err(ApiError::from_internal_err)?;
     Ok(response)
 }

--- a/libs/utils/src/http/json.rs
+++ b/libs/utils/src/http/json.rs
@@ -23,11 +23,11 @@ pub fn json_response<T: Serialize>(
 ) -> Result<Response<Body>, ApiError> {
     let json = serde_json::to_string(&data)
         .context("Failed to serialize JSON response")
-        .map_err(ApiError::from_internal_err)?;
+        .map_err(ApiError::InternalServerError)?;
     let response = Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(json))
-        .map_err(ApiError::from_internal_err)?;
+        .map_err(|e| ApiError::InternalServerError(e.into()))?;
     Ok(response)
 }

--- a/libs/utils/src/http/request.rs
+++ b/libs/utils/src/http/request.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use super::error::ApiError;
+use anyhow::anyhow;
 use hyper::{body::HttpBody, Body, Request};
 use routerify::ext::RequestExt;
 
@@ -10,9 +11,8 @@ pub fn get_request_param<'a>(
 ) -> Result<&'a str, ApiError> {
     match request.param(param_name) {
         Some(arg) => Ok(arg),
-        None => Err(ApiError::BadRequest(format!(
-            "no {} specified in path param",
-            param_name
+        None => Err(ApiError::BadRequest(anyhow!(
+            "no {param_name} specified in path param",
         ))),
     }
 }
@@ -23,16 +23,15 @@ pub fn parse_request_param<T: FromStr>(
 ) -> Result<T, ApiError> {
     match get_request_param(request, param_name)?.parse() {
         Ok(v) => Ok(v),
-        Err(_) => Err(ApiError::BadRequest(format!(
-            "failed to parse {}",
-            param_name
+        Err(_) => Err(ApiError::BadRequest(anyhow!(
+            "failed to parse {param_name}",
         ))),
     }
 }
 
 pub async fn ensure_no_body(request: &mut Request<Body>) -> Result<(), ApiError> {
     match request.body_mut().data().await {
-        Some(_) => Err(ApiError::BadRequest("Unexpected request body".into())),
+        Some(_) => Err(ApiError::BadRequest(anyhow!("Unexpected request body"))),
         None => Ok(()),
     }
 }


### PR DESCRIPTION
This is part of the work towards making sure that #2419 doesn't happen again.

The work in this PR (at least, so far) is _just_ around making sure that the return codes reflect the nature of the error that occurred. This isn't 100% possible in our current state, because all of our internal functions return an `anyhow::Result`, so in the places where the results are mixed, I've added reminder comments to fix them.

Brief summary of changes:
 * Rename `ApiError::from_error` to `ApiError::from_internal_error`
   * This is the functionality it had before, but the name didn't indicate that.
 * Add `ApiError::from_bad_request`
 * Change `ApiError::BadRequest` and `ApiError::NotFound` to use `anyhow::Error` internally
 * Remove `impl Into<ApiError> for anyhow::Error`
   * Note: this means the try operator (`?`) can no longer be used to implicitly turn an `anyhow::Error` into an `ApiError` in handler functions

There's a lot of subtly changed behavior here. I'm not 100% sure how testing for this should work.

I'd also appreciate some advice on whether it'd be better to make a cleaner (somewhat) PR with new error types supporting the return codes as well, or if this should be merged as soon as there's adequate tests.