### PR TITLE
try to toggle background activity without a race condition

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -201,3 +201,13 @@ pub struct FailpointConfig {
 pub struct TimelineGcRequest {
     pub gc_horizon: Option<u64>,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TenantSetBackgroundActivityRequest {
+    pub run_backround_jobs: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TenantSetBackgroundActivityResponse {
+    pub msg: String,
+}


### PR DESCRIPTION
Tried to avoid another lock around state change (watch has RWLock inside), but it seems that its still possible to have a race there, though in the opposite direction (we can shutdown what was a racy start)

Invoking `task_mgr::shutdown_tasks` directly in `set_state` is problematic, since `set_state` is synchronous and shutdown_tasks is asynchronous. Tried to go this way and stopped when in some place RWLockGuard started to be held across await points. Maybe worth it to try untying it further

submitting as WIP, still need to test it