### PR TITLE
Fix test_wal_backpressure tests

### DIFF
--- a/test_runner/performance/test_wal_backpressure.py
+++ b/test_runner/performance/test_wal_backpressure.py
@@ -216,7 +216,7 @@ def record_lsn_write_lag(env: PgCompare, run_cond: Callable[[], bool], pool_inte
             )
 
             res = cur.fetchone()
-            assert isinstance(res, list)
+            assert isinstance(res, tuple)
             lsn_write_lags.append(res[0])
 
             curr_received_lsn = Lsn(res[3])


### PR DESCRIPTION
Fix expected return type from `fetchone `:

```
AssertionError: assert False
 +  where False = isinstance((Decimal('56048'), '55 kB', '0/1CF52D8', '0/1CE77E8'), list)
```

Ref https://neon-github-public-dev.s3.amazonaws.com/reports/main/release/3436948720/index.html#categories/bdbf199525818fae7a8651db9eafe741