### PR TITLE
test_backward_compatibility: assign random port to compute

### DIFF
--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -177,7 +177,7 @@ def test_backward_compatibility(
         cli.raw_cli(["start"])
         request.addfinalizer(lambda: cli.raw_cli(["stop"]))
 
-        result = cli.pg_start("main")
+        result = cli.pg_start("main", port=port_distributor.get_port())
         request.addfinalizer(lambda: cli.pg_stop("main"))
     except Exception:
         breaking_changes_allowed = (


### PR DESCRIPTION
This should fix the flakiness caused by reusing the same default port like [this](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-2714/debug/3377962108/index.html#categories/ae7dbf95e697b5018adebe38a0bbdc1d/aef399bf2ca8418e/).