### PR TITLE
test_runner: replace global variables with fixtures

### DIFF
--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -15,12 +15,13 @@ from psycopg2.extensions import cursor
 Fn = TypeVar("Fn", bound=Callable[..., Any])
 
 
-def get_self_dir() -> str:
+def get_self_dir() -> Path:
     """Get the path to the directory where this script lives."""
-    return os.path.dirname(os.path.abspath(__file__))
+    # return os.path.dirname(os.path.abspath(__file__))
+    return Path(__file__).resolve().parent
 
 
-def subprocess_capture(capture_dir: str, cmd: List[str], **kwargs: Any) -> str:
+def subprocess_capture(capture_dir: Path, cmd: List[str], **kwargs: Any) -> str:
     """Run a process and capture its output
 
     Output will go to files named "cmd_NNN.stdout" and "cmd_NNN.stderr"

--- a/test_runner/pg_clients/test_pg_clients.py
+++ b/test_runner/pg_clients/test_pg_clients.py
@@ -46,9 +46,9 @@ def test_pg_clients(test_output_dir: Path, remote_pg: RemotePostgres, client: st
         raise RuntimeError("docker is required for running this test")
 
     build_cmd = [docker_bin, "build", "--tag", image_tag, f"{Path(__file__).parent / client}"]
-    subprocess_capture(str(test_output_dir), build_cmd, check=True)
+    subprocess_capture(test_output_dir, build_cmd, check=True)
 
     run_cmd = [docker_bin, "run", "--rm", "--env-file", env_file, image_tag]
-    basepath = subprocess_capture(str(test_output_dir), run_cmd, check=True)
+    basepath = subprocess_capture(test_output_dir, run_cmd, check=True)
 
     assert Path(f"{basepath}.stdout").read_text().strip() == "1"

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -80,7 +80,12 @@ class PortReplacer(object):
 
 @pytest.mark.order(after="test_prepare_snapshot")
 def test_backward_compatibility(
-    pg_bin: PgBin, port_distributor: PortDistributor, test_output_dir: Path, request: FixtureRequest
+    pg_bin: PgBin,
+    port_distributor: PortDistributor,
+    test_output_dir: Path,
+    request: FixtureRequest,
+    neon_binpath: Path,
+    pg_distrib_dir: Path,
 ):
     compatibility_snapshot_dir = Path(
         os.environ.get("COMPATIBILITY_SNAPSHOT_DIR", DEFAILT_LOCAL_SNAPSHOT_DIR)
@@ -170,6 +175,8 @@ def test_backward_compatibility(
     config.repo_dir = repo_dir
     config.pg_version = "14"  # Note: `pg_dumpall` (from pg_bin) version is set by DEFAULT_PG_VERSION_DEFAULT and can be overriden by DEFAULT_PG_VERSION env var
     config.initial_tenant = snapshot_config["default_tenant_id"]
+    config.neon_binpath = neon_binpath
+    config.pg_distrib_dir = pg_distrib_dir
 
     # Check that we can start the project
     cli = NeonCli(config)

--- a/test_runner/regress/test_pageserver_api.py
+++ b/test_runner/regress/test_pageserver_api.py
@@ -1,5 +1,5 @@
-import pathlib
 import subprocess
+from pathlib import Path
 from typing import Optional
 
 from fixtures.neon_fixtures import (
@@ -7,18 +7,18 @@ from fixtures.neon_fixtures import (
     NeonEnv,
     NeonEnvBuilder,
     PageserverHttpClient,
-    neon_binpath,
-    pg_distrib_dir,
 )
 from fixtures.types import Lsn, TenantId, TimelineId
 from fixtures.utils import wait_until
 
 
 # test that we cannot override node id after init
-def test_pageserver_init_node_id(neon_simple_env: NeonEnv):
+def test_pageserver_init_node_id(
+    neon_simple_env: NeonEnv, neon_binpath: Path, pg_distrib_dir: Path
+):
     repo_dir = neon_simple_env.repo_dir
     pageserver_config = repo_dir / "pageserver.toml"
-    pageserver_bin = pathlib.Path(neon_binpath) / "pageserver"
+    pageserver_bin = neon_binpath / "pageserver"
 
     def run_pageserver(args):
         return subprocess.run(

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -1,11 +1,10 @@
 #
 # This file runs pg_regress-based tests.
 #
-import os
 from pathlib import Path
 
 import pytest
-from fixtures.neon_fixtures import NeonEnv, base_dir, check_restored_datadir_content, pg_distrib_dir
+from fixtures.neon_fixtures import NeonEnv, check_restored_datadir_content
 
 
 # Run the main PostgreSQL regression tests, in src/test/regress.
@@ -13,7 +12,14 @@ from fixtures.neon_fixtures import NeonEnv, base_dir, check_restored_datadir_con
 # This runs for a long time, especially in debug mode, so use a larger-than-default
 # timeout.
 @pytest.mark.timeout(1800)
-def test_pg_regress(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, capsys):
+def test_pg_regress(
+    neon_simple_env: NeonEnv,
+    test_output_dir: Path,
+    pg_bin,
+    capsys,
+    base_dir: Path,
+    pg_distrib_dir: Path,
+):
     env = neon_simple_env
 
     env.neon_cli.create_branch("test_pg_regress", "empty")
@@ -26,20 +32,20 @@ def test_pg_regress(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, cap
     (runpath / "testtablespace").mkdir(parents=True)
 
     # Compute all the file locations that pg_regress will need.
-    build_path = os.path.join(pg_distrib_dir, "build/v{}/src/test/regress").format(env.pg_version)
-    src_path = os.path.join(base_dir, "vendor/postgres-v{}/src/test/regress").format(env.pg_version)
-    bindir = os.path.join(pg_distrib_dir, "v{}".format(env.pg_version), "bin")
-    schedule = os.path.join(src_path, "parallel_schedule")
-    pg_regress = os.path.join(build_path, "pg_regress")
+    build_path = pg_distrib_dir / f"build/v{env.pg_version}/src/test/regress"
+    src_path = base_dir / f"vendor/postgres-v{env.pg_version}/src/test/regress"
+    bindir = pg_distrib_dir / f"v{env.pg_version}/bin"
+    schedule = src_path / "parallel_schedule"
+    pg_regress = build_path / "pg_regress"
 
     pg_regress_command = [
-        pg_regress,
+        str(pg_regress),
         '--bindir=""',
         "--use-existing",
-        "--bindir={}".format(bindir),
-        "--dlpath={}".format(build_path),
-        "--schedule={}".format(schedule),
-        "--inputdir={}".format(src_path),
+        f"--bindir={bindir}",
+        f"--dlpath={build_path}",
+        f"--schedule={schedule}",
+        f"--inputdir={src_path}",
     ]
 
     env_vars = {
@@ -66,7 +72,14 @@ def test_pg_regress(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, cap
 # This runs for a long time, especially in debug mode, so use a larger-than-default
 # timeout.
 @pytest.mark.timeout(1800)
-def test_isolation(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, capsys):
+def test_isolation(
+    neon_simple_env: NeonEnv,
+    test_output_dir: Path,
+    pg_bin,
+    capsys,
+    base_dir: Path,
+    pg_distrib_dir: Path,
+):
     env = neon_simple_env
 
     env.neon_cli.create_branch("test_isolation", "empty")
@@ -80,21 +93,19 @@ def test_isolation(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, caps
     (runpath / "testtablespace").mkdir(parents=True)
 
     # Compute all the file locations that pg_isolation_regress will need.
-    build_path = os.path.join(pg_distrib_dir, "build/v{}/src/test/isolation".format(env.pg_version))
-    src_path = os.path.join(
-        base_dir, "vendor/postgres-v{}/src/test/isolation".format(env.pg_version)
-    )
-    bindir = os.path.join(pg_distrib_dir, "v{}".format(env.pg_version), "bin")
-    schedule = os.path.join(src_path, "isolation_schedule")
-    pg_isolation_regress = os.path.join(build_path, "pg_isolation_regress")
+    build_path = pg_distrib_dir / f"build/v{env.pg_version}/src/test/isolation"
+    src_path = base_dir / f"vendor/postgres-v{env.pg_version}/src/test/isolation"
+    bindir = pg_distrib_dir / f"v{env.pg_version}/bin"
+    schedule = src_path / "isolation_schedule"
+    pg_isolation_regress = build_path / "pg_isolation_regress"
 
     pg_isolation_regress_command = [
-        pg_isolation_regress,
+        str(pg_isolation_regress),
         "--use-existing",
-        "--bindir={}".format(bindir),
-        "--dlpath={}".format(build_path),
-        "--inputdir={}".format(src_path),
-        "--schedule={}".format(schedule),
+        f"--bindir={bindir}",
+        f"--dlpath={build_path}",
+        f"--inputdir={src_path}",
+        f"--schedule={schedule}",
     ]
 
     env_vars = {
@@ -112,7 +123,14 @@ def test_isolation(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, caps
 
 # Run extra Neon-specific pg_regress-based tests. The tests and their
 # schedule file are in the sql_regress/ directory.
-def test_sql_regress(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, capsys):
+def test_sql_regress(
+    neon_simple_env: NeonEnv,
+    test_output_dir: Path,
+    pg_bin,
+    capsys,
+    base_dir: Path,
+    pg_distrib_dir: Path,
+):
     env = neon_simple_env
 
     env.neon_cli.create_branch("test_sql_regress", "empty")
@@ -126,19 +144,19 @@ def test_sql_regress(neon_simple_env: NeonEnv, test_output_dir: Path, pg_bin, ca
 
     # Compute all the file locations that pg_regress will need.
     # This test runs neon specific tests
-    build_path = os.path.join(pg_distrib_dir, "build/v{}/src/test/regress").format(env.pg_version)
-    src_path = os.path.join(base_dir, "test_runner/sql_regress")
-    bindir = os.path.join(pg_distrib_dir, "v{}".format(env.pg_version), "bin")
-    schedule = os.path.join(src_path, "parallel_schedule")
-    pg_regress = os.path.join(build_path, "pg_regress")
+    build_path = pg_distrib_dir / f"build/v{env.pg_version}/src/test/regress"
+    src_path = base_dir / "test_runner/sql_regress"
+    bindir = pg_distrib_dir / f"v{env.pg_version}/bin"
+    schedule = src_path / "parallel_schedule"
+    pg_regress = build_path / "pg_regress"
 
     pg_regress_command = [
-        pg_regress,
+        str(pg_regress),
         "--use-existing",
-        "--bindir={}".format(bindir),
-        "--dlpath={}".format(build_path),
-        "--schedule={}".format(schedule),
-        "--inputdir={}".format(src_path),
+        f"--bindir={bindir}",
+        f"--dlpath={build_path}",
+        f"--schedule={schedule}",
+        f"--inputdir={src_path}",
     ]
 
     env_vars = {

--- a/test_runner/regress/test_timeline_size.py
+++ b/test_runner/regress/test_timeline_size.py
@@ -338,6 +338,7 @@ def test_timeline_size_metrics(
     neon_simple_env: NeonEnv,
     test_output_dir: Path,
     port_distributor: PortDistributor,
+    pg_distrib_dir: Path,
     pg_version: str,
 ):
     env = neon_simple_env
@@ -382,7 +383,7 @@ def test_timeline_size_metrics(
     tl_logical_size_metric = int(matches.group(1))
 
     pgdatadir = test_output_dir / "pgdata-vanilla"
-    pg_bin = PgBin(test_output_dir, pg_version)
+    pg_bin = PgBin(test_output_dir, pg_distrib_dir, pg_version)
     port = port_distributor.get_port()
     with VanillaPostgres(pgdatadir, pg_bin, port) as vanilla_pg:
         vanilla_pg.configure([f"port={port}"])

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -30,7 +30,6 @@ from fixtures.neon_fixtures import (
     SafekeeperHttpClient,
     SafekeeperPort,
     available_remote_storages,
-    neon_binpath,
     wait_for_last_record_lsn,
     wait_for_upload,
 )
@@ -797,6 +796,7 @@ class SafekeeperEnv:
         repo_dir: Path,
         port_distributor: PortDistributor,
         pg_bin: PgBin,
+        neon_binpath: Path,
         num_safekeepers: int = 1,
     ):
         self.repo_dir = repo_dir
@@ -808,7 +808,7 @@ class SafekeeperEnv:
         )
         self.pg_bin = pg_bin
         self.num_safekeepers = num_safekeepers
-        self.bin_safekeeper = os.path.join(str(neon_binpath), "safekeeper")
+        self.bin_safekeeper = str(neon_binpath / "safekeeper")
         self.safekeepers: Optional[List[subprocess.CompletedProcess[Any]]] = None
         self.postgres: Optional[ProposerPostgres] = None
         self.tenant_id: Optional[TenantId] = None
@@ -911,7 +911,10 @@ class SafekeeperEnv:
 
 
 def test_safekeeper_without_pageserver(
-    test_output_dir: str, port_distributor: PortDistributor, pg_bin: PgBin
+    test_output_dir: str,
+    port_distributor: PortDistributor,
+    pg_bin: PgBin,
+    neon_binpath: Path,
 ):
     # Create the environment in the test-specific output dir
     repo_dir = Path(os.path.join(test_output_dir, "repo"))
@@ -920,6 +923,7 @@ def test_safekeeper_without_pageserver(
         repo_dir,
         port_distributor,
         pg_bin,
+        neon_binpath,
     )
 
     with env:


### PR DESCRIPTION
This PR replaces the following global variables in the test framework with fixtures to make tests more configurable. I mainly need this for the forward compatibility tests (draft in https://github.com/neondatabase/neon/pull/2766).

```
base_dir
neon_binpath 
pg_distrib_dir
top_output_dir
default_pg_version (this one got replaced with a fixture named pg_version)
```

Also, this PR adds more `Path` type where the code implies it.
