### PR TITLE
Walredo channel

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1752,6 +1752,7 @@ pub mod harness {
             );
             // populate tenant with locally available timelines
             let mut timelines_to_load = HashMap::new();
+            let mut pg_version = 0u32;
             for timeline_dir_entry in fs::read_dir(self.conf.timelines_path(&self.tenant_id))
                 .expect("should be able to read timelines dir")
             {
@@ -1764,13 +1765,14 @@ pub mod harness {
                     .parse()?;
 
                 let timeline_metadata = load_metadata(self.conf, timeline_id, self.tenant_id)?;
+                pg_version = timeline_metadata.pg_version();
                 timelines_to_load.insert(timeline_id, timeline_metadata);
             }
             tenant
                 .walredo_mgrs
                 .lock()
                 .unwrap()
-                .insert(timeline.pg_version, Arc::new(TestRedoManager));
+                .insert(pg_version, Arc::new(TestRedoManager));
             tenant.init_attach_timelines(timelines_to_load)?;
             tenant.set_state(TenantState::Active {
                 background_jobs_running: false,

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -21,7 +21,6 @@ use crate::tenant::{
     ephemeral_file::is_ephemeral_file, metadata::TimelineMetadata, Tenant, TenantState,
 };
 use crate::tenant_config::TenantConfOpt;
-use crate::walredo::PostgresRedoManager;
 use crate::TEMP_FILE_SUFFIX;
 
 use utils::crashsafe::{self, path_with_suffix_extension};
@@ -154,7 +153,6 @@ pub fn attach_local_tenants(
                 let tenant = Arc::new(Tenant::new(
                     conf,
                     TenantConfOpt::default(),
-                    Arc::new(PostgresRedoManager::new(conf, tenant_id)),
                     tenant_id,
                     remote_index.clone(),
                     conf.remote_storage_config.is_some(),
@@ -384,12 +382,10 @@ pub fn create_tenant(
             Ok(None)
         }
         hash_map::Entry::Vacant(v) => {
-            let wal_redo_manager = Arc::new(PostgresRedoManager::new(conf, tenant_id));
             create_tenant_files(conf, tenant_conf, tenant_id)?;
             let tenant = Arc::new(Tenant::new(
                 conf,
                 tenant_conf,
-                wal_redo_manager,
                 tenant_id,
                 remote_index,
                 conf.remote_storage_config.is_some(),

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -623,7 +623,7 @@ impl PostgresRedoProcess {
                 // The message might not be split correctly into lines here. But this is
                 // good enough, the important thing is to get the message to the log.
                 if n > 0 {
-                    panic!(
+                    error!(
                         "wal-redo-postgres: {}",
                         String::from_utf8_lossy(&errbuf[0..n])
                     );

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -202,7 +202,7 @@ impl PostgresRedoManager {
     /// Create a new PostgresRedoManager.
     ///
     pub fn new(conf: &'static PageServerConf, tenant_id: TenantId) -> PostgresRedoManager {
-        #[allow(clippy::type_xscomplexity)]
+        #[allow(clippy::type_complexity)]
         let (tx, rx): (
             SyncSender<(ChannelId, Vec<u8>)>,
             Receiver<(ChannelId, Vec<u8>)>,

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -202,6 +202,7 @@ impl PostgresRedoManager {
     /// Create a new PostgresRedoManager.
     ///
     pub fn new(conf: &'static PageServerConf, tenant_id: TenantId) -> PostgresRedoManager {
+        #[allow(clippy::type_xscomplexity)]
         let (tx, rx): (
             SyncSender<(ChannelId, Vec<u8>)>,
             Receiver<(ChannelId, Vec<u8>)>,
@@ -620,7 +621,7 @@ struct PostgresRedoProcess {
 
 impl PostgresRedoProcess {
     #[instrument(skip_all,fields(tenant_id=%self.tenant_id))]
-    fn receive(&mut self, senders: &Vec<Sender<Bytes>>) -> Result<(), Error> {
+    fn receive(&mut self, senders: &[Sender<Bytes>]) -> Result<(), Error> {
         while self.n_buffered != 0 {
             let n = loop {
                 match nix::poll::poll(
@@ -684,7 +685,7 @@ impl PostgresRedoProcess {
         &mut self,
         id: ChannelId,
         data: Vec<u8>,
-        senders: &Vec<Sender<Bytes>>,
+        senders: &[Sender<Bytes>],
     ) -> Result<(), Error> {
         let mut written = 0usize;
         let data_len = data.len();

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -23,7 +23,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 use nix::poll::*;
 use serde::Serialize;
 use std::collections::VecDeque;
-use std::fs;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::io::{Error, ErrorKind};
@@ -582,7 +581,7 @@ impl<C: CommandExt> CloseFileDescriptors for C {
 ///
 struct PostgresRedoProcess {
     tenant_id: TenantId,
-    child: NoLeakChild,
+    _child: NoLeakChild,
     stdin: ChildStdin,
     stdout: ChildStdout,
     stderr: ChildStderr,
@@ -859,7 +858,7 @@ impl PostgresRedoProcess {
 
         Ok(PostgresRedoProcess {
             tenant_id,
-            child,
+            _child: child,
             stdin,
             stdout,
             stderr,


### PR DESCRIPTION
See #1339
Buffering walredo requests has critical impact on performance.
This PR tried to do it using Rst channels.
It allows to reduce Ketteq Q1 execution from 30 to 17 seconds.
Unfortunately average number of buffered requests with 6 parallel is only 2.5. 
10 seconds is time of Q1 execution without page reconstruction (with latest image layers).
So remaining 7 seconds  - is walredo time with 2.5 buffered requests.
Not sure if we can provide large level of bufferisation. Maximal number of buffered requests is 7 (6 parallel workers + master), 
so channels are really able to provide requests buffering. But average number is just 2.5
