### PR TITLE
Don't override other options than statement_timeout in test conn string.

### DIFF
--- a/test_runner/performance/test_perf_pgbench.py
+++ b/test_runner/performance/test_perf_pgbench.py
@@ -84,9 +84,8 @@ def run_test_pgbench(env: PgCompare, scale: int, duration: int, workload_type: P
 
     if workload_type == PgBenchLoadType.INIT:
         # Run initialize
-        init_pgbench(
-            env, ["pgbench", f"-s{scale}", "-i", env.pg.connstr(options="-cstatement_timeout=1h")]
-        )
+        options = "-cstatement_timeout=1h " + env.pg.default_options["options"]
+        init_pgbench(env, ["pgbench", f"-s{scale}", "-i", env.pg.connstr(options=options)])
 
     if workload_type == PgBenchLoadType.SIMPLE_UPDATE:
         # Run simple-update workload


### PR DESCRIPTION
In commit 6985f6cd6c, I tried passing extra GUCs in the 'options' part of the connection string, but it didn't work because the pgbench test overrode it with the statement_timeout. Change it so that it adds the statement_timeout to any other options, instead of replacing them.