### PR TITLE
Make it possible to build with old cargo version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,14 @@
+# 'named-profiles' feature was stabilized in cargo 1.57. This line makes the
+# build work with older cargo versions.
+#
+# We have this because as of this writing, the latest cargo Debian package
+# that's available is 1.56. (Confusingly, the Debian package version number
+# is 0.57, whereas 'cargo --version' says 1.56.)
+#
+# See https://tracker.debian.org/pkg/cargo for the current status of the
+# package. When that gets updated, we can remove this.
+cargo-features = ["named-profiles"]
+
 [workspace]
 members = [
     "compute_tools",


### PR DESCRIPTION
I'm using the Rust compiler and cargo versions from Debian packages, but the latest available cargo Debian package is quite old, version 1.57.  The 'named-profiles' features was not stabilized at that version yet, so ever since commit a463749f5, I've had to manually add this line to the Cargo.toml file to compile. I've been wishing that someone would update the cargo Debian package, but it doesn't seem to be happening any time soon.

This doesn't seem to bother anyone else but me, but it shouldn't hurt anyone else either. If there was a good reason, I could install a newer cargo version with 'rustup', but if all we need is this one line in Cargo.toml, I'd prefer to continue using the Debian packages.