### PR TITLE
Fix test_compare_child_and_root_pgbench_perf to do a fair comparison

### DIFF
--- a/test_runner/performance/test_branching.py
+++ b/test_runner/performance/test_branching.py
@@ -4,6 +4,7 @@ from typing import List
 
 from fixtures.benchmark_fixture import PgBenchRunResult
 from fixtures.compare_fixtures import NeonCompare
+from fixtures.neon_fixtures import fork_at_current_lsn
 from performance.test_perf_pgbench import utc_now_timestamp
 
 # -----------------------------------------------------------------------
@@ -43,7 +44,8 @@ def test_compare_child_and_root_pgbench_perf(neon_compare: NeonCompare):
     pg_root = env.postgres.create_start("root")
     pg_bin.run_capture(["pgbench", "-i", pg_root.connstr(), "-s10"])
 
-    env.neon_cli.create_branch("child", "root")
+    fork_at_current_lsn(env, pg_root, "child", "root")
+
     pg_child = env.postgres.create_start("child")
 
     run_pgbench_on_branch("root", ["pgbench", "-c10", "-T10", pg_root.connstr()])


### PR DESCRIPTION
Prev
```

test_compare_child_and_root_pgbench_perf.root.number_of_clients: 10 
test_compare_child_and_root_pgbench_perf.root.number_of_threads: 1 
test_compare_child_and_root_pgbench_perf.root.number_of_transactions_actually_processed: 7251 
test_compare_child_and_root_pgbench_perf.root.latency_average: 13.756 ms
test_compare_child_and_root_pgbench_perf.root.tps: 726.9653 
test_compare_child_and_root_pgbench_perf.root.run_duration: 10.087 s
test_compare_child_and_root_pgbench_perf.root.run_start_timestamp: 1667759210 
test_compare_child_and_root_pgbench_perf.root.run_end_timestamp: 1667759221 
test_compare_child_and_root_pgbench_perf.root.scale: 10 
test_compare_child_and_root_pgbench_perf.child.number_of_clients: 10 
test_compare_child_and_root_pgbench_perf.child.number_of_threads: 1 
test_compare_child_and_root_pgbench_perf.child.number_of_transactions_actually_processed: 10 <---------
test_compare_child_and_root_pgbench_perf.child.latency_average: 14,035.954 ms <---------
test_compare_child_and_root_pgbench_perf.child.tps: 0.7125 <---------
test_compare_child_and_root_pgbench_perf.child.run_duration: 14.188 s
test_compare_child_and_root_pgbench_perf.child.run_start_timestamp: 1667759221 
test_compare_child_and_root_pgbench_perf.child.run_end_timestamp: 1667759235 
test_compare_child_and_root_pgbench_perf.child.scale: 10 
```

Now:
```
test_compare_child_and_root_pgbench_perf.root.number_of_clients: 10 
test_compare_child_and_root_pgbench_perf.root.number_of_threads: 1 
test_compare_child_and_root_pgbench_perf.root.number_of_transactions_actually_processed: 6115 
test_compare_child_and_root_pgbench_perf.root.latency_average: 16.320 ms
test_compare_child_and_root_pgbench_perf.root.tps: 612.7417 
test_compare_child_and_root_pgbench_perf.root.run_duration: 10.089 s
test_compare_child_and_root_pgbench_perf.root.run_start_timestamp: 1667762440 
test_compare_child_and_root_pgbench_perf.root.run_end_timestamp: 1667762450 
test_compare_child_and_root_pgbench_perf.root.scale: 10 
test_compare_child_and_root_pgbench_perf.child.number_of_clients: 10 
test_compare_child_and_root_pgbench_perf.child.number_of_threads: 1 
test_compare_child_and_root_pgbench_perf.child.number_of_transactions_actually_processed: 6382 <---------
test_compare_child_and_root_pgbench_perf.child.latency_average: 15.637 ms <---------
test_compare_child_and_root_pgbench_perf.child.tps: 639.5096 <---------
test_compare_child_and_root_pgbench_perf.child.run_duration: 10.115 s
test_compare_child_and_root_pgbench_perf.child.run_start_timestamp: 1667762450 
test_compare_child_and_root_pgbench_perf.child.run_end_timestamp: 1667762460 
test_compare_child_and_root_pgbench_perf.child.scale: 10 
```

So much noise in this test though...

Thanks!