### PR TITLE
walredo process management: handle every error on the kill() and drop path

### DIFF
--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -697,7 +697,7 @@ impl PostgresRedoProcess {
             ($file:ident) => {{
                 let res = set_nonblock($file.as_raw_fd());
                 if let Err(e) = &res {
-                    error!(error = %e, concat!("set_nonblock failed on ", stringify!($file)));
+                    error!(error = %e, file = stringify!($file), pid = child.id(), "set_nonblock failed");
                 }
                 res
             }};


### PR DESCRIPTION
If we're not calling kill() before dropping the PostgresRedoProcess, we currently leak it.
That's most likely the root cause for #2761.
This patch
1. adds an error log message for that case and
2. adds error handling for all errors on the kill() path. If we're a `testing` build, we panic. Otherwise, we log an error and leak the process.

The error handling changes (2) are necessary to conclusively state that the root cause for #2761 is indeed (1). If we didn't have them, the root cause could be missing error handling instead.

To make the log messages useful, I've added tracing::instrument attributes that log the tenant_id and PID. That helps mapping back the PID of `defunct` processes to pageserver log messages. Note that a defunct process's `/proc/$PID/` directory isn't very useful. We have left little more than its PID.

Once we have validated the root cause, we'll find a fix, but that's still an ongoing discussion.

refs https://github.com/neondatabase/neon/issues/2761