### PR TITLE
Add an alias to build test images simply

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,6 @@ opt-level = 3
 [profile.dev]
 # Turn on a small amount of optimization in Development mode.
 opt-level = 1
+
+[alias]
+build_testing = ["build", "--features", "failpoints"]

--- a/test_runner/README.md
+++ b/test_runner/README.md
@@ -7,6 +7,8 @@ Prerequisites:
 - Neon and Postgres binaries
     - See the root [README.md](/README.md) for build directions
       If you want to test tests with failpoints, you would need to add `--features failpoints` to Rust code build commands.
+      For convenience, repository cargo config contains `build_testing` alias, that serves as a subcommand, adding the required feature flags.
+      Usage example: `cargo build_testing --release` is equivalent to `cargo build --features failpoints --release`
     - Tests can be run from the git tree; or see the environment variables
       below to run from other directories.
 - The neon git repo, including the postgres submodule


### PR DESCRIPTION
Follow-up of https://github.com/neondatabase/neon/pull/2446

> Yet, this makes local testing harder since all failpoints need a special flag to be used during cargo build to work locally.
https://github.com/rust-lang/cargo/issues/4829 hints it's impossible to set cargo features via env vars, so there seems to be no good way to get around it with cargo config file.

fixing that, by adding a new "command" `build_testing` that unfolds to `build --features failpoints` now.

I think `build_*` name should reflect the name of the feature we select for https://github.com/neondatabase/neon/pull/2429#issuecomment-1248768802 idea

> (a) I think that if we're using a feature flag to turn on/off testing APIs, it should be something more general than failpoints, and (b) I'm not sure what the name for that should be, or if there's a name that's typically used.

I've picked `testing` as a proposal, but feel free to propose yours.