### PR TITLE
Update pg_version for old timelines

### DIFF
--- a/safekeeper/src/control_file_upgrade.rs
+++ b/safekeeper/src/control_file_upgrade.rs
@@ -249,6 +249,18 @@ pub fn upgrade_control_file(buf: &[u8], version: u32) -> Result<SafeKeeperState>
         oldstate.local_start_lsn = Lsn(1);
 
         return Ok(oldstate);
+    } else if version == 6 {
+        info!("reading safekeeper control file version {}", version);
+        let mut oldstate = SafeKeeperState::des(&buf[..buf.len()])?;
+        if oldstate.server.pg_version != 0 {
+            return Ok(oldstate);
+        }
+
+        // set pg_version to the default v14
+        info!("setting pg_version to 140005");
+        oldstate.server.pg_version = 140005;
+
+        return Ok(oldstate);
     }
     bail!("unsupported safekeeper control file version {}", version)
 }

--- a/safekeeper/src/safekeeper.rs
+++ b/safekeeper/src/safekeeper.rs
@@ -25,7 +25,7 @@ use utils::{
 };
 
 pub const SK_MAGIC: u32 = 0xcafeceefu32;
-pub const SK_FORMAT_VERSION: u32 = 6;
+pub const SK_FORMAT_VERSION: u32 = 7;
 const SK_PROTOCOL_VERSION: u32 = 2;
 pub const UNKNOWN_SERVER_VERSION: u32 = 0;
 
@@ -639,7 +639,6 @@ where
 
             let mut state = self.state.clone();
             state.server.system_id = msg.system_id;
-            state.server.wal_seg_size = msg.wal_seg_size;
             if msg.pg_version != UNKNOWN_SERVER_VERSION {
                 state.server.pg_version = msg.pg_version;
             }

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -314,6 +314,8 @@ impl Timeline {
         ttid: TenantTimelineId,
         wal_backup_launcher_tx: Sender<TenantTimelineId>,
     ) -> Result<Timeline> {
+        let _enter = info_span!("load_timeline", timeline = %ttid.timeline_id).entered();
+
         let shared_state = SharedState::restore(&conf, &ttid)?;
         let (commit_lsn_watch_tx, commit_lsn_watch_rx) =
             watch::channel(shared_state.sk.state.commit_lsn);


### PR DESCRIPTION
Some time ago, we had this code for handling ProposerGreeting requests in safekeeper:
https://github.com/neondatabase/neon/blob/87bf7be5370cc2a621cd51d5a4cb3b1ed76e4633/safekeeper/src/safekeeper.rs#L611-L616

It didn't persist `pg_version` to the timeline control file. As a result, we have a lot of old projects with `pg_version == 0`.
This PR bumps control file version and sets `pg_version` to 140005 for all such timelines.