### PR TITLE
Silence test failure caused by race condition between GC and detach.

### DIFF
--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -21,6 +21,9 @@ def test_tenant_detach_smoke(neon_env_builder: NeonEnvBuilder):
     pageserver_http = env.pageserver.http_client()
 
     env.pageserver.allowed_errors.append(".*NotFound\\(Tenant .* not found in the local state")
+    # FIXME: we have a race condition between GC and detach. GC might fail with this
+    # error. Similar to https://github.com/neondatabase/neon/issues/2671
+    env.pageserver.allowed_errors.append(".*InternalServerError\\(No such file or directory.*")
 
     # first check for non existing tenant
     tenant_id = TenantId.generate()


### PR DESCRIPTION
Thanks to the race condition, GC sometimes fails with "no such file or directory" error, if the tenant is detached concurrently. That's a known issue, but it didn't cause test failures until we started to check for unexpected ERRORs in the log in commit 46d30bf054. We should fix the race condition, of course, but until we do, let's silence the failures.