### PR TITLE
Try to silence test_gc_cutoff flakiness.

### DIFF
--- a/test_runner/regress/test_gc_cutoff.py
+++ b/test_runner/regress/test_gc_cutoff.py
@@ -38,7 +38,7 @@ def test_gc_cutoff(neon_env_builder: NeonEnvBuilder, pg_bin: PgBin):
 
     for _ in range(5):
         with pytest.raises(Exception):
-            pg_bin.run_capture(["pgbench", "-N", "-c5", "-T100", "-Mprepared", connstr])
+            pg_bin.run_capture(["pgbench", "-N", "-c5", "-T200", "-Mprepared", connstr])
         env.pageserver.stop()
         env.pageserver.start()
         pageserver_http.configure_failpoints(("after-timeline-gc-removed-layers", "exit"))


### PR DESCRIPTION
Commit d013a2b227 changed the test, so that it fails if pgbench runs to completion without triggering the failpoint. That has now happened several times in the CI. That's not expected, so this needs some investigation, but as a quick fix just make the pgbench runs longer so that we're closer to the situation before commit d013a2b227.

See https://github.com/neondatabase/neon/issues/2856