### PR TITLE
WIP: Nightly Benchmarks: Add 100 GB project

### DIFF
--- a/.github/actions/neon-project-create/action.yml
+++ b/.github/actions/neon-project-create/action.yml
@@ -11,6 +11,9 @@ inputs:
   region_id:
     desctiption: 'Region ID, if not set the project will be created in the default region'
     required: false
+  postgres_version:
+    desctiption: 'Postgres version; default is 15'
+    required: false
 outputs:
   dsn:
     description: 'Created Project DSN (for main database)'
@@ -41,11 +44,15 @@ runs:
             ;;
         esac
 
+        POSTGRES_VERSION=${POSTGRES_VERSION:-15}
+
         echo "api_host=${API_HOST}" >> $GITHUB_OUTPUT
         echo "region_id=${REGION_ID}" >> $GITHUB_OUTPUT
+        echo "postgres_version=${POSTGRES_VERSION}" >> $GITHUB_OUTPUT
       env:
         ENVIRONMENT: ${{ inputs.environment }}
         REGION_ID: ${{ inputs.region_id }}
+        POSTGRES_VERSION: ${{ inputs.postgres_version }}
 
     - name: Create Neon Project
       id: create-neon-project
@@ -61,6 +68,7 @@ runs:
           --data "{
             \"project\": {
               \"name\": \"Created by actions/neon-project-create; GITHUB_RUN_ID=${GITHUB_RUN_ID}\",
+              \"pg_version\": ${POSTGRES_VERSION},
               \"platform_id\": \"aws\",
               \"region_id\": \"${REGION_ID}\",
               \"settings\": { }
@@ -80,3 +88,4 @@ runs:
         API_KEY: ${{ inputs.api_key }}
         API_HOST: ${{ steps.parse-input.outputs.api_host }}
         REGION_ID: ${{ steps.parse-input.outputs.region_id }}
+        POSTGRES_VERSION: ${{ steps.parse-input.outputs.postgres_version }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -36,107 +36,107 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bench:
-    # this workflow runs on self hosteed runner
-    # it's environment is quite different from usual guthub runner
-    # probably the most important difference is that it doesn't start from clean workspace each time
-    # e g if you install system packages they are not cleaned up since you install them directly in host machine
-    # not a container or something
-    # See documentation for more info: https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners
-    runs-on: [self-hosted, zenith-benchmarker]
+  # bench:
+  #   # this workflow runs on self hosteed runner
+  #   # it's environment is quite different from usual guthub runner
+  #   # probably the most important difference is that it doesn't start from clean workspace each time
+  #   # e g if you install system packages they are not cleaned up since you install them directly in host machine
+  #   # not a container or something
+  #   # See documentation for more info: https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners
+  #   runs-on: [self-hosted, zenith-benchmarker]
 
-    env:
-      POSTGRES_DISTRIB_DIR: /usr/pgsql
-      DEFAULT_PG_VERSION: 14
+  #   env:
+  #     POSTGRES_DISTRIB_DIR: /usr/pgsql
+  #     DEFAULT_PG_VERSION: 14
 
-    steps:
-    - name: Checkout zenith repo
-      uses: actions/checkout@v3
+  #   steps:
+  #   - name: Checkout zenith repo
+  #     uses: actions/checkout@v3
 
-    # actions/setup-python@v2 is not working correctly on self-hosted runners
-    # see https://github.com/actions/setup-python/issues/162
-    # and probably https://github.com/actions/setup-python/issues/162#issuecomment-865387976 in particular
-    # so the simplest solution to me is to use already installed system python and spin virtualenvs for job runs.
-    # there is Python 3.7.10 already installed on the machine so use it to install poetry and then use poetry's virtuealenvs
-    - name: Install poetry & deps
-      run: |
-        python3 -m pip install --upgrade poetry wheel
-        # since pip/poetry caches are reused there shouldn't be any troubles with install every time
-        ./scripts/pysync
+  #   # actions/setup-python@v2 is not working correctly on self-hosted runners
+  #   # see https://github.com/actions/setup-python/issues/162
+  #   # and probably https://github.com/actions/setup-python/issues/162#issuecomment-865387976 in particular
+  #   # so the simplest solution to me is to use already installed system python and spin virtualenvs for job runs.
+  #   # there is Python 3.7.10 already installed on the machine so use it to install poetry and then use poetry's virtuealenvs
+  #   - name: Install poetry & deps
+  #     run: |
+  #       python3 -m pip install --upgrade poetry wheel
+  #       # since pip/poetry caches are reused there shouldn't be any troubles with install every time
+  #       ./scripts/pysync
 
-    - name: Show versions
-      run: |
-        echo Python
-        python3 --version
-        poetry run python3 --version
-        echo Poetry
-        poetry --version
-        echo Pgbench
-        ${POSTGRES_DISTRIB_DIR}/v${DEFAULT_PG_VERSION}/bin/pgbench --version
+  #   - name: Show versions
+  #     run: |
+  #       echo Python
+  #       python3 --version
+  #       poetry run python3 --version
+  #       echo Poetry
+  #       poetry --version
+  #       echo Pgbench
+  #       ${POSTGRES_DISTRIB_DIR}/v${DEFAULT_PG_VERSION}/bin/pgbench --version
 
-    - name: Create Neon Project
-      id: create-neon-project
-      uses: ./.github/actions/neon-project-create
-      with:
-        postgres_version: ${{ env.DEFAULT_PG_VERSION }}
-        environment: ${{ github.event.inputs.environment || 'staging' }}
-        api_key: ${{ ( github.event.inputs.environment || 'staging' ) == 'staging' && secrets.NEON_STAGING_API_KEY  || secrets.NEON_CAPTEST_API_KEY }}
+  #   - name: Create Neon Project
+  #     id: create-neon-project
+  #     uses: ./.github/actions/neon-project-create
+  #     with:
+  #       postgres_version: ${{ env.DEFAULT_PG_VERSION }}
+  #       environment: ${{ github.event.inputs.environment || 'staging' }}
+  #       api_key: ${{ ( github.event.inputs.environment || 'staging' ) == 'staging' && secrets.NEON_STAGING_API_KEY  || secrets.NEON_CAPTEST_API_KEY }}
 
-    - name: Run benchmark
-      # pgbench is installed system wide from official repo
-      # https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-7-x86_64/
-      # via
-      # sudo tee /etc/yum.repos.d/pgdg.repo<<EOF
-      # [pgdg13]
-      # name=PostgreSQL 13 for RHEL/CentOS 7 - x86_64
-      # baseurl=https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-7-x86_64/
-      # enabled=1
-      # gpgcheck=0
-      # EOF
-      # sudo yum makecache
-      # sudo yum install postgresql13-contrib
-      # actual binaries are located in /usr/pgsql-13/bin/
-      env:
-        # The pgbench test runs two tests of given duration against each scale.
-        # So the total runtime with these parameters is 2 * 2 * 300 = 1200, or 20 minutes.
-        # Plus time needed to initialize the test databases.
-        TEST_PG_BENCH_DURATIONS_MATRIX: "300"
-        TEST_PG_BENCH_SCALES_MATRIX: "10,100"
-        PLATFORM: "neon-staging"
-        BENCHMARK_CONNSTR: ${{ steps.create-neon-project.outputs.dsn }}
-        REMOTE_ENV: "1" # indicate to test harness that we do not have zenith binaries locally
-      run: |
-        # just to be sure that no data was cached on self hosted runner
-        # since it might generate duplicates when calling ingest_perf_test_result.py
-        rm -rf perf-report-staging
-        mkdir -p perf-report-staging
-        # Set --sparse-ordering option of pytest-order plugin to ensure tests are running in order of appears in the file,
-        # it's important for test_perf_pgbench.py::test_pgbench_remote_* tests
-        ./scripts/pytest test_runner/performance/ -v -m "remote_cluster" --sparse-ordering --out-dir perf-report-staging --timeout 5400
+  #   - name: Run benchmark
+  #     # pgbench is installed system wide from official repo
+  #     # https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-7-x86_64/
+  #     # via
+  #     # sudo tee /etc/yum.repos.d/pgdg.repo<<EOF
+  #     # [pgdg13]
+  #     # name=PostgreSQL 13 for RHEL/CentOS 7 - x86_64
+  #     # baseurl=https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-7-x86_64/
+  #     # enabled=1
+  #     # gpgcheck=0
+  #     # EOF
+  #     # sudo yum makecache
+  #     # sudo yum install postgresql13-contrib
+  #     # actual binaries are located in /usr/pgsql-13/bin/
+  #     env:
+  #       # The pgbench test runs two tests of given duration against each scale.
+  #       # So the total runtime with these parameters is 2 * 2 * 300 = 1200, or 20 minutes.
+  #       # Plus time needed to initialize the test databases.
+  #       TEST_PG_BENCH_DURATIONS_MATRIX: "300"
+  #       TEST_PG_BENCH_SCALES_MATRIX: "10,100"
+  #       PLATFORM: "neon-staging"
+  #       BENCHMARK_CONNSTR: ${{ steps.create-neon-project.outputs.dsn }}
+  #       REMOTE_ENV: "1" # indicate to test harness that we do not have zenith binaries locally
+  #     run: |
+  #       # just to be sure that no data was cached on self hosted runner
+  #       # since it might generate duplicates when calling ingest_perf_test_result.py
+  #       rm -rf perf-report-staging
+  #       mkdir -p perf-report-staging
+  #       # Set --sparse-ordering option of pytest-order plugin to ensure tests are running in order of appears in the file,
+  #       # it's important for test_perf_pgbench.py::test_pgbench_remote_* tests
+  #       ./scripts/pytest test_runner/performance/ -v -m "remote_cluster" --sparse-ordering --out-dir perf-report-staging --timeout 5400
 
-    - name: Submit result
-      env:
-        VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
-        PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
-      run: |
-        REPORT_FROM=$(realpath perf-report-staging) REPORT_TO=staging scripts/generate_and_push_perf_report.sh
+  #   - name: Submit result
+  #     env:
+  #       VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
+  #       PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
+  #     run: |
+  #       REPORT_FROM=$(realpath perf-report-staging) REPORT_TO=staging scripts/generate_and_push_perf_report.sh
 
-    - name: Delete Neon Project
-      if: ${{ always() }}
-      uses: ./.github/actions/neon-project-delete
-      with:
-        environment: staging
-        project_id: ${{ steps.create-neon-project.outputs.project_id }}
-        api_key: ${{ secrets.NEON_STAGING_API_KEY }}
+  #   - name: Delete Neon Project
+  #     if: ${{ always() }}
+  #     uses: ./.github/actions/neon-project-delete
+  #     with:
+  #       environment: staging
+  #       project_id: ${{ steps.create-neon-project.outputs.project_id }}
+  #       api_key: ${{ secrets.NEON_STAGING_API_KEY }}
 
-    - name: Post to a Slack channel
-      if: ${{ github.event.schedule && failure() }}
-      uses: slackapi/slack-github-action@v1
-      with:
-        channel-id: "C033QLM5P7D" # dev-staging-stream
-        slack-message: "Periodic perf testing: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  #   - name: Post to a Slack channel
+  #     if: ${{ github.event.schedule && failure() }}
+  #     uses: slackapi/slack-github-action@v1
+  #     with:
+  #       channel-id: "C033QLM5P7D" # dev-staging-stream
+  #       slack-message: "Periodic perf testing: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  #     env:
+  #       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   pgbench-compare:
     strategy:
@@ -145,15 +145,16 @@ jobs:
         # neon-captest-new: Run pgbench in a freshly created project
         # neon-captest-reuse: Same, but reusing existing project
         # neon-captest-prefetch: Same, with prefetching enabled (new project)
-        platform: [ neon-captest-new, neon-captest-reuse, neon-captest-prefetch ]
+        # platform: [ neon-captest-new, neon-captest-reuse, neon-captest-prefetch ]
+        platform: [ neon-captest-prefetch ]
         db_size: [ 10gb ]
         include:
           - platform: neon-captest-prefetch
             db_size: 100gb
-          - platform: neon-captest-prefetch
-            db_size: 50gb
-          - platform: rds-aurora
-            db_size: 50gb
+          # - platform: neon-captest-prefetch
+          #   db_size: 50gb
+          # - platform: rds-aurora
+          #   db_size: 50gb
 
     env:
       TEST_PG_BENCH_DURATIONS_MATRIX: "60m"

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -148,8 +148,8 @@ jobs:
         platform: [ neon-captest-new, neon-captest-reuse, neon-captest-prefetch ]
         db_size: [ 10gb ]
         include:
-          - platform: neon-captest-new
-            db_size: 50gb
+          - platform: neon-captest-prefetch
+            db_size: 100gb
           - platform: neon-captest-prefetch
             db_size: 50gb
           - platform: rds-aurora

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -78,6 +78,7 @@ jobs:
       id: create-neon-project
       uses: ./.github/actions/neon-project-create
       with:
+        postgres_version: ${{ env.DEFAULT_PG_VERSION }}
         environment: ${{ github.event.inputs.environment || 'staging' }}
         api_key: ${{ ( github.event.inputs.environment || 'staging' ) == 'staging' && secrets.NEON_STAGING_API_KEY  || secrets.NEON_CAPTEST_API_KEY }}
 
@@ -191,6 +192,7 @@ jobs:
       id: create-neon-project
       uses: ./.github/actions/neon-project-create
       with:
+        postgres_version: ${{ env.DEFAULT_PG_VERSION }}
         environment: ${{ github.event.inputs.environment || 'dev' }}
         api_key: ${{ ( github.event.inputs.environment || 'dev' ) == 'staging' && secrets.NEON_STAGING_API_KEY  || secrets.NEON_CAPTEST_API_KEY }}
 

--- a/.github/workflows/pg_clients.yml
+++ b/.github/workflows/pg_clients.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
 
     env:
+      DEFAULT_PG_VERSION: 14
       TEST_OUTPUT: /tmp/test_output
 
     steps:
@@ -53,6 +54,7 @@ jobs:
       with:
         environment: staging
         api_key: ${{ secrets.NEON_STAGING_API_KEY }}
+        postgres_version: ${{ env.DEFAULT_PG_VERSION }}
 
     - name: Run pytest
       env:
@@ -63,7 +65,7 @@ jobs:
       run: |
         # Test framework expects we have psql binary;
         # but since we don't really need it in this test, let's mock it
-        mkdir -p "$POSTGRES_DISTRIB_DIR/v14/bin" && touch "$POSTGRES_DISTRIB_DIR/v14/bin/psql";
+        mkdir -p "$POSTGRES_DISTRIB_DIR/v${DEFAULT_PG_VERSION}/bin" && touch "$POSTGRES_DISTRIB_DIR/v${DEFAULT_PG_VERSION}/bin/psql";
         ./scripts/pytest \
           --junitxml=$TEST_OUTPUT/junit.xml \
           --tb=short \


### PR DESCRIPTION
- Add 100 GB project to see if we can collect results on a daily basis
- Set Postgres version for projects created via API
- Remove `neon-captest-new` 50 GB project — it requires longer statement timeout, and anyway we collect a version with enabled prefetch

- TODO: Add RDS Aurora 100GB project