### PR TITLE
Do not fail pageserver startup because of one broken index_part

### DIFF
--- a/test_runner/fixtures/remote_storage.py
+++ b/test_runner/fixtures/remote_storage.py
@@ -1,0 +1,84 @@
+import json
+import time
+from typing import Any, Dict
+
+from fixtures.log_helper import log
+from fixtures.neon_fixtures import LocalFsStorage, NeonPageserverHttpClient
+from fixtures.types import Lsn, TenantId, TimelineId
+
+
+def assert_no_in_progress_downloads_for_tenant(
+    pageserver_http_client: NeonPageserverHttpClient,
+    tenant: TenantId,
+):
+    tenant_status = pageserver_http_client.tenant_status(tenant)
+    assert tenant_status["has_in_progress_downloads"] is False, tenant_status
+
+
+def remote_consistent_lsn(
+    pageserver_http_client: NeonPageserverHttpClient, tenant: TenantId, timeline: TimelineId
+) -> Lsn:
+    detail = pageserver_http_client.timeline_detail(tenant, timeline)
+
+    lsn_str = detail["remote_consistent_lsn"]
+    if lsn_str is None:
+        # No remote information at all. This happens right after creating
+        # a timeline, before any part of it has been uploaded to remote
+        # storage yet.
+        return Lsn(0)
+    assert isinstance(lsn_str, str)
+    return Lsn(lsn_str)
+
+
+def wait_for_upload(
+    pageserver_http_client: NeonPageserverHttpClient,
+    tenant: TenantId,
+    timeline: TimelineId,
+    lsn: Lsn,
+):
+    """waits for local timeline upload up to specified lsn"""
+    for i in range(20):
+        current_lsn = remote_consistent_lsn(pageserver_http_client, tenant, timeline)
+        if current_lsn >= lsn:
+            return
+        log.info(
+            "waiting for remote_consistent_lsn to reach {}, now {}, iteration {}".format(
+                lsn, current_lsn, i + 1
+            )
+        )
+        time.sleep(1)
+    raise Exception(
+        "timed out while waiting for remote_consistent_lsn to reach {}, was {}".format(
+            lsn, current_lsn
+        )
+    )
+
+
+def read_local_fs_index_part(env, tenant_id: TenantId, timeline_id: TimelineId):
+    """
+    Return json.load parsed index_part.json of tenant and timeline from LOCAL_FS
+    """
+    timeline_path = local_fs_index_part_path(env, tenant_id, timeline_id)
+    return json.loads(timeline_path.read_text())
+
+
+def write_local_fs_index_part(
+    env, tenant_id: TenantId, timeline_id: TimelineId, index_part: Dict[str, Any]
+):
+    timeline_path = local_fs_index_part_path(env, tenant_id, timeline_id)
+    timeline_path.write_text(json.dumps(index_part))
+
+
+def local_fs_index_part_path(env, tenant_id: TenantId, timeline_id: TimelineId):
+    """
+    Return path to the LOCAL_FS index_part.json of the tenant and timeline.
+    """
+    assert isinstance(env.remote_storage, LocalFsStorage)
+    return (
+        env.remote_storage.root
+        / "tenants"
+        / str(tenant_id)
+        / "timelines"
+        / str(timeline_id)
+        / "index_part.json"
+    )

--- a/test_runner/regress/test_import.py
+++ b/test_runner/regress/test_import.py
@@ -15,8 +15,8 @@ from fixtures.neon_fixtures import (
     Postgres,
     pg_distrib_dir,
     wait_for_last_record_lsn,
-    wait_for_upload,
 )
+from fixtures.remote_storage import wait_for_upload
 from fixtures.types import Lsn, TenantId, TimelineId
 from fixtures.utils import subprocess_capture
 

--- a/test_runner/regress/test_tenant_relocation.py
+++ b/test_runner/regress/test_tenant_relocation.py
@@ -15,14 +15,13 @@ from fixtures.neon_fixtures import (
     NeonPageserverHttpClient,
     PortDistributor,
     Postgres,
-    assert_no_in_progress_downloads_for_tenant,
     base_dir,
     neon_binpath,
     pg_distrib_dir,
     wait_for_last_record_lsn,
-    wait_for_upload,
     wait_until,
 )
+from fixtures.remote_storage import assert_no_in_progress_downloads_for_tenant, wait_for_upload
 from fixtures.types import Lsn, TenantId, TimelineId
 from fixtures.utils import query_scalar, subprocess_capture
 

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -31,8 +31,8 @@ from fixtures.neon_fixtures import (
     available_remote_storages,
     neon_binpath,
     wait_for_last_record_lsn,
-    wait_for_upload,
 )
+from fixtures.remote_storage import wait_for_upload
 from fixtures.types import Lsn, TenantId, TimelineId
 from fixtures.utils import get_dir_size, query_scalar
 


### PR DESCRIPTION
This was one of the issues during production outage. This patch turns `?` to match around error and an error message.

On the other side this approach allows for other bad thing to happen. Error does not get propagated to timeline registration code which leads to incorrect registration of broken timeline. Which is bad since initial sync for such timeline is skipped.

This part is reworked in on-demand patch so I think main contribution is the test, not the fix itself.