### PR TITLE
Fix test_seqscans on remote cluster

### DIFF
--- a/test_runner/performance/test_seqscans.py
+++ b/test_runner/performance/test_seqscans.py
@@ -33,6 +33,7 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore
 def test_seqscans(env: PgCompare, rows: int, iters: int, workers: int):
     with closing(env.pg.connect()) as conn:
         with conn.cursor() as cur:
+            cur.execute("drop table if exists t;")
             cur.execute("create table t (i integer);")
             cur.execute(f"insert into t values (generate_series(1,{rows}));")
 


### PR DESCRIPTION
A remote project is reused between tests, so we need to ensure that we don't have a table with the same name.

Fixes https://github.com/neondatabase/neon/actions/runs/3501815792/jobs/5865782525