### PR TITLE
More error types and logging

### DIFF
--- a/libs/utils/src/http/error.rs
+++ b/libs/utils/src/http/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
-    #[error("Bad request: {0:#?}")]
+    #[error("Bad request: {0:?}")]
     BadRequest(anyhow::Error),
 
     #[error("Forbidden: {0}")]
@@ -27,7 +27,7 @@ impl ApiError {
     pub fn into_response(self) -> Response<Body> {
         match self {
             ApiError::BadRequest(err) => HttpErrorBody::response_from_msg_and_status(
-                format!("{err:#?}"), // use debug printing so that we give the cause
+                format!("{err:?}"), // use debug printing so that we give the cause
                 StatusCode::BAD_REQUEST,
             ),
             ApiError::Forbidden(_) => {
@@ -44,7 +44,7 @@ impl ApiError {
                 HttpErrorBody::response_from_msg_and_status(self.to_string(), StatusCode::CONFLICT)
             }
             ApiError::InternalServerError(err) => HttpErrorBody::response_from_msg_and_status(
-                err.to_string(),
+                format!("{err:?}"),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ),
         }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -71,7 +71,7 @@ mod timeline;
 
 use storage_layer::Layer;
 
-pub use timeline::Timeline;
+pub use timeline::{PageLookupError, Timeline};
 
 // re-export this function so that page_cache.rs can use it.
 pub use crate::tenant::ephemeral_file::writeback as writeback_ephemeral_file;

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -230,7 +230,7 @@ impl LayerMap {
     /// contain the version, even if it's missing from the returned
     /// layer.
     ///
-    pub fn search(&self, key: Key, end_lsn: Lsn) -> Result<Option<SearchResult>> {
+    pub fn search(&self, key: Key, end_lsn: Lsn) -> Option<SearchResult> {
         // linear search
         // Find the latest image layer that covers the given key
         let mut latest_img: Option<Arc<dyn Layer>> = None;
@@ -255,10 +255,10 @@ impl LayerMap {
             assert!(img_lsn < end_lsn);
             if Lsn(img_lsn.0 + 1) == end_lsn {
                 // found exact match
-                return Ok(Some(SearchResult {
+                return Some(SearchResult {
                     layer: Arc::clone(l),
                     lsn_floor: img_lsn,
-                }));
+                });
             }
             if img_lsn > latest_img_lsn.unwrap_or(Lsn(0)) {
                 latest_img = Some(Arc::clone(l));
@@ -315,19 +315,19 @@ impl LayerMap {
                 Lsn(latest_img_lsn.unwrap_or(Lsn(0)).0 + 1),
                 l.get_lsn_range().start,
             );
-            Ok(Some(SearchResult {
+            Some(SearchResult {
                 lsn_floor,
                 layer: l,
-            }))
+            })
         } else if let Some(l) = latest_img {
             trace!("found img layer and no deltas for request on {key} at {end_lsn}");
-            Ok(Some(SearchResult {
+            Some(SearchResult {
                 lsn_floor: latest_img_lsn.unwrap(),
                 layer: l,
-            }))
+            })
         } else {
             trace!("no layer found for request on {key} at {end_lsn}");
-            Ok(None)
+            None
         }
     }
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -694,11 +694,11 @@ impl Timeline {
         result
     }
 
-    pub fn launch_wal_receiver(self: &Arc<Self>) -> anyhow::Result<()> {
+    pub fn launch_wal_receiver(self: &Arc<Self>) {
         if !is_etcd_client_initialized() {
             if cfg!(test) {
                 info!("not launching WAL receiver because etcd client hasn't been initialized");
-                return Ok(());
+                return;
             } else {
                 panic!("etcd client not initialized");
             }
@@ -720,15 +720,13 @@ impl Timeline {
             .unwrap_or(self.conf.default_tenant_conf.max_lsn_wal_lag);
         drop(tenant_conf_guard);
         let self_clone = Arc::clone(self);
-        let _ = spawn_connection_manager_task(
+        spawn_connection_manager_task(
             self.conf.broker_etcd_prefix.clone(),
             self_clone,
             walreceiver_connect_timeout,
             lagging_wal_timeout,
             max_lsn_wal_lag,
-        )?;
-
-        Ok(())
+        );
     }
 
     ///

--- a/pageserver/src/walreceiver/connection_manager.rs
+++ b/pageserver/src/walreceiver/connection_manager.rs
@@ -47,7 +47,7 @@ pub fn spawn_connection_manager_task(
     wal_connect_timeout: Duration,
     lagging_wal_timeout: Duration,
     max_lsn_wal_lag: NonZeroU64,
-) -> anyhow::Result<()> {
+) {
     let mut etcd_client = get_etcd_client().clone();
 
     let tenant_id = timeline.tenant_id;
@@ -95,7 +95,6 @@ pub fn spawn_connection_manager_task(
             info_span!("wal_connection_manager", tenant = %tenant_id, timeline = %timeline_id),
         ),
     );
-    Ok(())
 }
 
 /// Attempts to subscribe for timeline updates, pushed by safekeepers into the broker.

--- a/test_runner/regress/test_branch_and_gc.py
+++ b/test_runner/regress/test_branch_and_gc.py
@@ -164,7 +164,7 @@ def test_branch_creation_before_gc(neon_simple_env: NeonEnv):
     time.sleep(1.0)
 
     # The starting LSN is invalid as the corresponding record is scheduled to be removed by in-queue GC.
-    with pytest.raises(Exception, match="invalid branch start lsn: .*"):
+    with pytest.raises(Exception, match="Invalid branch start LSN"):
         env.neon_cli.create_branch("b1", "b0", tenant_id=tenant, ancestor_start_lsn=lsn)
 
     thread.join()

--- a/test_runner/regress/test_branch_behind.py
+++ b/test_runner/regress/test_branch_behind.py
@@ -95,11 +95,11 @@ def test_branch_behind(neon_env_builder: NeonEnvBuilder):
     assert pg.safe_psql("SELECT 1")[0][0] == 1
 
     # branch at pre-initdb lsn
-    with pytest.raises(Exception, match="invalid branch start lsn: .*"):
+    with pytest.raises(Exception, match="Invalid branch start LSN"):
         env.neon_cli.create_branch("test_branch_preinitdb", ancestor_start_lsn=Lsn("0/42"))
 
     # branch at pre-ancestor lsn
-    with pytest.raises(Exception, match="less than timeline ancestor lsn"):
+    with pytest.raises(Exception, match="Start LSN .* less than ancestor timeline's start LSN"):
         env.neon_cli.create_branch(
             "test_branch_preinitdb", "test_branch_behind", ancestor_start_lsn=Lsn("0/42")
         )
@@ -109,7 +109,7 @@ def test_branch_behind(neon_env_builder: NeonEnvBuilder):
         gc_result = pageserver_http.timeline_gc(env.initial_tenant, timeline, 0)
         print_gc_result(gc_result)
 
-    with pytest.raises(Exception, match="invalid branch start lsn: .*"):
+    with pytest.raises(Exception, match="Invalid branch start LSN"):
         # this gced_lsn is pretty random, so if gc is disabled this woudln't fail
         env.neon_cli.create_branch(
             "test_branch_create_fail", "test_branch_behind", ancestor_start_lsn=gced_lsn

--- a/test_runner/regress/test_broken_timeline.py
+++ b/test_runner/regress/test_broken_timeline.py
@@ -71,7 +71,7 @@ def test_broken_timeline(neon_env_builder: NeonEnvBuilder):
 
     # First timeline would not get loaded into pageserver due to corrupt metadata file
     with pytest.raises(
-        Exception, match=f"Timeline {timeline1} was not found for tenant {tenant1}"
+        Exception, match=f"Timeline {timeline1} not found for Tenant {tenant1}"
     ) as err:
         pg1.start()
     log.info(f"compute startup failed eagerly for timeline with corrupt metadata: {err}")
@@ -80,7 +80,7 @@ def test_broken_timeline(neon_env_builder: NeonEnvBuilder):
     # We don't have the remote storage enabled, which means timeline is in an incorrect state,
     # it's not loaded at all
     with pytest.raises(
-        Exception, match=f"Timeline {timeline2} was not found for tenant {tenant2}"
+        Exception, match=f"Timeline {timeline2} not found for Tenant {tenant2}"
     ) as err:
         pg2.start()
     log.info(f"compute startup failed eagerly for timeline with corrupt metadata: {err}")

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -28,7 +28,7 @@ def test_tenant_detach_smoke(neon_env_builder: NeonEnvBuilder):
     tenant_id = TenantId.generate()
     with pytest.raises(
         expected_exception=NeonPageserverApiException,
-        match=f"Tenant not found for id {tenant_id}",
+        match=f"Tenant {tenant_id} not found",
     ):
         pageserver_http.tenant_detach(tenant_id)
 
@@ -48,10 +48,11 @@ def test_tenant_detach_smoke(neon_env_builder: NeonEnvBuilder):
     )
 
     # gc should not try to even start
+    bogus_timeline_id = TimelineId.generate()
     with pytest.raises(
-        expected_exception=NeonPageserverApiException, match="gc target timeline does not exist"
+        expected_exception=NeonPageserverApiException,
+        match=f"Timeline {bogus_timeline_id} not found for Tenant {tenant_id}",
     ):
-        bogus_timeline_id = TimelineId.generate()
         pageserver_http.timeline_gc(tenant_id, bogus_timeline_id, 0)
 
     # try to concurrently run gc and detach

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -11,7 +11,10 @@ def test_timeline_delete(neon_simple_env: NeonEnv):
     # first try to delete non existing timeline
     # for existing tenant:
     invalid_timeline_id = TimelineId.generate()
-    with pytest.raises(NeonPageserverApiException, match="timeline not found"):
+    with pytest.raises(
+        NeonPageserverApiException,
+        match=f"Timeline {invalid_timeline_id} not found for Tenant {env.initial_tenant}",
+    ):
         ps_http.timeline_delete(tenant_id=env.initial_tenant, timeline_id=invalid_timeline_id)
 
     # for non existing tenant:


### PR DESCRIPTION
Intended to resolve #2419.

I'll keep updating the comment here as I add changes. My current plan is to sprinkle lots of new error types around `pageserver`, `safekeeper`, and some places in `libs`, moving away from `anyhow::Result` but using `anyhow::Error` internally to track source chains.

**Changelist**:
- Add `ControlFileDecodeError`
- Add `anyhow::Error` for sources in `WalRedoError`
- Add `PageLookupError` for failures from pageserver's `Timeline::get(key, lsn)`
- Add `TenantError` and `TimelineError` for representing failure of high-level pageserver operations

### General design

The general idea is to move `error!` logging into error creation, figuring that that it's better to double-report an error than to not report it at all. Distinct error types exist mostly to handle generalized classes of errors, internally using `anyhow::Error` for source chains (e.g, `WalRedoError`) or just wrapping it directly (e.g., `ControlFileDecodeError`).

Separating out error types will also help to resolve some of the cases from #2461 where we can't quite tell whether an error should be 4XX or 5XX.

### Possible pain points

- If too many `enum`s are transitively included into the same error, we might run into size issues with regard to the return types we're passing around. That probably won't matter *too* too much, because that'll tend to be very high-level operations, but something worth considering either way.
- Verbosity: It's possible that this will require a significant amount of extra code devoted to error handling and propagation. I've tried to reduce that with constructor methods, but for enums like `WalRedoError`, that's not very intuitive.