### PR TITLE
Disable statement timeout for performance tests

### DIFF
--- a/test_runner/performance/test_perf_pgbench.py
+++ b/test_runner/performance/test_perf_pgbench.py
@@ -88,7 +88,7 @@ def run_test_pgbench(env: PgCompare, scale: int, duration: int, workload_type: P
     env.zenbenchmark.record("scale", scale, "", MetricReport.TEST_PARAM)
 
     password = env.pg.default_options.get("password", None)
-    options = "-cstatement_timeout=1h " + env.pg.default_options.get("options", "")
+    options = "-cstatement_timeout=0 " + env.pg.default_options.get("options", "")
     # drop password from the connection string by passing password=None and set password separately
     connstr = env.pg.connstr(password=None, options=options)
 

--- a/test_runner/performance/test_seqscans.py
+++ b/test_runner/performance/test_seqscans.py
@@ -36,7 +36,7 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore
 def test_seqscans(env: PgCompare, scale: int, rows: int, iters: int, workers: int):
     rows = scale * rows
 
-    with closing(env.pg.connect()) as conn:
+    with closing(env.pg.connect(options="-cstatement_timeout=0")) as conn:
         with conn.cursor() as cur:
             cur.execute("drop table if exists t;")
             cur.execute("create table t (i integer);")

--- a/test_runner/performance/test_wal_backpressure.py
+++ b/test_runner/performance/test_wal_backpressure.py
@@ -154,7 +154,7 @@ def test_pgbench_simple_update_workload(pg_compare: PgCompare, scale: int, durat
 
 def start_pgbench_intensive_initialization(env: PgCompare, scale: int, done_event: threading.Event):
     with env.record_duration("run_duration"):
-        # Needs to increase the statement timeout (default: 120s) because the
+        # Disable statement timeout (default: 120s) because the
         # initialization step can be slow with a large scale.
         env.pg_bin.run_capture(
             [
@@ -162,7 +162,7 @@ def start_pgbench_intensive_initialization(env: PgCompare, scale: int, done_even
                 f"-s{scale}",
                 "-i",
                 "-Idtg",
-                env.pg.connstr(options="-cstatement_timeout=600s"),
+                env.pg.connstr(options="-cstatement_timeout=0"),
             ]
         )
 


### PR DESCRIPTION
Fix `test_seqscans` by disabling statement timeout.

Also, replace increasing statement timeout with disabling it for performance tests. This should make tests more stable and allow us to observe performance degradation instead of test failures.

Ref https://github.com/neondatabase/neon/actions/runs/3520063845/jobs/5900633702#step:6:277