### PR TITLE
Impl serialize for pagestream FeMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,7 @@ name = "pageserver_api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "byteorder",
  "bytes",
  "const_format",
  "postgres_ffi",

--- a/libs/pageserver_api/Cargo.toml
+++ b/libs/pageserver_api/Cargo.toml
@@ -9,6 +9,7 @@ serde_with = "2.0"
 const_format = "0.2.21"
 anyhow = { version = "1.0", features = ["backtrace"] }
 bytes = "1.0.1"
+byteorder = "1.4.3"
 
 utils = { path = "../utils" }
 postgres_ffi = { path = "../postgres_ffi" }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -10,6 +10,7 @@
 //
 
 use anyhow::{bail, ensure, Context, Result};
+use bytes::Buf;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use pageserver_api::models::{
@@ -299,7 +300,7 @@ impl PageServerHandler {
 
             trace!("query: {copy_data_bytes:?}");
 
-            let neon_fe_msg = PagestreamFeMessage::parse(copy_data_bytes)?;
+            let neon_fe_msg = PagestreamFeMessage::parse(&mut copy_data_bytes.reader())?;
 
             let response = match neon_fe_msg {
                 PagestreamFeMessage::Exists(req) => {


### PR DESCRIPTION
Also generalize `parse` to work with `Read`, so that we can also parse a list of consecutive messages without knowing lengths up front.

Ideally we'd use BeSer, but the API isn't exactly what's needed so it's not trivial.