### PR TITLE
Move proxies to neon-proxy namespace

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -768,5 +768,5 @@ jobs:
       - name: Re-deploy proxy
         run: |
           DOCKER_TAG=${{needs.tag.outputs.build-tag}}
-          helm upgrade ${{ matrix.proxy_job }}       neondatabase/neon-proxy --namespace default --install -f .github/helm-values/${{ matrix.proxy_config }}.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
-          helm upgrade ${{ matrix.proxy_job }}-scram neondatabase/neon-proxy --namespace default --install -f .github/helm-values/${{ matrix.proxy_config }}-scram.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
+          helm upgrade ${{ matrix.proxy_job }}       neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/${{ matrix.proxy_config }}.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s
+          helm upgrade ${{ matrix.proxy_job }}-scram neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/${{ matrix.proxy_config }}-scram.yaml --set image.tag=${DOCKER_TAG} --wait --timeout 15m0s


### PR DESCRIPTION
I'm going to move staging/neon-stress proxies manually just before merging this to main, for production proxies process described in https://github.com/neondatabase/cloud/issues/2305
```
helm --kube-context zenith-us-stage --namespace default uninstall neon-proxy
helm --kube-context zenith-us-stage upgrade neon-proxy neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/staging.proxy.yaml --set image.tag=${DOCKER_TAG}
helm --kube-context zenith-us-stage --namespace default uninstall neon-proxy-scram
helm --kube-context zenith-us-stage upgrade neon-proxy-scram neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/staging.proxy-scram.yaml --set image.tag=${DOCKER_TAG}


helm --kube-context neon-stress --namespace default uninstall neon-stress-proxy
helm --kube-context neon-stress upgrade neon-stress-proxy neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/neon-stress.proxy.yaml --set image.tag=${DOCKER_TAG}
helm --kube-context neon-stress --namespace default uninstall neon-stress-proxy-scram
helm --kube-context neon-stress upgrade neon-stress-proxy-scram neondatabase/neon-proxy --namespace neon-proxy --install -f .github/helm-values/neon-stress.proxy-scram.yaml --set image.tag=${DOCKER_TAG}
```