### PR TITLE
Download as much as possible for missing remote storage files

### DIFF
--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -156,7 +156,7 @@ pub enum DownloadError {
     /// Validation or other error happened due to user input.
     BadInput(anyhow::Error),
     /// The file was not found in the remote storage.
-    NotFound,
+    NotFound(RemoteObjectId),
     /// The file was found in the remote storage, but the download failed.
     Other(anyhow::Error),
 }
@@ -167,7 +167,10 @@ impl std::fmt::Display for DownloadError {
             DownloadError::BadInput(e) => {
                 write!(f, "Failed to download a remote file due to user input: {e}")
             }
-            DownloadError::NotFound => write!(f, "No file found for the remote object id given"),
+            DownloadError::NotFound(remote_id) => write!(
+                f,
+                "No remote storage object was found remotely, id {remote_id}",
+            ),
             DownloadError::Other(e) => write!(f, "Failed to download a remote file: {e}"),
         }
     }

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -248,7 +248,7 @@ impl RemoteStorage for LocalFs {
                 download_stream: Box::pin(source),
             })
         } else {
-            Err(DownloadError::NotFound)
+            Err(DownloadError::NotFound(from.clone()))
         }
     }
 
@@ -304,7 +304,7 @@ impl RemoteStorage for LocalFs {
                 },
             })
         } else {
-            Err(DownloadError::NotFound)
+            Err(DownloadError::NotFound(from.clone()))
         }
     }
 
@@ -688,7 +688,7 @@ mod fs_tests {
 
         let non_existing_path = "somewhere/else";
         match storage.download(&RemoteObjectId(non_existing_path.to_string())).await {
-            Err(DownloadError::NotFound) => {} // Should get NotFound for non existing keys
+            Err(DownloadError::NotFound{..}) => {} // Should get NotFound for non existing keys
             other => panic!("Should get a NotFound error when downloading non-existing storage files, but got: {other:?}"),
         }
         Ok(())

--- a/pageserver/src/storage_sync/index.rs
+++ b/pageserver/src/storage_sync/index.rs
@@ -233,8 +233,10 @@ impl RemoteTimeline {
         self.timeline_layers.extend(new_layers.into_iter());
     }
 
-    pub fn add_upload_failures(&mut self, upload_failures: impl IntoIterator<Item = PathBuf>) {
-        self.missing_layers.extend(upload_failures.into_iter());
+    pub fn add_missing_layers(&mut self, missing_layers: HashSet<PathBuf>) {
+        self.timeline_layers
+            .retain(|layer| !missing_layers.contains(layer));
+        self.missing_layers.extend(missing_layers.into_iter());
     }
 
     pub fn remove_layers(&mut self, layers_to_remove: &HashSet<PathBuf>) {


### PR DESCRIPTION
Fixes issues with https://console.stage.neon.tech/admin/projects/lucky-recipe-031952 cluster: some of its layers had been uploaded remotely and then stored into the corresponding index.json.

Then, something had removed those files from the remote storage:

```
❯ tree local/8e55ac1825979110b7674974e98e434b/timelines/40d4e857a3d01567afde1d4c8fcc9896
local/8e55ac1825979110b7674974e98e434b/timelines/40d4e857a3d01567afde1d4c8fcc9896
├── 000000000000000000000000000000000000-030000000000000000000000000000000002__0000000001696070-0000000004B35021
├── 000000000000000000000000000000000000-030000000000000000000000000000000002__0000000004B89388
├── 000000000000000000000000000000000000-030000000000000000000000000000000002__0000000004BD0B48
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BBA8C1-0000000004BBD921.___temp
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BBD921-0000000004BBF3B1.___temp
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BBF3B1-0000000004BC25B9.___temp
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BC25B9-0000000004BC7631.___temp
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BC7631-0000000004BC9529.___temp
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BC9529-0000000004BCB1D9.___temp
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCB1D9-0000000004BCBE51
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCBE51-0000000004BCDC91
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCDC91-0000000004BD0B49
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BD1BC1-0000000004BD3D21
├── 000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004B35021-0000000004B65BA9
├── 000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004B65BA9-0000000004B89389
├── 000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004B89389-0000000004BA6781
├── 000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004BA6781-0000000004BBA8C1
├── 000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004BBA8C1-0000000004BD1BC1
└── metadata
```

```
❯ tree remote/tenants/8e55ac1825979110b7674974e98e434b/timelines/40d4e857a3d01567afde1d4c8fcc9896
remote/tenants/8e55ac1825979110b7674974e98e434b/timelines/40d4e857a3d01567afde1d4c8fcc9896
├── 000000000000000000000000000000000000-030000000000000000000000000000000002__0000000004BD0B48
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCB1D9-0000000004BCBE51
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCBE51-0000000004BCDC91
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCDC91-0000000004BD0B49
├── 000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BD1BC1-0000000004BD3D21
├── 000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004BBA8C1-0000000004BD1BC1
└── index_part.json
```

```
❯ cat remote/tenants/8e55ac1825979110b7674974e98e434b/timelines/40d4e857a3d01567afde1d4c8fcc9896/index_part.json
{"timeline_layers":[
    "000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004BBA8C1-0000000004BD1BC1",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCDC91-0000000004BD0B49",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BC7631-0000000004BC9529",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BBF3B1-0000000004BC25B9",
    "000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004B35021-0000000004B65BA9",
    "000000000000000000000000000000000000-030000000000000000000000000000000002__0000000004B89388",
    "000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004B89389-0000000004BA6781",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BBA8C1-0000000004BBD921",
    "000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004BA6781-0000000004BBA8C1",
    "000000000000000000000000000000000000-030000000000000000000000000000000002__0000000004BD0B48",
    "000000000000000000000000000000000000-030000000000000000000000000000000002__0000000001696070-0000000004B35021",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BD1BC1-0000000004BD3D21",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BBD921-0000000004BBF3B1",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BC25B9-0000000004BC7631",
    "000000067F000032AC000040040000000000-030000000000000000000000000000000002__0000000004B65BA9-0000000004B89389",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCB1D9-0000000004BCBE51",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BCBE51-0000000004BCDC91",
    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000004BC9529-0000000004BCB1D9"],"missing_layers":[],"disk_consistent_lsn":"0/4BD3D20",
    "metadata_bytes":[93,229,35,187,0,54,0,4,0,0,0,0,4,189,61,32,1,0,0,0,0,4,189,60,248,0,0,0,0,0,0,0,0,0,0,0,0,0,1,105,96,112,0,0,0,0,1,105,96,112,0,0,0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}%
```

All our deletion operations update the index first, so I'm not sure what exactly happened and consider that it's a manual intervention that corrupted the remote storage.

Despite that corruption, we still should be functioning. Right now, I just add things to missing layers and log it, as we've been doing this for similar cases already.

It's not clear to me what should be the better way (maybe, determine missing file WAL ranges and query them from safekeepers?), but clear that it's not a simple task, and for now it's better for us to restore another staging project.