### PR TITLE
Nightly Benchmarks: fix workflow

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -74,6 +74,7 @@ runs:
       run: ./scripts/pysync
 
     - name: Download compatibility snapshot for Postgres 14
+      if: inputs.build_type != 'remote'
       uses: ./.github/actions/download
       with:
         name: compatibility-snapshot-${{ inputs.build_type }}-pg14


### PR DESCRIPTION
We don't produce a compatibility snapshot for remote runs, so we don't have it.
This PR fixes https://github.com/neondatabase/neon/actions/runs/3334302969/jobs/5517116241