### PR TITLE
fix: path in scripts/docker-compose_test.sh missed '-'

### DIFF
--- a/scripts/docker-compose_test.sh
+++ b/scripts/docker-compose_test.sh
@@ -6,7 +6,7 @@ set -eux -o pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 COMPOSE_FILE=$SCRIPT_DIR/../docker-compose/docker-compose.yml
 
-COMPUTE_CONTAINER_NAME=dockercompose_compute_1
+COMPUTE_CONTAINER_NAME=docker-compose_compute_1
 SQL="CREATE TABLE t(key int primary key, value text); insert into t values(1,1); select * from t;"
 PSQL_OPTION="-h localhost -U cloud_admin -p 55433 -c '$SQL' postgres"
 


### PR DESCRIPTION
AWESOME with serverless postgres! 

When taking a look at https://github.com/neondatabase/neon/issues/2697 and playing around with neon to check it out I realised that the path in  docker-compose_test.sh where wrong. 