### PR TITLE
Fix neon.flush_output_after GUC.

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -42,7 +42,6 @@ PGconn	   *pageserver_conn = NULL;
 
 char	   *page_server_connstring_raw;
 
-int			n_unflushed_requests = 0;
 int			flush_every_n_requests = 8;
 
 static void pageserver_flush(void);
@@ -205,11 +204,6 @@ pageserver_send(NeonRequest * request)
 	}
 	pfree(req_buff.data);
 
-	n_unflushed_requests++;
-
-	if (flush_every_n_requests > 0 && n_unflushed_requests >= flush_every_n_requests)
-		pageserver_flush();
-
 	if (message_level_is_interesting(PageStoreTrace))
 	{
 		char	   *msg = nm_to_string((NeonMessage *) request);
@@ -274,7 +268,6 @@ pageserver_flush(void)
 		pageserver_disconnect();
 		neon_log(ERROR, "failed to flush page requests: %s", msg);
 	}
-	n_unflushed_requests = 0;
 }
 
 page_server_api api = {
@@ -436,7 +429,7 @@ pg_init_libpagestore(void)
 							NULL,
 							&flush_every_n_requests,
 							8, -1, INT_MAX,
-							PGC_SIGHUP,
+							PGC_USERSET,
 							0,	/* no flags required */
 							NULL, NULL, NULL);
 

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -150,6 +150,7 @@ extern void prefetch_on_ps_disconnect(void);
 extern page_server_api * page_server;
 
 extern char *page_server_connstring;
+extern int flush_every_n_requests;
 extern bool seqscan_prefetch_enabled;
 extern int seqscan_prefetch_distance;
 extern char *neon_timeline;


### PR DESCRIPTION
The neon.flush_output_after was not effective, at least not in a sequential scan, because neon_read_at_lsn() flushed the prefetch queue on every call anyway. Change neon_read_at_lsn() so that it only flushes the queue if the GetPage request that it needs to wait for hasn't alrady been flushed. To make that possible, move the tracking of unflushed requests into a new ring_flush variable, alongside the other ring buffer indexes.

While we're at it, mark neon.flush_output_after as PGC_USERSET, so that it can be changed per-session with "SET neon.flush_output_after = ...". Makes it easier to test different values.