### PR TITLE
per-tenant-remote-sync: storage_sync metrics + upload retry unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,6 +2140,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pageserver_api",
+ "pin-project-lite",
  "postgres",
  "postgres-protocol",
  "postgres-types",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -35,6 +35,7 @@ itertools = "0.10.3"
 nix = "0.25"
 num-traits = "0.2.15"
 once_cell = "1.13.0"
+pin-project-lite = "0.2.7"
 postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="d052ee8b86fff9897c77b0fe89ea9daba0e1fa38" }
 postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="d052ee8b86fff9897c77b0fe89ea9daba0e1fa38" }
 postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="d052ee8b86fff9897c77b0fe89ea9daba0e1fa38" }

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -3,7 +3,7 @@ pub mod config;
 pub mod http;
 pub mod import_datadir;
 pub mod keyspace;
-pub mod metrics;
+pub(crate) mod metrics;
 pub mod page_cache;
 pub mod page_service;
 pub mod pgdatadir_mapping;

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -1,9 +1,8 @@
 use metrics::core::{AtomicU64, GenericCounter};
 use metrics::{
-    register_gauge_vec, register_histogram, register_histogram_vec, register_int_counter,
-    register_int_counter_vec, register_int_gauge, register_int_gauge_vec, register_uint_gauge_vec,
-    GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, UIntGauge,
-    UIntGaugeVec,
+    register_histogram, register_histogram_vec, register_int_counter, register_int_counter_vec,
+    register_int_gauge, register_int_gauge_vec, register_uint_gauge_vec, Histogram, HistogramVec,
+    IntCounter, IntCounterVec, IntGauge, IntGaugeVec, UIntGauge, UIntGaugeVec,
 };
 use once_cell::sync::Lazy;
 use utils::id::{TenantId, TimelineId};
@@ -200,63 +199,56 @@ pub static NUM_ONDISK_LAYERS: Lazy<IntGauge> = Lazy::new(|| {
         .expect("failed to define a metric")
 });
 
-pub static REMAINING_SYNC_ITEMS: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
-        "pageserver_remote_storage_remaining_sync_items",
-        "Number of storage sync items left in the queue"
-    )
-    .expect("failed to register pageserver remote storage remaining sync items int gauge")
-});
-
-pub static IMAGE_SYNC_TIME: Lazy<GaugeVec> = Lazy::new(|| {
-    register_gauge_vec!(
-        "pageserver_remote_storage_image_sync_duration",
-        "Time spent to synchronize (up/download) a whole pageserver image",
+// remote storage metrics
+pub static REMOTE_UPLOAD_QUEUE_ITEMS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "pageserver_remote_upload_queue_items",
+        "Number of items left in the upload queue",
         &["tenant_id", "timeline_id"],
     )
-    .expect("failed to register per-timeline pageserver image sync time vec")
+    .expect("failed to define a metric")
 });
 
-pub static IMAGE_SYNC_OPERATION_KINDS: &[&str] = &["upload", "download", "delete"];
-pub static IMAGE_SYNC_STATUS: &[&str] = &["success", "failure", "abort"];
+pub enum RemoteOpKind {
+    Upload,
+    Download,
+    Delete,
+}
+impl RemoteOpKind {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Upload => "upload",
+            Self::Download => "download",
+            Self::Delete => "delete",
+        }
+    }
+}
 
-pub static IMAGE_SYNC_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "pageserver_remote_storage_image_sync_count",
-        "Number of synchronization operations executed for pageserver images. \
-        Grouped by tenant, timeline, operation_kind and status",
-        &["tenant_id", "timeline_id", "operation_kind", "status"]
-    )
-    .expect("failed to register pageserver image sync count vec")
-});
+pub enum RemoteOpFileKind {
+    Layer,
+    Index,
+}
+impl RemoteOpFileKind {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Layer => "layer",
+            Self::Index => "index",
+        }
+    }
+}
 
-pub static IMAGE_SYNC_TIME_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
+pub static REMOTE_OPERATION_KINDS: &[&str] = &["upload", "download", "delete"];
+pub static REMOTE_OPERATION_FILE_KINDS: &[&str] = &["layer", "index"];
+pub static REMOTE_OPERATION_STATUSES: &[&str] = &["success", "failure"];
+
+pub static REMOTE_OPERATION_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "pageserver_remote_storage_image_sync_seconds",
-        "Time took to synchronize (download or upload) a whole pageserver image. \
-        Grouped by operation_kind and status",
-        &["operation_kind", "status"],
-        vec![0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 3.0, 10.0, 20.0]
+        "pageserver_remote_operation_seconds",
+        "Time spent on remote storage operations. \
+        Grouped by tenant, timeline, operation_kind and status",
+        &["tenant_id", "timeline_id", "file_kind", "op_kind", "status"]
     )
-    .expect("failed to register pageserver image sync time histogram vec")
-});
-
-pub static REMOTE_INDEX_UPLOAD: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "pageserver_remote_storage_remote_index_uploads_total",
-        "Number of remote index uploads",
-        &["tenant_id", "timeline_id"],
-    )
-    .expect("failed to register pageserver remote index upload vec")
-});
-
-pub static NO_LAYERS_UPLOAD: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "pageserver_remote_storage_no_layers_uploads_total",
-        "Number of skipped uploads due to no layers",
-        &["tenant_id", "timeline_id"],
-    )
-    .expect("failed to register pageserver no layers upload vec")
+    .expect("failed to define a metric")
 });
 
 pub static TENANT_TASK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -473,16 +465,90 @@ impl Drop for TimelineMetrics {
             let _ = SMGR_QUERY_TIME.remove_label_values(&[op, tenant_id, timeline_id]);
         }
 
-        for op in IMAGE_SYNC_OPERATION_KINDS {
-            for status in IMAGE_SYNC_STATUS {
-                let _ = IMAGE_SYNC_COUNT.remove_label_values(&[tenant_id, timeline_id, op, status]);
+        let _ = REMOTE_UPLOAD_QUEUE_ITEMS.remove_label_values(&[tenant_id, timeline_id]);
+        for file_kind in REMOTE_OPERATION_FILE_KINDS {
+            for op in REMOTE_OPERATION_KINDS {
+                for status in REMOTE_OPERATION_STATUSES {
+                    let _ = REMOTE_OPERATION_TIME.remove_label_values(&[
+                        tenant_id,
+                        timeline_id,
+                        file_kind,
+                        op,
+                        status,
+                    ]);
+                }
             }
         }
-
-        let _ = IMAGE_SYNC_TIME.remove_label_values(&[tenant_id, timeline_id]);
     }
 }
 
 pub fn remove_tenant_metrics(tenant_id: &TenantId) {
     let _ = STORAGE_TIME.remove_label_values(&["gc", &tenant_id.to_string(), "-"]);
+}
+
+use futures::Future;
+use pin_project_lite::pin_project;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+/// Wrapper future that measures the time spent by a remote storage operation,
+/// and records the time and success/failure as a prometheus metric.
+pub trait MeasureRemoteOp: Sized {
+    fn measure_remote_op(
+        self,
+        tenant_id: TenantId,
+        timeline_id: TimelineId,
+        file_kind: RemoteOpFileKind,
+        op: RemoteOpKind,
+    ) -> MeasuredRemoteOp<Self> {
+        let start = Instant::now();
+        MeasuredRemoteOp {
+            inner: self,
+            tenant_id,
+            timeline_id,
+            file_kind,
+            op,
+            start,
+        }
+    }
+}
+
+impl<T: Sized> MeasureRemoteOp for T {}
+
+pin_project! {
+    pub struct MeasuredRemoteOp<F>
+    {
+        #[pin]
+        inner: F,
+        tenant_id: TenantId,
+        timeline_id: TimelineId,
+        file_kind: RemoteOpFileKind,
+        op: RemoteOpKind,
+        start: Instant,
+    }
+}
+
+impl<F: Future<Output = Result<O, E>>, O, E> Future for MeasuredRemoteOp<F> {
+    type Output = Result<O, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let poll_result = this.inner.poll(cx);
+        if let Poll::Ready(ref res) = poll_result {
+            let duration = this.start.elapsed();
+            let status = if res.is_ok() { &"success" } else { &"failure" };
+            REMOTE_OPERATION_TIME
+                .get_metric_with_label_values(&[
+                    &this.tenant_id.to_string(),
+                    &this.timeline_id.to_string(),
+                    this.file_kind.as_str(),
+                    this.op.as_str(),
+                    status,
+                ])
+                .unwrap()
+                .observe(duration.as_secs_f64());
+        }
+        poll_result
+    }
 }

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -200,10 +200,11 @@ pub static NUM_ONDISK_LAYERS: Lazy<IntGauge> = Lazy::new(|| {
 });
 
 // remote storage metrics
-pub static REMOTE_UPLOAD_QUEUE_ITEMS: Lazy<IntGaugeVec> = Lazy::new(|| {
+
+pub static REMOTE_UPLOAD_QUEUE_UNFINISHED_TASKS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
-        "pageserver_remote_upload_queue_items",
-        "Number of items left in the upload queue",
+        "pageserver_remote_upload_queue_unfinished_tasks",
+        "Number of tasks in the upload queue that are not finished yet.",
         &["tenant_id", "timeline_id"],
     )
     .expect("failed to define a metric")
@@ -465,7 +466,7 @@ impl Drop for TimelineMetrics {
             let _ = SMGR_QUERY_TIME.remove_label_values(&[op, tenant_id, timeline_id]);
         }
 
-        let _ = REMOTE_UPLOAD_QUEUE_ITEMS.remove_label_values(&[tenant_id, timeline_id]);
+        let _ = REMOTE_UPLOAD_QUEUE_UNFINISHED_TASKS.remove_label_values(&[tenant_id, timeline_id]);
         for file_kind in REMOTE_OPERATION_FILE_KINDS {
             for op in REMOTE_OPERATION_KINDS {
                 for status in REMOTE_OPERATION_STATUSES {

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -205,18 +205,19 @@ pub static REMOTE_UPLOAD_QUEUE_UNFINISHED_TASKS: Lazy<IntGaugeVec> = Lazy::new(|
     register_int_gauge_vec!(
         "pageserver_remote_upload_queue_unfinished_tasks",
         "Number of tasks in the upload queue that are not finished yet.",
-        &["tenant_id", "timeline_id"],
+        &["tenant_id", "timeline_id", "file_kind", "op_kind"],
     )
     .expect("failed to define a metric")
 });
 
+#[derive(Debug, Clone, Copy)]
 pub enum RemoteOpKind {
     Upload,
     Download,
     Delete,
 }
 impl RemoteOpKind {
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Upload => "upload",
             Self::Download => "download",
@@ -225,12 +226,13 @@ impl RemoteOpKind {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum RemoteOpFileKind {
     Layer,
     Index,
 }
 impl RemoteOpFileKind {
-    fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Layer => "layer",
             Self::Index => "index",

--- a/pageserver/src/storage_sync.rs
+++ b/pageserver/src/storage_sync.rs
@@ -823,12 +823,12 @@ impl RemoteTimelineClient {
 
     fn upload_queue_items_metric(&self, delta: i64) {
         REMOTE_UPLOAD_QUEUE_UNFINISHED_TASKS
-                .get_metric_with_label_values(&[
-                    &self.tenant_id.to_string(),
-                    &self.timeline_id.to_string(),
-                ])
-                .unwrap()
-                .add(delta)
+            .get_metric_with_label_values(&[
+                &self.tenant_id.to_string(),
+                &self.timeline_id.to_string(),
+            ])
+            .unwrap()
+            .add(delta)
     }
 }
 

--- a/pageserver/src/storage_sync/delete.rs
+++ b/pageserver/src/storage_sync/delete.rs
@@ -9,6 +9,9 @@ pub(super) async fn delete_layer(
     storage: &GenericRemoteStorage,
     local_layer_path: &Path,
 ) -> anyhow::Result<()> {
+    fail::fail_point!("before-delete-layer", |_| {
+        anyhow::bail!("failpoint before-delete-layer")
+    });
     async {
         debug!(
             "Deleting layer from remote storage: {:?}",

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1162,7 +1162,10 @@ impl Timeline {
 
         let local_only_filenames = match index_part {
             Some(index_part) => {
-                info!("initializing upload queue from index");
+                info!(
+                    "initializing upload queue from remote index with {} layer files",
+                    index_part.timeline_layers.len()
+                );
                 remote_client.init_upload_queue(index_part)?;
                 let local_only_filenames = self
                     .download_missing(
@@ -2224,6 +2227,13 @@ impl Timeline {
             let new_delta_path = l.path();
 
             let metadata = new_delta_path.metadata()?;
+
+            if let Some(remote_client) = &self.remote_client {
+                remote_client.schedule_layer_file_upload(
+                    &new_delta_path,
+                    &LayerFileMetadata::new(metadata.len()),
+                )?;
+            }
 
             // update the timeline's physical size
             self.metrics.current_physical_size_gauge.add(metadata.len());

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -12,6 +12,7 @@ from fixtures.log_helper import log
 from fixtures.neon_fixtures import (
     NeonEnvBuilder,
     RemoteStorageKind,
+    assert_no_in_progress_downloads_for_tenant,
     available_remote_storages,
     wait_for_last_record_lsn,
     wait_for_last_flush_lsn,

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -2,10 +2,10 @@
 # env NEON_PAGESERVER_OVERRIDES="remote_storage={local_path='/tmp/neon_zzz/'}" poetry ......
 
 import os
+import re
 import shutil
 import time
 from pathlib import Path
-import re
 
 import pytest
 from fixtures.log_helper import log
@@ -14,12 +14,12 @@ from fixtures.neon_fixtures import (
     RemoteStorageKind,
     assert_no_in_progress_downloads_for_tenant,
     available_remote_storages,
-    wait_for_last_record_lsn,
     wait_for_last_flush_lsn,
+    wait_for_last_record_lsn,
     wait_for_upload,
 )
 from fixtures.types import Lsn, TenantId, TimelineId
-from fixtures.utils import query_scalar, wait_until, print_gc_result
+from fixtures.utils import print_gc_result, query_scalar, wait_until
 
 
 #
@@ -232,16 +232,16 @@ def test_remote_storage_upload_queue_retries(
     # let all of them queue up
     configure_storage_sync_failpoints("return")
 
-    overwrite_data_and_wait_for_it_to_arrive_at_pageserver('a')
+    overwrite_data_and_wait_for_it_to_arrive_at_pageserver("a")
     client.timeline_checkpoint(tenant_id, timeline_id)
     # now overwrite it again
-    overwrite_data_and_wait_for_it_to_arrive_at_pageserver('b')
+    overwrite_data_and_wait_for_it_to_arrive_at_pageserver("b")
     # trigger layer deletion by doing Compaction, then GC
     client.timeline_compact(tenant_id, timeline_id)
     gc_result = client.timeline_gc(tenant_id, timeline_id, 0)
     print_gc_result(gc_result)
     # FIXME why doesn't this assertion work? I think GC is happening....
-    #assert gc_result["layers_removed"] > 0
+    # assert gc_result["layers_removed"] > 0
 
     # confirm all operations are queued up
     def get_queued_count():

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -221,7 +221,7 @@ def test_remote_storage_upload_queue_retries(
         pg.safe_psql(
             f"""
                INSERT INTO foo (id, val)
-               SELECT g, '{data}' 
+               SELECT g, '{data}'
                FROM generate_series(1, 1000) g
                ON CONFLICT (id) DO UPDATE
                SET val = EXCLUDED.val
@@ -282,7 +282,7 @@ def test_remote_storage_upload_queue_retries(
     def tenant_active():
         all_states = client.tenant_list()
         [tenant] = [t for t in all_states if TenantId(t["id"]) == tenant_id]
-        assert tenant["has_in_progress_downloads"] == False
+        assert tenant["has_in_progress_downloads"] is False
         assert tenant["state"] == {"Active": {"background_jobs_running": True}}
 
     wait_until(5, 1, tenant_active)

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -256,6 +256,7 @@ def test_remote_storage_upload_queue_retries(
     # create some layers & wait for uploads to finish
     overwrite_data_and_wait_for_it_to_arrive_at_pageserver("a")
     client.timeline_checkpoint(tenant_id, timeline_id)
+    client.timeline_compact(tenant_id, timeline_id)
     overwrite_data_and_wait_for_it_to_arrive_at_pageserver("b")
     client.timeline_checkpoint(tenant_id, timeline_id)
     client.timeline_compact(tenant_id, timeline_id)

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -285,7 +285,7 @@ def test_remote_storage_upload_queue_retries(
         assert tenant["has_in_progress_downloads"] is False
         assert tenant["state"] == {"Active": {"background_jobs_running": True}}
 
-    wait_until(5, 1, tenant_active)
+    wait_until(30, 1, tenant_active)
 
     log.info("restarting postgres to validate")
     pg = env.postgres.create_start("main", tenant_id=tenant_id)


### PR DESCRIPTION
Curiously, the added unit test fails after attach with

```
              stdout: Starting existing postgres main_pg_node...
Safekeepers synced on 0/174DCF0
Extracting base backup to create postgres instance: path=/home/cs/src/neon-work-2/test_output/test_remote_storage_upload_queue_retries[local_fs]/repo/pgdatadirs/tenants/c5debc0d4332fb4c4068c8d7ed3ee6d7/main_pg_node port=15012

              stderr: command failed: extracting base backup failed

Caused by:
    0: failed to iterate over archive
    1: db error: ERROR: could not find data for key 010000000000000000000000000000000000 at LSN 0/174DCF1, for request at LSN 0/174DCF0
```

But it even fails if I disable the failpoints, so, it can't be related to the retry logic.