### PR TITLE
PR for dkr/on-demand-split/per-tenant-remote-sync

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1865,7 +1865,7 @@ impl Tenant {
                 tenant_id,
                 new_timeline_id,
             )?;
-            remote_client.init_upload_queue_empty()?;
+            remote_client.init_upload_queue_for_empty_remote(&new_metadata)?;
             Some(remote_client)
         } else {
             None

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1865,7 +1865,7 @@ impl Tenant {
                 tenant_id,
                 new_timeline_id,
             )?;
-            remote_client.init_upload_queue_empty(&new_metadata)?;
+            remote_client.init_upload_queue_empty()?;
             Some(remote_client)
         } else {
             None

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1198,6 +1198,7 @@ impl Timeline {
         };
         let (local_only_filenames, up_to_date_metadata) = match index_part {
             Ok(index_part) => {
+                remote_client.init_upload_queue(&index_part)?;
                 let (local_only_filenames, up_to_date_metadata) = self
                     .download_missing(
                         &index_part,
@@ -1207,12 +1208,11 @@ impl Timeline {
                         first_save,
                     )
                     .await?;
-                remote_client.init_upload_queue(&index_part)?;
                 (local_only_filenames, up_to_date_metadata)
             }
             Err(DownloadError::NotFound) => {
                 info!("no index file was found on the remote");
-                remote_client.init_upload_queue_empty(&local_metadata)?;
+                remote_client.init_upload_queue_empty()?;
                 (local_filenames, local_metadata)
             }
             Err(e) => return Err(anyhow::anyhow!(e)),

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1211,8 +1211,8 @@ impl Timeline {
                 (local_only_filenames, up_to_date_metadata)
             }
             Err(DownloadError::NotFound) => {
-                info!("no index file was found on the remote");
-                remote_client.init_upload_queue_empty()?;
+                info!("no index file was found on the remote, assuming initial upload");
+                remote_client.init_upload_queue_for_empty_remote(&local_metadata)?;
                 (local_filenames, local_metadata)
             }
             Err(e) => return Err(anyhow::anyhow!(e)),


### PR DESCRIPTION
With these changes, ` test_pageserver_with_empty_tenants` passes