### PR TITLE
Use dashmap in page cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2154,7 @@ dependencies = [
  "criterion",
  "crossbeam-utils",
  "daemonize",
+ "dashmap",
  "etcd_broker",
  "fail",
  "futures",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -67,6 +67,7 @@ remote_storage = { path = "../libs/remote_storage" }
 workspace_hack = { version = "0.1", path = "../workspace_hack" }
 close_fds = "0.3.2"
 walkdir = "2.3.2"
+dashmap = "5.4.0"
 
 [dev-dependencies]
 criterion = "0.4"


### PR DESCRIPTION
The cross-tenant page cache locks show up at 8-12% on some single-tenant tests. Removing them doesn't make these tests run any faster, but I suspect the number is higher on multi-tenant tests. Would be good to add controlled concurrent tests (10 pgbench runs at exactly the same time), but until then it's easier to fix the problem than to monitor it.

Before merging, I need to go over the crate docs and make sure I'm using it properly. There were some vague warnings about locking and deadlocks https://docs.rs/dashmap/latest/dashmap/struct.DashMap.html