### PR TITLE
Use modern flex and bison in macOS compilations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 1. Install XCode and dependencies
 ```
 xcode-select --install
-brew install protobuf etcd openssl
+brew install protobuf etcd openssl flex bison
 ```
 
 2. [Install Rust](https://www.rust-lang.org/tools/install)


### PR DESCRIPTION
Interestingly, our macOS GH Actions run already has flex and bison installed:
https://github.com/neondatabase/neon/blob/24d3ed09524b156e6726853aaa14902c695bf039/.github/workflows/codestyle.yml#L55

Thanks to @hlinnaka for pointing to the right direction