### PR TITLE
Use a simpler way to set extra options for benchmark test.

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -183,11 +183,8 @@ jobs:
           neon-captest-reuse)
             CONNSTR=${{ secrets.BENCHMARK_CAPTEST_CONNSTR }}
             ;;
-          neon-captest-new)
+          neon-captest-new | neon-captest-prefetch)
             CONNSTR=${{ steps.create-neon-project.outputs.dsn }}
-            ;;
-         neon-captest-prefetch)
-            CONNSTR=${{ steps.create-neon-project.outputs.dsn }}?options=-cenable_seqscan_prefetch%3Don%20-cseqscan_prefetch_buffers%3D10
             ;;
           rds-aurora)
             CONNSTR=${{ secrets.BENCHMARK_RDS_CONNSTR }}
@@ -203,6 +200,14 @@ jobs:
         psql ${CONNSTR} -c "SELECT version();"
       env:
         PLATFORM: ${{ matrix.platform }}
+
+    - name: Set database options
+      if: matrix.platform == 'neon-captest-prefetch'
+      run: |
+        psql ${BENCHMARK_CONNSTR} -c "ALTER DATABASE main SET enable_seqscan_prefetch=on"
+        psql ${BENCHMARK_CONNSTR} -c "ALTER DATABASE main SET seqscan_prefetch_buffers=10"
+      env:
+        BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
 
     - name: Benchmark init
       uses: ./.github/actions/run-python-test-set

--- a/test_runner/performance/test_perf_pgbench.py
+++ b/test_runner/performance/test_perf_pgbench.py
@@ -84,7 +84,7 @@ def run_test_pgbench(env: PgCompare, scale: int, duration: int, workload_type: P
 
     if workload_type == PgBenchLoadType.INIT:
         # Run initialize
-        options = "-cstatement_timeout=1h " + env.pg.default_options["options"]
+        options = "-cstatement_timeout=1h " + env.pg.default_options.get("options", "")
         init_pgbench(env, ["pgbench", f"-s{scale}", "-i", env.pg.connstr(options=options)])
 
     if workload_type == PgBenchLoadType.SIMPLE_UPDATE:


### PR DESCRIPTION
Commit 43a4f7173e fixed the case that there are extra options in the connection string, but broke it in the case when there are not. Revert changes from commit 43a4f7173e, and set the options with ALTER DATABASE instead. This easier to read and extend, too.