### PR TITLE
Fix profiling check fixture

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -159,7 +159,7 @@ def profiling_supported():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    return "profiling:true" in res.stdout
+    return "profiling" in res.stdout
 
 
 def shareable_scope(fixture_name, config) -> Literal["session", "function"]:


### PR DESCRIPTION
We changed how we show whether profiling was enabled but didn't update this test. So we've been skipping the profiling test even when pageserver is compiled with the profiling feature.