### PR TITLE
Nightly Benchmarks: increase timeout for perf tests

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -111,7 +111,7 @@ jobs:
         mkdir -p perf-report-staging
         # Set --sparse-ordering option of pytest-order plugin to ensure tests are running in order of appears in the file,
         # it's important for test_perf_pgbench.py::test_pgbench_remote_* tests
-        ./scripts/pytest test_runner/performance/ -v -m "remote_cluster" --sparse-ordering --out-dir perf-report-staging --timeout 5400
+        ./scripts/pytest test_runner/performance/ -v -m "remote_cluster" --sparse-ordering --out-dir perf-report-staging --timeout 7200
 
     - name: Submit result
       env:


### PR DESCRIPTION
Suddenly `test_hot_page[remote].write` and `test_hot_table[remote].write` started to take ~ 115 minutes (instead of 75 minutes), which caused our `bench` job to fail. This PR increases a timeout to let these tests pass and collect results.

We have a discussion on internal slack: https://neondb.slack.com/archives/C033RQ5SPDH/p1667226785865769 (I will create a new issue, if we won't figure it out fast)