### PR TITLE
Reduce metrics footprint in safekeeper

### DIFF
--- a/safekeeper/src/safekeeper.rs
+++ b/safekeeper/src/safekeeper.rs
@@ -998,6 +998,10 @@ mod tests {
         fn remove_up_to(&self) -> Box<dyn Fn(XLogSegNo) -> Result<()>> {
             Box::new(move |_segno_up_to: XLogSegNo| Ok(()))
         }
+
+        fn get_metrics(&self) -> crate::metrics::WalStorageMetrics {
+            crate::metrics::WalStorageMetrics::default()
+        }
     }
 
     #[test]

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -534,6 +534,7 @@ impl Timeline {
                 mem_state: state.sk.inmem.clone(),
                 persisted_state: state.sk.state.clone(),
                 flush_lsn: state.sk.wal_store.flush_lsn(),
+                wal_storage: state.sk.wal_store.get_metrics(),
             })
         } else {
             None


### PR DESCRIPTION
https://github.com/neondatabase/neon/pull/2329 was recently merged to main and deployed to staging, which made Prometheus unhappy because of a large metrics inflow. It happened because #2329 made all timelines preload from disk on startup and it helped to find a bug: we report wal_storage and control_file metrics even for inactive timelines. This PR fixes it and makes some other safekeeper metrics improvements.