### PR TITLE
Don't run perf tests in parallel

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -149,6 +149,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         # neon-captest-new: Run pgbench in a freshly created project
         # neon-captest-reuse: Same, but reusing existing project


### PR DESCRIPTION
Trying to see if measurement noise comes from parallel runs.

Currently we run the tests once a day so there's enough time in a day to run all tests sequentially. When we increase test size we'll have to do parallel again. But that's fine, since I'm just trying to see if the measurement noise disappears. We can revert this.