### PR TITLE
Improve pytest ergonomics

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ filterwarnings =
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning
 addopts =
     -m 'not remote_cluster'
+    --ignore=test_runner/performance
 markers =
     remote_cluster
 testpaths =

--- a/test_runner/README.md
+++ b/test_runner/README.md
@@ -56,6 +56,14 @@ If you want to run all tests that have the string "bench" in their names:
 
 `./scripts/pytest -k bench`
 
+To run tests in parellel we utilize `pytest-xdist` plugin. By default everything runs single threaded. Number of workers can be specified with `-n` argument:
+
+`./scripts/pytest -n4`
+
+By default performance tests are excluded. To run them explicitly pass performance tests selection to the script:
+
+`./scripts/pytest test_runner/performance`
+
 Useful environment variables:
 
 `NEON_BIN`: The directory where neon binaries can be found.


### PR DESCRIPTION
1. Disable perf tests by default
2. Add instruction to run tests in parallel

@MMeent could you please try it out? Does it behave as you would expect? I didnt place automatic detection for parallelism because it is not as simple as using all available cores