### PR TITLE
Rename more zid-like idents

### DIFF
--- a/libs/utils/benches/benchmarks.rs
+++ b/libs/utils/benches/benchmarks.rs
@@ -3,20 +3,20 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use utils::id;
 
-pub fn bench_zid_stringify(c: &mut Criterion) {
+pub fn bench_id_stringify(c: &mut Criterion) {
     // Can only use public methods.
-    let ztl = id::TenantTimelineId::generate();
+    let ttid = id::TenantTimelineId::generate();
 
-    c.bench_function("zid.to_string", |b| {
+    c.bench_function("id.to_string", |b| {
         b.iter(|| {
             // FIXME measurement overhead?
             //for _ in 0..1000 {
-            //    ztl.tenant_id.to_string();
+            //    ttid.tenant_id.to_string();
             //}
-            ztl.tenant_id.to_string();
+            ttid.tenant_id.to_string();
         })
     });
 }
 
-criterion_group!(benches, bench_zid_stringify);
+criterion_group!(benches, bench_id_stringify);
 criterion_main!(benches);

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -132,7 +132,7 @@ pub enum TenantState {
 /// A repository corresponds to one .neon directory. One repository holds multiple
 /// timelines, forked off from the same initial call to 'initdb'.
 impl Tenant {
-    /// Get Timeline handle for given zenith timeline ID.
+    /// Get Timeline handle for given Neon timeline ID.
     /// This function is idempotent. It doesn't change internal state in any way.
     pub fn get_timeline(&self, timeline_id: TimelineId) -> anyhow::Result<Arc<Timeline>> {
         self.timelines

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -183,7 +183,7 @@ pageserver_send(NeonRequest * request)
 	if (!connected)
 		pageserver_connect();
 
-	req_buff = zm_pack_request(request);
+	req_buff = nm_pack_request(request);
 
 	/*
 	 * Send request.
@@ -204,7 +204,7 @@ pageserver_send(NeonRequest * request)
 
 	if (message_level_is_interesting(PageStoreTrace))
 	{
-		char	   *msg = zm_to_string((NeonMessage *) request);
+		char	   *msg = nm_to_string((NeonMessage *) request);
 
 		neon_log(PageStoreTrace, "sent request: %s", msg);
 		pfree(msg);
@@ -230,12 +230,12 @@ pageserver_receive(void)
 			else if (resp_buff.len == -2)
 				neon_log(ERROR, "could not read COPY data: %s", PQerrorMessage(pageserver_conn));
 		}
-		resp = zm_unpack_response(&resp_buff);
+		resp = nm_unpack_response(&resp_buff);
 		PQfreemem(resp_buff.data);
 
 		if (message_level_is_interesting(PageStoreTrace))
 		{
-			char	   *msg = zm_to_string((NeonMessage *) resp);
+			char	   *msg = nm_to_string((NeonMessage *) resp);
 
 			neon_log(PageStoreTrace, "got response: %s", msg);
 			pfree(msg);
@@ -282,9 +282,9 @@ page_server_api api = {
 static bool
 check_neon_id(char **newval, void **extra, GucSource source)
 {
-	uint8		zid[16];
+	uint8		id[16];
 
-	return **newval == '\0' || HexDecodeString(zid, *newval, 16);
+	return **newval == '\0' || HexDecodeString(id, *newval, 16);
 }
 
 static char *

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -128,9 +128,9 @@ typedef struct
 												 * message */
 }			NeonErrorResponse;
 
-extern StringInfoData zm_pack_request(NeonRequest * msg);
-extern NeonResponse * zm_unpack_response(StringInfo s);
-extern char *zm_to_string(NeonMessage * msg);
+extern StringInfoData nm_pack_request(NeonRequest * msg);
+extern NeonResponse * nm_unpack_response(StringInfo s);
+extern char *nm_to_string(NeonMessage * msg);
 
 /*
  * API

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -160,7 +160,7 @@ page_server_request(void const *req)
 
 
 StringInfoData
-zm_pack_request(NeonRequest * msg)
+nm_pack_request(NeonRequest * msg)
 {
 	StringInfoData s;
 
@@ -235,7 +235,7 @@ zm_pack_request(NeonRequest * msg)
 }
 
 NeonResponse *
-zm_unpack_response(StringInfo s)
+nm_unpack_response(StringInfo s)
 {
 	NeonMessageTag tag = pq_getmsgbyte(s);
 	NeonResponse *resp = NULL;
@@ -329,7 +329,7 @@ zm_unpack_response(StringInfo s)
 
 /* dump to json for debugging / error reporting purposes */
 char *
-zm_to_string(NeonMessage * msg)
+nm_to_string(NeonMessage * msg)
 {
 	StringInfoData s;
 
@@ -632,7 +632,7 @@ neon_init(void)
  * It may cause problems with XLogFlush. So return pointer backward to the origin of the page.
  */
 static XLogRecPtr
-zm_adjust_lsn(XLogRecPtr lsn)
+nm_adjust_lsn(XLogRecPtr lsn)
 {
 	/*
 	 * If lsn points to the beging of first record on page or segment, then
@@ -685,7 +685,7 @@ neon_get_request_lsn(bool *latest, RelFileNode rnode, ForkNumber forknum, BlockN
 		elog(DEBUG1, "neon_get_request_lsn GetLastWrittenLSN lsn %X/%X ",
 			 (uint32) ((lsn) >> 32), (uint32) (lsn));
 
-		lsn = zm_adjust_lsn(lsn);
+		lsn = nm_adjust_lsn(lsn);
 
 		/*
 		 * Is it possible that the last-written LSN is ahead of last flush
@@ -1569,7 +1569,7 @@ neon_truncate(SMgrRelation reln, ForkNumber forknum, BlockNumber nblocks)
 	 */
 	lsn = GetXLogInsertRecPtr();
 
-	lsn = zm_adjust_lsn(lsn);
+	lsn = nm_adjust_lsn(lsn);
 
 	/*
 	 * Flush it, too. We don't actually care about it here, but let's uphold

--- a/safekeeper/src/control_file_upgrade.rs
+++ b/safekeeper/src/control_file_upgrade.rs
@@ -167,7 +167,7 @@ pub fn upgrade_control_file(buf: &[u8], version: u32) -> Result<SafeKeeperState>
             remote_consistent_lsn: Lsn(0),
             peers: Peers(vec![]),
         });
-    // migrate to hexing some zids
+    // migrate to hexing some ids
     } else if version == 2 {
         info!("reading safekeeper control file version {}", version);
         let oldstate = SafeKeeperStateV2::des(&buf[..buf.len()])?;


### PR DESCRIPTION
Follow-up to PR #2433 (b8eb908a). There's still a few more unresolved locations that have been left as-is for compatibility reasons (as in the original PR).

These were found with various permutations of `rg '\bz[a-z_]+\b'`. More information below.

<details>
<summary>Full ripgrep command</summary>
<pre>
rg --pcre2 '(?!zzz|zip|zap|zero|zope|zlib|zenbenchmark|zenith_admin|zenith\.tech|zclippy|zenith_ctl)\bz[a-z_]+\b' \
    -g '!vendor' -g '!docs'
</pre>
</details>

<details>
<summary>Remaining ripgrep output unaffected by this PR</summary>
<pre><code>
cli-v2-story.md
3:    ~/git-sandbox/zenith (cli-v2)$ ./target/debug/cli init
18:    selecting default time zone ... Europe/Helsinki
27:    new zenith repository was created in .zenith
31:    ~/git-sandbox/zenith (cli-v2)$ ./target/debug/cli branch
36:    ~/git-sandbox/zenith (cli-v2)$ ./target/debug/cli start main
53:    ~/git-sandbox/zenith (cli-v2)$ psql postgres -c "create table foo (t text);"
55:    ~/git-sandbox/zenith (cli-v2)$ psql postgres -c "insert into foo values ('inserted on the main branch');"
57:    ~/git-sandbox/zenith (cli-v2)$ psql postgres -c "select * from foo"
67:    ~/git-sandbox/zenith (cli-v2)$ ./target/debug/cli branch experimental main
70:    ~/git-sandbox/zenith (cli-v2)$ ./target/debug/cli branch
76:    ~/git-sandbox/zenith (cli-v2)$ ./target/debug/cli start experimental -- -o -p5433
93:    ~/git-sandbox/zenith (cli-v2)$ psql postgres -p5433 -c "select * from foo"
99:    ~/git-sandbox/zenith (cli-v2)$ psql postgres -p5433 -c "insert into foo values ('inserted on experimental')"
101:    ~/git-sandbox/zenith (cli-v2)$ psql postgres -p5433 -c "select * from foo"
111:    ~/git-sandbox/zenith (cli-v2)$ psql postgres -p5432 -c "select * from foo"
120:Everything is stored in the .zenith directory:
122:    ~/git-sandbox/zenith (cli-v2)$ ls -l .zenith/
130:    ~/git-sandbox/zenith (cli-v2)$ ls -l .zenith/datadirs/
134:    ~/git-sandbox/zenith (cli-v2)$ ls -l .zenith/datadirs/3c0c634c1674079b2c6d4edf7c91523e/
166:    ~/git-sandbox/zenith (cli-v2)$ killall -9 postgres
167:    ~/git-sandbox/zenith (cli-v2)$ rm -rf .zenith/datadirs/*
168:    ~/git-sandbox/zenith (cli-v2)$ ./target/debug/cli start experimental -- -o -p5433
182:    ~/git-sandbox/zenith (cli-v2)$ psql postgres -p5433 -c "select * from foo"
<br>
scripts/generate_and_push_perf_report.sh
17:echo "Uploading perf result to zenith-perf-data"
19:    --repo=https://"$VIP_VAP_ACCESS_TOKEN"@github.com/neondatabase/zenith-perf-data.git \
<br>
README.md
6:still refer to "zenith", but we are in the process of renaming things.
<br>
safekeeper/src/handler.rs
71:                    // FIXME `ztenantid` and `ztimelineid` left for compatibility during deploy,
75:                        Some(("ztenantid", value)) | Some(("tenant_id", value)) => {
78:                        Some(("ztimelineid", value)) | Some(("timeline_id", value)) => {
<br>
pgxn/neon/inmem_smgr.c
6: * process (see src/backend/tcop/zenith_wal_redo.c). It has no persistent
<br>
pageserver/src/import_datadir.rs
532:    } else if file_path.starts_with("zenith.signal") {
533:        // Parse zenith signal file to set correct previous LSN
535:        // zenith.signal format is "PREV LSN: prev_lsn"
537:        let zenith_signal = std::str::from_utf8(&bytes)?.trim();
538:        let prev_lsn = match zenith_signal {
546:                    .context("can't parse zenith.signal")?
550:        // zenith.signal is not necessarily the last file, that we handle
556:        debug!("imported zenith signal {}", prev_lsn);
<br>
pageserver/src/walredo.rs
13://! See src/backend/tcop/zenith_wal_redo.c for the other side of
632:            // (see seccomp in zenith_wal_redo.c). We have to make sure it doesn't
811:// process. See vendor/postgres/src/backend/tcop/zenith_wal_redo.c for
<br>
pgxn/neon/relsize_cache.c
4: *      Relation size cache for better zentih performance.
<br>
pageserver/src/basebackup.rs
73:        // "zenith.signal" file, so that postgres can read it during startup.
348:    // Also send zenith.signal file with extra bootstrap data.
375:        // add zenith.signal file
376:        let mut zenith_signal = String::new();
379:                write!(zenith_signal, "PREV LSN: none")?;
381:                write!(zenith_signal, "PREV LSN: invalid")?;
384:            write!(zenith_signal, "PREV LSN: {}", self.prev_record_lsn)?;
387:            &new_tar_header("zenith.signal", zenith_signal.len() as u64)?,
388:            zenith_signal.as_bytes(),
<br>
pageserver/src/walreceiver/walreceiver_connection.rs
337:                .zenith_status_update(data.len() as u64, &data)
<br>
pgxn/neon_test_utils/neontest.c
102:	 * Temporarily set the zenith_test_evict GUC, so that when we pin and
107:	save_neon_test_evict = zenith_test_evict;
108:	zenith_test_evict = true;
139:			 * zenith_test_evict==true, this will evict the page from the
152:		zenith_test_evict = save_neon_test_evict;
<br>
Cargo.toml
29:[profile.release-line-debug-zize]
38:[profile.release-line-debug-zize-lto]
52:[profile.release-no-debug-zize]
63:[profile.release-no-debug-zize-lto]
<br>
test_runner/fixtures/neon_fixtures.py
2401:        "zenith.signal",
<br>
pgxn/typedefs.list
3774:z_stream
3775:z_streamp
3776:zic_t
<br>
compute_tools/tests/cluster_spec.json
23:                "name": "zenith \"new\"",
28:                "name": "zen",
63:                "name": "zenith",
67:                "name": "zen",
68:                "owner": "zen"
187:            "name": "zenith_test"
200:            "name": "zenith new",
201:            "new_name": "zenith \"new\""
</code></pre>
</details>

There's some matches I'm not sure about -- like  whether we can change things in `cluster_spec.json`; or if `zenith.signal` needs to remain as-is. I've left those unchanged for now.

I wasn't sure whether to change the stuff in our postgres forks, so I've excluded those from the search, and haven't changed references to `zenith_wal_redo.c`.