### PR TITLE
Adjust spans around gc and compaction

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1090,6 +1090,9 @@ impl postgres_backend_async::Handler for PageServerHandler {
             let tenant_id = TenantId::from_str(caps.get(1).unwrap().as_str())?;
             let timeline_id = TimelineId::from_str(caps.get(2).unwrap().as_str())?;
 
+            let _span_guard =
+                info_span!("manual_gc", tenant = %tenant_id, timeline = %timeline_id).entered();
+
             let tenant = tenant_mgr::get_tenant(tenant_id, true)?;
 
             let gc_horizon: u64 = caps

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -342,8 +342,7 @@ impl Tenant {
         drop(timelines);
 
         for (timeline_id, timeline) in &timelines_to_compact {
-            let _entered =
-                info_span!("compact", timeline = %timeline_id, tenant = %self.tenant_id).entered();
+            let _entered = info_span!("compact_timeline", timeline = %timeline_id).entered();
             timeline.compact()?;
         }
 
@@ -835,9 +834,6 @@ impl Tenant {
         pitr: Duration,
         checkpoint_before_gc: bool,
     ) -> Result<GcResult> {
-        let _span_guard =
-            info_span!("gc iteration", tenant = %self.tenant_id, timeline = ?target_timeline_id)
-                .entered();
         let mut totals: GcResult = Default::default();
         let now = Instant::now();
 

--- a/pageserver/src/walreceiver/connection_manager.rs
+++ b/pageserver/src/walreceiver/connection_manager.rs
@@ -58,7 +58,10 @@ pub fn spawn_connection_manager_task(
         TaskKind::WalReceiverManager,
         Some(tenant_id),
         Some(timeline_id),
-        &format!("walreceiver for tenant {} timeline {}", timeline.tenant_id, timeline.timeline_id),
+        &format!(
+            "walreceiver for tenant {} timeline {}",
+            timeline.tenant_id, timeline.timeline_id
+        ),
         false,
         async move {
             info!("WAL receiver broker started, connecting to etcd");
@@ -88,7 +91,9 @@ pub fn spawn_connection_manager_task(
                 }
             }
         }
-        .instrument(info_span!("wal_connection_manager", tenant_id = %tenant_id, timeline_id = %timeline_id))
+        .instrument(
+            info_span!("wal_connection_manager", tenant = %tenant_id, timeline = %timeline_id),
+        ),
     );
     Ok(())
 }


### PR DESCRIPTION
So compaction and gc loops have their own span to always show tenant id in log messages.