### PR TITLE
Do not remove empty timelines/ directory for tenants

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -455,6 +455,9 @@ class RemoteStorageKind(enum.Enum):
     LOCAL_FS = "local_fs"
     MOCK_S3 = "mock_s3"
     REAL_S3 = "real_s3"
+    # Pass to tests that are generic to remote storage
+    # to ensure the test pass with or without the remote storage
+    NOOP = "noop"
 
 
 def available_remote_storages() -> List[RemoteStorageKind]:
@@ -583,7 +586,9 @@ class NeonEnvBuilder:
         test_name: str,
         force_enable: bool = True,
     ):
-        if remote_storage_kind == RemoteStorageKind.LOCAL_FS:
+        if remote_storage_kind == RemoteStorageKind.NOOP:
+            return
+        elif remote_storage_kind == RemoteStorageKind.LOCAL_FS:
             self.enable_local_fs_remote_storage(force_enable=force_enable)
         elif remote_storage_kind == RemoteStorageKind.MOCK_S3:
             self.enable_mock_s3_remote_storage(bucket_name=test_name, force_enable=force_enable)


### PR DESCRIPTION
 Part of work on the staging recovery, fixes issues for a few latest clusters, stuck on staging:

```
https://console.stage.neon.tech/admin/projects/steep-voice-412165

zenith-us-stage-ps-4/63387f1aded0790526c9fd84a23364c7/2bbb937d306e72c8ff4ce96e7269d8ec
2022-10-03T11:14:49.631494Z ERROR init_tenant_mgr:local_tenant_timeline_files: Failed to collect tenant files from dir '/storage/pageserver/data/tenants' for entry DirEntry("/storage/pageserver/data/tenants/63387f1aded0790526c9fd84a23364c7"), reason: Failed to list timelines dir entry for tenant 63387f1aded0790526c9fd84a23364c7: No such file or directory (os error 2)

------------------

https://console.stage.neon.tech/admin/projects/solitary-sound-889138

zenith-us-stage-ps-4/bfb91c0842f010f925f8c4c79a57873e/bf54622f59eb105b432c70581997b196

2022-10-03T18:31:19.475359Z ERROR Error processing HTTP request: InternalServerError(cannot create new tenant repo: 'bfb91c0842f010f925f8c4c79a57873e' directory already exists

------------------

https://console.stage.neon.tech/admin/projects/summer-bird-073759

zenith-us-stage-ps-4/b123d21e0a210f11a58bd05bf2d225f4/1cfe16da20ccd7d0f35e417fb39b6d9e

same as above: missing `timelines/` in the tenant dir

------------------

https://console.stage.neon.tech/admin/projects/plain-violet-755403

zenith-us-stage-ps-4/d5ce671c64e125a3c3d4c2766f7906d8/2756c16ea6fb4d3b2ef50b5e34a8c5b1

same as above: missing `timelines/` in the tenant dir
```


-------------

The clusters had their timelines removed entirely and, due the bug in the code, their `timelines/` subdirectory removed as an empty one.
No `timelines/` subdirectory caused the timeline attach logic to fail, as we could not check timeline presence.
I've decided to not restore the `timelines/` directory automatically, since its absence is abnormal, and only hardened the tenant load logic to check for directory existence and fail fast + fixed the bug.