### PR TITLE
remove redundant expect_tenant_to_download_timeline

### DIFF
--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -10,8 +10,8 @@ import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import (
     NeonEnvBuilder,
-    NeonPageserverHttpClient,
     RemoteStorageKind,
+    assert_no_in_progress_downloads_for_tenant,
     available_remote_storages,
     wait_for_last_record_lsn,
     wait_for_upload,
@@ -125,7 +125,7 @@ def test_remote_storage_backup_and_restore(
     wait_until(
         number_of_iterations=20,
         interval=1,
-        func=lambda: expect_tenant_to_download_timeline(client, tenant_id),
+        func=lambda: assert_no_in_progress_downloads_for_tenant(client, tenant_id),
     )
 
     detail = client.timeline_detail(tenant_id, timeline_id)
@@ -142,16 +142,3 @@ def test_remote_storage_backup_and_restore(
                 query_scalar(cur, f"SELECT secret FROM t{checkpoint_number} WHERE id = {data_id};")
                 == f"{data_secret}|{checkpoint_number}"
             )
-
-
-def expect_tenant_to_download_timeline(
-    client: NeonPageserverHttpClient,
-    tenant_id: TenantId,
-):
-    for tenant in client.tenant_list():
-        if tenant["id"] == str(tenant_id):
-            assert not tenant.get(
-                "has_in_progress_downloads", True
-            ), f"Tenant {tenant_id} should have no downloads in progress"
-            return
-    assert False, f"Tenant {tenant_id} is missing on pageserver"


### PR DESCRIPTION
Not sure what happened there, probably some merge conflict. 

There were two copies of `expect_tenant_to_download_timeline`, one added by @SomeoneToIgnore and the second one by @hlinnaka. From the usage I believe existing `assert_no_in_progress_downloads_for_tenant` should work the same way

Let me know if I've missed something

