### PR TITLE
pageserver: make wal_source_connstring: String a separate type

### DIFF
--- a/pageserver/src/connection_string.rs
+++ b/pageserver/src/connection_string.rs
@@ -1,0 +1,19 @@
+use std::fmt::{Debug, Formatter};
+
+/// Contains two versions of a Postgres connection string: one without secrets (can be logged safely),
+/// one with secrets (e.g. JWT token) which is only used for connection.
+///
+/// URLs look much worse in logs because we use urlencoded query parameters extensively,
+/// e.g. `?options=-c%20timelineid%3D12345678` instead of `options='-c timelineid=12345678'`.
+/// We rarely  "build" connection strings on the fly, so we don't need much structure either.
+#[derive(Clone)]
+pub struct ConnectionString {
+    pub no_secrets: String,
+    pub with_secrets: String,
+}
+
+impl Debug for ConnectionString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.no_secrets.fmt(f)
+    }
+}

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -91,7 +91,7 @@ async fn build_timeline_info(
         let guard = timeline.last_received_wal.lock().unwrap();
         if let Some(info) = guard.as_ref() {
             (
-                Some(info.wal_source_connstr.clone()),
+                Some(info.wal_source_connstr.no_secrets.clone()), // Password is hidden, but it's for statistics only.
                 Some(info.last_received_msg_lsn),
                 Some(info.last_received_msg_ts),
             )

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod basebackup;
 pub mod config;
+mod connection_string;
 pub mod http;
 pub mod import_datadir;
 pub mod keyspace;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -48,6 +48,7 @@ use utils::{
     simple_rcu::{Rcu, RcuReadGuard},
 };
 
+use crate::connection_string::ConnectionString;
 use crate::repository::GcResult;
 use crate::repository::{Key, Value};
 use crate::task_mgr;
@@ -288,7 +289,7 @@ impl LogicalSize {
 }
 
 pub struct WalReceiverInfo {
-    pub wal_source_connstr: String,
+    pub wal_source_connstr: ConnectionString,
     pub last_received_msg_lsn: Lsn,
     pub last_received_msg_ts: u128,
 }


### PR DESCRIPTION
* Now it is `wal_source: tokio_postgres::Config`.
* In the future the connection string will include password, which should not be dumped into logs. Using a structured type allows such customization: `tokio_postgres::Config` does not implement `Display`, and its `Debug` implementation hides the password.
* Performance hits are not measured, but we rarely manipulate configs.

Kind of continuing #2724 