### PR TITLE
Fix test feature detection

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1665,11 +1665,11 @@ class NeonPageserver(PgProtocol):
         self.stop(immediate=True)
 
     def is_testing_enabled_or_skip(self):
-        if "testing:true" not in self.version:
+        if '"testing"' not in self.version:
             pytest.skip("pageserver was built without 'testing' feature")
 
     def is_profiling_enabled_or_skip(self):
-        if "profiling:true" not in self.version:
+        if '"profiling"' not in self.version:
             pytest.skip("pageserver was built without 'profiling' feature")
 
     def http_client(self, auth_token: Optional[str] = None) -> NeonPageserverHttpClient:


### PR DESCRIPTION
Follow-up of https://github.com/neondatabase/neon/pull/2636 and https://github.com/neondatabase/neon/pull/2654 , fixing the test detection feature.

Pageserver currently outputs features as
```
/target/debug/pageserver --version
Neon page server git:7734929a8202c8cc41596a861ffbe0b51b5f3cb9 failpoints: true, features: ["testing", "profiling"]
```