### PR TITLE
Omit dependencies' debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 # Besides, debug info should not affect the performance.
 debug = true
 
-# disable debug symbols for all packages except this one
+# disable debug symbols for all packages except this one to decrease binaries size
 [profile.release.package."*"]
 debug = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ members = [
 # Besides, debug info should not affect the performance.
 debug = true
 
+# disable debug symbols for all packages except this one
+[profile.release.package."*"]
+debug = false
+
 [profile.release-line-debug]
 inherits = "release"
 debug = 1 # true = 2 = all symbols, 1 = line only


### PR DESCRIPTION
Based on https://neondb.slack.com/archives/C0277TKAJCA/p1668079753506749

I did not measure build times properly, since run multiple compilations in parallel, but did not notice drastic compile time increases. CI could show more, presumably needs its cache repopulated first.

```
Old sizes (Linux):
383M    target/release/pageserver
4.4M    target/release/tenant_size_model
199M    target/release/neon_local
327M    target/release/safekeeper
331M    target/release/pageserver_binutils
81M     target/release/wal_craft
320M    target/release/draw_timeline_dir
113M    target/release/compute_ctl
204M    target/release/proxy
----
New sizes (Linux):
167M    target/release/pageserver
4.4M    target/release/tenant_size_model
52M     target/release/neon_local
120M    target/release/safekeeper
115M    target/release/pageserver_binutils
21M     target/release/wal_craft
113M    target/release/draw_timeline_dir
32M     target/release/compute_ctl
62M     target/release/proxy
```

```
Old sizes (Mac):
 25M    target/release/pageserver
523K    target/release/tenant_size_model
 13M    target/release/neon_local
 21M    target/release/safekeeper
2.3M    target/release/pageserver_binutils
5.8M    target/release/wal_craft
963K    target/release/draw_timeline_dir
8.9M    target/release/compute_ctl
 14M    target/release/proxy
----
New sizes (Mac):
 22M    target/release/pageserver
523K    target/release/tenant_size_model
9.6M    target/release/neon_local
 17M    target/release/safekeeper
1.9M    target/release/pageserver_binutils
4.5M    target/release/wal_craft
865K    target/release/draw_timeline_dir
7.1M    target/release/compute_ctl
 11M    target/release/proxy
```

Mac build difference could be explained by them having debug symbols split off by default in Cargo:
https://github.com/rust-lang/cargo/pull/9298
https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#splitting-debug-information

Debug symbols seems to be present still for the binaries with the changes:
```
objdump -h target/release/pageserver| rg debug
 16 .debug_gdb_scripts 00000022  0000000000d5a9e8  0000000000d5a9e8  00d5a9e8  2**0
 30 .debug_aranges 0008d9f0  0000000000000000  0000000000000000  01086a70  2**4
 31 .debug_pubnames 0143b5f6  0000000000000000  0000000000000000  01114460  2**0
 32 .debug_info   0231e549  0000000000000000  0000000000000000  0254fa56  2**0
 33 .debug_abbrev 000228e3  0000000000000000  0000000000000000  0486df9f  2**0
 34 .debug_line   005c5833  0000000000000000  0000000000000000  04890882  2**0
 35 .debug_frame  00000148  0000000000000000  0000000000000000  04e560b8  2**3
 36 .debug_str    01522729  0000000000000000  0000000000000000  04e56200  2**0
 37 .debug_loc    01864cbc  0000000000000000  0000000000000000  06378929  2**0
 38 .debug_pubtypes 01b79837  0000000000000000  0000000000000000  07bdd5e5  2**0
 39 .debug_ranges 00946b10  0000000000000000  0000000000000000  09756e1c  2**0
 40 .debug_macro  00002814  0000000000000000  0000000000000000  0a09d92c  2**0
```

