### PR TITLE
Validate index scans for remotexacts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "vendor/postgres-v14"]
 	path = vendor/postgres-v14
-	url = https://github.com/neondatabase/postgres.git
-	branch = REL_14_STABLE_neon
+	url = https://github.com/DSLAM-UMD/postgres.git
+	branch = remotexact
 [submodule "vendor/postgres-v15"]
 	path = vendor/postgres-v15
-	url = https://github.com/neondatabase/postgres.git
-	branch = REL_15_STABLE_neon
+	url = https://github.com/DSLAM-UMD/postgres.git
+	branch = REL_15_STABLE_remotexact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,6 +2007,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2200,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "const_format",
+ "num_enum",
  "postgres_ffi",
  "serde",
  "serde_with",
@@ -2462,6 +2484,17 @@ checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,6 @@ postgres-v14: postgres-v14-configure \
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/pg_buffercache install
 	+@echo "Compiling pageinspect v14"
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/pageinspect install
-	+@echo "Compiling remotexact v14"
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/remotexact install
 
 .PHONY: postgres-v15
 postgres-v15: postgres-v15-configure \
@@ -129,8 +127,6 @@ postgres-v15: postgres-v15-configure \
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v15/contrib/pg_buffercache install
 	+@echo "Compiling pageinspect v15"
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v15/contrib/pageinspect install
-	+@echo "Compiling remotexact v15"
-	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v15/contrib/remotexact install
 
 # shorthand to build all Postgres versions
 postgres: postgres-v14 postgres-v15
@@ -165,6 +161,11 @@ neon-pg-ext-v14: postgres-v14
 	(cd $(POSTGRES_INSTALL_DIR)/build/neon-test-utils-v14 && \
 	$(MAKE) PG_CONFIG=$(POSTGRES_INSTALL_DIR)/v14/bin/pg_config CFLAGS='$(PG_CFLAGS) $(COPT)' \
 		-f $(ROOT_PROJECT_DIR)/pgxn/neon_test_utils/Makefile install)
+	+@echo "Compiling remotexact v14"
+	mkdir -p $(POSTGRES_INSTALL_DIR)/build/remotexact-v14
+	(cd $(POSTGRES_INSTALL_DIR)/build/remotexact-v14 && \
+	$(MAKE) PG_CONFIG=$(POSTGRES_INSTALL_DIR)/v14/bin/pg_config \
+		-f $(ROOT_PROJECT_DIR)/pgxn/remotexact/Makefile install)
 
 neon-pg-ext-v15: postgres-v15
 	+@echo "Compiling neon v15"
@@ -182,6 +183,11 @@ neon-pg-ext-v15: postgres-v15
 	(cd $(POSTGRES_INSTALL_DIR)/build/neon-test-utils-v15 && \
 	$(MAKE) PG_CONFIG=$(POSTGRES_INSTALL_DIR)/v15/bin/pg_config CFLAGS='$(PG_CFLAGS) $(COPT)' \
 		-f $(ROOT_PROJECT_DIR)/pgxn/neon_test_utils/Makefile install)
+	+@echo "Compiling remotexact v15"
+	mkdir -p $(POSTGRES_INSTALL_DIR)/build/remotexact-v15
+	(cd $(POSTGRES_INSTALL_DIR)/build/remotexact-v15 && \
+	$(MAKE) PG_CONFIG=$(POSTGRES_INSTALL_DIR)/v15/bin/pg_config \
+		-f $(ROOT_PROJECT_DIR)/pgxn/remotexact/Makefile install)
 
 .PHONY: neon-pg-ext-clean
 	$(MAKE) -C $(ROOT_PROJECT_DIR)/pgxn/neon clean
@@ -199,6 +205,7 @@ clean:
 	$(CARGO_CMD_PREFIX) cargo clean
 	cd pgxn/neon && $(MAKE) clean
 	cd pgxn/neon_test_utils && $(MAKE) clean
+	cd pgxn/remotexact && $(MAKE) clean
 
 # This removes everything
 .PHONY: distclean

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ postgres-v14: postgres-v14-configure \
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/pg_buffercache install
 	+@echo "Compiling pageinspect v14"
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/pageinspect install
+	+@echo "Compiling remotexact v14"
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v14/contrib/remotexact install
 
 .PHONY: postgres-v15
 postgres-v15: postgres-v15-configure \
@@ -127,6 +129,8 @@ postgres-v15: postgres-v15-configure \
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v15/contrib/pg_buffercache install
 	+@echo "Compiling pageinspect v15"
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v15/contrib/pageinspect install
+	+@echo "Compiling remotexact v15"
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/v15/contrib/remotexact install
 
 # shorthand to build all Postgres versions
 postgres: postgres-v14 postgres-v15

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -1018,7 +1018,7 @@ fn cli() -> Command {
                 .about("Create a new blank timeline")
                 .arg(tenant_id_arg.clone())
                 .arg(branch_name_arg.clone())
-                .arg(region_id_arg.clone())
+                .arg(region_id_arg)
                 .arg(pg_version_arg.clone())
             )
             .subcommand(Command::new("import")

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -37,6 +37,7 @@ use utils::{
 const DEFAULT_SAFEKEEPER_ID: NodeId = NodeId(1);
 const DEFAULT_PAGESERVER_ID: NodeId = NodeId(1);
 const DEFAULT_BRANCH_NAME: &str = "main";
+const DEFAULT_REMOTEXACT_PG_ADDR: &str = "127.0.0.1:10000";
 project_git_version!(GIT_VERSION);
 
 const DEFAULT_PG_VERSION: &str = "14";
@@ -59,6 +60,9 @@ auth_type = '{pageserver_auth_type}'
 id = {DEFAULT_SAFEKEEPER_ID}
 pg_port = {DEFAULT_SAFEKEEPER_PG_PORT}
 http_port = {DEFAULT_SAFEKEEPER_HTTP_PORT}
+
+[xactserver]
+listen_pg_addr = '{DEFAULT_REMOTEXACT_PG_ADDR}'
 "#,
         etcd_binary_path = etcd_binary_path.display(),
         pageserver_auth_type = AuthType::Trust,

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -73,6 +73,7 @@ impl ComputeControlPlane {
             .unwrap_or(self.base_port)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_node(
         &mut self,
         tenant_id: TenantId,

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -332,7 +332,7 @@ impl PostgresNode {
         conf.append("shared_buffers", "1MB");
         conf.append("fsync", "off");
         conf.append("max_connections", "100");
-        conf.append("wal_level", "replica");
+        conf.append("wal_level", "remote_xact");
         // wal_sender_timeout is the maximum time to wait for WAL replication.
         // It also defines how often the walreciever will send a feedback message to the wal sender.
         conf.append("wal_sender_timeout", "5s");

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -415,6 +415,8 @@ impl PostgresNode {
             conf.append("synchronous_standby_names", "pageserver");
         }
 
+        // UMD: Remotexact and multi-region configurations
+        conf.append("enable_csn_snapshot", "on");
         // TODO(ctring): consider a different value or make this an argument somewhere
         conf.append("max_prepared_transactions", "64");
         conf.append(

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -376,7 +376,7 @@ impl PostgresNode {
             // testing.
             conf.append("synchronous_standby_names", "pageserver");
         }
-        
+
         //
         // Remotexact: multi-region configurations
         //

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -81,8 +81,26 @@ impl ComputeControlPlane {
         lsn: Option<Lsn>,
         port: Option<u16>,
         pg_version: u32,
+        region_timeline_ids: Option<Vec<TimelineId>>,
     ) -> Result<Arc<PostgresNode>> {
         let port = port.unwrap_or_else(|| self.get_port());
+        let multi_region = region_timeline_ids
+            .map(|timeline_ids| -> Result<_> {
+                let current_region = timeline_ids
+                    .iter()
+                    .position(|&id| id == timeline_id)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Found no timeline id '{}' in the list of region timeline ids",
+                            timeline_id
+                        )
+                    })?;
+                Ok(MultiRegion {
+                    timeline_ids,
+                    current_region,
+                })
+            })
+            .transpose()?;
         let node = Arc::new(PostgresNode {
             name: name.to_owned(),
             address: SocketAddr::new("127.0.0.1".parse().unwrap(), port),
@@ -94,6 +112,7 @@ impl ComputeControlPlane {
             tenant_id,
             uses_wal_proposer: false,
             pg_version,
+            multi_region,
         });
 
         node.create_pgdata()?;
@@ -109,6 +128,12 @@ impl ComputeControlPlane {
 ///////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug)]
+struct MultiRegion {
+    timeline_ids: Vec<TimelineId>,
+    current_region: usize,
+}
+
+#[derive(Debug)]
 pub struct PostgresNode {
     pub address: SocketAddr,
     name: String,
@@ -120,6 +145,7 @@ pub struct PostgresNode {
     pub tenant_id: TenantId,
     uses_wal_proposer: bool,
     pg_version: u32,
+    multi_region: Option<MultiRegion>,
 }
 
 impl PostgresNode {
@@ -152,6 +178,8 @@ impl PostgresNode {
         let port: u16 = conf.parse_field("port", &context)?;
         let timeline_id: TimelineId = conf.parse_field("neon.timeline_id", &context)?;
         let tenant_id: TenantId = conf.parse_field("neon.tenant_id", &context)?;
+        let region_timelines = conf.parse_field("neon.region_timelines", &context);
+        let current_region = conf.parse_field("current_region", &context);
         let uses_wal_proposer = conf.get("neon.safekeepers").is_some();
 
         // Read postgres version from PG_VERSION file to determine which postgres version binary to use.
@@ -166,6 +194,22 @@ impl PostgresNode {
         let recovery_target_lsn: Option<Lsn> =
             conf.parse_field_optional("recovery_target_lsn", &context)?;
 
+        let multi_region = current_region
+            .and_then(|current_region| {
+                region_timelines.and_then(|timelines: String| {
+                    Ok(MultiRegion {
+                        current_region,
+                        timeline_ids: timelines
+                            .split(',')
+                            .map(|s| -> Result<_> {
+                                TimelineId::from_str(s).map_err(anyhow::Error::from)
+                            })
+                            .collect::<Result<Vec<_>>>()?,
+                    })
+                })
+            })
+            .ok();
+
         // ok now
         Ok(PostgresNode {
             address: SocketAddr::new("127.0.0.1".parse().unwrap(), port),
@@ -178,6 +222,7 @@ impl PostgresNode {
             tenant_id,
             uses_wal_proposer,
             pg_version,
+            multi_region,
         })
     }
 
@@ -368,6 +413,17 @@ impl PostgresNode {
             // This isn't really a supported configuration, but can be useful for
             // testing.
             conf.append("synchronous_standby_names", "pageserver");
+        }
+
+        if let Some(multi_region) = &self.multi_region {
+            let region_timelines = multi_region
+                .timeline_ids
+                .iter()
+                .map(TimelineId::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            conf.append("neon.region_timelines", &region_timelines);
+            conf.append("current_region", &multi_region.current_region.to_string());
         }
 
         let mut file = File::create(self.pgdata().join("postgresql.conf"))?;

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use utils::{
-    id::{TenantId, TimelineId},
+    id::{RegionId, TenantId, TimelineId},
     lsn::Lsn,
     postgres_backend::AuthType,
 };
@@ -81,26 +81,9 @@ impl ComputeControlPlane {
         lsn: Option<Lsn>,
         port: Option<u16>,
         pg_version: u32,
-        region_timeline_ids: Option<Vec<TimelineId>>,
+        region_id: RegionId,
     ) -> Result<Arc<PostgresNode>> {
         let port = port.unwrap_or_else(|| self.get_port());
-        let multi_region = region_timeline_ids
-            .map(|timeline_ids| -> Result<_> {
-                let current_region = timeline_ids
-                    .iter()
-                    .position(|&id| id == timeline_id)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Found no timeline id '{}' in the list of region timeline ids",
-                            timeline_id
-                        )
-                    })?;
-                Ok(MultiRegion {
-                    timeline_ids,
-                    current_region,
-                })
-            })
-            .transpose()?;
         let node = Arc::new(PostgresNode {
             name: name.to_owned(),
             address: SocketAddr::new("127.0.0.1".parse().unwrap(), port),
@@ -112,7 +95,7 @@ impl ComputeControlPlane {
             tenant_id,
             uses_wal_proposer: false,
             pg_version,
-            multi_region,
+            region_id,
         });
 
         node.create_pgdata()?;
@@ -128,12 +111,6 @@ impl ComputeControlPlane {
 ///////////////////////////////////////////////////////////////////////////////
 
 #[derive(Debug)]
-struct MultiRegion {
-    timeline_ids: Vec<TimelineId>,
-    current_region: usize,
-}
-
-#[derive(Debug)]
 pub struct PostgresNode {
     pub address: SocketAddr,
     name: String,
@@ -145,7 +122,7 @@ pub struct PostgresNode {
     pub tenant_id: TenantId,
     uses_wal_proposer: bool,
     pg_version: u32,
-    multi_region: Option<MultiRegion>,
+    region_id: RegionId,
 }
 
 impl PostgresNode {
@@ -178,8 +155,9 @@ impl PostgresNode {
         let port: u16 = conf.parse_field("port", &context)?;
         let timeline_id: TimelineId = conf.parse_field("neon.timeline_id", &context)?;
         let tenant_id: TenantId = conf.parse_field("neon.tenant_id", &context)?;
-        let region_timelines = conf.parse_field("neon.region_timelines", &context);
-        let current_region = conf.parse_field("current_region", &context);
+        let current_region = conf
+            .parse_field("current_region", &context)
+            .unwrap_or_default();
         let uses_wal_proposer = conf.get("neon.safekeepers").is_some();
 
         // Read postgres version from PG_VERSION file to determine which postgres version binary to use.
@@ -194,22 +172,6 @@ impl PostgresNode {
         let recovery_target_lsn: Option<Lsn> =
             conf.parse_field_optional("recovery_target_lsn", &context)?;
 
-        let multi_region = current_region
-            .and_then(|current_region| {
-                region_timelines.and_then(|timelines: String| {
-                    Ok(MultiRegion {
-                        current_region,
-                        timeline_ids: timelines
-                            .split(',')
-                            .map(|s| -> Result<_> {
-                                TimelineId::from_str(s).map_err(anyhow::Error::from)
-                            })
-                            .collect::<Result<Vec<_>>>()?,
-                    })
-                })
-            })
-            .ok();
-
         // ok now
         Ok(PostgresNode {
             address: SocketAddr::new("127.0.0.1".parse().unwrap(), port),
@@ -222,7 +184,7 @@ impl PostgresNode {
             tenant_id,
             uses_wal_proposer,
             pg_version,
-            multi_region,
+            region_id: current_region,
         })
     }
 
@@ -423,16 +385,7 @@ impl PostgresNode {
             "remotexact.connstring",
             &format!("postgresql://{}", &self.env.xactserver.listen_pg_addr),
         );
-        if let Some(multi_region) = &self.multi_region {
-            let region_timelines = multi_region
-                .timeline_ids
-                .iter()
-                .map(TimelineId::to_string)
-                .collect::<Vec<_>>()
-                .join(",");
-            conf.append("neon.region_timelines", &region_timelines);
-            conf.append("current_region", &multi_region.current_region.to_string());
-        }
+        conf.append("current_region", &self.region_id.to_string());
 
         let mut file = File::create(self.pgdata().join("postgresql.conf"))?;
         file.write_all(conf.to_string().as_bytes())?;

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -364,7 +364,7 @@ impl PostgresNode {
             // uses only needed variables namely host, port, user, password.
             format!("postgresql://no_user:{password}@{host}:{port}")
         };
-        conf.append("shared_preload_libraries", "neon");
+        conf.append("shared_preload_libraries", "neon,remotexact");
         conf.append_line("");
         conf.append("neon.pageserver_connstring", &pageserver_connstr);
         conf.append("neon.tenant_id", &self.tenant_id.to_string());

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -376,9 +376,12 @@ impl PostgresNode {
             // testing.
             conf.append("synchronous_standby_names", "pageserver");
         }
-
-        // UMD: Remotexact and multi-region configurations
+        
+        //
+        // Remotexact: multi-region configurations
+        //
         conf.append("enable_csn_snapshot", "on");
+        conf.append("neon.slru_csnlog", "on");
         // TODO(ctring): consider a different value or make this an argument somewhere
         conf.append("max_prepared_transactions", "64");
         conf.append(

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -415,6 +415,12 @@ impl PostgresNode {
             conf.append("synchronous_standby_names", "pageserver");
         }
 
+        // TODO(ctring): consider a different value or make this an argument somewhere
+        conf.append("max_prepared_transactions", "64");
+        conf.append(
+            "remotexact.connstring",
+            &format!("postgresql://{}", &self.env.xactserver.listen_pg_addr),
+        );
         if let Some(multi_region) = &self.multi_region {
             let region_timelines = multi_region
                 .timeline_ids

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use utils::{
     auth::{encode_from_key_file, Claims, Scope},
-    id::{NodeId, TenantId, TenantTimelineId, TimelineId},
+    id::{NodeId, RegionId, TenantId, TenantTimelineId, TimelineId},
     postgres_backend::AuthType,
 };
 
@@ -74,8 +74,8 @@ pub struct LocalEnv {
     // A `HashMap<String, HashMap<TenantId, TimelineId>>` would be more appropriate here,
     // but deserialization into a generic toml object as `toml::Value::try_from` fails with an error.
     // https://toml.io/en/v1.0.0 does not contain a concept of "a table inside another table".
-    #[serde_as(as = "HashMap<_, Vec<(DisplayFromStr, DisplayFromStr)>>")]
-    branch_name_mappings: HashMap<String, Vec<(TenantId, TimelineId)>>,
+    #[serde_as(as = "HashMap<_, Vec<(DisplayFromStr, DisplayFromStr, DisplayFromStr)>>")]
+    branch_name_mappings: HashMap<String, Vec<(TenantId, TimelineId, RegionId)>>,
 
     #[serde(default)]
     pub xactserver: XactServerConf,
@@ -267,6 +267,7 @@ impl LocalEnv {
         branch_name: String,
         tenant_id: TenantId,
         timeline_id: TimelineId,
+        region_id: RegionId,
     ) -> anyhow::Result<()> {
         let existing_values = self
             .branch_name_mappings
@@ -275,16 +276,16 @@ impl LocalEnv {
 
         let existing_ids = existing_values
             .iter()
-            .find(|(existing_tenant_id, _)| existing_tenant_id == &tenant_id);
+            .find(|(existing_tenant_id, _, _)| existing_tenant_id == &tenant_id);
 
-        if let Some((_, old_timeline_id)) = existing_ids {
+        if let Some((_, old_timeline_id, _)) = existing_ids {
             if old_timeline_id == &timeline_id {
                 Ok(())
             } else {
                 bail!("branch '{branch_name}' is already mapped to timeline {old_timeline_id}, cannot map to another timeline {timeline_id}");
             }
         } else {
-            existing_values.push((tenant_id, timeline_id));
+            existing_values.push((tenant_id, timeline_id, region_id));
             Ok(())
         }
     }
@@ -293,20 +294,19 @@ impl LocalEnv {
         &self,
         branch_name: &str,
         tenant_id: TenantId,
-    ) -> Option<TimelineId> {
+    ) -> Option<(TimelineId, RegionId)> {
         self.branch_name_mappings
             .get(branch_name)?
             .iter()
-            .find(|(mapped_tenant_id, _)| mapped_tenant_id == &tenant_id)
-            .map(|&(_, timeline_id)| timeline_id)
-            .map(TimelineId::from)
+            .find(|(mapped_tenant_id, _, _)| mapped_tenant_id == &tenant_id)
+            .map(|&(_, timeline_id, region_id)| (timeline_id, region_id))
     }
 
     pub fn timeline_name_mappings(&self) -> HashMap<TenantTimelineId, String> {
         self.branch_name_mappings
             .iter()
             .flat_map(|(name, tenant_timelines)| {
-                tenant_timelines.iter().map(|&(tenant_id, timeline_id)| {
+                tenant_timelines.iter().map(|&(tenant_id, timeline_id, _)| {
                     (TenantTimelineId::new(tenant_id, timeline_id), name.clone())
                 })
             })

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -76,6 +76,9 @@ pub struct LocalEnv {
     // https://toml.io/en/v1.0.0 does not contain a concept of "a table inside another table".
     #[serde_as(as = "HashMap<_, Vec<(DisplayFromStr, DisplayFromStr)>>")]
     branch_name_mappings: HashMap<String, Vec<(TenantId, TimelineId)>>,
+
+    #[serde(default)]
+    pub xactserver: XactServerConf,
 }
 
 /// Etcd broker config for cluster internal communication.
@@ -194,6 +197,12 @@ impl Default for SafekeeperConf {
             auth_enabled: false,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone, Debug)]
+#[serde(default)]
+pub struct XactServerConf {
+    pub listen_pg_addr: String,
 }
 
 impl LocalEnv {

--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -16,7 +16,7 @@ use reqwest::{IntoUrl, Method};
 use thiserror::Error;
 use utils::{
     http::error::HttpErrorBody,
-    id::{TenantId, TimelineId},
+    id::{RegionId, TenantId, TimelineId},
     lsn::Lsn,
     postgres_backend::AuthType,
 };
@@ -165,7 +165,12 @@ impl PageServerNode {
             })?;
 
         let init_result = self
-            .try_init_timeline(create_tenant, initial_timeline_id, pg_version)
+            .try_init_timeline(
+                create_tenant,
+                initial_timeline_id,
+                pg_version,
+                RegionId::default(),
+            )
             .context("Failed to create initial tenant and timeline for pageserver");
         match &init_result {
             Ok(initial_timeline_id) => {
@@ -204,6 +209,7 @@ impl PageServerNode {
         new_tenant_id: Option<TenantId>,
         new_timeline_id: Option<TimelineId>,
         pg_version: u32,
+        region_id: RegionId,
     ) -> anyhow::Result<TimelineId> {
         let initial_tenant_id = self.tenant_create(new_tenant_id, HashMap::new())?;
         let initial_timeline_info = self.timeline_create(
@@ -212,6 +218,7 @@ impl PageServerNode {
             None,
             None,
             Some(pg_version),
+            Some(region_id),
         )?;
         Ok(initial_timeline_info.timeline_id)
     }
@@ -461,6 +468,7 @@ impl PageServerNode {
         ancestor_start_lsn: Option<Lsn>,
         ancestor_timeline_id: Option<TimelineId>,
         pg_version: Option<u32>,
+        region_id: Option<RegionId>,
     ) -> anyhow::Result<TimelineInfo> {
         self.http_request(
             Method::POST,
@@ -471,6 +479,7 @@ impl PageServerNode {
             ancestor_start_lsn,
             ancestor_timeline_id,
             pg_version,
+            region_id,
         })
         .send()?
         .error_from_body()?

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -202,8 +202,8 @@ relation exceeds that size, it is split into multiple segments.
 
 ### SLRU
 
-SLRUs include pg_clog, pg_multixact/members, and
-pg_multixact/offsets. There are other SLRUs in PostgreSQL, but
+SLRUs include pg_clog, pg_multixact/members, pg_multixact/offsets,
+and pg_csn. There are other SLRUs in PostgreSQL, but
 they don't need to be stored permanently (e.g. pg_subtrans),
 or we do not support them in neon yet (pg_commit_ts).
 

--- a/libs/pageserver_api/Cargo.toml
+++ b/libs/pageserver_api/Cargo.toml
@@ -10,6 +10,7 @@ const_format = "0.2.21"
 anyhow = { version = "1.0", features = ["backtrace"] }
 bytes = "1.0.1"
 byteorder = "1.4.3"
+num_enum = "0.5.7"
 
 utils = { path = "../utils" }
 postgres_ffi = { path = "../postgres_ffi" }

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -252,25 +252,25 @@ pub enum PagestreamBeMessage {
 pub struct PagestreamExistsRequest {
     pub latest: bool,
     pub lsn: Lsn,
-    pub rel: RelTag,
     pub region: u32,
+    pub rel: RelTag,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PagestreamNblocksRequest {
     pub latest: bool,
     pub lsn: Lsn,
-    pub rel: RelTag,
     pub region: u32,
+    pub rel: RelTag,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PagestreamGetPageRequest {
     pub latest: bool,
     pub lsn: Lsn,
+    pub region: u32,
     pub rel: RelTag,
     pub blkno: u32,
-    pub region: u32,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -293,21 +293,25 @@ pub struct PagestreamGetSlruPageRequest {
 
 #[derive(Debug)]
 pub struct PagestreamExistsResponse {
+    pub lsn: Lsn,
     pub exists: bool,
 }
 
 #[derive(Debug)]
 pub struct PagestreamNblocksResponse {
+    pub lsn: Lsn,
     pub n_blocks: u32,
 }
 
 #[derive(Debug)]
 pub struct PagestreamGetPageResponse {
+    pub lsn: Lsn,
     pub page: Bytes,
 }
 
 #[derive(Debug)]
 pub struct PagestreamGetSlruPageResponse {
+    pub lsn: Lsn,
     pub seg_exists: bool,
     pub page: Option<Bytes>,
 }
@@ -454,21 +458,25 @@ impl PagestreamBeMessage {
         match self {
             Self::Exists(resp) => {
                 bytes.put_u8(100); /* tag from pagestore_client.h */
+                bytes.put_u64(resp.lsn.0);
                 bytes.put_u8(resp.exists as u8);
             }
 
             Self::Nblocks(resp) => {
                 bytes.put_u8(101); /* tag from pagestore_client.h */
+                bytes.put_u64(resp.lsn.0);
                 bytes.put_u32(resp.n_blocks);
             }
 
             Self::GetPage(resp) => {
                 bytes.put_u8(102); /* tag from pagestore_client.h */
+                bytes.put_u64(resp.lsn.0);
                 bytes.put(&resp.page[..]);
             }
 
             Self::GetSlruPage(resp) => {
                 bytes.put_u8(103); /* tag from pagestore_client.h */
+                bytes.put_u64(resp.lsn.0);
                 bytes.put_u8(resp.seg_exists as u8);
                 if let Some(page) = &resp.page {
                     bytes.put_u8(1); // page exists

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -339,34 +339,34 @@ impl PagestreamFeMessage {
                 bytes.put_u8(0);
                 bytes.put_u8(if req.latest { 1 } else { 0 });
                 bytes.put_u64(req.lsn.0);
+                bytes.put_u8(req.region.0);
                 bytes.put_u32(req.rel.spcnode);
                 bytes.put_u32(req.rel.dbnode);
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
-                bytes.put_u8(req.region.0);
             }
 
             Self::Nblocks(req) => {
                 bytes.put_u8(1);
                 bytes.put_u8(if req.latest { 1 } else { 0 });
                 bytes.put_u64(req.lsn.0);
+                bytes.put_u8(req.region.0);
                 bytes.put_u32(req.rel.spcnode);
                 bytes.put_u32(req.rel.dbnode);
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
-                bytes.put_u8(req.region.0);
             }
 
             Self::GetPage(req) => {
                 bytes.put_u8(2);
                 bytes.put_u8(if req.latest { 1 } else { 0 });
                 bytes.put_u64(req.lsn.0);
+                bytes.put_u8(req.region.0);
                 bytes.put_u32(req.rel.spcnode);
                 bytes.put_u32(req.rel.dbnode);
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
                 bytes.put_u32(req.blkno);
-                bytes.put_u8(req.region.0);
             }
 
             Self::DbSize(req) => {
@@ -380,11 +380,11 @@ impl PagestreamFeMessage {
                 bytes.put_u8(4); /* tag from pagestore_client.h */
                 bytes.put_u8(if req.latest { 1 } else { 0 });
                 bytes.put_u64(req.lsn.0);
+                bytes.put_u8(req.region.0);
                 bytes.put_u8(req.kind.into());
                 bytes.put_u32(req.segno);
                 bytes.put_u32(req.blkno);
                 bytes.put_u8(if req.check_exists_only { 1 } else { 0 });
-                bytes.put_u8(req.region.0);
             }
         }
 

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -251,6 +251,7 @@ pub struct PagestreamExistsRequest {
     pub latest: bool,
     pub lsn: Lsn,
     pub rel: RelTag,
+    pub region: u32,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -258,6 +259,7 @@ pub struct PagestreamNblocksRequest {
     pub latest: bool,
     pub lsn: Lsn,
     pub rel: RelTag,
+    pub region: u32,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -266,6 +268,7 @@ pub struct PagestreamGetPageRequest {
     pub lsn: Lsn,
     pub rel: RelTag,
     pub blkno: u32,
+    pub region: u32,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -365,6 +368,7 @@ impl PagestreamFeMessage {
                     relnode: body.read_u32::<BigEndian>()?,
                     forknum: body.read_u8()?,
                 },
+                region: body.read_u32::<BigEndian>()?,
             })),
             1 => Ok(PagestreamFeMessage::Nblocks(PagestreamNblocksRequest {
                 latest: body.read_u8()? != 0,
@@ -375,6 +379,7 @@ impl PagestreamFeMessage {
                     relnode: body.read_u32::<BigEndian>()?,
                     forknum: body.read_u8()?,
                 },
+                region: body.read_u32::<BigEndian>()?,
             })),
             2 => Ok(PagestreamFeMessage::GetPage(PagestreamGetPageRequest {
                 latest: body.read_u8()? != 0,
@@ -386,6 +391,7 @@ impl PagestreamFeMessage {
                     forknum: body.read_u8()?,
                 },
                 blkno: body.read_u32::<BigEndian>()?,
+                region: body.read_u32::<BigEndian>()?,
             })),
             3 => Ok(PagestreamFeMessage::DbSize(PagestreamDbSizeRequest {
                 latest: body.read_u8()? != 0,
@@ -451,6 +457,7 @@ mod tests {
                     dbnode: 3,
                     relnode: 4,
                 },
+                region: 0,
             }),
             PagestreamFeMessage::Nblocks(PagestreamNblocksRequest {
                 latest: false,
@@ -461,6 +468,7 @@ mod tests {
                     dbnode: 3,
                     relnode: 4,
                 },
+                region: 0,
             }),
             PagestreamFeMessage::GetPage(PagestreamGetPageRequest {
                 latest: true,
@@ -472,6 +480,7 @@ mod tests {
                     relnode: 4,
                 },
                 blkno: 7,
+                region: 0,
             }),
             PagestreamFeMessage::DbSize(PagestreamDbSizeRequest {
                 latest: true,

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -4,7 +4,7 @@ use byteorder::{BigEndian, ReadBytesExt};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use utils::{
-    id::{NodeId, TenantId, TimelineId},
+    id::{NodeId, RegionId, TenantId, TimelineId},
     lsn::Lsn,
 };
 
@@ -53,6 +53,9 @@ pub struct TimelineCreateRequest {
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub ancestor_start_lsn: Option<Lsn>,
     pub pg_version: Option<u32>,
+    #[serde(default)]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub region_id: Option<RegionId>,
 }
 
 #[serde_as]

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -255,7 +255,7 @@ pub enum PagestreamBeMessage {
 pub struct PagestreamExistsRequest {
     pub latest: bool,
     pub lsn: Lsn,
-    pub region: u32,
+    pub region: RegionId,
     pub rel: RelTag,
 }
 
@@ -263,7 +263,7 @@ pub struct PagestreamExistsRequest {
 pub struct PagestreamNblocksRequest {
     pub latest: bool,
     pub lsn: Lsn,
-    pub region: u32,
+    pub region: RegionId,
     pub rel: RelTag,
 }
 
@@ -271,7 +271,7 @@ pub struct PagestreamNblocksRequest {
 pub struct PagestreamGetPageRequest {
     pub latest: bool,
     pub lsn: Lsn,
-    pub region: u32,
+    pub region: RegionId,
     pub rel: RelTag,
     pub blkno: u32,
 }
@@ -287,7 +287,7 @@ pub struct PagestreamDbSizeRequest {
 pub struct PagestreamGetSlruPageRequest {
     pub latest: bool,
     pub lsn: Lsn,
-    pub region: u32,
+    pub region: RegionId,
     pub kind: SlruKind,
     pub segno: u32,
     pub blkno: u32,
@@ -343,7 +343,7 @@ impl PagestreamFeMessage {
                 bytes.put_u32(req.rel.dbnode);
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
-                bytes.put_u32(req.region);
+                bytes.put_u8(req.region.0);
             }
 
             Self::Nblocks(req) => {
@@ -354,7 +354,7 @@ impl PagestreamFeMessage {
                 bytes.put_u32(req.rel.dbnode);
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
-                bytes.put_u32(req.region);
+                bytes.put_u8(req.region.0);
             }
 
             Self::GetPage(req) => {
@@ -366,7 +366,7 @@ impl PagestreamFeMessage {
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
                 bytes.put_u32(req.blkno);
-                bytes.put_u32(req.region);
+                bytes.put_u8(req.region.0);
             }
 
             Self::DbSize(req) => {
@@ -384,7 +384,7 @@ impl PagestreamFeMessage {
                 bytes.put_u32(req.segno);
                 bytes.put_u32(req.blkno);
                 bytes.put_u8(if req.check_exists_only { 1 } else { 0 });
-                bytes.put_u32(req.region);
+                bytes.put_u8(req.region.0);
             }
         }
 
@@ -403,7 +403,7 @@ impl PagestreamFeMessage {
             0 => Ok(PagestreamFeMessage::Exists(PagestreamExistsRequest {
                 latest: body.read_u8()? != 0,
                 lsn: Lsn::from(body.read_u64::<BigEndian>()?),
-                region: body.read_u32::<BigEndian>()?,
+                region: RegionId(body.read_u8()?),
                 rel: RelTag {
                     spcnode: body.read_u32::<BigEndian>()?,
                     dbnode: body.read_u32::<BigEndian>()?,
@@ -414,7 +414,7 @@ impl PagestreamFeMessage {
             1 => Ok(PagestreamFeMessage::Nblocks(PagestreamNblocksRequest {
                 latest: body.read_u8()? != 0,
                 lsn: Lsn::from(body.read_u64::<BigEndian>()?),
-                region: body.read_u32::<BigEndian>()?,
+                region: RegionId(body.read_u8()?),
                 rel: RelTag {
                     spcnode: body.read_u32::<BigEndian>()?,
                     dbnode: body.read_u32::<BigEndian>()?,
@@ -425,7 +425,7 @@ impl PagestreamFeMessage {
             2 => Ok(PagestreamFeMessage::GetPage(PagestreamGetPageRequest {
                 latest: body.read_u8()? != 0,
                 lsn: Lsn::from(body.read_u64::<BigEndian>()?),
-                region: body.read_u32::<BigEndian>()?,
+                region: RegionId(body.read_u8()?),
                 rel: RelTag {
                     spcnode: body.read_u32::<BigEndian>()?,
                     dbnode: body.read_u32::<BigEndian>()?,
@@ -443,7 +443,7 @@ impl PagestreamFeMessage {
                 PagestreamGetSlruPageRequest {
                     latest: body.read_u8()? != 0,
                     lsn: Lsn::from(body.read_u64::<BigEndian>()?),
-                    region: body.read_u32::<BigEndian>()?,
+                    region: RegionId(body.read_u8()?),
                     kind: SlruKind::try_from(body.read_u8()?)?,
                     segno: body.read_u32::<BigEndian>()?,
                     blkno: body.read_u32::<BigEndian>()?,
@@ -525,7 +525,7 @@ mod tests {
                     dbnode: 3,
                     relnode: 4,
                 },
-                region: 0,
+                region: RegionId(0),
             }),
             PagestreamFeMessage::Nblocks(PagestreamNblocksRequest {
                 latest: false,
@@ -536,7 +536,7 @@ mod tests {
                     dbnode: 3,
                     relnode: 4,
                 },
-                region: 0,
+                region: RegionId(0),
             }),
             PagestreamFeMessage::GetPage(PagestreamGetPageRequest {
                 latest: true,
@@ -548,7 +548,7 @@ mod tests {
                     relnode: 4,
                 },
                 blkno: 7,
-                region: 0,
+                region: RegionId(0),
             }),
             PagestreamFeMessage::DbSize(PagestreamDbSizeRequest {
                 latest: true,

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -323,6 +323,7 @@ pub struct PagestreamErrorResponse {
 
 #[derive(Debug)]
 pub struct PagestreamDbSizeResponse {
+    pub lsn: Lsn,
     pub db_size: i64,
 }
 
@@ -493,6 +494,7 @@ impl PagestreamBeMessage {
             }
             Self::DbSize(resp) => {
                 bytes.put_u8(105); /* tag from pagestore_client.h */
+                bytes.put_u64(resp.lsn.0);
                 bytes.put_i64(resp.db_size);
             }
         }

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -8,7 +8,7 @@ use utils::{
     lsn::Lsn,
 };
 
-use crate::reltag::RelTag;
+use crate::reltag::{RelTag, SlruKind};
 use anyhow::bail;
 use bytes::{BufMut, Bytes, BytesMut};
 
@@ -235,6 +235,7 @@ pub enum PagestreamFeMessage {
     Nblocks(PagestreamNblocksRequest),
     GetPage(PagestreamGetPageRequest),
     DbSize(PagestreamDbSizeRequest),
+    GetSlruPage(PagestreamGetSlruPageRequest),
 }
 
 // Wrapped in libpq CopyData
@@ -242,6 +243,7 @@ pub enum PagestreamBeMessage {
     Exists(PagestreamExistsResponse),
     Nblocks(PagestreamNblocksResponse),
     GetPage(PagestreamGetPageResponse),
+    GetSlruPage(PagestreamGetSlruPageResponse),
     Error(PagestreamErrorResponse),
     DbSize(PagestreamDbSizeResponse),
 }
@@ -278,6 +280,17 @@ pub struct PagestreamDbSizeRequest {
     pub dbnode: u32,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct PagestreamGetSlruPageRequest {
+    pub latest: bool,
+    pub lsn: Lsn,
+    pub kind: SlruKind,
+    pub segno: u32,
+    pub blkno: u32,
+    pub check_exists_only: bool,
+    pub region: u32,
+}
+
 #[derive(Debug)]
 pub struct PagestreamExistsResponse {
     pub exists: bool,
@@ -291,6 +304,12 @@ pub struct PagestreamNblocksResponse {
 #[derive(Debug)]
 pub struct PagestreamGetPageResponse {
     pub page: Bytes,
+}
+
+#[derive(Debug)]
+pub struct PagestreamGetSlruPageResponse {
+    pub seg_exists: bool,
+    pub page: Option<Bytes>,
 }
 
 #[derive(Debug)]
@@ -316,6 +335,7 @@ impl PagestreamFeMessage {
                 bytes.put_u32(req.rel.dbnode);
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
+                bytes.put_u32(req.region);
             }
 
             Self::Nblocks(req) => {
@@ -326,6 +346,7 @@ impl PagestreamFeMessage {
                 bytes.put_u32(req.rel.dbnode);
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
+                bytes.put_u32(req.region);
             }
 
             Self::GetPage(req) => {
@@ -337,6 +358,7 @@ impl PagestreamFeMessage {
                 bytes.put_u32(req.rel.relnode);
                 bytes.put_u8(req.rel.forknum);
                 bytes.put_u32(req.blkno);
+                bytes.put_u32(req.region);
             }
 
             Self::DbSize(req) => {
@@ -344,6 +366,17 @@ impl PagestreamFeMessage {
                 bytes.put_u8(if req.latest { 1 } else { 0 });
                 bytes.put_u64(req.lsn.0);
                 bytes.put_u32(req.dbnode);
+            }
+
+            Self::GetSlruPage(req) => {
+                bytes.put_u8(4); /* tag from pagestore_client.h */
+                bytes.put_u8(if req.latest { 1 } else { 0 });
+                bytes.put_u64(req.lsn.0);
+                bytes.put_u8(req.kind.into());
+                bytes.put_u32(req.segno);
+                bytes.put_u32(req.blkno);
+                bytes.put_u8(if req.check_exists_only { 1 } else { 0 });
+                bytes.put_u32(req.region);
             }
         }
 
@@ -398,6 +431,17 @@ impl PagestreamFeMessage {
                 lsn: Lsn::from(body.read_u64::<BigEndian>()?),
                 dbnode: body.read_u32::<BigEndian>()?,
             })),
+            4 => Ok(PagestreamFeMessage::GetSlruPage(
+                PagestreamGetSlruPageRequest {
+                    latest: body.read_u8()? != 0,
+                    lsn: Lsn::from(body.read_u64::<BigEndian>()?),
+                    kind: SlruKind::try_from(body.read_u8()?)?,
+                    segno: body.read_u32::<BigEndian>()?,
+                    blkno: body.read_u32::<BigEndian>()?,
+                    check_exists_only: body.read_u8()? != 0,
+                    region: body.read_u32::<BigEndian>()?,
+                },
+            )),
             _ => bail!("unknown smgr message tag: {:?}", msg_tag),
         }
     }
@@ -421,6 +465,17 @@ impl PagestreamBeMessage {
             Self::GetPage(resp) => {
                 bytes.put_u8(102); /* tag from pagestore_client.h */
                 bytes.put(&resp.page[..]);
+            }
+
+            Self::GetSlruPage(resp) => {
+                bytes.put_u8(103); /* tag from pagestore_client.h */
+                bytes.put_u8(resp.seg_exists as u8);
+                if let Some(page) = &resp.page {
+                    bytes.put_u8(1); // page exists
+                    bytes.put(&page[..]);
+                } else {
+                    bytes.put_u8(0); // page does not exist
+                }
             }
 
             Self::Error(resp) => {

--- a/libs/pageserver_api/src/reltag.rs
+++ b/libs/pageserver_api/src/reltag.rs
@@ -1,3 +1,4 @@
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
@@ -110,7 +111,21 @@ impl RelTag {
 /// These files are divided into segments, which are divided into
 /// pages of the same BLCKSZ as used for relation files.
 ///
-#[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    TryFromPrimitive,
+    IntoPrimitive,
+)]
+#[repr(u8)]
 pub enum SlruKind {
     Clog,
     MultiXactMembers,

--- a/libs/pageserver_api/src/reltag.rs
+++ b/libs/pageserver_api/src/reltag.rs
@@ -130,6 +130,7 @@ pub enum SlruKind {
     Clog,
     MultiXactMembers,
     MultiXactOffsets,
+    Csn,
 }
 
 impl SlruKind {
@@ -138,6 +139,7 @@ impl SlruKind {
             Self::Clog => "pg_xact",
             Self::MultiXactMembers => "pg_multixact/members",
             Self::MultiXactOffsets => "pg_multixact/offsets",
+            Self::Csn => "pg_csn",
         }
     }
 }

--- a/libs/postgres_ffi/bindgen_deps.h
+++ b/libs/postgres_ffi/bindgen_deps.h
@@ -12,3 +12,4 @@
 #include "storage/bufpage.h"
 #include "storage/off.h"
 #include "access/multixact.h"
+#include "utils/snapshot.h"

--- a/libs/postgres_ffi/build.rs
+++ b/libs/postgres_ffi/build.rs
@@ -128,6 +128,8 @@ fn main() -> anyhow::Result<()> {
             .allowlist_var("PG_CONTROLFILEDATA_OFFSETOF_CRC")
             .allowlist_type("PageHeaderData")
             .allowlist_type("DBState")
+            .allowlist_type("XidCSN")
+            .allowlist_type("SnapshotCSN")
             // Because structs are used for serialization, tell bindgen to emit
             // explicit padding fields.
             .explicit_padding(true)

--- a/libs/postgres_ffi/src/lib.rs
+++ b/libs/postgres_ffi/src/lib.rs
@@ -55,8 +55,8 @@ pub mod relfile_utils;
 pub use v14::bindings::{uint32, uint64, Oid};
 pub use v14::bindings::{BlockNumber, OffsetNumber};
 pub use v14::bindings::{MultiXactId, TransactionId};
+pub use v14::bindings::{SnapshotCSN, XidCSN};
 pub use v14::bindings::{TimeLineID, TimestampTz, XLogRecPtr, XLogSegNo};
-pub use v14::bindings::{XidCSN, SnapshotCSN};
 
 // Likewise for these, although the assumption that these don't change is a little more iffy.
 pub use v14::bindings::{MultiXactOffset, MultiXactStatus};

--- a/libs/postgres_ffi/src/lib.rs
+++ b/libs/postgres_ffi/src/lib.rs
@@ -56,6 +56,7 @@ pub use v14::bindings::{uint32, uint64, Oid};
 pub use v14::bindings::{BlockNumber, OffsetNumber};
 pub use v14::bindings::{MultiXactId, TransactionId};
 pub use v14::bindings::{TimeLineID, TimestampTz, XLogRecPtr, XLogSegNo};
+pub use v14::bindings::{XidCSN, SnapshotCSN};
 
 // Likewise for these, although the assumption that these don't change is a little more iffy.
 pub use v14::bindings::{MultiXactOffset, MultiXactStatus};

--- a/libs/postgres_ffi/src/nonrelfile_utils.rs
+++ b/libs/postgres_ffi/src/nonrelfile_utils.rs
@@ -39,9 +39,8 @@ pub fn transaction_id_set_csn(xid: u32, csn: XidCSN, page: &mut BytesMut) {
     trace!("handle_apply_csn_request for RM_XACT_ID-{}", csn);
 
     let entryno: usize = (xid as usize % pg_constants::CSN_LOG_XACTS_PER_PAGE as usize) as usize;
-    let csnsize: usize = (std::mem::size_of::<XidCSN>()) as usize;
-    let bytebegin: usize = (entryno * csnsize) as usize;
-    let byteend: usize = (bytebegin + csnsize) as usize;
+    let bytebegin: usize = (entryno * pg_constants::CSN_SIZE as usize) as usize;
+    let byteend: usize = (bytebegin + pg_constants::CSN_SIZE as usize) as usize;
 
     LittleEndian::write_u64(&mut page[bytebegin..byteend], csn);
 }

--- a/libs/postgres_ffi/src/nonrelfile_utils.rs
+++ b/libs/postgres_ffi/src/nonrelfile_utils.rs
@@ -3,7 +3,7 @@
 //!
 use crate::pg_constants;
 use crate::transaction_id_precedes;
-use byteorder::{LittleEndian, ByteOrder};
+use byteorder::{ByteOrder, LittleEndian};
 use bytes::BytesMut;
 use log::*;
 
@@ -95,9 +95,13 @@ pub fn mx_offset_to_member_segment(xid: u32) -> i32 {
 
 // See CSNLogPagePrecedes in csn_log.c
 pub const fn csnlogpage_precedes(page1: u32, page2: u32) -> bool {
-    let mut xid1: u32 = page1 * pg_constants::CSN_LOG_XACTS_PER_PAGE;
+    if (page1 % pg_constants::MAX_REGIONS) != (page2 % pg_constants::MAX_REGIONS) {
+        // The two pages don't belong to the same region.
+        return false;
+    }
+    let mut xid1: u32 = (page1 / pg_constants::MAX_REGIONS) * pg_constants::CSN_LOG_XACTS_PER_PAGE;
     xid1 += pg_constants::FIRST_NORMAL_TRANSACTION_ID + 1;
-    let mut xid2: u32 = page2 * pg_constants::CSN_LOG_XACTS_PER_PAGE;
+    let mut xid2: u32 = (page2 / pg_constants::MAX_REGIONS) * pg_constants::CSN_LOG_XACTS_PER_PAGE;
     xid2 += pg_constants::FIRST_NORMAL_TRANSACTION_ID + 1;
 
     transaction_id_precedes(xid1, xid2)

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -10,7 +10,7 @@
 //!
 
 use crate::BLCKSZ;
-use crate::{PageHeaderData, XLogRecord};
+use crate::{PageHeaderData, XLogRecord, XidCSN};
 
 //
 // From pg_tablespace_d.h
@@ -48,6 +48,23 @@ pub const TRANSACTION_STATUS_SUB_COMMITTED: u8 = 0x03;
 
 pub const CLOG_ZEROPAGE: u8 = 0x00;
 pub const CLOG_TRUNCATE: u8 = 0x10;
+
+//
+// Constants from csn_log.c, csn_log.h, and csn_snapshpot.h
+// 
+
+pub const CSN_LOG_XACTS_PER_PAGE: u32 = BLCKSZ as u32 / std::mem::size_of::<XidCSN>() as u32;
+
+pub const InProgressXidCSN: u64 = 0x0;
+pub const AbortedXidCSN: u64 = 0x1;
+pub const FrozenXidCSN: u64 = 0x2; 
+pub const InDoubtXidCSN: u64 = 0x3; 
+pub const FirstNormalXidCSN: u64 = 0x4;
+
+pub const XLOG_CSN_ASSIGNMENT: u8 = 0x00;
+pub const XLOG_CSN_SETXIDCSN: u8 = 0x10;
+pub const XLOG_CSN_ZEROPAGE: u8 = 0x20;
+pub const XLOG_CSN_TRUNCATE: u8 = 0x30;
 
 //
 // Constants from visibilitymap.h, visibilitymapdefs.h and visibilitymap.c
@@ -157,6 +174,7 @@ pub const RM_RELMAP_ID: u8 = 7;
 pub const RM_STANDBY_ID: u8 = 8;
 pub const RM_HEAP2_ID: u8 = 9;
 pub const RM_HEAP_ID: u8 = 10;
+pub const RM_CSNLOG_ID: u8 = 22;
 
 // from xlogreader.h
 pub const XLR_INFO_MASK: u8 = 0x0F;

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -216,6 +216,9 @@ pub const XLOG_CHECKPOINT_SHUTDOWN: u8 = 0x00;
 pub const XLOG_CHECKPOINT_ONLINE: u8 = 0x10;
 pub const XLP_LONG_HEADER: u16 = 0x0002;
 
+/* From remotexact.h */
+pub const MAX_REGIONS: u32 = 64;
+
 // List of subdirectories inside pgdata.
 // Copied from src/bin/initdb/initdb.c
 pub const PGDATA_SUBDIRS: [&str; 23] = [

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -53,7 +53,8 @@ pub const CLOG_TRUNCATE: u8 = 0x10;
 // Constants from csn_log.c, csn_log.h, and csn_snapshpot.h
 // 
 
-pub const CSN_LOG_XACTS_PER_PAGE: u32 = BLCKSZ as u32 / std::mem::size_of::<XidCSN>() as u32;
+pub const CSN_SIZE: u32 = std::mem::size_of::<XidCSN>() as u32;
+pub const CSN_LOG_XACTS_PER_PAGE: u32 = BLCKSZ as u32 / CSN_SIZE;
 
 pub const InProgressXidCSN: u64 = 0x0;
 pub const AbortedXidCSN: u64 = 0x1;

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -51,15 +51,15 @@ pub const CLOG_TRUNCATE: u8 = 0x10;
 
 //
 // Constants from csn_log.c, csn_log.h, and csn_snapshpot.h
-// 
+//
 
 pub const CSN_SIZE: u32 = std::mem::size_of::<XidCSN>() as u32;
 pub const CSN_LOG_XACTS_PER_PAGE: u32 = BLCKSZ as u32 / CSN_SIZE;
 
 pub const InProgressXidCSN: u64 = 0x0;
 pub const AbortedXidCSN: u64 = 0x1;
-pub const FrozenXidCSN: u64 = 0x2; 
-pub const InDoubtXidCSN: u64 = 0x3; 
+pub const FrozenXidCSN: u64 = 0x2;
+pub const InDoubtXidCSN: u64 = 0x3;
 pub const FirstNormalXidCSN: u64 = 0x4;
 
 pub const XLOG_CSN_ASSIGNMENT: u8 = 0x00;

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -199,10 +199,11 @@ pub const XLP_LONG_HEADER: u16 = 0x0002;
 
 // List of subdirectories inside pgdata.
 // Copied from src/bin/initdb/initdb.c
-pub const PGDATA_SUBDIRS: [&str; 22] = [
+pub const PGDATA_SUBDIRS: [&str; 23] = [
     "global",
     "pg_wal/archive_status",
     "pg_commit_ts",
+    "pg_csn",
     "pg_dynshmem",
     "pg_notify",
     "pg_serial",

--- a/libs/utils/src/id.rs
+++ b/libs/utils/src/id.rs
@@ -257,15 +257,11 @@ impl fmt::Display for NodeId {
     }
 }
 
-#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Eq, Default, Ord, PartialEq, PartialOrd, Hash, Debug, Serialize, Deserialize,
+)]
 #[serde(transparent)]
 pub struct RegionId(pub u8);
-
-impl Default for RegionId {
-    fn default() -> Self {
-        RegionId(0)
-    }
-}
 
 impl FromStr for RegionId {
     type Err = <u8 as ::core::str::FromStr>::Err;

--- a/libs/utils/src/id.rs
+++ b/libs/utils/src/id.rs
@@ -256,3 +256,27 @@ impl fmt::Display for NodeId {
         write!(f, "{}", self.0)
     }
 }
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RegionId(pub u8);
+
+impl Default for RegionId {
+    fn default() -> Self {
+        RegionId(0)
+    }
+}
+
+impl FromStr for RegionId {
+    type Err = <u8 as ::core::str::FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(u8::from_str(s)?))
+    }
+}
+
+impl fmt::Display for RegionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -230,7 +230,7 @@ where
             let img = self
                 .timeline
                 .get_slru_page_at_lsn(slru, segno, blknum, self.lsn)?;
-
+ 
             if slru == SlruKind::Clog {
                 ensure!(img.len() == BLCKSZ as usize || img.len() == BLCKSZ as usize + 8);
             } else {

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -230,7 +230,7 @@ where
             let img = self
                 .timeline
                 .get_slru_page_at_lsn(slru, segno, blknum, self.lsn)?;
- 
+
             if slru == SlruKind::Clog {
                 ensure!(img.len() == BLCKSZ as usize || img.len() == BLCKSZ as usize + 8);
             } else {

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -151,6 +151,7 @@ where
             SlruKind::Clog,
             SlruKind::MultiXactOffsets,
             SlruKind::MultiXactMembers,
+            SlruKind::Csn,
         ] {
             for segno in self.timeline.list_slru_segments(kind, self.lsn)? {
                 self.add_slru_segment(kind, segno)?;

--- a/pageserver/src/bin/pageserver_binutils.rs
+++ b/pageserver/src/bin/pageserver_binutils.rs
@@ -92,6 +92,7 @@ fn handle_metadata(path: &Path, arg_matches: &clap::ArgMatches) -> Result<(), an
             meta.latest_gc_cutoff_lsn(),
             meta.initdb_lsn(),
             meta.pg_version(),
+            meta.region_id(),
         );
         update_meta = true;
     }
@@ -104,6 +105,7 @@ fn handle_metadata(path: &Path, arg_matches: &clap::ArgMatches) -> Result<(), an
             meta.latest_gc_cutoff_lsn(),
             meta.initdb_lsn(),
             meta.pg_version(),
+            meta.region_id(),
         );
         update_meta = true;
     }

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -191,13 +191,16 @@ async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<
 
     let tenant = tenant_mgr::get_tenant(tenant_id, true).map_err(ApiError::NotFound)?;
     let new_timeline_info = async {
-        match tenant.create_timeline(
-            request_data.new_timeline_id.map(TimelineId::from),
-            request_data.ancestor_timeline_id.map(TimelineId::from),
-            request_data.ancestor_start_lsn,
-            request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
-            request_data.region_id.unwrap_or_default(),
-        ).await {
+        match tenant
+            .create_timeline(
+                request_data.new_timeline_id.map(TimelineId::from),
+                request_data.ancestor_timeline_id.map(TimelineId::from),
+                request_data.ancestor_start_lsn,
+                request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
+                request_data.region_id.unwrap_or_default(),
+            )
+            .await
+        {
             Ok(Some(new_timeline)) => {
                 // Created. Construct a TimelineInfo for it.
                 let timeline_info = build_timeline_info(state, &new_timeline, false, false)
@@ -214,7 +217,7 @@ async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<
                                               lsn=?request_data.ancestor_start_lsn,
                                               pg_version=?request_data.pg_version,
                                               region_id=?request_data.region_id))
-        .await?;
+    .await?;
 
     Ok(match new_timeline_info {
         Some(info) => json_response(StatusCode::CREATED, info)?,

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -209,7 +209,11 @@ async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<
             Err(err) => Err(ApiError::InternalServerError(err)),
         }
     }
-    .instrument(info_span!("timeline_create", tenant = %tenant_id, new_timeline = ?request_data.new_timeline_id, lsn=?request_data.ancestor_start_lsn, pg_version=?request_data.pg_version))
+    .instrument(info_span!("timeline_create", tenant = %tenant_id,
+                                              new_timeline = ?request_data.new_timeline_id,
+                                              lsn=?request_data.ancestor_start_lsn,
+                                              pg_version=?request_data.pg_version,
+                                              region_id=?request_data.region_id))
         .await?;
 
     Ok(match new_timeline_info {

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -195,7 +195,8 @@ async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<
             request_data.new_timeline_id.map(TimelineId::from),
             request_data.ancestor_timeline_id.map(TimelineId::from),
             request_data.ancestor_start_lsn,
-            request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION)
+            request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
+            request_data.region_id.unwrap_or_default(),
         ).await {
             Ok(Some(new_timeline)) => {
                 // Created. Construct a TimelineInfo for it.

--- a/pageserver/src/import_datadir.rs
+++ b/pageserver/src/import_datadir.rs
@@ -519,6 +519,11 @@ fn import_file<Reader: Read>(
 
         import_slru(modification, slru, file_path, reader, len)?;
         debug!("imported multixact members slru");
+    } else if file_path.starts_with("pg_csn") {
+        let slru = SlruKind::Csn;
+
+        import_slru(modification, slru, file_path, reader, len)?;
+        debug!("imported csn slru");
     } else if file_path.starts_with("pg_twophase") {
         let file_name = &file_path
             .file_name()

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -392,7 +392,12 @@ impl PageServerHandler {
         // Create empty timeline
         info!("creating new timeline");
         let tenant = tenant_mgr::get_tenant(tenant_id, true)?;
-        let timeline = tenant.create_empty_timeline(timeline_id, base_lsn, pg_version)?;
+        let timeline = tenant.create_empty_timeline(
+            timeline_id,
+            base_lsn,
+            pg_version,
+            utils::id::RegionId::default(),
+        )?;
 
         // TODO mark timeline as not ready until it reaches end_lsn.
         // We might have some wal to import as well, and we should prevent compute

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -344,43 +344,44 @@ impl PageServerHandler {
             let response = match neon_fe_msg {
                 PagestreamFeMessage::Exists(req) => {
                     let _timer = metrics.get_rel_exists.start_timer();
-                    self.handle_get_rel_exists_request(
-                        &*get_timeline_by_region_id(&timelines, req.region)?,
-                        &req,
-                    )
-                    .await
+                    match get_timeline_by_region_id(&timelines, req.region) {
+                        Ok(timeline) => {
+                            self.handle_get_rel_exists_request(timeline.as_ref(), &req)
+                                .await
+                        }
+                        Err(e) => Err(e),
+                    }
                 }
                 PagestreamFeMessage::Nblocks(req) => {
                     let _timer = metrics.get_rel_size.start_timer();
-                    self.handle_get_nblocks_request(
-                        &*get_timeline_by_region_id(&timelines, req.region)?,
-                        &req,
-                    )
-                    .await
+                    match get_timeline_by_region_id(&timelines, req.region) {
+                        Ok(timeline) => self.handle_get_nblocks_request(&*timeline, &req).await,
+                        Err(e) => Err(e),
+                    }
                 }
                 PagestreamFeMessage::GetPage(req) => {
                     let _timer = metrics.get_page_at_lsn.start_timer();
-                    self.handle_get_page_at_lsn_request(
-                        &*get_timeline_by_region_id(&timelines, req.region)?,
-                        &req,
-                    )
-                    .await
+                    match get_timeline_by_region_id(&timelines, req.region) {
+                        Ok(timeline) => self.handle_get_page_at_lsn_request(&*timeline, &req).await,
+                        Err(e) => Err(e),
+                    }
                 }
                 PagestreamFeMessage::DbSize(req) => {
                     let _timer = metrics.get_db_size.start_timer();
-                    self.handle_db_size_request(
-                        &*get_timeline_by_region_id(&timelines, RegionId::default())?,
-                        &req,
-                    )
-                    .await
+                    match get_timeline_by_region_id(&timelines, RegionId::default()) {
+                        Ok(timeline) => self.handle_db_size_request(&*timeline, &req).await,
+                        Err(e) => Err(e),
+                    }
                 }
                 PagestreamFeMessage::GetSlruPage(req) => {
                     let _timer = metrics.get_slru_page.start_timer();
-                    self.handle_get_slru_page_at_lsn_request(
-                        &*get_timeline_by_region_id(&timelines, req.region)?,
-                        &req,
-                    )
-                    .await
+                    match get_timeline_by_region_id(&timelines, req.region) {
+                        Ok(timeline) => {
+                            self.handle_get_slru_page_at_lsn_request(&*timeline, &req)
+                                .await
+                        }
+                        Err(e) => Err(e),
+                    }
                 }
             };
 
@@ -1057,7 +1058,7 @@ fn get_timeline_by_region_id(
     index
         .get(&region_id)
         .map(Arc::to_owned)
-        .ok_or_else(|| anyhow::anyhow!("Region id {} does not exists", region_id))
+        .ok_or_else(|| anyhow::anyhow!("Region {} does not exists", region_id))
 }
 
 ///

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -265,11 +265,15 @@ impl PageServerHandler {
         &self,
         pgb: &mut PostgresBackend,
         tenant_id: TenantId,
-        timeline_id: TimelineId,
+        timeline_ids: Vec<TimelineId>,
     ) -> anyhow::Result<()> {
+        let dummy_timeline_id = *timeline_ids
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("List of timeline ids must not be empty"))?;
+
         // NOTE: pagerequests handler exits when connection is closed,
         //       so there is no need to reset the association
-        task_mgr::associate_with(Some(tenant_id), Some(timeline_id));
+        task_mgr::associate_with(Some(tenant_id), Some(dummy_timeline_id));
 
         // Make request tracer if needed
         let tenant = tenant_mgr::get_tenant(tenant_id, true)?;
@@ -284,13 +288,17 @@ impl PageServerHandler {
         };
 
         // Check that the timeline exists
-        let timeline = get_local_timeline(tenant_id, timeline_id)?;
+        let timelines = timeline_ids
+            .into_iter()
+            .map(|tlid| get_local_timeline(tenant_id, tlid))
+            .collect::<Result<Vec<_>, _>>()
+            .context("Cannot load local timeline")?;
 
         // switch client to COPYBOTH
         pgb.write_message(&BeMessage::CopyBothResponse)?;
         pgb.flush().await?;
 
-        let metrics = PageRequestMetrics::new(&tenant_id, &timeline_id);
+        let metrics = PageRequestMetrics::new(&tenant_id, &dummy_timeline_id);
 
         loop {
             let msg = tokio::select! {
@@ -325,19 +333,19 @@ impl PageServerHandler {
             let response = match neon_fe_msg {
                 PagestreamFeMessage::Exists(req) => {
                     let _timer = metrics.get_rel_exists.start_timer();
-                    self.handle_get_rel_exists_request(&timeline, &req).await
+                    self.handle_get_rel_exists_request(&timelines[req.region as usize], &req).await
                 }
                 PagestreamFeMessage::Nblocks(req) => {
                     let _timer = metrics.get_rel_size.start_timer();
-                    self.handle_get_nblocks_request(&timeline, &req).await
+                    self.handle_get_nblocks_request(&timelines[req.region as usize], &req).await
                 }
                 PagestreamFeMessage::GetPage(req) => {
                     let _timer = metrics.get_page_at_lsn.start_timer();
-                    self.handle_get_page_at_lsn_request(&timeline, &req).await
+                    self.handle_get_page_at_lsn_request(&timelines[req.region as usize], &req).await
                 }
                 PagestreamFeMessage::DbSize(req) => {
                     let _timer = metrics.get_db_size.start_timer();
-                    self.handle_db_size_request(&timeline, &req).await
+                    self.handle_db_size_request(&timelines[0], &req).await
                 }
             };
 
@@ -718,8 +726,25 @@ impl postgres_backend_async::Handler for PageServerHandler {
 
             self.check_permission(Some(tenant_id))?;
 
-            self.handle_pagerequests(pgb, tenant_id, timeline_id)
-                .await?;
+            self.handle_pagerequests(pgb, tenant_id, vec![timeline_id]).await?;
+        } else if query_string.starts_with("multipagestream ") {
+            // multipagestream <tenant id as hex string> <timelineid>,<timelineid>,...
+            let (_, params_raw) = query_string.split_at("multipagestream ".len());
+            let params: Vec<_> = params_raw.split(' ').collect();
+            ensure!(
+                params.len() == 2,
+                "invalid param number for multipagestream command"
+            );
+
+            let tenant_id = TenantId::from_str(params[0])?;
+            self.check_permission(Some(tenant_id))?;
+
+            let timeline_ids = params[1]
+                .split(',')
+                .map(TimelineId::from_str)
+                .collect::<Result<_, _>>()?;
+
+            self.handle_pagerequests(pgb, tenant_id, timeline_ids).await?;
         } else if query_string.starts_with("basebackup ") {
             let (_, params_raw) = query_string.split_at("basebackup ".len());
             let params = params_raw.split_whitespace().collect::<Vec<_>>();

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -571,7 +571,7 @@ impl PageServerHandler {
         Ok(lsn)
     }
 
-    #[instrument(skip(self, timeline, req), fields(rel = %req.rel, req_lsn = %req.lsn))]
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, rel = %req.rel, req_lsn = %req.lsn))]
     async fn handle_get_rel_exists_request(
         &self,
         timeline: &Timeline,
@@ -589,7 +589,7 @@ impl PageServerHandler {
         }))
     }
 
-    #[instrument(skip(self, timeline, req), fields(rel = %req.rel, req_lsn = %req.lsn))]
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, rel = %req.rel, req_lsn = %req.lsn))]
     async fn handle_get_nblocks_request(
         &self,
         timeline: &Timeline,
@@ -607,7 +607,7 @@ impl PageServerHandler {
         }))
     }
 
-    #[instrument(skip(self, timeline, req), fields(dbnode = %req.dbnode, req_lsn = %req.lsn))]
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, dbnode = %req.dbnode, req_lsn = %req.lsn))]
     async fn handle_db_size_request(
         &self,
         timeline: &Timeline,
@@ -628,7 +628,7 @@ impl PageServerHandler {
         }))
     }
 
-    #[instrument(skip(self, timeline, req), fields(rel = %req.rel, blkno = %req.blkno, req_lsn = %req.lsn))]
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, rel = %req.rel, blkno = %req.blkno, req_lsn = %req.lsn))]
     async fn handle_get_page_at_lsn_request(
         &self,
         timeline: &Timeline,
@@ -658,7 +658,7 @@ impl PageServerHandler {
         }))
     }
 
-    #[instrument(skip(self, timeline, req), fields(slru_kind = %req.kind.to_str(), segno = %req.segno,
+    #[instrument(skip(self, timeline, req), fields(region = %timeline.region_id, slru_kind = %req.kind.to_str(), segno = %req.segno,
                  check_blkno = %req.blkno, req_lsn = %req.lsn, check_exists_only = %req.check_exists_only))]
     async fn handle_get_slru_page_at_lsn_request(
         &self,

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -597,6 +597,7 @@ impl PageServerHandler {
         let db_size = total_blocks as i64 * BLCKSZ as i64;
 
         Ok(PagestreamBeMessage::DbSize(PagestreamDbSizeResponse {
+            lsn,
             db_size,
         }))
     }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -21,6 +21,7 @@ use pageserver_api::models::{
     PagestreamNblocksResponse,
 };
 use pq_proto::{BeMessage, FeMessage, RowDescriptor};
+use std::collections::HashMap;
 use std::io;
 use std::net::TcpListener;
 use std::str;
@@ -33,7 +34,7 @@ use tracing::*;
 use utils::id::ConnectionId;
 use utils::{
     auth::{self, Claims, JwtAuth, Scope},
-    id::{TenantId, TimelineId},
+    id::{RegionId, TenantId, TimelineId},
     lsn::Lsn,
     postgres_backend::AuthType,
     postgres_backend_async::{self, PostgresBackend},
@@ -271,15 +272,11 @@ impl PageServerHandler {
         &self,
         pgb: &mut PostgresBackend,
         tenant_id: TenantId,
-        timeline_ids: Vec<TimelineId>,
+        timeline_id: Option<TimelineId>,
     ) -> anyhow::Result<()> {
-        let dummy_timeline_id = *timeline_ids
-            .get(0)
-            .ok_or_else(|| anyhow::anyhow!("List of timeline ids must not be empty"))?;
-
         // NOTE: pagerequests handler exits when connection is closed,
         //       so there is no need to reset the association
-        task_mgr::associate_with(Some(tenant_id), Some(dummy_timeline_id));
+        task_mgr::associate_with(Some(tenant_id), timeline_id);
 
         // Make request tracer if needed
         let tenant = tenant_mgr::get_tenant(tenant_id, true)?;
@@ -294,17 +291,25 @@ impl PageServerHandler {
         };
 
         // Check that the timeline exists
-        let timelines = timeline_ids
-            .into_iter()
-            .map(|tlid| get_local_timeline(tenant_id, tlid))
-            .collect::<Result<Vec<_>, _>>()
-            .context("Cannot load local timeline")?;
+        let timelines = if let Some(id) = timeline_id {
+            HashMap::from([(RegionId::default(), get_local_timeline(tenant_id, id)?)])
+        } else {
+            get_local_timelines_indexed_by_region_id(tenant_id)?
+        };
 
         // switch client to COPYBOTH
         pgb.write_message(&BeMessage::CopyBothResponse)?;
         pgb.flush().await?;
 
-        let metrics = PageRequestMetrics::new(&tenant_id, &dummy_timeline_id);
+        let empty_timeline_id = TimelineId::from([0u8; 16]);
+        let metrics = PageRequestMetrics::new(
+            &tenant_id,
+            if let Some(ref id) = timeline_id {
+                id
+            } else {
+                &empty_timeline_id
+            },
+        );
 
         loop {
             let msg = tokio::select! {
@@ -339,27 +344,43 @@ impl PageServerHandler {
             let response = match neon_fe_msg {
                 PagestreamFeMessage::Exists(req) => {
                     let _timer = metrics.get_rel_exists.start_timer();
-                    self.handle_get_rel_exists_request(&timelines[req.region as usize], &req)
-                        .await
+                    self.handle_get_rel_exists_request(
+                        &*get_timeline_by_region_id(&timelines, req.region)?,
+                        &req,
+                    )
+                    .await
                 }
                 PagestreamFeMessage::Nblocks(req) => {
                     let _timer = metrics.get_rel_size.start_timer();
-                    self.handle_get_nblocks_request(&timelines[req.region as usize], &req)
-                        .await
+                    self.handle_get_nblocks_request(
+                        &*get_timeline_by_region_id(&timelines, req.region)?,
+                        &req,
+                    )
+                    .await
                 }
                 PagestreamFeMessage::GetPage(req) => {
                     let _timer = metrics.get_page_at_lsn.start_timer();
-                    self.handle_get_page_at_lsn_request(&timelines[req.region as usize], &req)
-                        .await
+                    self.handle_get_page_at_lsn_request(
+                        &*get_timeline_by_region_id(&timelines, req.region)?,
+                        &req,
+                    )
+                    .await
                 }
                 PagestreamFeMessage::DbSize(req) => {
                     let _timer = metrics.get_db_size.start_timer();
-                    self.handle_db_size_request(&timelines[0], &req).await
+                    self.handle_db_size_request(
+                        &*get_timeline_by_region_id(&timelines, RegionId::default())?,
+                        &req,
+                    )
+                    .await
                 }
                 PagestreamFeMessage::GetSlruPage(req) => {
                     let _timer = metrics.get_slru_page.start_timer();
-                    self.handle_get_slru_page_at_lsn_request(&timelines[req.region as usize], &req)
-                        .await
+                    self.handle_get_slru_page_at_lsn_request(
+                        &*get_timeline_by_region_id(&timelines, req.region)?,
+                        &req,
+                    )
+                    .await
                 }
             };
 
@@ -791,27 +812,21 @@ impl postgres_backend_async::Handler for PageServerHandler {
 
             self.check_permission(Some(tenant_id))?;
 
-            self.handle_pagerequests(pgb, tenant_id, vec![timeline_id])
+            self.handle_pagerequests(pgb, tenant_id, Some(timeline_id))
                 .await?;
         } else if query_string.starts_with("multipagestream ") {
-            // multipagestream <tenant id as hex string> <timelineid>,<timelineid>,...
             let (_, params_raw) = query_string.split_at("multipagestream ".len());
-            let params: Vec<_> = params_raw.split(' ').collect();
+            let params = params_raw.split(' ').collect::<Vec<_>>();
             ensure!(
-                params.len() == 2,
+                params.len() == 1,
                 "invalid param number for multipagestream command"
             );
 
             let tenant_id = TenantId::from_str(params[0])?;
+
             self.check_permission(Some(tenant_id))?;
 
-            let timeline_ids = params[1]
-                .split(',')
-                .map(TimelineId::from_str)
-                .collect::<Result<_, _>>()?;
-
-            self.handle_pagerequests(pgb, tenant_id, timeline_ids)
-                .await?;
+            self.handle_pagerequests(pgb, tenant_id, None).await?;
         } else if query_string.starts_with("basebackup ") {
             let (_, params_raw) = query_string.split_at("basebackup ".len());
             let params = params_raw.split_whitespace().collect::<Vec<_>>();
@@ -1021,6 +1036,28 @@ impl postgres_backend_async::Handler for PageServerHandler {
 fn get_local_timeline(tenant_id: TenantId, timeline_id: TimelineId) -> Result<Arc<Timeline>> {
     tenant_mgr::get_tenant(tenant_id, true)
         .and_then(|tenant| tenant.get_timeline(timeline_id, true))
+}
+
+fn get_local_timelines_indexed_by_region_id(
+    tenant_id: TenantId,
+) -> Result<HashMap<RegionId, Arc<Timeline>>> {
+    let timelines =
+        tenant_mgr::get_tenant(tenant_id, true).map(|tenant| tenant.list_timelines())?;
+    let mut map = HashMap::new();
+    for timeline in timelines {
+        map.insert(timeline.region_id, timeline);
+    }
+    Ok(map)
+}
+
+fn get_timeline_by_region_id(
+    index: &HashMap<RegionId, Arc<Timeline>>,
+    region_id: RegionId,
+) -> Result<Arc<Timeline>> {
+    index
+        .get(&region_id)
+        .map(Arc::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("Region id {} does not exists", region_id))
 }
 
 ///

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -17,7 +17,8 @@ use pageserver_api::models::{
     PagestreamBeMessage, PagestreamDbSizeRequest, PagestreamDbSizeResponse,
     PagestreamErrorResponse, PagestreamExistsRequest, PagestreamExistsResponse,
     PagestreamFeMessage, PagestreamGetPageRequest, PagestreamGetPageResponse,
-    PagestreamNblocksRequest, PagestreamNblocksResponse,
+    PagestreamGetSlruPageRequest, PagestreamGetSlruPageResponse, PagestreamNblocksRequest,
+    PagestreamNblocksResponse,
 };
 use pq_proto::{BeMessage, FeMessage, RowDescriptor};
 use std::io;
@@ -216,6 +217,7 @@ struct PageRequestMetrics {
     get_rel_size: metrics::Histogram,
     get_page_at_lsn: metrics::Histogram,
     get_db_size: metrics::Histogram,
+    get_slru_page: metrics::Histogram,
 }
 
 impl PageRequestMetrics {
@@ -235,11 +237,15 @@ impl PageRequestMetrics {
         let get_db_size =
             SMGR_QUERY_TIME.with_label_values(&["get_db_size", &tenant_id, &timeline_id]);
 
+        let get_slru_page =
+            SMGR_QUERY_TIME.with_label_values(&["get_slru_page", &tenant_id, &timeline_id]);
+
         Self {
             get_rel_exists,
             get_rel_size,
             get_page_at_lsn,
             get_db_size,
+            get_slru_page,
         }
     }
 }
@@ -333,19 +339,27 @@ impl PageServerHandler {
             let response = match neon_fe_msg {
                 PagestreamFeMessage::Exists(req) => {
                     let _timer = metrics.get_rel_exists.start_timer();
-                    self.handle_get_rel_exists_request(&timelines[req.region as usize], &req).await
+                    self.handle_get_rel_exists_request(&timelines[req.region as usize], &req)
+                        .await
                 }
                 PagestreamFeMessage::Nblocks(req) => {
                     let _timer = metrics.get_rel_size.start_timer();
-                    self.handle_get_nblocks_request(&timelines[req.region as usize], &req).await
+                    self.handle_get_nblocks_request(&timelines[req.region as usize], &req)
+                        .await
                 }
                 PagestreamFeMessage::GetPage(req) => {
                     let _timer = metrics.get_page_at_lsn.start_timer();
-                    self.handle_get_page_at_lsn_request(&timelines[req.region as usize], &req).await
+                    self.handle_get_page_at_lsn_request(&timelines[req.region as usize], &req)
+                        .await
                 }
                 PagestreamFeMessage::DbSize(req) => {
                     let _timer = metrics.get_db_size.start_timer();
                     self.handle_db_size_request(&timelines[0], &req).await
+                }
+                PagestreamFeMessage::GetSlruPage(req) => {
+                    let _timer = metrics.get_slru_page.start_timer();
+                    self.handle_get_slru_page_at_lsn_request(&timelines[req.region as usize], &req)
+                        .await
                 }
             };
 
@@ -614,6 +628,44 @@ impl PageServerHandler {
         }))
     }
 
+    #[instrument(skip(self, timeline, req), fields(slru_kind = %req.kind.to_str(), segno = %req.segno,
+                 check_blkno = %req.blkno, req_lsn = %req.lsn, check_exists_only = %req.check_exists_only))]
+    async fn handle_get_slru_page_at_lsn_request(
+        &self,
+        timeline: &Timeline,
+        req: &PagestreamGetSlruPageRequest,
+    ) -> Result<PagestreamBeMessage> {
+        let latest_gc_cutoff_lsn = timeline.get_latest_gc_cutoff_lsn();
+        let lsn = Self::wait_or_get_last_lsn(timeline, req.lsn, req.latest, &latest_gc_cutoff_lsn)
+            .await?;
+
+        let seg_exists = timeline.get_slru_segment_exists(req.kind, req.segno, lsn)?;
+        let mut page = None;
+
+        /*
+         * During recovery, postgres treats non-existent segment files as truncated files and
+         * returns an empty SLRU page instead of error (see notes in SlruPhysicalWritePage in slru.c).
+         * Hence, we don't return error here when the segment file does not exist.
+         */
+        if seg_exists {
+            let page_res = timeline.get_slru_page_at_lsn(req.kind, req.segno, req.blkno, lsn);
+            if req.check_exists_only {
+                page = page_res.and(Ok(Bytes::default())).ok();
+            } else {
+                page = Some(page_res.map(|mut buf| {
+                    // Neon appends an 8-byte timestamp to the page so need to ensure that the
+                    // page has postgres page size
+                    buf.truncate(BLCKSZ as usize);
+                    buf
+                })?);
+            }
+        }
+
+        Ok(PagestreamBeMessage::GetSlruPage(
+            PagestreamGetSlruPageResponse { seg_exists, page },
+        ))
+    }
+
     #[instrument(skip(self, pgb))]
     async fn handle_basebackup_request(
         &self,
@@ -726,7 +778,8 @@ impl postgres_backend_async::Handler for PageServerHandler {
 
             self.check_permission(Some(tenant_id))?;
 
-            self.handle_pagerequests(pgb, tenant_id, vec![timeline_id]).await?;
+            self.handle_pagerequests(pgb, tenant_id, vec![timeline_id])
+                .await?;
         } else if query_string.starts_with("multipagestream ") {
             // multipagestream <tenant id as hex string> <timelineid>,<timelineid>,...
             let (_, params_raw) = query_string.split_at("multipagestream ".len());
@@ -744,7 +797,8 @@ impl postgres_backend_async::Handler for PageServerHandler {
                 .map(TimelineId::from_str)
                 .collect::<Result<_, _>>()?;
 
-            self.handle_pagerequests(pgb, tenant_id, timeline_ids).await?;
+            self.handle_pagerequests(pgb, tenant_id, timeline_ids)
+                .await?;
         } else if query_string.starts_with("basebackup ") {
             let (_, params_raw) = query_string.split_at("basebackup ".len());
             let params = params_raw.split_whitespace().collect::<Vec<_>>();

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -282,9 +282,11 @@ impl PageServerHandler {
         let tenant = tenant_mgr::get_tenant(tenant_id, true)?;
         let mut tracer = if tenant.get_trace_read_requests() {
             let connection_id = ConnectionId::generate();
-            let path = tenant
-                .conf
-                .trace_path(&tenant_id, &timeline_id, &connection_id);
+            let path = tenant.conf.trace_path(
+                &tenant_id,
+                &timeline_id.unwrap_or_else(|| TimelineId::from([0u8; 16])),
+                &connection_id,
+            );
             Some(Tracer::new(path))
         } else {
             None

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -558,6 +558,7 @@ impl PageServerHandler {
         let exists = timeline.get_rel_exists(req.rel, lsn, req.latest)?;
 
         Ok(PagestreamBeMessage::Exists(PagestreamExistsResponse {
+            lsn,
             exists,
         }))
     }
@@ -575,6 +576,7 @@ impl PageServerHandler {
         let n_blocks = timeline.get_rel_size(req.rel, lsn, req.latest)?;
 
         Ok(PagestreamBeMessage::Nblocks(PagestreamNblocksResponse {
+            lsn,
             n_blocks,
         }))
     }
@@ -624,6 +626,7 @@ impl PageServerHandler {
         let page = timeline.get_rel_page_at_lsn(req.rel, req.blkno, lsn, req.latest)?;
 
         Ok(PagestreamBeMessage::GetPage(PagestreamGetPageResponse {
+            lsn,
             page,
         }))
     }
@@ -662,7 +665,11 @@ impl PageServerHandler {
         }
 
         Ok(PagestreamBeMessage::GetSlruPage(
-            PagestreamGetSlruPageResponse { seg_exists, page },
+            PagestreamGetSlruPageResponse {
+                lsn,
+                seg_exists,
+                page,
+            },
         ))
     }
 

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -1425,7 +1425,7 @@ pub fn create_test_timeline(
     pg_version: u32,
 ) -> Result<std::sync::Arc<Timeline>> {
     let tline = tenant
-        .create_empty_timeline(timeline_id, Lsn(8), pg_version)?
+        .create_empty_timeline(timeline_id, Lsn(8), pg_version, utils::id::RegionId(0))?
         .initialize()?;
     let mut m = tline.begin_modification(Lsn(8));
     m.init_empty()?;

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -436,6 +436,7 @@ impl Timeline {
             SlruKind::Clog,
             SlruKind::MultiXactMembers,
             SlruKind::MultiXactOffsets,
+            SlruKind::Csn,
         ] {
             let slrudir_key = slru_dir_to_key(kind);
             result.add_key(slrudir_key);
@@ -555,7 +556,11 @@ impl<'a> DatadirModification<'a> {
             slru_dir_to_key(SlruKind::MultiXactMembers),
             empty_dir.clone(),
         );
-        self.put(slru_dir_to_key(SlruKind::MultiXactOffsets), empty_dir);
+        self.put(
+            slru_dir_to_key(SlruKind::MultiXactOffsets),
+            empty_dir.clone(),
+        );
+        self.put(slru_dir_to_key(SlruKind::Csn), empty_dir);
 
         Ok(())
     }
@@ -1228,6 +1233,7 @@ fn slru_dir_to_key(kind: SlruKind) -> Key {
             SlruKind::Clog => 0x00,
             SlruKind::MultiXactMembers => 0x01,
             SlruKind::MultiXactOffsets => 0x02,
+            SlruKind::Csn => 0x03,
         },
         field3: 0,
         field4: 0,
@@ -1243,6 +1249,7 @@ fn slru_block_to_key(kind: SlruKind, segno: u32, blknum: BlockNumber) -> Key {
             SlruKind::Clog => 0x00,
             SlruKind::MultiXactMembers => 0x01,
             SlruKind::MultiXactOffsets => 0x02,
+            SlruKind::Csn => 0x03,
         },
         field3: 1,
         field4: segno,
@@ -1258,6 +1265,7 @@ fn slru_segment_size_to_key(kind: SlruKind, segno: u32) -> Key {
             SlruKind::Clog => 0x00,
             SlruKind::MultiXactMembers => 0x01,
             SlruKind::MultiXactOffsets => 0x02,
+            SlruKind::Csn => 0x03,
         },
         field3: 1,
         field4: segno,
@@ -1271,6 +1279,7 @@ fn slru_segment_key_range(kind: SlruKind, segno: u32) -> Range<Key> {
         SlruKind::Clog => 0x00,
         SlruKind::MultiXactMembers => 0x01,
         SlruKind::MultiXactOffsets => 0x02,
+        SlruKind::Csn => 0x03,
     };
 
     Key {
@@ -1391,6 +1400,7 @@ pub fn key_to_slru_block(key: Key) -> Result<(SlruKind, u32, BlockNumber)> {
                 0x00 => SlruKind::Clog,
                 0x01 => SlruKind::MultiXactMembers,
                 0x02 => SlruKind::MultiXactOffsets,
+                0x03 => SlruKind::Csn,
                 _ => bail!("unrecognized slru kind 0x{:02x}", key.field2),
             };
             let segno = key.field4;

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -560,7 +560,7 @@ impl<'a> DatadirModification<'a> {
             slru_dir_to_key(SlruKind::MultiXactOffsets),
             empty_dir.clone(),
         );
-        self.put(slru_dir_to_key(SlruKind::Csn), empty_dir);
+        self.put(slru_dir_to_key(SlruKind::Csn), empty_dir.clone());
 
         Ok(())
     }

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -560,7 +560,7 @@ impl<'a> DatadirModification<'a> {
             slru_dir_to_key(SlruKind::MultiXactOffsets),
             empty_dir.clone(),
         );
-        self.put(slru_dir_to_key(SlruKind::Csn), empty_dir.clone());
+        self.put(slru_dir_to_key(SlruKind::Csn), empty_dir);
 
         Ok(())
     }

--- a/pageserver/src/storage_sync.rs
+++ b/pageserver/src/storage_sync.rs
@@ -1573,6 +1573,7 @@ mod test_utils {
             // Any version will do
             // but it should be consistent with the one in the tests
             crate::DEFAULT_PG_VERSION,
+            utils::id::RegionId(0),
         )
     }
 }

--- a/pageserver/src/storage_sync/index.rs
+++ b/pageserver/src/storage_sync/index.rs
@@ -476,6 +476,7 @@ mod tests {
     use super::*;
     use crate::tenant::harness::{TenantHarness, TIMELINE_ID};
     use crate::DEFAULT_PG_VERSION;
+    use utils::id::RegionId;
 
     #[test]
     fn index_part_conversion() {
@@ -489,6 +490,7 @@ mod tests {
             Lsn(2),
             Lsn(1),
             DEFAULT_PG_VERSION,
+            RegionId(0),
         );
         let remote_timeline = RemoteTimeline {
             timeline_layers: HashMap::from([
@@ -614,6 +616,7 @@ mod tests {
             Lsn(2),
             Lsn(1),
             DEFAULT_PG_VERSION,
+            RegionId(0),
         );
 
         let conversion_result = IndexPart::from_remote_timeline(

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -492,7 +492,10 @@ impl Tenant {
                     region_id,
                 )?
             }
-            None => self.bootstrap_timeline(new_timeline_id, pg_version, region_id).await?,
+            None => {
+                self.bootstrap_timeline(new_timeline_id, pg_version, region_id)
+                    .await?
+            }
         };
 
         // Have added new timeline into the tenant, now its background tasks are needed.

--- a/pageserver/src/tenant/metadata.rs
+++ b/pageserver/src/tenant/metadata.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info_span;
 use utils::{
     bin_ser::BeSer,
-    id::{TenantId, TimelineId},
+    id::{RegionId, TenantId, TimelineId},
     lsn::Lsn,
 };
 
@@ -69,6 +69,7 @@ struct TimelineMetadataBodyV2 {
     latest_gc_cutoff_lsn: Lsn,
     initdb_lsn: Lsn,
     pg_version: u32,
+    region_id: RegionId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -89,6 +90,7 @@ struct TimelineMetadataBodyV1 {
     ancestor_lsn: Lsn,
     latest_gc_cutoff_lsn: Lsn,
     initdb_lsn: Lsn,
+    region_id: RegionId,
 }
 
 impl TimelineMetadata {
@@ -100,6 +102,7 @@ impl TimelineMetadata {
         latest_gc_cutoff_lsn: Lsn,
         initdb_lsn: Lsn,
         pg_version: u32,
+        region_id: RegionId,
     ) -> Self {
         Self {
             hdr: TimelineMetadataHeader {
@@ -115,6 +118,7 @@ impl TimelineMetadata {
                 latest_gc_cutoff_lsn,
                 initdb_lsn,
                 pg_version,
+                region_id,
             },
         }
     }
@@ -142,6 +146,7 @@ impl TimelineMetadata {
             latest_gc_cutoff_lsn: body.latest_gc_cutoff_lsn,
             initdb_lsn: body.initdb_lsn,
             pg_version: 14, // All timelines created before this version had pg_version 14
+            region_id: body.region_id,
         };
 
         hdr.format_version = METADATA_FORMAT_VERSION;
@@ -226,6 +231,10 @@ impl TimelineMetadata {
     pub fn pg_version(&self) -> u32 {
         self.body.pg_version
     }
+
+    pub fn region_id(&self) -> RegionId {
+        self.body.region_id
+    }
 }
 
 /// Save timeline metadata to file
@@ -280,6 +289,7 @@ mod tests {
             Lsn(0),
             // Any version will do here, so use the default
             crate::DEFAULT_PG_VERSION,
+            RegionId(0),
         );
 
         let metadata_bytes = original_metadata
@@ -318,6 +328,7 @@ mod tests {
                 ancestor_lsn: Lsn(0),
                 latest_gc_cutoff_lsn: Lsn(0),
                 initdb_lsn: Lsn(0),
+                region_id: RegionId(0),
             },
         };
 
@@ -354,6 +365,7 @@ mod tests {
             Lsn(0),
             Lsn(0),
             14, // All timelines created before this version had pg_version 14
+            RegionId(0),
         );
 
         assert_eq!(

--- a/pageserver/src/tenant/metadata.rs
+++ b/pageserver/src/tenant/metadata.rs
@@ -94,6 +94,7 @@ struct TimelineMetadataBodyV1 {
 }
 
 impl TimelineMetadata {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         disk_consistent_lsn: Lsn,
         prev_record_lsn: Option<Lsn>,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -42,7 +42,7 @@ use pageserver_api::reltag::RelTag;
 
 use postgres_ffi::to_pg_timestamp;
 use utils::{
-    id::{TenantId, TimelineId},
+    id::{RegionId, TenantId, TimelineId},
     lsn::{AtomicLsn, Lsn, RecordLsn},
     seqwait::SeqWait,
     simple_rcu::{Rcu, RcuReadGuard},
@@ -172,6 +172,9 @@ pub struct Timeline {
     pub rel_size_cache: RwLock<HashMap<RelTag, (Lsn, BlockNumber)>>,
 
     state: watch::Sender<TimelineState>,
+
+    /// Region id
+    pub region_id: RegionId,
 }
 
 /// Internal structure to hold all data needed for logical size calculation.
@@ -788,6 +791,7 @@ impl Timeline {
             last_received_wal: Mutex::new(None),
             rel_size_cache: RwLock::new(HashMap::new()),
             state,
+            region_id: metadata.region_id(),
         };
         result.repartition_threshold = result.get_checkpoint_distance() / 10;
         result
@@ -1491,6 +1495,7 @@ impl Timeline {
             *self.latest_gc_cutoff_lsn.read(),
             self.initdb_lsn,
             self.pg_version,
+            self.region_id,
         );
 
         fail_point!("checkpoint-before-saving-metadata", |x| bail!(

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -23,7 +23,8 @@
 
 use anyhow::Context;
 use postgres_ffi::v14::nonrelfile_utils::clogpage_precedes;
-use postgres_ffi::v14::nonrelfile_utils::slru_may_delete_clogsegment;
+use postgres_ffi::v14::nonrelfile_utils::slru_may_delete_segment;
+use postgres_ffi::v14::nonrelfile_utils::csnlogpage_precedes;
 use postgres_ffi::{page_is_new, page_set_lsn};
 
 use anyhow::Result;
@@ -42,6 +43,7 @@ use postgres_ffi::v14::xlog_utils::*;
 use postgres_ffi::v14::CheckPoint;
 use postgres_ffi::TransactionId;
 use postgres_ffi::BLCKSZ;
+use postgres_ffi::XidCSN;
 use utils::lsn::Lsn;
 
 pub struct WalIngest<'a> {
@@ -274,6 +276,27 @@ impl<'a> WalIngest<'a> {
                     self.checkpoint_modified = true;
                 }
             }
+        } else if decoded.xl_rmid == pg_constants::RM_CSNLOG_ID {
+            let info = decoded.xl_info & !pg_constants::XLR_INFO_MASK;
+            if info == pg_constants::XLOG_CSN_ZEROPAGE {
+                let pageno = buf.get_u32_le();
+                let segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
+                let rpageno = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
+                self.put_slru_page_image(
+                    modification,
+                    SlruKind::Csn,
+                    segno,
+                    rpageno,
+                    ZERO_PAGE.clone(),
+                )?;
+            } else if info == pg_constants::XLOG_CSN_TRUNCATE {
+                let pageno: u32 = buf.get_u32_le();
+                self.ingest_csnlog_truncate_record(modification, pageno)?;
+            }
+            // We don't handle assignment and set records to avoid the
+            // ambiguity of the commit order. Instead we rely on the 
+            // XLOG records to determine the LSN and thus commit order.
+
         }
 
         // Iterate through all the blocks that the record modifies, and
@@ -703,6 +726,48 @@ impl<'a> WalIngest<'a> {
             },
         )?;
 
+        // Record update of CSN pages.
+        let mut csn_pageno = parsed.xid / pg_constants::CSN_LOG_XACTS_PER_PAGE;
+        let mut csn_segno = csn_pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
+        let mut csn_rpageno = csn_pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
+        let mut csn_page_xids: Vec<TransactionId> = vec![parsed.xid];
+        let lsn : XidCSN = modification.lsn.0;
+
+        for subxact in &parsed.subxacts {
+            let csn_subxact_pageno = subxact / pg_constants::CSN_LOG_XACTS_PER_PAGE;
+            if csn_subxact_pageno != csn_pageno {
+                // This subxact goes to different page. Write the record
+                // for all the XIDs on the previous page, and continue
+                // accumulating XIDs on this new page.
+                modification.put_slru_wal_record(
+                    SlruKind::Csn,
+                    csn_segno,
+                    csn_rpageno,
+                    if is_commit {
+                        NeonWalRecord::CsnLogSetCommitted { xids: csn_page_xids, lsn: lsn }
+                    } else {
+                        NeonWalRecord::CsnLogSetAborted { xids: csn_page_xids }
+                    },
+                )?;
+                csn_page_xids = Vec::new();
+            }
+            csn_pageno = csn_subxact_pageno;
+            csn_segno = csn_pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
+            csn_rpageno = csn_pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
+            csn_page_xids.push(*subxact);
+        }
+        modification.put_slru_wal_record(
+            SlruKind::Csn,
+            csn_segno,
+            csn_rpageno,
+            if is_commit {
+                NeonWalRecord::CsnLogSetCommitted { xids: csn_page_xids, lsn: lsn }
+            } else {
+                NeonWalRecord::CsnLogSetAborted { xids: csn_page_xids }
+            },
+        )?;
+
+
         for xnode in &parsed.xnodes {
             for forknum in MAIN_FORKNUM..=VISIBILITYMAP_FORKNUM {
                 let rel = RelTag {
@@ -769,7 +834,7 @@ impl<'a> WalIngest<'a> {
             .list_slru_segments(SlruKind::Clog, req_lsn)?
         {
             let segpage = segno * pg_constants::SLRU_PAGES_PER_SEGMENT;
-            if slru_may_delete_clogsegment(segpage, xlrec.pageno) {
+            if slru_may_delete_segment(segpage, xlrec.pageno) {
                 modification.drop_slru_segment(SlruKind::Clog, segno)?;
                 trace!("Drop CLOG segment {:>04X}", segno);
             }
@@ -904,6 +969,44 @@ impl<'a> WalIngest<'a> {
 
         modification.put_relmap_file(xlrec.tsid, xlrec.dbid, Bytes::copy_from_slice(&buf[..]))?;
 
+        Ok(())
+    }
+
+    fn ingest_csnlog_truncate_record(
+        &mut self,
+        modification: &mut DatadirModification,
+        pageno: u32,
+    ) -> Result<()> {
+        info!("XLOG_CSN_TRUNCATE truncate pageno {} ", pageno);
+
+        let latest_page_number = 
+            self.checkpoint.nextXid.value as u32 / pg_constants::CSN_LOG_XACTS_PER_PAGE;
+
+        // First, make an important safety check:
+        // the current endpoint page must not be eligible for removal.
+        // See SimpleLruTruncate() in slru.c
+        if csnlogpage_precedes(latest_page_number, pageno) {
+            info!("could not truncate directory pg_csn apparent wraparound");
+            return Ok(());
+        }
+
+        // Iterate via SLRU CsnLog segments and drop segments that we're ready to truncate
+        //
+        // We cannot pass 'lsn' to the Timeline.list_nonrels(), or it
+        // will block waiting for the last valid LSN to advance up to
+        // it. So we use the previous record's LSN in the get calls
+        // instead.
+        let req_lsn = modification.tline.get_last_record_lsn();
+        for segno in modification
+            .tline
+            .list_slru_segments(SlruKind::Csn, req_lsn)?
+        {
+            let segpage = segno * pg_constants::SLRU_PAGES_PER_SEGMENT;
+            if slru_may_delete_segment(segpage, pageno) {
+                modification.drop_slru_segment(SlruKind::Csn, segno)?;
+                trace!("Drop Csn segment {:>04X}", segno);
+            }
+        }
         Ok(())
     }
 

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -750,13 +750,13 @@ impl<'a> WalIngest<'a> {
                     if is_commit {
                         NeonWalRecord::CsnLogSetCommitted {
                             xids: csn_page_xids,
-                            region: region,
-                            lsn: lsn,
+                            region,
+                            lsn,
                         }
                     } else {
                         NeonWalRecord::CsnLogSetAborted {
                             xids: csn_page_xids,
-                            region: region,
+                            region,
                         }
                     },
                 )?;
@@ -774,13 +774,13 @@ impl<'a> WalIngest<'a> {
             if is_commit {
                 NeonWalRecord::CsnLogSetCommitted {
                     xids: csn_page_xids,
-                    region: region,
-                    lsn: lsn,
+                    region,
+                    lsn,
                 }
             } else {
                 NeonWalRecord::CsnLogSetAborted {
                     xids: csn_page_xids,
-                    region: region,
+                    region,
                 }
             },
         )?;

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -726,14 +726,19 @@ impl<'a> WalIngest<'a> {
         )?;
 
         // Record update of CSN pages.
-        let mut csn_pageno = parsed.xid / pg_constants::CSN_LOG_XACTS_PER_PAGE;
+        let region: u32 = self.timeline.region_id.0 as u32;
+        let mut csn_pageno = ((parsed.xid / pg_constants::CSN_LOG_XACTS_PER_PAGE)
+            * pg_constants::MAX_REGIONS)
+            + region;
         let mut csn_segno = csn_pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
         let mut csn_rpageno = csn_pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
         let mut csn_page_xids: Vec<TransactionId> = vec![parsed.xid];
         let lsn: XidCSN = modification.lsn.0;
 
         for subxact in &parsed.subxacts {
-            let csn_subxact_pageno = subxact / pg_constants::CSN_LOG_XACTS_PER_PAGE;
+            let csn_subxact_pageno = ((subxact / pg_constants::CSN_LOG_XACTS_PER_PAGE)
+                * pg_constants::MAX_REGIONS)
+                + region;
             if csn_subxact_pageno != csn_pageno {
                 // This subxact goes to different page. Write the record
                 // for all the XIDs on the previous page, and continue
@@ -745,11 +750,13 @@ impl<'a> WalIngest<'a> {
                     if is_commit {
                         NeonWalRecord::CsnLogSetCommitted {
                             xids: csn_page_xids,
+                            region: region,
                             lsn: lsn,
                         }
                     } else {
                         NeonWalRecord::CsnLogSetAborted {
                             xids: csn_page_xids,
+                            region: region,
                         }
                     },
                 )?;
@@ -767,11 +774,13 @@ impl<'a> WalIngest<'a> {
             if is_commit {
                 NeonWalRecord::CsnLogSetCommitted {
                     xids: csn_page_xids,
+                    region: region,
                     lsn: lsn,
                 }
             } else {
                 NeonWalRecord::CsnLogSetAborted {
                     xids: csn_page_xids,
+                    region: region,
                 }
             },
         )?;

--- a/pageserver/src/walreceiver/connection_manager.rs
+++ b/pageserver/src/walreceiver/connection_manager.rs
@@ -1480,7 +1480,12 @@ mod tests {
             },
             timeline: harness
                 .load()
-                .create_empty_timeline(TIMELINE_ID, Lsn(0), crate::DEFAULT_PG_VERSION)
+                .create_empty_timeline(
+                    TIMELINE_ID,
+                    Lsn(0),
+                    crate::DEFAULT_PG_VERSION,
+                    utils::id::RegionId(0),
+                )
                 .expect("Failed to create an empty timeline for dummy wal connection manager")
                 .initialize()
                 .unwrap(),

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -43,9 +43,16 @@ pub enum NeonWalRecord {
         members: Vec<MultiXactMember>,
     },
     /// Mark transaction ID as committed with the given LSN on a CsnLog page
-    CsnLogSetCommitted { xids: Vec<TransactionId>, region: u32, lsn: u64 },
+    CsnLogSetCommitted {
+        xids: Vec<TransactionId>,
+        region: u32,
+        lsn: u64,
+    },
     /// Mark transaction ID as aborted on a CsnLog page
-    CsnLogSetAborted { xids: Vec<TransactionId>, region: u32},
+    CsnLogSetAborted {
+        xids: Vec<TransactionId>,
+        region: u32,
+    },
 }
 
 impl NeonWalRecord {

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -42,6 +42,13 @@ pub enum NeonWalRecord {
         moff: MultiXactOffset,
         members: Vec<MultiXactMember>,
     },
+    /// Mark transaction ID as committed with the given LSN on a CsnLog page
+    CsnLogSetCommitted {
+        xids: Vec<TransactionId>,
+        lsn: u64,
+    },
+    /// Mark transaction ID as aborted on a CsnLog page
+    CsnLogSetAborted { xids: Vec<TransactionId> },
 }
 
 impl NeonWalRecord {

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -43,10 +43,7 @@ pub enum NeonWalRecord {
         members: Vec<MultiXactMember>,
     },
     /// Mark transaction ID as committed with the given LSN on a CsnLog page
-    CsnLogSetCommitted {
-        xids: Vec<TransactionId>,
-        lsn: u64,
-    },
+    CsnLogSetCommitted { xids: Vec<TransactionId>, lsn: u64 },
     /// Mark transaction ID as aborted on a CsnLog page
     CsnLogSetAborted { xids: Vec<TransactionId> },
 }

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -43,9 +43,9 @@ pub enum NeonWalRecord {
         members: Vec<MultiXactMember>,
     },
     /// Mark transaction ID as committed with the given LSN on a CsnLog page
-    CsnLogSetCommitted { xids: Vec<TransactionId>, lsn: u64 },
+    CsnLogSetCommitted { xids: Vec<TransactionId>, region: u32, lsn: u64 },
     /// Mark transaction ID as aborted on a CsnLog page
-    CsnLogSetAborted { xids: Vec<TransactionId> },
+    CsnLogSetAborted { xids: Vec<TransactionId>, region: u32},
 }
 
 impl NeonWalRecord {

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -53,7 +53,7 @@ use postgres_ffi::pg_constants;
 use postgres_ffi::relfile_utils::VISIBILITYMAP_FORKNUM;
 use postgres_ffi::v14::nonrelfile_utils::{
     mx_offset_to_flags_bitshift, mx_offset_to_flags_offset, mx_offset_to_member_offset,
-    transaction_id_set_status, transaction_id_set_csn,
+    transaction_id_set_csn, transaction_id_set_status,
 };
 use postgres_ffi::BLCKSZ;
 

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -537,7 +537,7 @@ impl PostgresRedoManager {
                     LittleEndian::write_u32(&mut page[memberoff..memberoff + 4], member.xid);
                 }
             }
-            NeonWalRecord::CsnLogSetCommitted { xids, lsn } => {
+            NeonWalRecord::CsnLogSetCommitted { xids, region, lsn } => {
                 let (slru_kind, segno, blknum) =
                     key_to_slru_block(key).or(Err(WalRedoError::InvalidRecord))?;
                 assert_eq!(
@@ -548,7 +548,9 @@ impl PostgresRedoManager {
                 );
 
                 for &xid in xids {
-                    let pageno = xid as u32 / pg_constants::CSN_LOG_XACTS_PER_PAGE;
+                    let pageno = ((xid as u32 / pg_constants::CSN_LOG_XACTS_PER_PAGE)
+                        * pg_constants::MAX_REGIONS)
+                        + *region;
                     let expected_segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
                     let expected_blknum = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
 
@@ -568,7 +570,7 @@ impl PostgresRedoManager {
                     transaction_id_set_csn(xid, *lsn, page);
                 }
             }
-            NeonWalRecord::CsnLogSetAborted { xids } => {
+            NeonWalRecord::CsnLogSetAborted { xids, region } => {
                 let (slru_kind, segno, blknum) =
                     key_to_slru_block(key).or(Err(WalRedoError::InvalidRecord))?;
                 assert_eq!(
@@ -579,7 +581,9 @@ impl PostgresRedoManager {
                 );
 
                 for &xid in xids {
-                    let pageno = xid as u32 / pg_constants::CSN_LOG_XACTS_PER_PAGE;
+                    let pageno = ((xid as u32 / pg_constants::CSN_LOG_XACTS_PER_PAGE)
+                        * pg_constants::MAX_REGIONS)
+                        + *region;
                     let expected_segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
                     let expected_blknum = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
 

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -56,7 +56,6 @@ use postgres_ffi::v14::nonrelfile_utils::{
     transaction_id_set_status, transaction_id_set_csn,
 };
 use postgres_ffi::BLCKSZ;
-use postgres_ffi::pg_constants::AbortedXidCSN;
 
 ///
 /// `RelTag` + block number (`blknum`) gives us a unique id of the page in the cluster.
@@ -568,8 +567,6 @@ impl PostgresRedoManager {
                     );
                     transaction_id_set_csn(xid, *lsn, page);
                 }
-
-
             }
             NeonWalRecord::CsnLogSetAborted { xids } => {
                 let (slru_kind, segno, blknum) =
@@ -600,7 +597,7 @@ impl PostgresRedoManager {
                         key
                     );
 
-                    transaction_id_set_csn(xid, AbortedXidCSN, page);
+                    transaction_id_set_csn(xid, pg_constants::AbortedXidCSN, page);
                 }
             }
         }

--- a/pgxn/neon/Makefile
+++ b/pgxn/neon/Makefile
@@ -1,6 +1,5 @@
 # pgxs/neon/Makefile
 
-
 MODULE_big = neon
 OBJS = \
 	$(WIN32RES) \

--- a/pgxn/neon/Makefile
+++ b/pgxn/neon/Makefile
@@ -10,7 +10,8 @@ OBJS = \
 	relsize_cache.o \
 	neon.o \
 	walproposer.o \
-	walproposer_utils.o
+	walproposer_utils.o \
+	multiregion.o
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
 SHLIB_LINK_INTERNAL = $(libpq)

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -80,10 +80,10 @@ pageserver_connect()
 				 errdetail_internal("%s", msg)));
 	}
 
-	if (neon_multiregion_enabled())
+	if (IsMultiRegion())
 	{
-		neon_log(LOG, "multi-region enabled, timelines: %s", neon_region_timelines);
-		query = psprintf("multipagestream %s %s", neon_tenant, neon_region_timelines);
+		neon_log(LOG, "multi-region enabled");
+		query = psprintf("multipagestream %s", neon_tenant);
 	}
 	else
 		query = psprintf("pagestream %s %s", neon_tenant, neon_timeline);
@@ -495,8 +495,6 @@ pg_init_libpagestore(void)
 							 PGC_POSTMASTER,
 							 0, /* no flags required */
 							 NULL, NULL, NULL);
-
-	DefineMultiRegionCustomVariables();
 
 	relsize_hash_init();
 

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -524,4 +524,5 @@ pg_init_libpagestore(void)
 	slru_page_exists_hook = neon_slru_page_exists;
 
 	get_region_lsn_hook = get_region_lsn;
+	get_all_region_lsns_hook = get_all_region_lsns;
 }

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -14,8 +14,10 @@
  */
 #include "postgres.h"
 
+#include "multiregion.h"
 #include "pagestore_client.h"
 #include "fmgr.h"
+#include "access/remotexact.h"
 #include "access/xlog.h"
 
 #include "libpq-fe.h"
@@ -78,7 +80,14 @@ pageserver_connect()
 				 errdetail_internal("%s", msg)));
 	}
 
-	query = psprintf("pagestream %s %s", neon_tenant, neon_timeline);
+	if (neon_multiregion_enabled())
+	{
+		neon_log(LOG, "multi-region enabled, timelines: %s", neon_region_timelines);
+		query = psprintf("multipagestream %s %s", neon_tenant, neon_region_timelines);
+	}
+	else
+		query = psprintf("pagestream %s %s", neon_tenant, neon_timeline);
+
 	ret = PQsendQuery(pageserver_conn, query);
 	if (ret != 1)
 	{
@@ -192,6 +201,10 @@ pageserver_send(NeonRequest * request)
 {
 	StringInfoData req_buff;
 
+	/* Fallback to the current region if the request region is unknown */
+	if (request->region == UNKNOWN_REGION)
+		request->region = current_region;
+
 	/* If the connection was lost for some reason, reconnect */
 	if (connected && PQstatus(pageserver_conn) == CONNECTION_BAD)
 		pageserver_disconnect();
@@ -233,7 +246,7 @@ pageserver_send(NeonRequest * request)
 }
 
 static NeonResponse *
-pageserver_receive(void)
+pageserver_receive(int region)
 {
 	StringInfoData resp_buff;
 	NeonResponse *resp;
@@ -268,6 +281,8 @@ pageserver_receive(void)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	set_region_lsn(region, resp);
 
 	return (NeonResponse *) resp;
 }
@@ -444,6 +459,7 @@ pg_init_libpagestore(void)
 							PGC_SIGHUP,
 							GUC_UNIT_MB,
 							NULL, NULL, NULL);
+
 	DefineCustomIntVariable("neon.flush_output_after",
 							"Flush the output buffer after every N unflushed requests",
 							NULL,
@@ -452,6 +468,26 @@ pg_init_libpagestore(void)
 							PGC_SIGHUP,
 							0,	/* no flags required */
 							NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("neon.slru_clog",
+							 "read clog from the page server",
+							 NULL,
+							 &neon_slru_clog,
+							 false,
+							 PGC_POSTMASTER,
+							 0, /* no flags required */
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("neon.slru_multixact",
+							 "read multixact from the page server",
+							 NULL,
+							 &neon_slru_multixact,
+							 false,
+							 PGC_POSTMASTER,
+							 0, /* no flags required */
+							 NULL, NULL, NULL);
+
+	DefineMultiRegionCustomVariables();
 
 	relsize_hash_init();
 
@@ -475,4 +511,10 @@ pg_init_libpagestore(void)
 		smgr_init_hook = smgr_init_neon;
 		dbsize_hook = neon_dbsize;
 	}
+
+	slru_kind_check_hook = neon_slru_kind_check;
+	slru_read_page_hook = neon_slru_read_page;
+	slru_page_exists_hook = neon_slru_page_exists;
+
+	get_region_lsn_hook = get_region_lsn;
 }

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -487,6 +487,15 @@ pg_init_libpagestore(void)
 							 0, /* no flags required */
 							 NULL, NULL, NULL);
 
+	DefineCustomBoolVariable("neon.slru_csnlog",
+							 "read csnlog from the page server",
+							 NULL,
+							 &neon_slru_csnlog,
+							 false,
+							 PGC_POSTMASTER,
+							 0, /* no flags required */
+							 NULL, NULL, NULL);
+
 	DefineMultiRegionCustomVariables();
 
 	relsize_hash_init();

--- a/pgxn/neon/multiregion.c
+++ b/pgxn/neon/multiregion.c
@@ -95,6 +95,20 @@ get_region_lsn(int region)
 	return region_lsns[region];
 }
 
+/*
+ * Return an array of currently known LSNs of MAX_REGIONS region
+ */
+XLogRecPtr *
+get_all_region_lsns(void)
+{
+	RelFileNode dummy_node = {InvalidOid, InvalidOid, InvalidOid};
+
+	region_lsns[current_region] =
+		GetLastWrittenLSN(dummy_node, MAIN_FORKNUM, REL_METADATA_PSEUDO_BLOCKNO);
+
+	return region_lsns;
+}
+
 void
 clear_region_lsns(void)
 {

--- a/pgxn/neon/multiregion.c
+++ b/pgxn/neon/multiregion.c
@@ -30,90 +30,7 @@
 		(errmsg(NEON_TAG fmt, ## __VA_ARGS__), \
 		 errhidestmt(true), errhidecontext(true)))
 
-/* GUCs */
-char *neon_region_timelines;
-
-static XLogRecPtr	*region_lsns = NULL;
-static int	num_regions = 1;
-
-static bool
-check_neon_region_timelines(char **newval, void **extra, GucSource source)
-{
-	char *rawstring;
-	List *timelines;
-	ListCell *l;
-	uint8 zid[16];
-
-	/* Need a modifiable copy of string */
-	rawstring = pstrdup(*newval);
-
-	/* Parse string into list of timeline ids */
-	if (!SplitIdentifierString(rawstring, ',', &timelines))
-	{
-		/* syntax error in list */
-		GUC_check_errdetail("List syntax is invalid.");
-		pfree(rawstring);
-		list_free(timelines);
-		return false;
-	}
-
-	/* Check if the given timeline ids are valid */
-	foreach (l, timelines)
-	{
-		char *tok = (char *)lfirst(l);
-
-		/* Taken from check_zenith_id in libpagestore.c */
-		if (*tok != '\0' && !HexDecodeString(zid, tok, 16))
-		{
-			GUC_check_errdetail("Invalid Zenith id: \"%s\".", tok);
-			pfree(rawstring);
-			list_free(timelines);
-			return false;
-		}
-	}
-
-	*extra = malloc(sizeof(int));
-	if (!*extra)
-		return false;
-
-	*((int *) *extra) = list_length(timelines);
-
-	pfree(rawstring);
-	list_free(timelines);
-	return true;
-}
-
-static void assign_neon_region_timelines(const char *newval, void *extra)
-{
-	/* Add 1 for the global region */
-	num_regions = *((int *) extra) + 1;
-}
-
-
-void DefineMultiRegionCustomVariables(void)
-{
-	DefineCustomStringVariable("neon.region_timelines",
-								"List of timelineids corresponding to the partitions",
-								NULL,
-								&neon_region_timelines,
-								"",
-								PGC_POSTMASTER,
-								GUC_LIST_INPUT,
-								check_neon_region_timelines, assign_neon_region_timelines, NULL);
-}
-
-bool neon_multiregion_enabled(void)
-{
-	return neon_region_timelines && neon_region_timelines[0];
-}
-
-static void
-init_region_lsns()
-{
-	region_lsns = (XLogRecPtr *)
-			MemoryContextAllocZero(TopTransactionContext,
-								   num_regions * sizeof(XLogRecPtr));
-}
+static XLogRecPtr	region_lsns[MAX_REGIONS];
 
 /*
  * Set the LSN for a given region if it wasn't previously set. 
@@ -128,7 +45,7 @@ set_region_lsn(int region, NeonResponse *msg)
 	if (!IsMultiRegion() || !RegionIsRemote(region))
 		return;
 
-	AssertArg(region < num_regions);
+	AssertArg(region < MAX_REGIONS);
 
 	switch (messageTag(msg))
 	{
@@ -156,9 +73,6 @@ set_region_lsn(int region, NeonResponse *msg)
 
 	Assert(lsn != InvalidXLogRecPtr);
 
-	if (region_lsns == NULL)
-		init_region_lsns();
-
 	if (region_lsns[region] == InvalidXLogRecPtr)
 		region_lsns[region] = lsn;
 	else
@@ -176,10 +90,7 @@ get_region_lsn(int region)
 	
 	// LSN of the current region is already tracked by postgres
 	AssertArg(region != current_region);
-	AssertArg(region < num_regions);
-
-	if (region_lsns == NULL)
-		init_region_lsns();
+	AssertArg(region < MAX_REGIONS);
 
 	return region_lsns[region];
 }
@@ -187,7 +98,9 @@ get_region_lsn(int region)
 void
 clear_region_lsns(void)
 {
-	/* The data is destroyed along with the transaction
-		context so only need to set this to NULL */
-	region_lsns = NULL;
+	int i;
+	for (i = 0; i < MAX_REGIONS; i++)
+	{
+		region_lsns[i] = InvalidXLogRecPtr;
+	}
 }

--- a/pgxn/neon/multiregion.c
+++ b/pgxn/neon/multiregion.c
@@ -30,11 +30,6 @@
 		(errmsg(NEON_TAG fmt, ## __VA_ARGS__), \
 		 errhidestmt(true), errhidecontext(true)))
 
-#define NEON_TAG "[NEON_SMGR] "
-#define neon_log(tag, fmt, ...) ereport(tag, \
-		(errmsg(NEON_TAG fmt, ## __VA_ARGS__), \
-		 errhidestmt(true), errhidecontext(true)))
-
 /* GUCs */
 char *neon_region_timelines;
 
@@ -121,8 +116,9 @@ init_region_lsns()
 }
 
 /*
- * Set the LSN for a given region if it wasn't previously set. The set LSN is use
- * for that region throughout the life of the transaction.
+ * Set the LSN for a given region if it wasn't previously set. 
+ * This LSN is used in Neon requests for that region throughout
+ * the life of the current transaction.
  */
 void
 set_region_lsn(int region, NeonResponse *msg)
@@ -147,6 +143,9 @@ set_region_lsn(int region, NeonResponse *msg)
 			break;
 		case T_NeonGetSlruPageResponse:
 			lsn = ((NeonGetSlruPageResponse *) msg)->lsn;
+			break;
+		case T_NeonDbSizeResponse:
+			lsn = ((NeonDbSizeResponse *) msg)->lsn;
 			break;
 		case T_NeonErrorResponse:
 			break;

--- a/pgxn/neon/multiregion.c
+++ b/pgxn/neon/multiregion.c
@@ -91,7 +91,7 @@ get_region_lsn(int region)
 	// LSN of the current region is already tracked by postgres
 	AssertArg(region != current_region);
 	AssertArg(region < MAX_REGIONS);
-
+	// TODO (ctring): If this is 0, proactively contact neon for the latest lsn
 	return region_lsns[region];
 }
 

--- a/pgxn/neon/multiregion.c
+++ b/pgxn/neon/multiregion.c
@@ -1,0 +1,194 @@
+/*-------------------------------------------------------------------------
+ *
+ * multiregion.c
+ *	  Handles network communications in a multi-region setup.
+ *
+ * IDENTIFICATION
+ *	 contrib/neon/multiregion.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "multiregion.h"
+
+#include "access/remotexact.h"
+#include "catalog/catalog.h"
+#include "libpq-fe.h"
+#include "libpq/pqformat.h"
+#include "libpq/libpq.h"
+#include "miscadmin.h"
+#include "pgstat.h"
+#include "utils/guc.h"
+#include "utils/memutils.h"
+#include "utils/syscache.h"
+#include "utils/varlena.h"
+#include "walproposer_utils.h"
+
+#define NEON_TAG "[NEON_SMGR] "
+#define neon_log(tag, fmt, ...) ereport(tag, \
+		(errmsg(NEON_TAG fmt, ## __VA_ARGS__), \
+		 errhidestmt(true), errhidecontext(true)))
+
+#define NEON_TAG "[NEON_SMGR] "
+#define neon_log(tag, fmt, ...) ereport(tag, \
+		(errmsg(NEON_TAG fmt, ## __VA_ARGS__), \
+		 errhidestmt(true), errhidecontext(true)))
+
+/* GUCs */
+char *neon_region_timelines;
+
+static XLogRecPtr	*region_lsns = NULL;
+static int	num_regions = 1;
+
+static bool
+check_neon_region_timelines(char **newval, void **extra, GucSource source)
+{
+	char *rawstring;
+	List *timelines;
+	ListCell *l;
+	uint8 zid[16];
+
+	/* Need a modifiable copy of string */
+	rawstring = pstrdup(*newval);
+
+	/* Parse string into list of timeline ids */
+	if (!SplitIdentifierString(rawstring, ',', &timelines))
+	{
+		/* syntax error in list */
+		GUC_check_errdetail("List syntax is invalid.");
+		pfree(rawstring);
+		list_free(timelines);
+		return false;
+	}
+
+	/* Check if the given timeline ids are valid */
+	foreach (l, timelines)
+	{
+		char *tok = (char *)lfirst(l);
+
+		/* Taken from check_zenith_id in libpagestore.c */
+		if (*tok != '\0' && !HexDecodeString(zid, tok, 16))
+		{
+			GUC_check_errdetail("Invalid Zenith id: \"%s\".", tok);
+			pfree(rawstring);
+			list_free(timelines);
+			return false;
+		}
+	}
+
+	*extra = malloc(sizeof(int));
+	if (!*extra)
+		return false;
+
+	*((int *) *extra) = list_length(timelines);
+
+	pfree(rawstring);
+	list_free(timelines);
+	return true;
+}
+
+static void assign_neon_region_timelines(const char *newval, void *extra)
+{
+	/* Add 1 for the global region */
+	num_regions = *((int *) extra) + 1;
+}
+
+
+void DefineMultiRegionCustomVariables(void)
+{
+	DefineCustomStringVariable("neon.region_timelines",
+								"List of timelineids corresponding to the partitions",
+								NULL,
+								&neon_region_timelines,
+								"",
+								PGC_POSTMASTER,
+								GUC_LIST_INPUT,
+								check_neon_region_timelines, assign_neon_region_timelines, NULL);
+}
+
+bool neon_multiregion_enabled(void)
+{
+	return neon_region_timelines && neon_region_timelines[0];
+}
+
+static void
+init_region_lsns()
+{
+	region_lsns = (XLogRecPtr *)
+			MemoryContextAllocZero(TopTransactionContext,
+								   num_regions * sizeof(XLogRecPtr));
+}
+
+/*
+ * Set the LSN for a given region if it wasn't previously set. The set LSN is use
+ * for that region throughout the life of the transaction.
+ */
+void
+set_region_lsn(int region, NeonResponse *msg)
+{
+	XLogRecPtr lsn;
+
+	if (!IsMultiRegion() || !RegionIsRemote(region))
+		return;
+
+	AssertArg(region < num_regions);
+
+	switch (messageTag(msg))
+	{
+		case T_NeonExistsResponse:
+			lsn = ((NeonExistsResponse *) msg)->lsn;
+			break;
+		case T_NeonNblocksResponse:
+			lsn = ((NeonNblocksResponse *) msg)->lsn;
+			break;
+		case T_NeonGetPageResponse:
+			lsn = ((NeonGetPageResponse *) msg)->lsn;
+			break;
+		case T_NeonGetSlruPageResponse:
+			lsn = ((NeonGetSlruPageResponse *) msg)->lsn;
+			break;
+		case T_NeonErrorResponse:
+			break;
+		default:
+			neon_log(ERROR, "unexpected neon message tag 0x%02x", messageTag(msg));
+			break;
+	}
+
+	Assert(lsn != InvalidXLogRecPtr);
+
+	if (region_lsns == NULL)
+		init_region_lsns();
+
+	if (region_lsns[region] == InvalidXLogRecPtr)
+		region_lsns[region] = lsn;
+	else
+		Assert(region_lsns[region] == lsn);
+}
+
+/*
+ * Get the LSN of a region
+ */
+XLogRecPtr
+get_region_lsn(int region)
+{
+	if (!IsMultiRegion())
+		return InvalidXLogRecPtr;
+	
+	// LSN of the current region is already tracked by postgres
+	AssertArg(region != current_region);
+	AssertArg(region < num_regions);
+
+	if (region_lsns == NULL)
+		init_region_lsns();
+
+	return region_lsns[region];
+}
+
+void
+clear_region_lsns(void)
+{
+	/* The data is destroyed along with the transaction
+		context so only need to set this to NULL */
+	region_lsns = NULL;
+}

--- a/pgxn/neon/multiregion.h
+++ b/pgxn/neon/multiregion.h
@@ -16,6 +16,7 @@
 
 extern void set_region_lsn(int region, NeonResponse *msg);
 extern XLogRecPtr get_region_lsn(int region);
+extern XLogRecPtr *get_all_region_lsns(void);
 extern void clear_region_lsns(void);
 
 #endif

--- a/pgxn/neon/multiregion.h
+++ b/pgxn/neon/multiregion.h
@@ -14,10 +14,6 @@
 #include "access/xlogdefs.h"
 #include "pagestore_client.h"
 
-extern char *neon_region_timelines;
-
-extern void DefineMultiRegionCustomVariables(void);
-extern bool neon_multiregion_enabled(void);
 extern void set_region_lsn(int region, NeonResponse *msg);
 extern XLogRecPtr get_region_lsn(int region);
 extern void clear_region_lsns(void);

--- a/pgxn/neon/multiregion.h
+++ b/pgxn/neon/multiregion.h
@@ -1,0 +1,25 @@
+/*-------------------------------------------------------------------------
+ *
+ * multiregion.h
+ * 
+ * contrib/neon/multiregion.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef MULTIREGION_H
+#define MULTIREGION_H
+
+#include "postgres.h"
+
+#include "access/xlogdefs.h"
+#include "pagestore_client.h"
+
+extern char *neon_region_timelines;
+
+extern void DefineMultiRegionCustomVariables(void);
+extern bool neon_multiregion_enabled(void);
+extern void set_region_lsn(int region, NeonResponse *msg);
+extern XLogRecPtr get_region_lsn(int region);
+extern void clear_region_lsns(void);
+
+#endif

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -238,7 +238,7 @@ extern void forget_cached_relsize(RelFileNode rnode, ForkNumber forknum);
 extern const char *slru_kind_to_string(NeonSlruKind kind);
 extern bool slru_kind_from_string(const char* str, NeonSlruKind* kind);
 extern bool neon_slru_kind_check(SlruCtl ctl);
-extern bool neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, XLogRecPtr min_lsn, char *buffer);
-extern bool neon_slru_page_exists(SlruCtl ctl, int segno, off_t offset);
+extern bool neon_slru_read_page(SlruCtl ctl, int segno, BlockNumber blkno, XLogRecPtr min_lsn, char *buffer);
+extern bool neon_slru_page_exists(SlruCtl ctl, int segno, BlockNumber blkno);
 
 #endif

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -102,6 +102,7 @@ typedef enum
 	NEON_CLOG = 0,
 	NEON_MULTI_XACT_MEMBERS,
 	NEON_MULTI_XACT_OFFSETS,
+	NEON_CSNLOG,
 } NeonSlruKind;
 
 typedef struct
@@ -192,6 +193,7 @@ extern bool wal_redo;
 extern int32 max_cluster_size;
 extern bool neon_slru_clog;
 extern bool neon_slru_multixact;
+extern bool neon_slru_csnlog;
 
 extern const f_smgr *smgr_neon(BackendId backend, RelFileNode rnode);
 extern void smgr_init_neon(void);

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -66,7 +66,7 @@ typedef struct
 	NeonMessageTag tag;
 	bool		latest;			/* if true, request latest page version */
 	XLogRecPtr	lsn;			/* request page version @ this LSN */
-	int			region;			/* region to fetch page from */
+	int8    	region;			/* region to fetch page from */
 }			NeonRequest;
 
 typedef struct

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -238,7 +238,7 @@ extern void forget_cached_relsize(RelFileNode rnode, ForkNumber forknum);
 extern const char *slru_kind_to_string(NeonSlruKind kind);
 extern bool slru_kind_from_string(const char* str, NeonSlruKind* kind);
 extern bool neon_slru_kind_check(SlruCtl ctl);
-extern bool neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, char *buffer);
+extern bool neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, XLogRecPtr min_lsn, char *buffer);
 extern bool neon_slru_page_exists(SlruCtl ctl, int segno, off_t offset);
 
 #endif

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -146,6 +146,7 @@ typedef struct
 typedef struct
 {
 	NeonMessageTag tag;
+	XLogRecPtr	lsn;
 	int64		db_size;
 }			NeonDbSizeResponse;
 

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1219,14 +1219,16 @@ neon_get_request_lsn(bool *latest, int region, RelFileNode rnode, ForkNumber for
 		elog(DEBUG1, "am walsender neon_get_request_lsn lsn 0 ");
 	}
 
-	// Since only keep track of the latest written LSN of the current region, we need to 
-	// rely on zenith to find the latest LSN. Hence, it is insufficient to use RegionIsRemote(region)
-	// because the global region is also separate from the current region.
+	/*
+	 * Remotexact
+	 * For region that is not the current one, we keep track of the first LSN fetched from
+	 * neon of a region. Any subsequent request of the same transaction to neon must reuse
+	 * the LSN for that region to avoid inconsistent snapshot read.
+	 */
 	else if (IsMultiRegion() && region != current_region)
 	{
 		*latest = false;
 		lsn = get_region_lsn(region);
-		elog(LOG, "get lsn %X/%X for region %d", LSN_FORMAT_ARGS(lsn), region);
 		if (lsn == InvalidXLogRecPtr)
 			*latest = true;
 	}
@@ -2508,22 +2510,23 @@ neon_slru_kind_check(SlruCtl ctl)
 	return false;
 }
 
+#define BlockNumberToRegion(blkno) (blkno % MAX_REGIONS)
+
 /**
  * neon_slru_read_page() -- Read the specified block from a Simple LRU.
  *
  * NOTE: Never call ereport(ERROR) in here to comply with the behavior expected in slru.c
  */
 bool
-neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, XLogRecPtr min_lsn, char *buffer)
+neon_slru_read_page(SlruCtl ctl, int segno, BlockNumber blkno, XLogRecPtr lsn, char *buffer)
 {
 	NeonResponse 				*resp;
 	NeonGetSlruPageResponse 	*get_slru_page_resp;
 	NeonSlruKind	kind;
 	bool			latest;
-	XLogRecPtr		request_lsn = min_lsn;
+	XLogRecPtr		request_lsn = lsn;
 	bool 			read_ok = false;
-	// FIXME: select the right region for specific slru kinds
-	int				region = current_region;
+	int				region = BlockNumberToRegion(blkno);
 	RelFileNode dummy_node = {InvalidOid, InvalidOid, InvalidOid};
 
 	if (!slru_kind_from_string(ctl->Dir, &kind))
@@ -2532,9 +2535,8 @@ neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, XLogRecPtr min_lsn, ch
 		return false;
 	}
 
-	// FIXME: select the right region for specific slru kinds
-	// IF the caller has set a min_lsn, then use the same for the request.
-	if (min_lsn == InvalidXLogRecPtr) {
+	// IF the caller has set a lsn, then use the same for the request.
+	if (lsn == InvalidXLogRecPtr) {
         request_lsn =
             neon_get_request_lsn(&latest, region, dummy_node, MAIN_FORKNUM,
                                 REL_METADATA_PSEUDO_BLOCKNO);
@@ -2564,7 +2566,7 @@ neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, XLogRecPtr min_lsn, ch
 			.req.region = region,
 			.kind = kind,
 			.segno = segno,
-			.blkno = offset,
+			.blkno = blkno,
 			.check_exists_only = false
 		};
 
@@ -2595,12 +2597,13 @@ neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, XLogRecPtr min_lsn, ch
 		case T_NeonErrorResponse:
 			ereport(WARNING,
 					(errcode(ERRCODE_IO_ERROR),
-					 errmsg("could not read block %lu in SLRU %s/%u in region %d, from page server at lsn %X/%08X",
-							offset,
+					 errmsg("could not read block %u in SLRU %s/%u in region %d, from page server at lsn %X/%08X (latest = %d)",
+							blkno,
 							slru_kind_to_string(kind),
 							segno,
 							region,
-							(uint32) (request_lsn >> 32), (uint32) request_lsn),
+							(uint32) (request_lsn >> 32), (uint32) request_lsn,
+							latest),
 					 errdetail("page server returned error: %s",
 							   ((NeonErrorResponse *) resp)->message)));
 			break;
@@ -2615,14 +2618,13 @@ neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, XLogRecPtr min_lsn, ch
 }
 
 bool
-neon_slru_page_exists(SlruCtl ctl, int segno, off_t offset)
+neon_slru_page_exists(SlruCtl ctl, int segno, BlockNumber blkno)
 {
 	NeonResponse	*resp;
 	NeonSlruKind	kind;
 	bool			latest;
 	XLogRecPtr		request_lsn;
-	// FIXME: select the right region for specific slru kinds
-	int				region = current_region;
+	int				region = BlockNumberToRegion(blkno);
 	bool			exists = false;
 	RelFileNode dummy_node = {InvalidOid, InvalidOid, InvalidOid};
 
@@ -2632,8 +2634,12 @@ neon_slru_page_exists(SlruCtl ctl, int segno, off_t offset)
 		return false;
 	}
 
-	// FIXME: select the right region for specific slru kinds
 	request_lsn = neon_get_request_lsn(&latest, region, dummy_node, MAIN_FORKNUM, REL_METADATA_PSEUDO_BLOCKNO);
+
+	/* See comment in neon_slru_read_page */
+	if (RecoveryInProgress() && request_lsn == InvalidXLogRecPtr) 
+		latest = true;
+
 	{
 		NeonGetSlruPageRequest request = {
 			.req.tag = T_NeonGetSlruPageRequest,
@@ -2642,7 +2648,7 @@ neon_slru_page_exists(SlruCtl ctl, int segno, off_t offset)
 			.req.region = region,
 			.kind = kind,
 			.segno = segno,
-			.blkno = offset,
+			.blkno = blkno,
 			.check_exists_only = true
 		};
 
@@ -2658,12 +2664,13 @@ neon_slru_page_exists(SlruCtl ctl, int segno, off_t offset)
 		case T_NeonErrorResponse:
 			ereport(ERROR,
 					(errcode(ERRCODE_IO_ERROR),
-					 errmsg("could not read block %lu in SLRU %s/%u in region %d from page server at lsn %X/%08X",
-							offset,
+					 errmsg("could not check existence of block %u in SLRU %s/%u in region %d from page server at lsn %X/%08X (latest = %d)",
+							blkno,
 							slru_kind_to_string(kind),
 							segno,
 							region,
-							(uint32) (request_lsn >> 32), (uint32) request_lsn),
+							(uint32) (request_lsn >> 32), (uint32) request_lsn,
+							latest),
 					 errdetail("page server returned error: %s",
 							   ((NeonErrorResponse *) resp)->message)));
 			break;

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -45,6 +45,7 @@
  */
 #include "postgres.h"
 
+#include "access/remotexact.h"
 #include "access/xact.h"
 #include "access/xlog.h"
 #include "access/xloginsert.h"
@@ -52,6 +53,7 @@
 #include "access/xlogdefs.h"
 #include "catalog/pg_class.h"
 #include "common/hashfn.h"
+#include "multiregion.h"
 #include "pagestore_client.h"
 #include "postmaster/interrupt.h"
 #include "postmaster/autovacuum.h"
@@ -98,6 +100,8 @@ char	   *page_server_connstring;
 char	   *neon_timeline;
 char	   *neon_tenant;
 int32		max_cluster_size;
+bool		neon_slru_clog;
+bool		neon_slru_multixact;
 
 /* unlogged relation build states */
 typedef enum
@@ -110,6 +114,9 @@ typedef enum
 
 static SMgrRelation unlogged_build_rel = NULL;
 static UnloggedBuildPhase unlogged_build_phase = UNLOGGED_BUILD_NOT_IN_PROGRESS;
+
+static void neon_read_at_lsn_multi_region(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno,
+										  int region, XLogRecPtr request_lsn, bool request_latest, char *buffer);
 
 /*
  * Prefetch implementation:
@@ -156,6 +163,7 @@ typedef enum PrefetchStatus {
 
 typedef struct PrefetchRequest {
 	BufferTag	buftag; /* must be first entry in the struct */
+	int	region;
 	XLogRecPtr	effective_request_lsn;
 	NeonResponse *response; /* may be null */
 	PrefetchStatus status;
@@ -231,14 +239,14 @@ int			n_prefetch_dupes = 0;
 XLogRecPtr	prefetch_lsn = 0;
 
 static void consume_prefetch_responses(void);
-static uint64 prefetch_register_buffer(BufferTag tag, bool *force_latest, XLogRecPtr *force_lsn);
+static uint64 prefetch_register_buffer(BufferTag tag, int region, bool *force_latest, XLogRecPtr *force_lsn);
 static void prefetch_read(PrefetchRequest *slot);
 static void prefetch_do_request(PrefetchRequest *slot, bool *force_latest, XLogRecPtr *force_lsn);
 static void prefetch_wait_for(uint64 ring_index);
 static void prefetch_cleanup(void);
 static inline void prefetch_set_unused(uint64 ring_index, bool hash_cleanup);
 
-static XLogRecPtr neon_get_request_lsn(bool *latest, RelFileNode rnode,
+static XLogRecPtr neon_get_request_lsn(bool *latest, int region, RelFileNode rnode,
 									   ForkNumber forknum, BlockNumber blkno);
 
 
@@ -310,7 +318,7 @@ prefetch_read(PrefetchRequest *slot)
 	Assert(slot->my_ring_index == MyPState->ring_receive);
 
 	old = MemoryContextSwitchTo(MyPState->errctx);
-	response = (NeonResponse *) page_server->receive();
+	response = (NeonResponse *) page_server->receive(slot->region);
 	MemoryContextSwitchTo(old);
 
 	/* update prefetch state */
@@ -401,6 +409,7 @@ prefetch_do_request(PrefetchRequest *slot, bool *force_latest, XLogRecPtr *force
 		.req.tag = T_NeonGetPageRequest,
 		.req.latest = false,
 		.req.lsn = 0,
+		.req.region = slot->region,
 		.rnode = slot->buftag.rnode,
 		.forknum = slot->buftag.forkNum,
 		.blkno = slot->buftag.blockNum,
@@ -416,6 +425,7 @@ prefetch_do_request(PrefetchRequest *slot, bool *force_latest, XLogRecPtr *force
 	{
 		XLogRecPtr lsn = neon_get_request_lsn(
 			&request.req.latest,
+			slot->region,
 			slot->buftag.rnode,
 			slot->buftag.forkNum,
 			slot->buftag.blockNum
@@ -467,7 +477,7 @@ prefetch_do_request(PrefetchRequest *slot, bool *force_latest, XLogRecPtr *force
  */
 
 static uint64
-prefetch_register_buffer(BufferTag tag, bool *force_latest, XLogRecPtr *force_lsn)
+prefetch_register_buffer(BufferTag tag, int region, bool *force_latest, XLogRecPtr *force_lsn)
 {
 	int		index;
 	bool	found;
@@ -490,6 +500,7 @@ prefetch_register_buffer(BufferTag tag, bool *force_latest, XLogRecPtr *force_ls
 
 		Assert(slot->status != PRFS_UNUSED);
 		Assert(BUFFERTAGS_EQUAL(slot->buftag, tag));
+		Assert(slot->region == region);
 		
 		/*
 		 * If we want a specific lsn, we do not accept requests that were made
@@ -569,6 +580,7 @@ prefetch_register_buffer(BufferTag tag, bool *force_latest, XLogRecPtr *force_ls
 	 * function reads the buffer tag from the slot.
 	 */
 	slot->buftag = tag;
+	slot->region = region;
 	slot->my_ring_index = ring_index;
 
 	prfh_insert(MyPState->prf_hash, slot, &found);
@@ -583,12 +595,12 @@ prefetch_register_buffer(BufferTag tag, bool *force_latest, XLogRecPtr *force_ls
 static NeonResponse *
 page_server_request(void const *req)
 {
-	page_server->send((NeonRequest *) req);
+	NeonRequest *neon_req = (NeonRequest *) req;
+	page_server->send(neon_req);
 	page_server->flush();
 	consume_prefetch_responses();
-	return page_server->receive();
+	return page_server->receive(neon_req->region);
 }
-
 
 StringInfoData
 nm_pack_request(NeonRequest * msg)
@@ -607,6 +619,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
+				pq_sendint32(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -620,6 +633,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
+				pq_sendint32(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -643,6 +657,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
+				pq_sendint32(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -651,11 +666,26 @@ nm_pack_request(NeonRequest * msg)
 
 				break;
 			}
+		case T_NeonGetSlruPageRequest:
+			{
+				NeonGetSlruPageRequest *msg_req = (NeonGetSlruPageRequest *) msg;
+
+				pq_sendbyte(&s, msg_req->req.latest);
+				pq_sendint64(&s, msg_req->req.lsn);
+				pq_sendint32(&s, msg_req->req.region);
+				pq_sendbyte(&s, msg_req->kind);
+				pq_sendint32(&s, msg_req->segno);
+				pq_sendint32(&s, msg_req->blkno);
+				pq_sendbyte(&s, msg_req->check_exists_only);
+
+				break;
+			}
 
 			/* pagestore -> pagestore_client. We never need to create these. */
 		case T_NeonExistsResponse:
 		case T_NeonNblocksResponse:
 		case T_NeonGetPageResponse:
+		case T_NeonGetSlruPageResponse:
 		case T_NeonErrorResponse:
 		case T_NeonDbSizeResponse:
 		default:
@@ -679,6 +709,7 @@ nm_unpack_response(StringInfo s)
 				NeonExistsResponse *msg_resp = palloc0(sizeof(NeonExistsResponse));
 
 				msg_resp->tag = tag;
+				msg_resp->lsn = pq_getmsgint64(s);
 				msg_resp->exists = pq_getmsgbyte(s);
 				pq_getmsgend(s);
 
@@ -691,6 +722,7 @@ nm_unpack_response(StringInfo s)
 				NeonNblocksResponse *msg_resp = palloc0(sizeof(NeonNblocksResponse));
 
 				msg_resp->tag = tag;
+				msg_resp->lsn = pq_getmsgint64(s);
 				msg_resp->n_blocks = pq_getmsgint(s, 4);
 				pq_getmsgend(s);
 
@@ -704,6 +736,7 @@ nm_unpack_response(StringInfo s)
 
 				msg_resp = MemoryContextAllocZero(MyPState->bufctx, PS_GETPAGERESPONSE_SIZE);
 				msg_resp->tag = tag;
+				msg_resp->lsn = pq_getmsgint64(s);
 				/* XXX:	should be varlena */
 				memcpy(msg_resp->page, pq_getmsgbytes(s, BLCKSZ), BLCKSZ);
 				pq_getmsgend(s);
@@ -720,6 +753,25 @@ nm_unpack_response(StringInfo s)
 
 				msg_resp->tag = tag;
 				msg_resp->db_size = pq_getmsgint64(s);
+				pq_getmsgend(s);
+
+				resp = (NeonResponse *) msg_resp;
+				break;
+			}
+
+		case T_NeonGetSlruPageResponse:
+			{
+				NeonGetSlruPageResponse *msg_resp = palloc0(offsetof(NeonGetSlruPageResponse, page) + BLCKSZ);
+
+				msg_resp->tag = tag;
+				msg_resp->lsn = pq_getmsgint64(s);
+				msg_resp->seg_exists = pq_getmsgbyte(s);
+				msg_resp->page_exists = pq_getmsgbyte(s);
+				if (msg_resp->page_exists)
+				{
+					/* XXX:	should be varlena */
+					memcpy(msg_resp->page, pq_getmsgbytes(s, BLCKSZ), BLCKSZ);
+				}
 				pq_getmsgend(s);
 
 				resp = (NeonResponse *) msg_resp;
@@ -782,6 +834,7 @@ nm_to_string(NeonMessage * msg)
 								 msg_req->rnode.dbNode,
 								 msg_req->rnode.relNode);
 				appendStringInfo(&s, ", \"forknum\": %d", msg_req->forknum);
+				appendStringInfo(&s, ", \"region\": %d", msg_req->req.region);
 				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_req->req.lsn));
 				appendStringInfo(&s, ", \"latest\": %d", msg_req->req.latest);
 				appendStringInfoChar(&s, '}');
@@ -798,6 +851,7 @@ nm_to_string(NeonMessage * msg)
 								 msg_req->rnode.dbNode,
 								 msg_req->rnode.relNode);
 				appendStringInfo(&s, ", \"forknum\": %d", msg_req->forknum);
+				appendStringInfo(&s, ", \"region\": %d", msg_req->req.region);
 				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_req->req.lsn));
 				appendStringInfo(&s, ", \"latest\": %d", msg_req->req.latest);
 				appendStringInfoChar(&s, '}');
@@ -815,11 +869,13 @@ nm_to_string(NeonMessage * msg)
 								 msg_req->rnode.relNode);
 				appendStringInfo(&s, ", \"forknum\": %d", msg_req->forknum);
 				appendStringInfo(&s, ", \"blkno\": %u", msg_req->blkno);
+				appendStringInfo(&s, ", \"region\": %d", msg_req->req.region);
 				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_req->req.lsn));
 				appendStringInfo(&s, ", \"latest\": %d", msg_req->req.latest);
 				appendStringInfoChar(&s, '}');
 				break;
 			}
+
 		case T_NeonDbSizeRequest:
 			{
 				NeonDbSizeRequest *msg_req = (NeonDbSizeRequest *) msg;
@@ -832,23 +888,42 @@ nm_to_string(NeonMessage * msg)
 				break;
 			}
 
+		case T_NeonGetSlruPageRequest:
+			{
+				NeonGetSlruPageRequest *msg_req = (NeonGetSlruPageRequest *) msg;
+
+				appendStringInfoString(&s, "{\"type\": \"NeonGetSlruPageRequest\"");
+				appendStringInfo(&s, ", \"kind\": %d", msg_req->kind);
+				appendStringInfo(&s, ", \"segno\": %d", msg_req->segno);
+				appendStringInfo(&s, ", \"blkno\": %u", msg_req->blkno);
+				appendStringInfo(&s, ", \"check_exists_only\": %d", msg_req->check_exists_only);
+				appendStringInfo(&s, ", \"region\": %d", msg_req->req.region);
+				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_req->req.lsn));
+				appendStringInfo(&s, ", \"latest\": %d", msg_req->req.latest);
+				appendStringInfoChar(&s, '}');
+				break;
+			}
+
 			/* pagestore -> pagestore_client */
 		case T_NeonExistsResponse:
 			{
 				NeonExistsResponse *msg_resp = (NeonExistsResponse *) msg;
 
 				appendStringInfoString(&s, "{\"type\": \"NeonExistsResponse\"");
+				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_resp->lsn));
 				appendStringInfo(&s, ", \"exists\": %d}",
 								 msg_resp->exists);
 				appendStringInfoChar(&s, '}');
 
 				break;
 			}
+
 		case T_NeonNblocksResponse:
 			{
 				NeonNblocksResponse *msg_resp = (NeonNblocksResponse *) msg;
 
 				appendStringInfoString(&s, "{\"type\": \"NeonNblocksResponse\"");
+				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_resp->lsn));
 				appendStringInfo(&s, ", \"n_blocks\": %u}",
 								 msg_resp->n_blocks);
 				appendStringInfoChar(&s, '}');
@@ -857,11 +932,22 @@ nm_to_string(NeonMessage * msg)
 			}
 		case T_NeonGetPageResponse:
 			{
-#if 0
 				NeonGetPageResponse *msg_resp = (NeonGetPageResponse *) msg;
-#endif
 
 				appendStringInfoString(&s, "{\"type\": \"NeonGetPageResponse\"");
+				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_resp->lsn));
+				appendStringInfo(&s, ", \"page\": \"XXX\"}");
+				appendStringInfoChar(&s, '}');
+				break;
+			}
+		case T_NeonGetSlruPageResponse:
+			{
+				NeonGetSlruPageResponse *msg_resp = (NeonGetSlruPageResponse *) msg;
+
+				appendStringInfoString(&s, "{\"type\": \"NeonGetSlruPageResponse\"");
+				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_resp->lsn));
+				appendStringInfo(&s, ", \"seg_exists\": %d", msg_resp->seg_exists);
+				appendStringInfo(&s, ", \"page_exists\": %d", msg_resp->page_exists);
 				appendStringInfo(&s, ", \"page\": \"XXX\"}");
 				appendStringInfoChar(&s, '}');
 				break;
@@ -1112,7 +1198,7 @@ nm_adjust_lsn(XLogRecPtr lsn)
  * Return LSN for requesting pages and number of blocks from page server
  */
 static XLogRecPtr
-neon_get_request_lsn(bool *latest, RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
+neon_get_request_lsn(bool *latest, int region, RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 {
 	XLogRecPtr	lsn;
 
@@ -1128,6 +1214,18 @@ neon_get_request_lsn(bool *latest, RelFileNode rnode, ForkNumber forknum, BlockN
 		*latest = true;
 		lsn = InvalidXLogRecPtr;
 		elog(DEBUG1, "am walsender neon_get_request_lsn lsn 0 ");
+	}
+
+	// Since only keep track of the latest written LSN of the current region, we need to 
+	// rely on zenith to find the latest LSN. Hence, it is insufficient to use RegionIsRemote(region)
+	// because the global region is also separate from the current region.
+	else if (IsMultiRegion() && region != current_region)
+	{
+		*latest = false;
+		lsn = get_region_lsn(region);
+		elog(LOG, "get lsn %X/%X for region %d", LSN_FORMAT_ARGS(lsn), region);
+		if (lsn == InvalidXLogRecPtr)
+			*latest = true;
 	}
 	else
 	{
@@ -1230,12 +1328,17 @@ neon_exists(SMgrRelation reln, ForkNumber forkNum)
 		return false;
 	}
 
-	request_lsn = neon_get_request_lsn(&latest, reln->smgr_rnode.node, forkNum, REL_METADATA_PSEUDO_BLOCKNO);
+	request_lsn = neon_get_request_lsn(&latest,
+					  				   reln->smgr_region,
+									   reln->smgr_rnode.node,
+									   forkNum,
+									   REL_METADATA_PSEUDO_BLOCKNO);
 	{
 		NeonExistsRequest request = {
 			.req.tag = T_NeonExistsRequest,
 			.req.latest = latest,
 			.req.lsn = request_lsn,
+			.req.region = reln->smgr_region,
 			.rnode = reln->smgr_rnode.node,
 		.forknum = forkNum};
 
@@ -1251,11 +1354,12 @@ neon_exists(SMgrRelation reln, ForkNumber forkNum)
 		case T_NeonErrorResponse:
 			ereport(ERROR,
 					(errcode(ERRCODE_IO_ERROR),
-					 errmsg("could not read relation existence of rel %u/%u/%u.%u from page server at lsn %X/%08X",
+					 errmsg("could not read relation existence of rel %u/%u/%u.%u in region %d from page server at lsn %X/%08X",
 							reln->smgr_rnode.node.spcNode,
 							reln->smgr_rnode.node.dbNode,
 							reln->smgr_rnode.node.relNode,
 							forkNum,
+							reln->smgr_region,
 							(uint32) (request_lsn >> 32), (uint32) request_lsn),
 					 errdetail("page server returned error: %s",
 							   ((NeonErrorResponse *) resp)->message)));
@@ -1492,7 +1596,7 @@ neon_prefetch(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum)
 		.blockNum = blocknum
 	};
 
-	ring_index = prefetch_register_buffer(tag, NULL, NULL);
+	ring_index = prefetch_register_buffer(tag, reln->smgr_region, NULL, NULL);
 
 	Assert(ring_index < MyPState->ring_unused &&
 		   MyPState->ring_last <= ring_index);
@@ -1546,6 +1650,12 @@ void
 neon_read_at_lsn(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno,
 				 XLogRecPtr request_lsn, bool request_latest, char *buffer)
 {
+	neon_read_at_lsn_multi_region(rnode, forkNum, blkno, current_region, request_lsn, request_latest, buffer);
+}
+
+static void neon_read_at_lsn_multi_region(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno,
+										  int region, XLogRecPtr request_lsn, bool request_latest, char *buffer)
+{
 	NeonResponse *resp;
 	BufferTag	buftag;
 	uint64		ring_index;
@@ -1595,7 +1705,7 @@ neon_read_at_lsn(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno,
 	{
 		n_prefetch_misses += 1;
 
-		ring_index = prefetch_register_buffer(buftag, &request_latest,
+		ring_index = prefetch_register_buffer(buftag, region, &request_latest,
 											  &request_lsn);
 		slot = &MyPState->prf_buffer[(ring_index % READ_BUFFER_SIZE)];
 	}
@@ -1617,16 +1727,27 @@ neon_read_at_lsn(RelFileNode rnode, ForkNumber forkNum, BlockNumber blkno,
 	{
 		case T_NeonGetPageResponse:
 			memcpy(buffer, ((NeonGetPageResponse *) resp)->page, BLCKSZ);
+			if (RegionIsRemote(region))
+			{
+				XLogRecPtr lsn = ((NeonGetPageResponse *) resp)->lsn;
+				/*
+					Set the LSN on the page to be equal to the LSN snapshot of the current transaction
+					so that we don't need to evict the page from local buffer if we use the same LSN
+					snapshot for the subsequent transactions.
+				*/
+				PageSetLSN((Page) buffer, lsn);
+			}
 			break;
 
 		case T_NeonErrorResponse:
 			ereport(ERROR,
 					(errcode(ERRCODE_IO_ERROR),
-					 errmsg("could not read block %u in rel %u/%u/%u.%u from page server at lsn %X/%08X",
+					 errmsg("could not read block %u in rel %u/%u/%u.%u in region %d, from page server at lsn %X/%08X",
 							blkno,
 							rnode.spcNode,
 							rnode.dbNode,
 							rnode.relNode,
+							region,
 							forkNum,
 							(uint32) (request_lsn >> 32), (uint32) request_lsn),
 					 errdetail("page server returned error: %s",
@@ -1668,9 +1789,8 @@ neon_read(SMgrRelation reln, ForkNumber forkNum, BlockNumber blkno,
 			elog(ERROR, "unknown relpersistence '%c'", reln->smgr_relpersistence);
 	}
 
-	request_lsn = neon_get_request_lsn(&latest, reln->smgr_rnode.node, forkNum, blkno);
-	neon_read_at_lsn(reln->smgr_rnode.node, forkNum, blkno, request_lsn, latest, buffer);
-
+	request_lsn = neon_get_request_lsn(&latest, reln->smgr_region, reln->smgr_rnode.node, forkNum, blkno);
+	neon_read_at_lsn_multi_region(reln->smgr_rnode.node, forkNum, blkno, reln->smgr_region, request_lsn, latest, buffer);
 #ifdef DEBUG_COMPARE_LOCAL
 	if (forkNum == MAIN_FORKNUM && IS_LOCAL_REL(reln))
 	{
@@ -1873,12 +1993,17 @@ neon_nblocks(SMgrRelation reln, ForkNumber forknum)
 		return n_blocks;
 	}
 
-	request_lsn = neon_get_request_lsn(&latest, reln->smgr_rnode.node, forknum, REL_METADATA_PSEUDO_BLOCKNO);
+	request_lsn = neon_get_request_lsn(&latest,
+									   reln->smgr_region,
+									   reln->smgr_rnode.node,
+									   forknum,
+									   REL_METADATA_PSEUDO_BLOCKNO);
 	{
 		NeonNblocksRequest request = {
 			.req.tag = T_NeonNblocksRequest,
 			.req.latest = latest,
 			.req.lsn = request_lsn,
+			.req.region = reln->smgr_region,
 			.rnode = reln->smgr_rnode.node,
 			.forknum = forknum,
 		};
@@ -1895,11 +2020,12 @@ neon_nblocks(SMgrRelation reln, ForkNumber forknum)
 		case T_NeonErrorResponse:
 			ereport(ERROR,
 					(errcode(ERRCODE_IO_ERROR),
-					 errmsg("could not read relation size of rel %u/%u/%u.%u from page server at lsn %X/%08X",
+					 errmsg("could not read relation size of rel %u/%u/%u.%u in region %d from page server at lsn %X/%08X",
 							reln->smgr_rnode.node.spcNode,
 							reln->smgr_rnode.node.dbNode,
 							reln->smgr_rnode.node.relNode,
 							forknum,
+							reln->smgr_region,
 							(uint32) (request_lsn >> 32), (uint32) request_lsn),
 					 errdetail("page server returned error: %s",
 							   ((NeonErrorResponse *) resp)->message)));
@@ -1910,11 +2036,12 @@ neon_nblocks(SMgrRelation reln, ForkNumber forknum)
 	}
 	update_cached_relsize(reln->smgr_rnode.node, forknum, n_blocks);
 
-	elog(SmgrTrace, "neon_nblocks: rel %u/%u/%u fork %u (request LSN %X/%08X): %u blocks",
+	elog(SmgrTrace, "neon_nblocks: rel %u/%u/%u fork %u region %d (request LSN %X/%08X): %u blocks",
 		 reln->smgr_rnode.node.spcNode,
 		 reln->smgr_rnode.node.dbNode,
 		 reln->smgr_rnode.node.relNode,
 		 forknum,
+		 reln->smgr_region,
 		 (uint32) (request_lsn >> 32), (uint32) request_lsn,
 		 n_blocks);
 
@@ -1934,7 +2061,7 @@ neon_dbsize(Oid dbNode)
 	bool		latest;
 	RelFileNode dummy_node = {InvalidOid, InvalidOid, InvalidOid};
 
-	request_lsn = neon_get_request_lsn(&latest, dummy_node, MAIN_FORKNUM, REL_METADATA_PSEUDO_BLOCKNO);
+	request_lsn = neon_get_request_lsn(&latest, GLOBAL_REGION, dummy_node, MAIN_FORKNUM, REL_METADATA_PSEUDO_BLOCKNO);
 	{
 		NeonDbSizeRequest request = {
 			.req.tag = T_NeonDbSizeRequest,
@@ -2229,10 +2356,13 @@ AtEOXact_neon(XactEvent event, void *arg)
 			 */
 			unlogged_build_rel = NULL;
 			unlogged_build_phase = UNLOGGED_BUILD_NOT_IN_PROGRESS;
+			clear_region_lsns();
 			break;
 
 		case XACT_EVENT_COMMIT:
 		case XACT_EVENT_PARALLEL_COMMIT:
+			clear_region_lsns();
+			/* fall through */
 		case XACT_EVENT_PREPARE:
 		case XACT_EVENT_PRE_COMMIT:
 		case XACT_EVENT_PARALLEL_PRE_COMMIT:
@@ -2291,3 +2421,231 @@ smgr_init_neon(void)
 	smgr_init_standard();
 	neon_init();
 }
+
+/*
+ * SLRU stuff
+ */
+
+const char *
+slru_kind_to_string(NeonSlruKind kind)
+{
+	switch (kind)
+	{
+		case NEON_CLOG:
+			return "pg_xact";
+		case NEON_MULTI_XACT_MEMBERS:
+			return "pg_multixact/members";
+		case NEON_MULTI_XACT_OFFSETS:
+			return "pg_multixact/offsets";
+		default:
+			return "invalid";
+	}
+}
+
+bool
+slru_kind_from_string(const char* str, NeonSlruKind* kind)
+{
+	if (strcmp(str, "pg_xact") == 0)
+	{
+		*kind = NEON_CLOG;
+		return true;
+	}
+	else if (strcmp(str, "pg_multixact/members") == 0)
+	{
+		*kind = NEON_MULTI_XACT_MEMBERS;
+		return true;
+	}
+	else if (strcmp(str, "pg_multixact/offsets") == 0)
+	{
+		*kind = NEON_MULTI_XACT_OFFSETS;
+		return true;
+	}
+	return false;
+}
+
+/**
+ * neon_slru_kind_check() - Check if the SLRU kind is supported by the pageserver
+ */
+bool
+neon_slru_kind_check(SlruCtl ctl)
+{
+	const char *dir = ctl->Dir;
+
+	if (strcmp(dir, "pg_xact") == 0 && neon_slru_clog)
+	{
+		return true;
+	}
+
+	if ((strcmp(dir, "pg_multixact/members") == 0 || strcmp(dir, "pg_multixact/offsets") == 0) &&
+		neon_slru_multixact)
+	{
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * neon_slru_read_page() -- Read the specified block from a Simple LRU.
+ *
+ * NOTE: Never call ereport(ERROR) in here to comply with the behavior expected in slru.c
+ */
+bool
+neon_slru_read_page(SlruCtl ctl, int segno, off_t offset, char *buffer)
+{
+	NeonResponse 				*resp;
+	NeonGetSlruPageResponse 	*get_slru_page_resp;
+	NeonSlruKind	kind;
+	bool			latest;
+	XLogRecPtr		request_lsn;
+	bool 			read_ok = false;
+	// FIXME: select the right region for specific slru kinds
+	int				region = current_region;
+	RelFileNode dummy_node = {InvalidOid, InvalidOid, InvalidOid};
+
+	if (!slru_kind_from_string(ctl->Dir, &kind))
+	{
+		ereport(WARNING, errmsg("unexpected slru kind \"%s\"", ctl->Dir));
+		return false;
+	}
+
+	// FIXME: select the right region for specific slru kinds
+	request_lsn = neon_get_request_lsn(&latest, region, dummy_node, MAIN_FORKNUM, REL_METADATA_PSEUDO_BLOCKNO);
+
+	/**
+	 * During recovery, if there is no WAL redoing, the function GetXLogReplayRecPtr will return
+	 * a lsn 0, causing zenith_get_request_lsn to give out an invalid lsn with "latest" being false,
+	 * which is later rejected by the page server.
+	 * 
+	 * For this corner case to occur, a backend has to request a page during recovery
+	 * mode and no WAL redoing actually happens, so this rarely happens with normal backends. 
+	 * However, since the startup process calls TrimCLOG and TrimMultiXact towards the end of
+	 * the recovery process, this case always happens with the startup process whenever there
+	 * is no WAL redoing.
+	 * 
+	 * It is safe to just grab the latest page here because TrimCLOG and TrimMultiXact are called
+	 * after log redoing.
+	 */
+	if (RecoveryInProgress() && request_lsn == InvalidXLogRecPtr) 
+		latest = true;
+
+	{
+		NeonGetSlruPageRequest request = {
+			.req.tag = T_NeonGetSlruPageRequest,
+			.req.latest = latest,
+			.req.lsn = request_lsn,
+			.req.region = region,
+			.kind = kind,
+			.segno = segno,
+			.blkno = offset,
+			.check_exists_only = false
+		};
+
+		resp = page_server_request(&request);
+	}
+
+	switch (resp->tag)
+	{
+		case T_NeonGetSlruPageResponse:
+			get_slru_page_resp = (NeonGetSlruPageResponse *) resp;
+
+			/* see notes about reading truncated segment in recovery in SlruPhysicalWritePage in slru.c */
+			if (get_slru_page_resp->seg_exists)
+			{
+				memcpy(buffer, get_slru_page_resp->page, BLCKSZ);
+			}
+			else if (InRecovery)
+			{
+				ereport(LOG,
+						(errmsg("segment \"%s/%d\" doesn't exist, reading as zeroes",
+								slru_kind_to_string(kind), segno)));
+				MemSet(buffer, 0, BLCKSZ);
+			}
+
+			read_ok = true;
+			break;
+
+		case T_NeonErrorResponse:
+			ereport(WARNING,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("could not read block %lu in SLRU %s/%u in region %d, from page server at lsn %X/%08X",
+							offset,
+							slru_kind_to_string(kind),
+							segno,
+							region,
+							(uint32) (request_lsn >> 32), (uint32) request_lsn),
+					 errdetail("page server returned error: %s",
+							   ((NeonErrorResponse *) resp)->message)));
+			break;
+
+		default:
+			elog(WARNING, "unexpected response from page server with tag 0x%02x", resp->tag);
+	}
+
+	pfree(resp);
+
+	return read_ok;
+}
+
+bool
+neon_slru_page_exists(SlruCtl ctl, int segno, off_t offset)
+{
+	NeonResponse	*resp;
+	NeonSlruKind	kind;
+	bool			latest;
+	XLogRecPtr		request_lsn;
+	// FIXME: select the right region for specific slru kinds
+	int				region = current_region;
+	bool			exists = false;
+	RelFileNode dummy_node = {InvalidOid, InvalidOid, InvalidOid};
+
+	if (!slru_kind_from_string(ctl->Dir, &kind))
+	{
+		ereport(ERROR, errmsg("unexpected slru kind \"%s\"", ctl->Dir));
+		return false;
+	}
+
+	// FIXME: select the right region for specific slru kinds
+	request_lsn = neon_get_request_lsn(&latest, region, dummy_node, MAIN_FORKNUM, REL_METADATA_PSEUDO_BLOCKNO);
+	{
+		NeonGetSlruPageRequest request = {
+			.req.tag = T_NeonGetSlruPageRequest,
+			.req.latest = latest,
+			.req.lsn = request_lsn,
+			.req.region = region,
+			.kind = kind,
+			.segno = segno,
+			.blkno = offset,
+			.check_exists_only = true
+		};
+
+		resp = page_server_request(&request);
+	}
+
+	switch (resp->tag)
+	{
+		case T_NeonGetSlruPageResponse:
+			exists = ((NeonGetSlruPageResponse *) resp)->page_exists;
+			break;
+
+		case T_NeonErrorResponse:
+			ereport(ERROR,
+					(errcode(ERRCODE_IO_ERROR),
+					 errmsg("could not read block %lu in SLRU %s/%u in region %d from page server at lsn %X/%08X",
+							offset,
+							slru_kind_to_string(kind),
+							segno,
+							region,
+							(uint32) (request_lsn >> 32), (uint32) request_lsn),
+					 errdetail("page server returned error: %s",
+							   ((NeonErrorResponse *) resp)->message)));
+			break;
+
+		default:
+			elog(ERROR, "unexpected response from page server with tag 0x%02x", resp->tag);
+	}
+
+	pfree(resp);
+
+	return exists;
+} 

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -753,6 +753,7 @@ nm_unpack_response(StringInfo s)
 				NeonDbSizeResponse *msg_resp = palloc0(sizeof(NeonDbSizeResponse));
 
 				msg_resp->tag = tag;
+				msg_resp->lsn = pq_getmsgint64(s);
 				msg_resp->db_size = pq_getmsgint64(s);
 				pq_getmsgend(s);
 
@@ -968,6 +969,7 @@ nm_to_string(NeonMessage * msg)
 				NeonDbSizeResponse *msg_resp = (NeonDbSizeResponse *) msg;
 
 				appendStringInfoString(&s, "{\"type\": \"NeonDbSizeResponse\"");
+				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_resp->lsn));
 				appendStringInfo(&s, ", \"db_size\": %ld}",
 								 msg_resp->db_size);
 				appendStringInfoChar(&s, '}');
@@ -1728,20 +1730,24 @@ static void neon_read_at_lsn_multi_region(RelFileNode rnode, ForkNumber forkNum,
 	{
 		case T_NeonGetPageResponse:
 			memcpy(buffer, ((NeonGetPageResponse *) resp)->page, BLCKSZ);
-			// TODO (ctring): potential optimization, but need more testing before uncommenting
-			// if (RegionIsRemote(region))
-			// {
-			// 	XLogRecPtr lsn = ((NeonGetPageResponse *) resp)->lsn;
-			// 	/*
-			// 	 * Set the LSN on the page to be equal to the LSN snapshot of the current transaction
-			// 	 * so that we don't need to evict the page from local buffer if we use the same LSN
-			// 	 * snapshot for the subsequent transactions.
-			// 	 * Only do this when the LSN is not 0, otherwise an all-zero page will be dirtied and
-			// 	 * not recognized as all-zero by PageIsVerifiedExtended.
-			// 	 */
-			// 	if (PageGetLSN((Page) buffer) != 0)
-			// 		PageSetLSN((Page) buffer, lsn);
-			// }
+			if (RegionIsRemote(region))
+			{
+				XLogRecPtr lsn = ((NeonGetPageResponse *) resp)->lsn;
+				/*
+				 * Set the LSN on the page to be equal to the LSN snapshot of the current transaction
+				 * so that we don't need to evict the page from local buffer if we use the same LSN
+				 * snapshot for the subsequent transactions.
+				 * 
+				 * When a page is requested to insert tuples, neon may response with an all-zero
+				 * page if the page does not exist previously (e.g. the relation is empty). The function
+				 * PageIsVerifiedExtended checks either the checksum of a page is valid or the page
+				 * is all-zero. If we set the LSN for an all-zero page, that function will consider the
+				 * page invalid, so we only set the LSN if the the LSN of the page is not zero, meaning
+				 * the page is not an all-zero page. 
+				 */
+				if (PageGetLSN((Page) buffer) != 0)
+					PageSetLSN((Page) buffer, lsn);
+			}
 			break;
 
 		case T_NeonErrorResponse:

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -2092,7 +2092,7 @@ neon_dbsize(Oid dbNode)
 	bool		latest;
 	RelFileNode dummy_node = {InvalidOid, InvalidOid, InvalidOid};
 
-	request_lsn = neon_get_request_lsn(&latest, GLOBAL_REGION, dummy_node, MAIN_FORKNUM, REL_METADATA_PSEUDO_BLOCKNO);
+	request_lsn = neon_get_request_lsn(&latest, current_region, dummy_node, MAIN_FORKNUM, REL_METADATA_PSEUDO_BLOCKNO);
 	{
 		NeonDbSizeRequest request = {
 			.req.tag = T_NeonDbSizeRequest,

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -620,7 +620,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
-				pq_sendint32(&s, msg_req->req.region);
+				pq_sendint8(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -634,7 +634,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
-				pq_sendint32(&s, msg_req->req.region);
+				pq_sendint8(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -658,7 +658,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
-				pq_sendint32(&s, msg_req->req.region);
+				pq_sendint8(&s, msg_req->req.region);
 				pq_sendint32(&s, msg_req->rnode.spcNode);
 				pq_sendint32(&s, msg_req->rnode.dbNode);
 				pq_sendint32(&s, msg_req->rnode.relNode);
@@ -673,7 +673,7 @@ nm_pack_request(NeonRequest * msg)
 
 				pq_sendbyte(&s, msg_req->req.latest);
 				pq_sendint64(&s, msg_req->req.lsn);
-				pq_sendint32(&s, msg_req->req.region);
+				pq_sendint8(&s, msg_req->req.region);
 				pq_sendbyte(&s, msg_req->kind);
 				pq_sendint32(&s, msg_req->segno);
 				pq_sendint32(&s, msg_req->blkno);

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1728,16 +1728,20 @@ static void neon_read_at_lsn_multi_region(RelFileNode rnode, ForkNumber forkNum,
 	{
 		case T_NeonGetPageResponse:
 			memcpy(buffer, ((NeonGetPageResponse *) resp)->page, BLCKSZ);
-			if (RegionIsRemote(region))
-			{
-				XLogRecPtr lsn = ((NeonGetPageResponse *) resp)->lsn;
-				/*
-					Set the LSN on the page to be equal to the LSN snapshot of the current transaction
-					so that we don't need to evict the page from local buffer if we use the same LSN
-					snapshot for the subsequent transactions.
-				*/
-				PageSetLSN((Page) buffer, lsn);
-			}
+			// TODO (ctring): potential optimization, but need more testing before uncommenting
+			// if (RegionIsRemote(region))
+			// {
+			// 	XLogRecPtr lsn = ((NeonGetPageResponse *) resp)->lsn;
+			// 	/*
+			// 	 * Set the LSN on the page to be equal to the LSN snapshot of the current transaction
+			// 	 * so that we don't need to evict the page from local buffer if we use the same LSN
+			// 	 * snapshot for the subsequent transactions.
+			// 	 * Only do this when the LSN is not 0, otherwise an all-zero page will be dirtied and
+			// 	 * not recognized as all-zero by PageIsVerifiedExtended.
+			// 	 */
+			// 	if (PageGetLSN((Page) buffer) != 0)
+			// 		PageSetLSN((Page) buffer, lsn);
+			// }
 			break;
 
 		case T_NeonErrorResponse:

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -102,6 +102,7 @@ char	   *neon_tenant;
 int32		max_cluster_size;
 bool		neon_slru_clog;
 bool		neon_slru_multixact;
+bool		neon_slru_csnlog;
 
 /* unlogged relation build states */
 typedef enum
@@ -2437,6 +2438,8 @@ slru_kind_to_string(NeonSlruKind kind)
 			return "pg_multixact/members";
 		case NEON_MULTI_XACT_OFFSETS:
 			return "pg_multixact/offsets";
+		case NEON_CSNLOG:
+			return "pg_csn";
 		default:
 			return "invalid";
 	}
@@ -2460,6 +2463,11 @@ slru_kind_from_string(const char* str, NeonSlruKind* kind)
 		*kind = NEON_MULTI_XACT_OFFSETS;
 		return true;
 	}
+	else if (strcmp(str, "pg_csn") == 0)
+	{
+		*kind = NEON_CSNLOG;
+		return true;
+	}
 	return false;
 }
 
@@ -2478,6 +2486,11 @@ neon_slru_kind_check(SlruCtl ctl)
 
 	if ((strcmp(dir, "pg_multixact/members") == 0 || strcmp(dir, "pg_multixact/offsets") == 0) &&
 		neon_slru_multixact)
+	{
+		return true;
+	}
+
+	if (strcmp(dir, "pg_csn") == 0 && neon_slru_csnlog) 
 	{
 		return true;
 	}

--- a/pgxn/neon_walredo/walredoproc.c
+++ b/pgxn/neon_walredo/walredoproc.c
@@ -65,6 +65,7 @@
 #include "rusagestub.h"
 #endif
 
+#include "access/remotexact.h"
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
 #if PG_VERSION_NUM >= 150000
@@ -499,7 +500,7 @@ BeginRedoForBlock(StringInfo input_message)
 		 target_redo_tag.forkNum,
 		 target_redo_tag.blockNum);
 
-	reln = smgropen(rnode, InvalidBackendId, RELPERSISTENCE_PERMANENT);
+	reln = smgropen(rnode, InvalidBackendId, RELPERSISTENCE_PERMANENT, current_region);
 	if (reln->smgr_cached_nblocks[forknum] == InvalidBlockNumber ||
 		reln->smgr_cached_nblocks[forknum] < blknum + 1)
 	{

--- a/pgxn/remotexact/Makefile
+++ b/pgxn/remotexact/Makefile
@@ -4,9 +4,10 @@ MODULE_big = remotexact
 OBJS = \
 	$(WIN32RES)\
 	apply.o \
+	funcs.o \
 	remotexact.o \
 	rwset.o \
-	funcs.o 
+	validate.o
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
 SHLIB_LINK_INTERNAL = $(libpq)

--- a/pgxn/remotexact/Makefile
+++ b/pgxn/remotexact/Makefile
@@ -1,0 +1,21 @@
+# pgxn/remotexact/Makefile
+
+MODULE_big = remotexact
+OBJS = \
+	$(WIN32RES)\
+	apply.o \
+	remotexact.o \
+	rwset.o \
+	funcs.o 
+
+PG_CPPFLAGS = -I$(libpq_srcdir)
+SHLIB_LINK_INTERNAL = $(libpq)
+
+EXTENSION = remotexact
+PGFILEDESC = "remotexact - remote transactions for multi-master PostgreSQL"
+DATA = remotexact--1.0.sql
+
+
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)

--- a/pgxn/remotexact/apply.c
+++ b/pgxn/remotexact/apply.c
@@ -1,0 +1,369 @@
+/*-------------------------------------------------------------------------
+ * contrib/remotexact/apply.c
+ * 
+ * This file contains function to decode and apply the writes in the rwset
+ * of a remote transaction. Many functions in this file are ported from
+ * backend/replication/logical/worker.c since we use the message format of
+ * logical replication to encode the writes.
+ * -------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "access/table.h"
+#include "access/remotexact.h"
+#include "access/xact.h"
+#include "apply.h"
+#include "commands/trigger.h"
+#include "executor/executor.h"
+#include "lib/stringinfo.h"
+#include "libpq/pqformat.h"
+#include "optimizer/optimizer.h"
+#include "replication/logicalproto.h"
+#include "rewrite/rewriteHandler.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+
+typedef struct ApplyExecutionData
+{
+	EState	        *estate;			/* executor state, used to track resources */
+
+	Relation        targetRel;	        /* replication target rel */
+	ResultRelInfo   *targetRelInfo;
+} ApplyExecutionData;
+
+typedef struct SlotErrCallbackArg
+{
+	Relation    rel;
+    int			attnum;
+} SlotErrCallbackArg;
+
+static void apply_handle_insert(StringInfo s, bool skip);
+static void apply_handle_update(StringInfo s, bool skip);
+static void apply_handle_delete(StringInfo s, bool skip);
+static Relation open_relation(LogicalRepRelId relid, LOCKMODE lockmode);
+static void close_relation(Relation rel, LOCKMODE lockmode);
+static ApplyExecutionData *create_edata_for_relation(Relation rel);
+static void finish_edata(ApplyExecutionData *edata);
+static void slot_store_data(TupleTableSlot *slot,
+                            Relation rel,
+				            LogicalRepTupleData *tupleData);
+
+void
+apply_writes(RWSet *rwset)
+{
+	StringInfoData s;
+
+	s.data = rwset->writes;
+	s.len = rwset->writes_len;
+	s.cursor = 0;
+	while (s.cursor < s.len)
+	{
+		int region;
+		LogicalRepMsgType action;
+		bool skip;
+
+		region = pq_getmsgbyte(&s);
+
+		// We ignore tuples that do not belong to the current region
+		// by setting the skip argument to true to the apply functions
+		// below. They will still decode the tuples but will not apply
+		// the changes for them.
+		skip = region != current_region;
+
+		action = pq_getmsgbyte(&s);
+		switch (action)
+		{
+			case LOGICAL_REP_MSG_INSERT:
+				apply_handle_insert(&s, skip);
+				break;
+
+			case LOGICAL_REP_MSG_UPDATE:
+				apply_handle_update(&s, skip);
+				break;
+
+			case LOGICAL_REP_MSG_DELETE:
+				apply_handle_delete(&s, skip);
+				break;
+
+			default:
+				ereport(ERROR,
+						(errcode(ERRCODE_PROTOCOL_VIOLATION),
+						 errmsg_internal("[remotexact] invalid write set message type \"%c\"", action)));
+		}
+	}
+}
+
+/*
+ * Ported from apply_handle_insert in backend/replication/logical/worker.c
+ */
+static void
+apply_handle_insert(StringInfo s, bool skip)
+{
+	Relation rel;
+	LogicalRepTupleData newtup;
+	LogicalRepRelId relid;
+	ApplyExecutionData *edata;
+	EState	   *estate;
+	TupleTableSlot *remoteslot;
+	MemoryContext oldctx;
+
+	relid = logicalrep_read_insert(s, &newtup);
+
+	if (skip)
+		return;
+
+	rel = open_relation(relid, RowExclusiveLock);
+
+	/* Initialize the executor state. */
+	edata = create_edata_for_relation(rel);
+	estate = edata->estate;
+	remoteslot = ExecInitExtraTupleSlot(estate,
+										RelationGetDescr(rel),
+										&TTSOpsVirtual);
+
+	/* Process and store remote tuple in the slot */
+	oldctx = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
+	slot_store_data(remoteslot, rel, &newtup);
+	MemoryContextSwitchTo(oldctx);
+
+	/* Unlike logical replication, we never write to a partitioned relation
+	   (but the relation can be  a partition of a partitioned relation), so
+	   we don't need to check whether the relation is partitioned or not. */
+
+	/* We must open indexes here. */
+	ExecOpenIndices(edata->targetRelInfo, false);
+
+	/* Do the insert. */
+	ExecSimpleRelationInsert(edata->targetRelInfo, edata->estate, remoteslot);
+
+	/* Cleanup. */
+	ExecCloseIndices(edata->targetRelInfo);
+
+	finish_edata(edata);
+
+	close_relation(rel, NoLock);
+}
+
+static void
+apply_handle_update(StringInfo s, bool skip)
+{
+}
+
+static void
+apply_handle_delete(StringInfo s, bool skip)
+{
+}
+
+/*
+ * Open the local relation.
+ */
+static Relation
+open_relation(LogicalRepRelId relid, LOCKMODE lockmode)
+{
+    if (!OidIsValid(relid))
+        ereport(ERROR,
+                (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+                    errmsg("relation with id \"%d\" does not exist", relid)));
+
+    return table_open(relid, lockmode);
+}
+
+/*
+ * Close the previously opened logical relation.
+ */
+static void
+close_relation(Relation rel, LOCKMODE lockmode)
+{
+	table_close(rel, lockmode);
+}
+
+/*
+ * Ported from create_edata_for_relation in backend/replication/logical/worker.c
+ */
+static ApplyExecutionData *
+create_edata_for_relation(Relation rel)
+{
+	ApplyExecutionData *edata;
+	EState	   *estate;
+	RangeTblEntry *rte;
+	ResultRelInfo *resultRelInfo;
+
+	edata = (ApplyExecutionData *) palloc0(sizeof(ApplyExecutionData));
+	edata->targetRel = rel;
+
+	edata->estate = estate = CreateExecutorState();
+
+	rte = makeNode(RangeTblEntry);
+	rte->rtekind = RTE_RELATION;
+	rte->relid = RelationGetRelid(rel);
+	rte->relkind = rel->rd_rel->relkind;
+	rte->rellockmode = AccessShareLock;
+	ExecInitRangeTable(estate, list_make1(rte));
+
+	edata->targetRelInfo = resultRelInfo = makeNode(ResultRelInfo);
+
+	/*
+	 * Use Relation opened by logicalrep_rel_open() instead of opening it
+	 * again.
+	 */
+	InitResultRelInfo(resultRelInfo, rel, 1, NULL, 0);
+
+	/*
+	 * We put the ResultRelInfo in the es_opened_result_relations list, even
+	 * though we don't populate the es_result_relations array.  That's a bit
+	 * bogus, but it's enough to make ExecGetTriggerResultRel() find them.
+	 *
+	 * ExecOpenIndices() is not called here either, each execution path doing
+	 * an apply operation being responsible for that.
+	 */
+	estate->es_opened_result_relations =
+		lappend(estate->es_opened_result_relations, resultRelInfo);
+
+	estate->es_output_cid = GetCurrentCommandId(true);
+
+	/* Prepare to catch AFTER triggers. */
+	AfterTriggerBeginQuery();
+
+	/* other fields of edata remain NULL for now */
+
+	return edata;
+}
+
+/*
+ * Ported from finish_edata in backend/replication/logical/worker.c
+ */
+static void
+finish_edata(ApplyExecutionData *edata)
+{
+	EState	   *estate = edata->estate;
+
+	/* Handle any queued AFTER triggers. */
+	AfterTriggerEndQuery(estate);
+
+	/*
+	 * Cleanup.  It might seem that we should call ExecCloseResultRelations()
+	 * here, but we intentionally don't.  It would close the rel we added to
+	 * es_opened_result_relations above, which is wrong because we took no
+	 * corresponding refcount.  We rely on ExecCleanupTupleRouting() to close
+	 * any other relations opened during execution.
+	 */
+	ExecResetTupleTable(estate->es_tupleTable, false);
+	FreeExecutorState(estate);
+	pfree(edata);
+}
+
+/*
+ * Ported from slot_store_error_callback in backend/replication/logical/worker.c
+ */
+static void
+slot_store_error_callback(void *arg)
+{
+	SlotErrCallbackArg *errarg = (SlotErrCallbackArg *) arg;
+	Relation rel;
+    
+    /* Nothing to do if attribute number is not set */
+	if (errarg->attnum < 0)
+		return;
+
+    rel = errarg->rel;
+
+	errcontext("applying remote data for relation %u column %d", rel->rd_id, errarg->attnum);
+}
+
+/*
+ * Ported from slot_store_data in backend/replication/logical/worker.c
+ */
+static void
+slot_store_data(TupleTableSlot *slot, Relation rel,
+				LogicalRepTupleData *tupleData)
+{
+	int			natts = slot->tts_tupleDescriptor->natts;
+	int			i;
+	SlotErrCallbackArg errarg;
+	ErrorContextCallback errcallback;
+
+	ExecClearTuple(slot);
+
+	/* Push callback + info on the error context stack */
+	errarg.rel = rel;
+	errarg.attnum = -1;
+	errcallback.callback = slot_store_error_callback;
+	errcallback.arg = (void *) &errarg;
+	errcallback.previous = error_context_stack;
+	error_context_stack = &errcallback;
+
+    Assert(tupleData->ncols == natts);
+
+	for (i = 0; i < natts; i++)
+	{
+		Form_pg_attribute att = TupleDescAttr(slot->tts_tupleDescriptor, i);
+
+		if (!att->attisdropped)
+		{
+			StringInfo	colvalue = &tupleData->colvalues[i];
+
+			errarg.attnum = i;
+
+			if (tupleData->colstatus[i] == LOGICALREP_COLUMN_TEXT)
+			{
+				Oid			typinput;
+				Oid			typioparam;
+
+				getTypeInputInfo(att->atttypid, &typinput, &typioparam);
+				slot->tts_values[i] =
+					OidInputFunctionCall(typinput, colvalue->data,
+										 typioparam, att->atttypmod);
+				slot->tts_isnull[i] = false;
+			}
+			else if (tupleData->colstatus[i] == LOGICALREP_COLUMN_BINARY)
+			{
+				Oid			typreceive;
+				Oid			typioparam;
+
+				/*
+				 * In some code paths we may be asked to re-parse the same
+				 * tuple data.  Reset the StringInfo's cursor so that works.
+				 */
+				colvalue->cursor = 0;
+
+				getTypeBinaryInputInfo(att->atttypid, &typreceive, &typioparam);
+				slot->tts_values[i] =
+					OidReceiveFunctionCall(typreceive, colvalue,
+										   typioparam, att->atttypmod);
+
+				/* Trouble if it didn't eat the whole buffer */
+				if (colvalue->cursor != colvalue->len)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
+							 errmsg("incorrect binary data format in logical replication column %d",
+									i + 1)));
+				slot->tts_isnull[i] = false;
+			}
+			else
+			{
+				/*
+				 * NULL value from remote.  (We don't expect to see
+				 * LOGICALREP_COLUMN_UNCHANGED here, but if we do, treat it as
+				 * NULL.)
+				 */
+				slot->tts_values[i] = (Datum) 0;
+				slot->tts_isnull[i] = true;
+			}
+
+			errarg.attnum = -1;
+		}
+		else
+		{
+			/*
+			 * We assign NULL to dropped attributes 
+			 */
+			slot->tts_values[i] = (Datum) 0;
+			slot->tts_isnull[i] = true;
+		}
+	}
+
+	/* Pop the error context stack */
+	error_context_stack = errcallback.previous;
+
+	ExecStoreVirtualTuple(slot);
+}

--- a/pgxn/remotexact/apply.h
+++ b/pgxn/remotexact/apply.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * apply.h
+ *
+ * contrib/remotexact/apply.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef APPLY_H
+#define APPLY_H
+
+#include "postgres.h"
+
+#include "rwset.h"
+
+void apply_writes(RWSet *rwset);
+
+#endif							/* APPLY_H */

--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -6,6 +6,7 @@
 #include "lib/stringinfo.h"
 #include "rwset.h"
 #include "storage/proc.h"
+#include "validate.h"
 
 PG_FUNCTION_INFO_V1(validate_and_apply_xact);
 
@@ -15,41 +16,66 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 	bytea	   *bytes = PG_GETARG_BYTEA_P(0);
 	StringInfoData buf;
 	RWSet	   *rwset;
+	dlist_iter	rel_iter;
 
-	// Signify that this is a surrogate transaction. This
-	// variable will be reset on transaction completion.
+	/*
+	 * Signify that this is a surrogate transaction. This
+	 * variable will be reset on transaction completion.
+	 */
 	is_surrogate = true;
 
-	// Extract the buffer from the function argument
+	/*
+	 * Decode the buffer into a rwset
+	 */
+	rwset = RWSetAllocate();
 	buf.data = VARDATA(bytes);
 	buf.len = VARSIZE(bytes) - VARHDRSZ;
 	buf.maxlen = buf.len;
 	buf.cursor = 0;
-
-	// Decode the buffer into a rwset
-	rwset = RWSetAllocate();
 	RWSetDecode(rwset, &buf);
 
-	ereport(LOG, errmsg("%s", RWSetToString(rwset)));
-
-	/* Mark the xact as remote before starting validation by setting the
+	/* 
+	 * Mark the xact as remote before starting validation by setting the
 	 * isRemoteXact flag in MyProc. We don't lock the ProcArray because its
 	 * our own process.
 	 */
 	MyProc->isRemoteXact = true;
 	pg_write_barrier();
 
-	// Apply the writes
+	/*
+	 * Validate the read set
+	 */
+	dlist_foreach(rel_iter, &rwset->relations)
+	{
+		RWSetRelation *rel = dlist_container(RWSetRelation, node, rel_iter.cur);
+		Oid relid = rel->relid;
+		int8 region = rel->region;
+		XidCSN read_csn = rel->csn;
+
+		if (region != current_region)
+			continue;
+
+		if (!rel->is_index)
+			validate_table_scan(relid, read_csn);
+	}
+
+	/*
+	 * Apply the write set
+	 */
 	apply_writes(rwset);
 
+	/*
+	 * Clean up
+	 */
 	RWSetFree(rwset);
 
-	/* Mark the xact as local because validation is complete by unsetting the
+	/*
+	 * Mark the xact as local because validation is complete by unsetting the
 	 * isRemoteXact flag in MyProc. We don't lock the ProcArray because its
 	 * our own process.
 	 */
 	MyProc->isRemoteXact = false;
 	pg_write_barrier();
 
-	PG_RETURN_BOOL(true);
+	PG_RETURN_VOID();
 }

--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -37,6 +37,7 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 	 * our own process.
 	 */
 	MyProc->isRemoteXact = true;
+	pg_write_barrier();
 
 	// Apply the writes
 	apply_writes(rwset);
@@ -48,6 +49,7 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 	 * our own process.
 	 */
 	MyProc->isRemoteXact = false;
+	pg_write_barrier();
 
 	PG_RETURN_BOOL(true);
 }

--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -58,7 +58,7 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 		if (region != current_region)
 			continue;
 
-		if (!rel->is_index)
+		if (!rel->is_index && rel->is_table_scan)
 			validate_table_scan(relid, read_csn);
 	}
 

--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -1,0 +1,40 @@
+#include "postgres.h"
+
+#include "access/remotexact.h"
+#include "apply.h"
+#include "fmgr.h"
+#include "lib/stringinfo.h"
+#include "rwset.h"
+
+PG_FUNCTION_INFO_V1(validate_and_apply_xact);
+
+Datum
+validate_and_apply_xact(PG_FUNCTION_ARGS)
+{
+	bytea	   *bytes = PG_GETARG_BYTEA_P(0);
+	StringInfoData buf;
+	RWSet	   *rwset;
+
+	// Signify that this is a surrogate transaction. This
+	// variable will be reset on transaction completion.
+	is_surrogate = true;
+
+	// Extract the buffer from the function argument
+	buf.data = VARDATA(bytes);
+	buf.len = VARSIZE(bytes) - VARHDRSZ;
+	buf.maxlen = buf.len;
+	buf.cursor = 0;
+
+	// Decode the buffer into a rwset
+	rwset = RWSetAllocate();
+	RWSetDecode(rwset, &buf);
+
+	ereport(LOG, errmsg("%s", RWSetToString(rwset)));
+
+	// Apply the writes
+	apply_writes(rwset);
+
+	RWSetFree(rwset);
+
+	PG_RETURN_BOOL(true);
+}

--- a/pgxn/remotexact/funcs.c
+++ b/pgxn/remotexact/funcs.c
@@ -58,8 +58,16 @@ validate_and_apply_xact(PG_FUNCTION_ARGS)
 		if (region != current_region)
 			continue;
 
-		if (!rel->is_index && rel->is_table_scan)
-			validate_table_scan(relid, read_csn);
+		/* TODO(pooja): Better organize this code in the following order:
+		 * 1. Index scan
+		 * 2. Tuple scans
+		 * 3. Table scan
+		 */
+		
+		if (rel->is_index && !rel->is_table_scan)
+			validate_index_scan(rel);
+		else if (!rel->is_index && rel->is_table_scan)
+			validate_table_scan(relid, read_csn); 
 	}
 
 	/*

--- a/pgxn/remotexact/remotexact--1.0.sql
+++ b/pgxn/remotexact/remotexact--1.0.sql
@@ -1,0 +1,9 @@
+/* contrib/remotexact/remotexact--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION remotexact" to load this file. \quit
+
+CREATE FUNCTION validate_and_apply_xact(IN bytes bytea)
+RETURNS bool
+AS 'MODULE_PATHNAME', 'validate_and_apply_xact'
+LANGUAGE C STRICT;

--- a/pgxn/remotexact/remotexact--1.0.sql
+++ b/pgxn/remotexact/remotexact--1.0.sql
@@ -4,6 +4,11 @@
 \echo Use "CREATE EXTENSION remotexact" to load this file. \quit
 
 CREATE FUNCTION validate_and_apply_xact(IN bytes bytea)
-RETURNS bool
+RETURNS void
 AS 'MODULE_PATHNAME', 'validate_and_apply_xact'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION lsn_snapshot(OUT region smallint, OUT lsn pg_lsn)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'lsn_snapshot'
 LANGUAGE C STRICT;

--- a/pgxn/remotexact/remotexact.c
+++ b/pgxn/remotexact/remotexact.c
@@ -255,7 +255,14 @@ rx_collect_update(Relation relation, HeapTuple oldtuple, HeapTuple newtuple)
 	if (relreplident != REPLICA_IDENTITY_DEFAULT &&
 		relreplident != REPLICA_IDENTITY_FULL &&
 		relreplident != REPLICA_IDENTITY_INDEX)
+	{
+		ereport(WARNING,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("target relation \"%s\" has neither REPLICA IDENTITY "
+						"index nor REPLICA IDENTITY FULL",
+						RelationGetRelationName(relation))));
 		return;
+	}
 
 	buf = &rwset_collection_buffer->writes;
 
@@ -305,7 +312,14 @@ rx_collect_delete(Relation relation, HeapTuple oldtuple)
 	if (relreplident != REPLICA_IDENTITY_DEFAULT &&
 		relreplident != REPLICA_IDENTITY_FULL &&
 		relreplident != REPLICA_IDENTITY_INDEX)
+	{
+		ereport(WARNING,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("target relation \"%s\" has neither REPLICA IDENTITY "
+						"index nor REPLICA IDENTITY FULL",
+						RelationGetRelationName(relation))));
 		return;
+	}
 
 	if (oldtuple == NULL)
 		return;

--- a/pgxn/remotexact/remotexact.c
+++ b/pgxn/remotexact/remotexact.c
@@ -249,9 +249,6 @@ rx_collect_update(Relation relation, HeapTuple oldtuple, HeapTuple newtuple)
 
 	init_rwset_collection_buffer(relation->rd_node.dbNode);
 
-	// TOOD(ctring): We need to set the replica identity to something other than NOTHING
-	// to collect the write set. Need to figure out a way to get rid of this step
-	// or a check to prevent us from forgetting to do this step.
 	if (relreplident != REPLICA_IDENTITY_DEFAULT &&
 		relreplident != REPLICA_IDENTITY_FULL &&
 		relreplident != REPLICA_IDENTITY_INDEX)
@@ -306,9 +303,6 @@ rx_collect_delete(Relation relation, HeapTuple oldtuple)
 
 	init_rwset_collection_buffer(relation->rd_node.dbNode);
 
-	// TOOD(ctring): We need to set the replica identity to something other than NOTHING
-	// to collect the write set. Need to figure out a way to get rid of this step
-	// or a check to prevent us from forgetting to do this step.
 	if (relreplident != REPLICA_IDENTITY_DEFAULT &&
 		relreplident != REPLICA_IDENTITY_FULL &&
 		relreplident != REPLICA_IDENTITY_INDEX)

--- a/pgxn/remotexact/remotexact.c
+++ b/pgxn/remotexact/remotexact.c
@@ -1,0 +1,543 @@
+/* contrib/remotexact/remotexact.c */
+#include "postgres.h"
+
+#include "access/csn_snapshot.h"
+#include "access/xact.h"
+#include "access/remotexact.h"
+#include "fmgr.h"
+#include "libpq-fe.h"
+#include "libpq/pqformat.h"
+#include "replication/logicalproto.h"
+#include "rwset.h"
+#include "storage/predicate.h"
+#include "storage/smgr.h"
+#include "utils/guc.h"
+#include "utils/hsearch.h"
+#include "utils/memutils.h"
+#include "utils/snapmgr.h"
+#include "utils/rel.h"
+#include "miscadmin.h"
+
+PG_MODULE_MAGIC;
+
+void		_PG_init(void);
+
+/* GUCs */
+char	   *remotexact_connstring;
+
+typedef struct CollectedRelationKey
+{
+	Oid			relid;
+} CollectedRelationKey;
+
+typedef struct CollectedRelation
+{
+	CollectedRelationKey key;
+
+	int8		region;
+	bool		is_index;
+	int			nitems;
+
+	StringInfoData pages;
+	StringInfoData tuples;
+} CollectedRelation;
+
+typedef struct RWSetCollectionBuffer
+{
+	MemoryContext context;
+
+	RWSetHeader header;
+	HTAB	   *collected_relations;
+	StringInfoData writes;
+} RWSetCollectionBuffer;
+
+static RWSetCollectionBuffer *rwset_collection_buffer = NULL;
+
+PGconn	   *XactServerConn;
+bool		Connected = false;
+
+static void init_rwset_collection_buffer(Oid dbid);
+static void rwset_add_region(int region);
+
+static void rx_collect_region(Relation relation);
+static void rx_collect_relation(Oid dbid, Oid relid);
+static void rx_collect_page(Oid dbid, Oid relid, BlockNumber blkno);
+static void rx_collect_tuple(Oid dbid, Oid relid, BlockNumber blkno, OffsetNumber tid);
+static void rx_collect_insert(Relation relation, HeapTuple newtuple);
+static void rx_collect_update(Relation relation, HeapTuple oldtuple, HeapTuple newtuple);
+static void rx_collect_delete(Relation relation, HeapTuple oldtuple);
+static void rx_clear_rwset_collection_buffer(void);
+static void rx_send_rwset_and_wait(void);
+
+static CollectedRelation *get_collected_relation(Oid relid, bool create_if_not_found);
+static bool connect_to_txn_server(void);
+
+static void
+init_rwset_collection_buffer(Oid dbid)
+{
+	MemoryContext old_context;
+	HASHCTL		hash_ctl;
+	Snapshot 	snapshot;
+
+	if (rwset_collection_buffer)
+	{
+		Oid old_dbid = rwset_collection_buffer->header.dbid;
+
+		if (old_dbid != dbid)
+			ereport(ERROR,
+					errmsg("[remotexact] Remotexact can access only one database"),
+					errdetail("old dbid: %u, new dbid: %u", old_dbid, dbid));
+		return;
+	}
+
+	old_context = MemoryContextSwitchTo(TopTransactionContext);
+
+	rwset_collection_buffer = (RWSetCollectionBuffer *) palloc(sizeof(RWSetCollectionBuffer));
+	rwset_collection_buffer->context = TopTransactionContext;
+
+	/* Initialize the header */
+	rwset_collection_buffer->header.dbid = dbid;
+	rwset_collection_buffer->header.xid = InvalidTransactionId;
+	snapshot = GetLatestSnapshot();
+	rwset_collection_buffer->header.csn = snapshot->snapshot_csn;
+	/* The current region is always a participant of the transaction */
+	rwset_collection_buffer->header.region_set = UINT64CONST(1) << current_region;
+
+	/* Initialize a map from relation oid to the read set of the relation */
+	hash_ctl.hcxt = rwset_collection_buffer->context;
+	hash_ctl.keysize = sizeof(CollectedRelationKey);
+	hash_ctl.entrysize = sizeof(CollectedRelation);
+	rwset_collection_buffer->collected_relations = hash_create("collected relations",
+															   max_predicate_locks_per_xact,
+															   &hash_ctl,
+															   HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+
+	/* Initialize the buffer for the write set */
+	initStringInfo(&rwset_collection_buffer->writes);
+
+	MemoryContextSwitchTo(old_context);
+}
+
+static void
+rwset_add_region(int region)
+{
+	Assert(RegionIsValid(region));
+	Assert(rwset_collection_buffer != NULL);
+
+	/* Set the corresponding region bit in the header */
+	rwset_collection_buffer->header.region_set |= UINT64CONST(1) << region;
+}
+
+static void
+rx_collect_region(Relation relation)
+{
+	int	region = RelationGetRegion(relation);
+	int	max_nregions = BITS_PER_BYTE * sizeof(uint64);
+	CollectedRelation *crel;
+
+	if (region < 0 || region >= max_nregions)
+		ereport(ERROR,
+				errmsg("[remotexact] Region id is out of bound"),
+				errdetail("region id: %u, min: 0, max: %u", region, max_nregions));
+
+	init_rwset_collection_buffer(relation->rd_node.dbNode);
+
+	crel = get_collected_relation(RelationGetRelid(relation), false);
+	Assert(crel != NULL);
+
+	/* Set the region for the individual relation */
+	crel->region = region;
+
+	rwset_add_region(region);
+}
+
+static void
+rx_collect_relation(Oid dbid, Oid relid)
+{
+	CollectedRelation *collected_relation;
+
+	init_rwset_collection_buffer(dbid);
+	collected_relation = get_collected_relation(relid, true);
+	collected_relation->is_index = false;
+}
+
+static void
+rx_collect_page(Oid dbid, Oid relid, BlockNumber blkno)
+{
+	CollectedRelation *collected_relation;
+	StringInfo	buf = NULL;
+	Snapshot snapshot;
+
+	init_rwset_collection_buffer(dbid);
+
+	collected_relation = get_collected_relation(relid, true);
+	collected_relation->is_index = true;
+	collected_relation->nitems++;
+
+	snapshot = GetLatestSnapshot();
+
+	buf = &collected_relation->pages;
+	pq_sendint32(buf, blkno);
+	pq_sendint64(buf, snapshot->snapshot_csn);
+}
+
+static void
+rx_collect_tuple(Oid dbid, Oid relid, BlockNumber blkno, OffsetNumber offset)
+{
+	CollectedRelation *collected_relation;
+	StringInfo	buf = NULL;
+
+	init_rwset_collection_buffer(dbid);
+
+	collected_relation = get_collected_relation(relid, true);
+	collected_relation->is_index = false;
+	collected_relation->nitems++;
+
+	buf = &collected_relation->tuples;
+	pq_sendint32(buf, blkno);
+	pq_sendint16(buf, offset);
+}
+
+static void
+rx_collect_insert(Relation relation, HeapTuple newtuple)
+{
+	StringInfo	buf = NULL;
+	int region = RelationGetRegion(relation);
+#if PG_VERSION_NUM >= 150000
+	TupleTableSlot *newslot;
+#endif
+
+	init_rwset_collection_buffer(relation->rd_node.dbNode);
+
+	buf = &rwset_collection_buffer->writes;
+
+	/* Starts with the region of the relation */
+	pq_sendbyte(buf, region);
+
+#if PG_VERSION_NUM >= 150000
+	// TODO (ctring): logicalrep_write_insert in postgres 15 requires a tuple slot,
+	//				  so creating it here to make things compile for now. This
+	//				  might not be efficient and should be revised.
+	newslot = MakeTupleTableSlot(RelationGetDescr(relation), &TTSOpsHeapTuple);
+	ExecStoreHeapTuple(newtuple, newslot, false);
+	/* Encode the insert using the logical replication protocol */
+	logicalrep_write_insert(buf,
+							InvalidTransactionId,
+							relation,
+							newslot,
+							true /* binary */,
+							NULL /* columns */);
+#else
+	/* Encode the insert using the logical replication protocol */
+	logicalrep_write_insert(buf, InvalidTransactionId, relation, newtuple, true /* binary */);
+#endif
+
+	rwset_add_region(region);
+}
+
+static void
+rx_collect_update(Relation relation, HeapTuple oldtuple, HeapTuple newtuple)
+{
+	StringInfo	buf = NULL;
+#if PG_VERSION_NUM >= 150000
+	TupleTableSlot *oldslot;
+	TupleTableSlot *newslot;
+#endif
+
+	char		relreplident = relation->rd_rel->relreplident;
+	int			region = RelationGetRegion(relation);
+
+	init_rwset_collection_buffer(relation->rd_node.dbNode);
+
+	// TOOD(ctring): We need to set the replica identity to something other than NOTHING
+	// to collect the write set. Need to figure out a way to get rid of this step
+	// or a check to prevent us from forgetting to do this step.
+	if (relreplident != REPLICA_IDENTITY_DEFAULT &&
+		relreplident != REPLICA_IDENTITY_FULL &&
+		relreplident != REPLICA_IDENTITY_INDEX)
+		return;
+
+	buf = &rwset_collection_buffer->writes;
+
+	/* Starts with the region of the relation */
+	pq_sendbyte(buf, region);
+
+#if PG_VERSION_NUM >= 150000
+	// TODO (ctring): logicalrep_write_update in postgres 15 requires tuple slots,
+	//				  so creating them here to make things compile for now. This
+	//				  might not be efficient and should be revised.
+	oldslot = MakeTupleTableSlot(RelationGetDescr(relation), &TTSOpsHeapTuple);
+	ExecStoreHeapTuple(oldtuple, oldslot, false);
+	newslot = MakeTupleTableSlot(RelationGetDescr(relation), &TTSOpsHeapTuple);
+	ExecStoreHeapTuple(newtuple, newslot, false);
+	/* Encode the update using the logical replication protocol */
+	logicalrep_write_update(buf,
+							InvalidTransactionId,
+							relation,
+							oldslot,
+							newslot,
+							true /* binary */,
+							NULL /* columns */);
+#else
+	/* Encode the update using the logical replication protocol */
+	logicalrep_write_update(buf, InvalidTransactionId, relation, oldtuple, newtuple, true /* binary */);
+#endif
+
+	rwset_add_region(region);
+}
+
+static void
+rx_collect_delete(Relation relation, HeapTuple oldtuple)
+{
+	StringInfo	buf = NULL;
+#if PG_VERSION_NUM >= 150000
+	TupleTableSlot *oldslot;
+#endif
+
+	char		relreplident = relation->rd_rel->relreplident;
+	int			region = RelationGetRegion(relation);
+
+	init_rwset_collection_buffer(relation->rd_node.dbNode);
+
+	// TOOD(ctring): We need to set the replica identity to something other than NOTHING
+	// to collect the write set. Need to figure out a way to get rid of this step
+	// or a check to prevent us from forgetting to do this step.
+	if (relreplident != REPLICA_IDENTITY_DEFAULT &&
+		relreplident != REPLICA_IDENTITY_FULL &&
+		relreplident != REPLICA_IDENTITY_INDEX)
+		return;
+
+	if (oldtuple == NULL)
+		return;
+
+	buf = &rwset_collection_buffer->writes;
+
+	/* Starts with the region of the relation */
+	pq_sendbyte(buf, region);
+
+#if PG_VERSION_NUM >= 150000
+	// TODO (ctring): logicalrep_write_delete in postgres 15 requires a tuple slot,
+	//				  so creating it here to make things compile for now. This
+	//				  might not be efficient and should be revised.
+	oldslot = MakeTupleTableSlot(RelationGetDescr(relation), &TTSOpsHeapTuple);
+	ExecStoreHeapTuple(oldtuple, oldslot, false);
+	/* Encode the delete using the logical replication protocol */
+	logicalrep_write_delete(buf, InvalidTransactionId, relation, oldslot, true /* binary */);
+#else
+	/* Encode the delete using the logical replication protocol */
+	logicalrep_write_delete(buf, InvalidTransactionId, relation, oldtuple, true /* binary */);
+#endif
+
+	rwset_add_region(region);
+}
+
+
+static void
+rx_clear_rwset_collection_buffer(void)
+{
+	rwset_collection_buffer = NULL;
+}
+
+static void
+rx_send_rwset_and_wait(void)
+{
+	RWSet	   *rwset;
+	RWSetHeader *header;
+	CollectedRelation *collected_relation;
+	HASH_SEQ_STATUS status;
+	int			read_len = 0;
+	StringInfoData buf;
+
+	if (rwset_collection_buffer == NULL)
+		return;
+
+	if (!connect_to_txn_server())
+		return;
+
+	initStringInfo(&buf);
+
+	/* Assemble the header */
+	header = &rwset_collection_buffer->header;
+	pq_sendint32(&buf, header->dbid);
+	pq_sendint32(&buf, header->xid);
+	pq_sendint64(&buf, header->csn);
+	pq_sendint64(&buf, header->region_set);
+
+	/* Cursor now points to where the length of the read section is stored */
+	buf.cursor = buf.len;
+	/* Read section length will be updated later */
+	pq_sendint32(&buf, 0);
+
+	/* Assemble the read set */
+	hash_seq_init(&status, rwset_collection_buffer->collected_relations);
+	while ((collected_relation = (CollectedRelation *) hash_seq_search(&status)) != NULL)
+	{
+		StringInfo	items = NULL;
+
+		/* Accumulate the length of the buffer used by each relation */
+		read_len -= buf.len;
+
+		if (collected_relation->is_index)
+		{
+			pq_sendbyte(&buf, 'I');
+			pq_sendint32(&buf, collected_relation->key.relid);
+			pq_sendbyte(&buf, collected_relation->region);
+			pq_sendint32(&buf, collected_relation->nitems);
+			items = &collected_relation->pages;
+		}
+		else
+		{
+			pq_sendbyte(&buf, 'T');
+			pq_sendint32(&buf, collected_relation->key.relid);
+			pq_sendbyte(&buf, collected_relation->region);
+			pq_sendint32(&buf, collected_relation->nitems);
+			items = &collected_relation->tuples;
+		}
+
+		pq_sendbytes(&buf, items->data, items->len);
+
+		read_len += buf.len;
+	}
+
+	/* Update the length of the read section */
+	*(int *) (buf.data + buf.cursor) = pg_hton32(read_len);
+
+	pq_sendbytes(&buf, rwset_collection_buffer->writes.data, rwset_collection_buffer->writes.len);
+
+	/* Actually send the buffer to the xact server */
+	if (PQputCopyData(XactServerConn, buf.data, buf.len) <= 0 || PQflush(XactServerConn))
+		ereport(WARNING, errmsg("[remotexact] failed to send read/write set"));
+
+	/*
+	 * TODO(ctring): This code is for debugging rwset remove all after the
+	 * remote worker is implemented
+	 */
+	rwset = RWSetAllocate();
+	buf.cursor = 0;
+	RWSetDecode(rwset, &buf);
+	ereport(LOG, errmsg("[remotexact] sent: %s", RWSetToString(rwset)));
+	RWSetFree(rwset);
+}
+
+static CollectedRelation *
+get_collected_relation(Oid relid, bool create_if_not_found)
+{
+	CollectedRelationKey key;
+	CollectedRelation *relation;
+	bool		found;
+
+	Assert(rwset_collection_buffer);
+
+	key.relid = relid;
+
+	/* Check if the relation is in the map */
+	relation = (CollectedRelation *) hash_search(rwset_collection_buffer->collected_relations,
+												 &key, HASH_ENTER, &found);
+	/* Initialize a new relation entry if not found */
+	if (!found) {
+		if (create_if_not_found)
+		{
+			MemoryContext old_context;
+
+			old_context = MemoryContextSwitchTo(rwset_collection_buffer->context);
+
+			relation->nitems = 0;
+			relation->region = UNKNOWN_REGION;
+			relation->is_index = false;
+			initStringInfo(&relation->pages);
+			initStringInfo(&relation->tuples);
+
+			MemoryContextSwitchTo(old_context);
+		}
+		else
+			relation = NULL;
+	}
+	return relation;
+}
+
+static bool
+connect_to_txn_server(void)
+{
+	PGresult   *res;
+
+	/* Reconnect if the connection is bad for some reason */
+	if (Connected && PQstatus(XactServerConn) == CONNECTION_BAD)
+	{
+		PQfinish(XactServerConn);
+		XactServerConn = NULL;
+		Connected = false;
+
+		ereport(LOG, errmsg("[remotexact] connection to transaction server broken, reconnecting..."));
+	}
+
+	if (Connected)
+	{
+		ereport(LOG, errmsg("[remotexact] reuse existing connection to transaction server"));
+		return true;
+	}
+
+	XactServerConn = PQconnectdb(remotexact_connstring);
+
+	if (PQstatus(XactServerConn) == CONNECTION_BAD)
+	{
+		char	   *msg = pchomp(PQerrorMessage(XactServerConn));
+
+		PQfinish(XactServerConn);
+		ereport(WARNING,
+				errmsg("[remotexact] could not connect to the transaction server"),
+				errdetail_internal("%s", msg));
+		return Connected;
+	}
+
+	/* TODO(ctring): send a more useful starting message */
+	res = PQexec(XactServerConn, "start");
+	if (PQresultStatus(res) != PGRES_COPY_BOTH)
+	{
+		ereport(WARNING, errmsg("[remotexact] invalid response from transaction server"));
+		return Connected;
+	}
+	PQclear(res);
+
+	Connected = true;
+
+	ereport(LOG, errmsg("[remotexact] connected to transaction server"));
+
+	return Connected;
+}
+
+static const RemoteXactHook remote_xact_hook =
+{
+	.collect_region = rx_collect_region,
+	.collect_tuple = rx_collect_tuple,
+	.collect_relation = rx_collect_relation,
+	.collect_page = rx_collect_page,
+	.clear_rwset = rx_clear_rwset_collection_buffer,
+	.collect_insert = rx_collect_insert,
+	.collect_update = rx_collect_update,
+	.collect_delete = rx_collect_delete,
+	.send_rwset_and_wait = rx_send_rwset_and_wait
+};
+
+void
+_PG_init(void)
+{
+	if (!process_shared_preload_libraries_in_progress)
+		return;
+
+	DefineCustomStringVariable("remotexact.connstring",
+							   "connection string to the transaction server",
+							   NULL,
+							   &remotexact_connstring,
+							   "postgresql://127.0.0.1:10000",
+							   PGC_POSTMASTER,
+							   0,	/* no flags required */
+							   NULL, NULL, NULL);
+
+	if (remotexact_connstring && remotexact_connstring[0])
+	{
+		SetRemoteXactHook(&remote_xact_hook);
+
+		ereport(LOG, errmsg("[remotexact] initialized"));
+		ereport(LOG, errmsg("[remotexact] xactserver connection string \"%s\"", remotexact_connstring));
+	}
+}

--- a/pgxn/remotexact/remotexact.control
+++ b/pgxn/remotexact/remotexact.control
@@ -1,0 +1,4 @@
+# remotetxn extension
+comment = 'remote transactions for multi-master PostgreSQL'
+default_version = '1.0'
+module_pathname = '$libdir/remotexact'

--- a/pgxn/remotexact/rwset.c
+++ b/pgxn/remotexact/rwset.c
@@ -1,0 +1,415 @@
+/* contrib/remotexact/rwset.c */
+#include "postgres.h"
+
+#include "access/csn_snapshot.h"
+#include "access/transam.h"
+#include "lib/stringinfo.h"
+#include "libpq/pqformat.h"
+#include "replication/logicalproto.h"
+#include "rwset.h"
+#include "utils/memutils.h"
+#include "utils/snapmgr.h"
+
+static void decode_header(RWSet *rwset, StringInfo msg);
+static RWSetRelation *decode_relation(RWSet *rwset, StringInfo msg);
+static RWSetRelation *alloc_relation(RWSet *rwset);
+static RWSetPage *decode_page(RWSet *rwset, StringInfo msg);
+static RWSetPage *alloc_page(RWSet *rwset);
+static RWSetTuple *decode_tuple(RWSet *rwset, StringInfo msg);
+static RWSetTuple *alloc_tuple(RWSet *rwset);
+
+static void append_tuple_string(StringInfo str, const LogicalRepTupleData *tuple);
+static void free_tuple(LogicalRepTupleData* tuple);
+
+RWSet *
+RWSetAllocate(void)
+{
+	RWSet	   *rwset;
+	MemoryContext new_ctx;
+	Snapshot snapshot;
+
+	new_ctx = AllocSetContextCreate(CurrentMemoryContext,
+									"Read/write set",
+									ALLOCSET_DEFAULT_SIZES);
+	rwset = (RWSet *) MemoryContextAlloc(new_ctx, sizeof(RWSet));
+
+	rwset->context = new_ctx;
+
+	rwset->header.dbid = 0;
+	rwset->header.xid = InvalidTransactionId;
+	snapshot = GetLatestSnapshot();
+	rwset->header.csn = snapshot->snapshot_csn;
+
+	dlist_init(&rwset->relations);
+
+	rwset->writes = NULL;
+	rwset->writes_len = 0;
+
+	return rwset;
+}
+
+void
+RWSetFree(RWSet *rwset)
+{
+	MemoryContextDelete(rwset->context);
+}
+
+void
+RWSetDecode(RWSet *rwset, StringInfo msg)
+{
+	int			read_set_len;
+	int			consumed = 0;
+	int			prev_cursor;
+
+	decode_header(rwset, msg);
+
+	read_set_len = pq_getmsgint(msg, 4);
+
+	if (read_set_len > msg->len)
+		ereport(ERROR,
+				errmsg("length of read set (%d) too large", read_set_len),
+				errdetail("remaining message length: %d", msg->len));
+
+	while (consumed < read_set_len)
+	{
+		RWSetRelation *rel;
+
+		prev_cursor = msg->cursor;
+
+		rel = decode_relation(rwset, msg);
+		dlist_push_tail(&rwset->relations, &rel->node);
+
+		consumed += msg->cursor - prev_cursor;
+	}
+
+	if (consumed > read_set_len)
+		ereport(ERROR,
+				errmsg("length of read set (%d) is corrupted", read_set_len),
+				errdetail("length of decoded read set: %d", consumed));
+	
+	rwset->writes_len = msg->len - msg->cursor;
+	rwset->writes = (char *) MemoryContextAlloc(rwset->context, sizeof(char) * rwset->writes_len);
+	pq_copymsgbytes(msg, rwset->writes, rwset->writes_len);
+}
+
+void
+decode_header(RWSet *rwset, StringInfo msg)
+{
+	rwset->header.dbid = pq_getmsgint(msg, 4);
+	rwset->header.xid = pq_getmsgint(msg, 4);
+	rwset->header.csn = pq_getmsgint64(msg);
+	rwset->header.region_set = pq_getmsgint64(msg);
+}
+
+RWSetRelation *
+decode_relation(RWSet *rwset, StringInfo msg)
+{
+	RWSetRelation *rel;
+	unsigned char reltype;
+	int			nitems;
+	int			i;
+
+	rel = alloc_relation(rwset);
+
+	reltype = pq_getmsgbyte(msg);
+
+	if (reltype == 'I')
+		rel->is_index = true;
+	else if (reltype == 'T')
+		rel->is_index = false;
+	else
+		ereport(ERROR, errmsg("invalid relation type: %c", reltype));
+
+	rel->relid = pq_getmsgint(msg, 4);
+	rel->region = pq_getmsgbyte(msg);
+	nitems = pq_getmsgint(msg, 4);
+
+	if (rel->is_index)
+	{
+		for (i = 0; i < nitems; i++)
+		{
+			RWSetPage  *page = decode_page(rwset, msg);
+
+			dlist_push_tail(&rel->pages, &page->node);
+		}
+	}
+	else
+	{
+
+		for (i = 0; i < nitems; i++)
+		{
+			RWSetTuple *tup = decode_tuple(rwset, msg);
+
+			dlist_push_tail(&rel->tuples, &tup->node);
+		}
+	}
+
+	return rel;
+}
+
+RWSetRelation *
+alloc_relation(RWSet *rwset)
+{
+	MemoryContext ctx;
+	RWSetRelation *rel;
+
+	ctx = rwset->context;
+	rel = (RWSetRelation *) MemoryContextAlloc(ctx, sizeof(RWSetRelation));
+
+	memset(rel, 0, sizeof(RWSetRelation));
+
+	dlist_init(&rel->pages);
+	dlist_init(&rel->tuples);
+
+	return rel;
+}
+
+RWSetPage *
+decode_page(RWSet *rwset, StringInfo msg)
+{
+	RWSetPage  *page;
+
+	page = alloc_page(rwset);
+
+	page->blkno = pq_getmsgint(msg, 4);
+	page->csn = pq_getmsgint64(msg);
+
+	return page;
+}
+
+
+RWSetPage *
+alloc_page(RWSet *rwset)
+{
+	MemoryContext ctx;
+	RWSetPage  *page;
+
+	ctx = rwset->context;
+	page = (RWSetPage *) MemoryContextAlloc(ctx, sizeof(RWSetPage));
+
+	memset(page, 0, sizeof(RWSetPage));
+
+	return page;
+}
+
+RWSetTuple *
+decode_tuple(RWSet *rwset, StringInfo msg)
+{
+	RWSetTuple *tup;
+	int			blkno;
+	int			offset;
+
+	blkno = pq_getmsgint(msg, 4);
+	offset = pq_getmsgint(msg, 2);
+
+	tup = alloc_tuple(rwset);
+	ItemPointerSet(&tup->tid, blkno, offset);
+
+	return tup;
+}
+
+RWSetTuple *
+alloc_tuple(RWSet *rwset)
+{
+	MemoryContext ctx;
+	RWSetTuple *tup;
+
+	ctx = rwset->context;
+	tup = (RWSetTuple *) MemoryContextAlloc(ctx, sizeof(RWSetTuple));
+
+	memset(tup, 0, sizeof(RWSetTuple));
+
+	return tup;
+}
+
+char *
+RWSetToString(RWSet *rwset)
+{
+	StringInfoData s;
+	bool	first_group = true;
+
+	RWSetHeader *header;
+	dlist_iter	rel_iter;
+
+	StringInfoData writes_cur;
+
+	initStringInfo(&s);
+
+	/* Header */
+	header = &rwset->header;
+	appendStringInfoString(&s, "{\n\"header\": ");
+	appendStringInfo(&s, 
+				"{ \"dbid\": %d, \"xid\": %d, \"csn\": %ld, \"region_set\": %ld }",
+				header->dbid, header->xid, header->csn, header->region_set);
+
+	/* Relations */
+	appendStringInfoString(&s, ",\n\"relations\": [");
+	dlist_foreach(rel_iter, &rwset->relations)
+	{
+		RWSetRelation *rel = dlist_container(RWSetRelation, node, rel_iter.cur);
+		dlist_iter	item_iter;
+		bool		first_item;
+
+		if (!first_group)
+			appendStringInfoString(&s, ",");
+		first_group = false;
+
+		appendStringInfoString(&s, "\n\t{");
+		appendStringInfo(&s, "\"relid\": %d", rel->relid);
+		appendStringInfo(&s, ", \"region\": %d", rel->region);
+		appendStringInfo(&s, ", \"is_index\": %d", rel->is_index);
+
+		/* Pages */
+		if (!dlist_is_empty(&rel->pages))
+		{
+			appendStringInfoString(&s, ",\n\t \"pages\": [");
+			first_item = true;
+			dlist_foreach(item_iter, &rel->pages)
+			{
+				RWSetPage  *page = dlist_container(RWSetPage, node, item_iter.cur);
+
+				if (!first_item)
+					appendStringInfoString(&s, ",");
+				first_item = false;
+
+				appendStringInfoString(&s, "\n\t\t{");
+				appendStringInfo(&s, "\"blkno\": %d, ", page->blkno);
+				appendStringInfo(&s, "\"csn\": %ld", page->csn);
+				appendStringInfoString(&s, "}");
+			}
+			appendStringInfoString(&s, "\n\t ]");
+		}
+
+		/* Tuples */
+		if (!dlist_is_empty(&rel->tuples))
+		{
+			appendStringInfoString(&s, ",\n\t \"tuples\": [");
+			first_item = true;
+			dlist_foreach(item_iter, &rel->tuples)
+			{
+				RWSetTuple *tup = dlist_container(RWSetTuple, node, item_iter.cur);
+
+				if (!first_item)
+					appendStringInfoString(&s, ",");
+				first_item = false;
+
+				appendStringInfoString(&s, "\n\t\t{");
+				appendStringInfo(&s, "\"blkno\": %d, ", ItemPointerGetBlockNumber(&tup->tid));
+				appendStringInfo(&s, "\"offset\": %d", ItemPointerGetOffsetNumber(&tup->tid));
+				appendStringInfoString(&s, "}");
+			}
+			appendStringInfoString(&s, "\n\t ]");
+		}
+
+		appendStringInfoString(&s, "}");
+	}
+	appendStringInfoString(&s, "\n]");
+
+	/* Writes */
+	appendStringInfoString(&s, ",\n\"writes\": [");
+	
+	writes_cur.data = rwset->writes;
+	writes_cur.len = rwset->writes_len;
+	writes_cur.cursor = 0;
+	first_group = true;
+	while (writes_cur.cursor < writes_cur.len)
+	{
+		int region;
+		LogicalRepMsgType action;
+		LogicalRepRelId relid;
+		bool hasoldtup;
+		LogicalRepTupleData newtup;
+		LogicalRepTupleData oldtup;
+
+		if (!first_group)
+			appendStringInfoString(&s, ",");
+		first_group = false;
+		appendStringInfoString(&s, "\n\t{");
+
+		region = pq_getmsgbyte(&writes_cur);
+		action = pq_getmsgbyte(&writes_cur);
+		switch (action)
+		{
+			case LOGICAL_REP_MSG_INSERT:
+				relid = logicalrep_read_insert(&writes_cur, &newtup);
+
+				appendStringInfo(&s, "\"action\": \"INSERT\"");
+				appendStringInfo(&s, ", \"relid\": %u", relid);
+				appendStringInfo(&s, ", \"region\": %d", region);
+				appendStringInfo(&s, ",\n\t \"new_tuple\": ");
+				append_tuple_string(&s, &newtup);
+				free_tuple(&newtup);
+				break;
+
+			case LOGICAL_REP_MSG_UPDATE:
+				relid = logicalrep_read_update(&writes_cur, &hasoldtup, &oldtup, &newtup);
+
+				appendStringInfo(&s, "\"action\": \"UPDATE\"");
+				appendStringInfo(&s, ", \"relid\": %u", relid);
+				appendStringInfo(&s, ", \"region\": %d", region);
+				appendStringInfo(&s, ", \"has_old_tup\": %d", hasoldtup);
+				appendStringInfo(&s, ",\n\t \"new_tuple\": ");
+				append_tuple_string(&s, &newtup);
+				free_tuple(&newtup);
+				if (hasoldtup)
+				{
+					appendStringInfo(&s, ",\n\t \"old_tuple\": ");
+					append_tuple_string(&s, &oldtup);
+					free_tuple(&oldtup);
+				}
+				break;
+
+			case LOGICAL_REP_MSG_DELETE:
+				relid = logicalrep_read_delete(&writes_cur, &oldtup);
+
+				appendStringInfo(&s, "\"action\": \"DELETE\"");
+				appendStringInfo(&s, ", \"relid\": %u", relid);
+				appendStringInfo(&s, ", \"region\": %d", region);
+				appendStringInfo(&s, ",\n\t \"old_tuple\": ");
+				append_tuple_string(&s, &oldtup);
+				free_tuple(&oldtup);
+				break;
+
+			default:
+				ereport(ERROR,
+						(errcode(ERRCODE_PROTOCOL_VIOLATION),
+						 errmsg_internal("invalid write set message type \"%c\"", action)));
+		}
+
+		appendStringInfoString(&s, "}");
+	}
+
+	appendStringInfoString(&s, "\n]");
+
+	appendStringInfoString(&s, "}");
+
+	return s.data;
+}
+
+static void
+append_tuple_string(StringInfo s, const LogicalRepTupleData *tuple)
+{
+	int	i;
+	appendStringInfoString(s, "{");
+	appendStringInfo(s, "\"ncols\": %d, ", tuple->ncols);
+	appendStringInfo(s, "\"status\": \"");
+	for (i = 0; i < tuple->ncols; i++)
+		appendStringInfoChar(s, tuple->colstatus[i]);
+	appendStringInfoString(s, "\", ");
+	appendStringInfo(s, "\"colsizes\": [");
+	for (i = 0; i < tuple->ncols; i++)
+	{
+		if (i > 0) appendStringInfo(s, ", ");
+		appendStringInfo(s, "%d", tuple->colvalues[i].len);
+	}
+	appendStringInfoString(s, "]");
+
+	appendStringInfoString(s, "}");
+}
+
+static void
+free_tuple(LogicalRepTupleData *tuple)
+{
+	pfree(tuple->colvalues);
+	pfree(tuple->colstatus);
+}

--- a/pgxn/remotexact/rwset.h
+++ b/pgxn/remotexact/rwset.h
@@ -1,0 +1,82 @@
+/*-------------------------------------------------------------------------
+ *
+ * rwset.h
+ *
+ * contrib/remotexact/rwset.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef RWSET_H
+#define RWSET_H
+
+#include "postgres.h"
+
+#include "lib/ilist.h"
+#include "lib/stringinfo.h"
+#include "storage/block.h"
+#include "storage/itemptr.h"
+
+/*
+ * Header of the read/write set
+ */
+typedef struct RWSetHeader
+{
+	Oid			dbid;
+	TransactionId xid;
+	uint64 		csn;
+	uint64 		region_set;
+} RWSetHeader;
+
+/*
+ * A page in the read set
+ */
+typedef struct RWSetPage
+{
+	BlockNumber blkno;
+	uint64		csn;
+
+	dlist_node	node;
+} RWSetPage;
+
+/*
+ * A tuple in the read set
+ */
+typedef struct RWSetTuple
+{
+	ItemPointerData tid;
+
+	dlist_node	node;
+} RWSetTuple;
+
+/*
+ * A relation in the read set
+ */
+typedef struct RWSetRelation
+{
+	Oid			relid;
+	int8		region;
+	bool		is_index;
+	dlist_head	pages;
+	dlist_head	tuples;
+
+	dlist_node	node;
+} RWSetRelation;
+
+/*
+ * A read/write set
+ */
+typedef struct RWSet
+{
+	MemoryContext context;
+	RWSetHeader header;
+	dlist_head	relations;
+	char	   *writes;
+	int			writes_len;
+} RWSet;
+
+extern RWSet *RWSetAllocate(void);
+extern void RWSetFree(RWSet *rwset);
+extern void RWSetDecode(RWSet *rwset, StringInfo msg);
+extern char *RWSetToString(RWSet *rwset);
+
+#endif							/* RWSET_H */

--- a/pgxn/remotexact/rwset.h
+++ b/pgxn/remotexact/rwset.h
@@ -51,10 +51,11 @@ typedef struct RWSetTuple
  */
 typedef struct RWSetRelation
 {
+	bool		is_index;
 	Oid			relid;
 	int8		region;
 	XidCSN		csn;
-	bool		is_index;
+	bool		is_table_scan;
 	dlist_head	pages;
 	dlist_head	tuples;
 

--- a/pgxn/remotexact/rwset.h
+++ b/pgxn/remotexact/rwset.h
@@ -11,6 +11,7 @@
 
 #include "postgres.h"
 
+#include "access/csn_snapshot.h"
 #include "lib/ilist.h"
 #include "lib/stringinfo.h"
 #include "storage/block.h"
@@ -22,8 +23,6 @@
 typedef struct RWSetHeader
 {
 	Oid			dbid;
-	TransactionId xid;
-	uint64 		csn;
 	uint64 		region_set;
 } RWSetHeader;
 
@@ -33,7 +32,6 @@ typedef struct RWSetHeader
 typedef struct RWSetPage
 {
 	BlockNumber blkno;
-	uint64		csn;
 
 	dlist_node	node;
 } RWSetPage;
@@ -55,6 +53,7 @@ typedef struct RWSetRelation
 {
 	Oid			relid;
 	int8		region;
+	SnapshotCSN	csn;
 	bool		is_index;
 	dlist_head	pages;
 	dlist_head	tuples;

--- a/pgxn/remotexact/rwset.h
+++ b/pgxn/remotexact/rwset.h
@@ -11,11 +11,11 @@
 
 #include "postgres.h"
 
-#include "access/csn_snapshot.h"
 #include "lib/ilist.h"
 #include "lib/stringinfo.h"
 #include "storage/block.h"
 #include "storage/itemptr.h"
+#include "utils/snapshot.h"
 
 /*
  * Header of the read/write set
@@ -53,7 +53,7 @@ typedef struct RWSetRelation
 {
 	Oid			relid;
 	int8		region;
-	SnapshotCSN	csn;
+	XidCSN		csn;
 	bool		is_index;
 	dlist_head	pages;
 	dlist_head	tuples;

--- a/pgxn/remotexact/validate.c
+++ b/pgxn/remotexact/validate.c
@@ -1,0 +1,120 @@
+/*-------------------------------------------------------------------------
+ * contrib/remotexact/validate.c
+ * 
+ * This file contains function to validate the read set in the rwset
+ * of a remote transaction.
+ * -------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "access/csn_log.h"
+#include "access/heapam.h"
+#include "access/htup_details.h"
+#include "access/relscan.h"
+#include "access/remotexact.h"
+#include "access/table.h"
+#include "access/tableam.h"
+#include "storage/bufmgr.h"
+#include "validate.h"
+
+void
+validate_table_scan(Oid relid, XidCSN read_csn)
+{
+    Relation rel;
+	TableScanDesc scan;
+    HeapScanDesc hscan;
+	HeapTuple	htup;
+    Snapshot    snapshot = GetActiveSnapshot();
+
+    rel = table_open(relid, AccessShareLock);
+
+    /*
+     * Use SnapshotAny to scan over all tuples
+     */
+    scan = table_beginscan(rel, SnapshotAny, 0, NULL);
+	hscan = (HeapScanDesc) scan;
+
+	while ((htup = heap_getnext(scan, ForwardScanDirection)) != NULL)
+    {
+        HeapTupleHeader tuple = htup->t_data;
+        TransactionId checked_xid = InvalidTransactionId;
+
+        /*
+         * Must lock the buffer before checking for visibility
+         */
+		LockBuffer(hscan->rs_cbuf, BUFFER_LOCK_SHARE);
+
+        /*
+         * If a tuple is visible now, it must also be visible to read_csn
+         */
+        if (HeapTupleSatisfiesVisibility(current_region, htup, snapshot, hscan->rs_cbuf))
+        {
+            TransactionId xmin = HeapTupleHeaderGetRawXmin(tuple);
+
+            /*
+             * Current transaction must not make any modification prior to validation
+             */
+            Assert(!TransactionIdIsCurrentTransactionId(xmin));
+
+            checked_xid = xmin;
+        }
+        /*
+         * If a tuple is not visible now, it must also not be visible to read_csn.
+         * We only need to consider tuples that are committed and then removed
+         * as seen by the current snapshot here. In-progress and aborted tuples
+         * are never visible to read_csn.
+         * 
+         * TODO (ctring): There is an edge case where a tuple is removed and
+         * then immediately vacuumed after the remote transaction starts but
+         * before validation. The physical tuple is no longer available for
+         * us to do these checks, resulting in wrong validation. One way to counter
+         * this is counting the number of visible tuples while scanning them and
+         * compare it with the number of visible tuples during validation.
+         */
+        else if (HeapTupleHeaderXminCommitted(tuple) &&
+                 (HeapTupleHeaderXminFrozen(tuple) ||
+                  !XidInMVCCSnapshot(HeapTupleHeaderGetRawXmin(tuple), snapshot)))
+        {
+            TransactionId xmax;
+
+            /*
+             * Xmax must be valid because the tuple is invisible because it 
+             * was deleted.
+             */
+            Assert(!(tuple->t_infomask & HEAP_XMAX_INVALID) &&
+                   !HEAP_XMAX_IS_LOCKED_ONLY(tuple->t_infomask));
+
+            /*
+             * Extract xmax based on whether it is a multixact or not
+             */
+            if (tuple->t_infomask & HEAP_XMAX_IS_MULTI)
+                xmax = HeapTupleGetUpdateXid(tuple);
+            else
+                xmax = HeapTupleHeaderGetRawXmax(tuple);
+
+            /*
+             * Cannot be the current transaction because it does not make any
+             * modification before validation.
+             */
+            Assert(!TransactionIdIsCurrentTransactionId(xmax));
+            
+            checked_xid = xmax;
+        }
+
+        LockBuffer(hscan->rs_cbuf, BUFFER_LOCK_UNLOCK);
+
+        /*
+         * Translate checked_xid into csn and compare it with csn used for the
+         * initial read.
+         */
+        if (TransactionIdIsValid(checked_xid) &&
+            CSNLogGetCSNByXid(current_region, checked_xid) > read_csn)
+            ereport(ERROR,
+                    (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+                        errmsg("read out-of-date data from a remote partition")));
+
+    }
+
+    table_endscan(scan);
+    table_close(rel, AccessShareLock);
+}

--- a/pgxn/remotexact/validate.c
+++ b/pgxn/remotexact/validate.c
@@ -8,6 +8,7 @@
 #include "postgres.h"
 
 #include "access/csn_log.h"
+#include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/relscan.h"
@@ -15,7 +16,66 @@
 #include "access/table.h"
 #include "access/tableam.h"
 #include "storage/bufmgr.h"
+#include "rwset.h"
 #include "validate.h"
+
+void validate_index_scan(RWSetRelation *rw_rel)
+{
+    Oid relid = rw_rel->relid;
+    int8 region = rw_rel->region;
+	XidCSN read_csn = rw_rel->csn;
+    Relation rel;
+    HeapScanDesc scan;
+    int nkeys = 0;
+    ScanKey keys = NULL;
+    int scan_flags = 0;
+    dlist_iter page_iter;
+    XLogRecPtr page_lsn = InvalidXLogRecPtr;
+
+    // This function must only be called for index scans in current_region.
+    Assert(region == current_region);
+    Assert(rw_rel->is_index && !rw_rel->is_table_scan);
+
+    // Lock in the same mode as SELECT (AccessShareLock).
+    // TODO(pooja): To avoid starvation, we might want to use RowShareLock.
+    rel = index_open(relid, AccessShareLock);
+    scan = (HeapScanDesc)heap_beginscan(rel, SnapshotAny, nkeys, keys, NULL,
+                                        scan_flags);
+
+    // For each index page, check if the lsn has been updated. 
+    dlist_foreach(page_iter, &rw_rel->pages)
+    {
+        RWSetPage *page = dlist_container(RWSetPage, node, page_iter.cur);
+        
+        // Advance the hscan to specified block and lock the page for sharing.
+        heap_get_page(scan, page->blkno);
+        LockBuffer(scan->rs_cbuf, BUFFER_LOCK_SHARE);
+
+        // Get the page_lsn and unlock the page.
+        Page index_page = BufferGetPage(scan->rs_cbuf);
+        page_lsn = PageGetLSN(index_page);
+        LockBuffer(scan->rs_cbuf, BUFFER_LOCK_UNLOCK);
+
+        if (page_lsn > read_csn) {
+            /* 
+             * This page has been updated since the last snapshot, so
+             * we need to fail validation. 
+             * TODO(pooja): We need to check for each tuple to avoid
+             * frequent aborts. 
+             */
+            break;
+        }
+    }
+
+    heap_endscan(scan);
+    index_close(rel, AccessShareLock);
+
+    if (page_lsn > read_csn) {
+        ereport(ERROR,
+        (errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+            errmsg("read out-of-date index data from a remote partition")));
+    }
+}
 
 void
 validate_table_scan(Oid relid, XidCSN read_csn)

--- a/pgxn/remotexact/validate.h
+++ b/pgxn/remotexact/validate.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * validate.h
+ *
+ * contrib/remotexact/validate.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef VALIDATE_H
+#define VALIDATE_H
+
+#include "postgres.h"
+
+#include "utils/snapshot.h"
+
+void validate_table_scan(Oid relid, XidCSN read_csn);
+
+#endif							/* VALIDATE_H */

--- a/pgxn/remotexact/validate.h
+++ b/pgxn/remotexact/validate.h
@@ -13,6 +13,7 @@
 
 #include "utils/snapshot.h"
 
+void validate_index_scan(RWSetRelation *rw_rel);
 void validate_table_scan(Oid relid, XidCSN read_csn);
 
 #endif							/* VALIDATE_H */


### PR DESCRIPTION
Validates index reads by checking if any of index pages collected by the remotexact have been updated since the read_csn. If any such updates are found, we abort immediately. This helps us handle the case of phantom reads. 

The next step would be to validate specific tuples within a table scan. Validating individual index entries might be tricky and not necessarily required in the common case. 

This change can't be merged before https://github.com/DSLAM-UMD/postgres/pull/61 and https://github.com/DSLAM-UMD/postgres/pull/62