### PR TITLE
remove wrong is_active filter for timelines in compaction/gc

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -523,7 +523,6 @@ impl Tenant {
         let timelines = self.timelines.lock().unwrap();
         let timelines_to_compact = timelines
             .iter()
-            .filter(|(_, timeline)| timeline.is_active())
             .map(|(timeline_id, timeline)| (*timeline_id, timeline.clone()))
             .collect::<Vec<_>>();
         drop(timelines);
@@ -995,7 +994,6 @@ impl Tenant {
 
             timelines
                 .iter()
-                .filter(|(_, timeline)| timeline.is_active())
                 .map(|(timeline_id, timeline_entry)| {
                     // This is unresolved question for now, how to do gc in presence of remote timelines
                     // especially when this is combined with branching.


### PR DESCRIPTION
Gc needs to know about all branch points, not only ones for timelines that are active at the moment of gc. If timeline is inactive then we wont know about branch point. In this case gc can delete data that is needed by child timeline.

For compaction it is less severe. Delaying compaction can cause an effect on performance. So it is still better to run it. There is a logic to exit it quickly if there is nothing to compact

Initially referenced [here](https://github.com/neondatabase/neon/pull/2710#discussion_r1007187510)

Would be good to create a test for it. Probably worth merging a fix right away and follow up with the test