### PR TITLE
Add codeowners section for /vendor/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,3 +8,4 @@
 /pgxn/ @neondatabase/compute
 /proxy/ @neondatabase/control-plane 
 /safekeeper/ @neondatabase/safekeepers
+/vendor/ @neondatabase/compute


### PR DESCRIPTION
After this, consent of @neondatabase/compute is required to update the vendored PostgreSQL versions.