### PR TITLE
export_import_between_pageserver: remove add_missing_rels

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -205,7 +205,7 @@ fn start_pageserver(conf: &'static PageServerConf) -> anyhow::Result<()> {
             new_lock_contents,
             file,
         } => {
-            info!("Created lock file at {lock_file_path:?} with contenst {new_lock_contents}");
+            info!("Created lock file at {lock_file_path:?} with contents {new_lock_contents}");
             file
         }
         lock_file::LockCreationResult::AlreadyLocked {

--- a/safekeeper/src/bin/safekeeper.rs
+++ b/safekeeper/src/bin/safekeeper.rs
@@ -147,7 +147,7 @@ fn start_safekeeper(mut conf: SafeKeeperConf, given_id: Option<NodeId>, init: bo
             new_lock_contents,
             file,
         } => {
-            info!("Created lock file at {lock_file_path:?} with contenst {new_lock_contents}");
+            info!("Created lock file at {lock_file_path:?} with contents {new_lock_contents}");
             file
         }
         lock_file::LockCreationResult::AlreadyLocked {


### PR DESCRIPTION
Following https://github.com/neondatabase/neon/pull/2743#pullrequestreview-1165654659, it seemed feasible to clean up the `scripts/export_import_between_pageservers.py`. Removes the `add_missing_rels` and all that follows. Might be a good win for test running perf, if these old pageservers no longer exist anywhere.

There is still a verification in tests that all relations are now accessible. 