### PR TITLE
do not nest wal_connection_manager span inside parent one

### DIFF
--- a/pageserver/src/walreceiver/connection_manager.rs
+++ b/pageserver/src/walreceiver/connection_manager.rs
@@ -93,7 +93,7 @@ pub fn spawn_connection_manager_task(
             }
         }
         .instrument(
-            info_span!("wal_connection_manager", tenant = %tenant_id, timeline = %timeline_id),
+            info_span!(parent: None, "wal_connection_manager", tenant = %tenant_id, timeline = %timeline_id),
         ),
     );
 }


### PR DESCRIPTION
It helps with log readability. Currently walreceiver_connection_manager span can be nested inside tenant_create span for example, which causes duplication of all the variables in those lines which is confusing (e g disconnect message with a tenant_create span in it)