### PR TITLE
More tenant state fixes on top of PR 2785

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -44,7 +44,8 @@ impl TenantState {
 /// A state of a timeline in pageserver's memory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TimelineState {
-    /// Timeline is fully operational, its background jobs are running.
+    /// Timeline is fully operational. If the containing Tenant is Active, the timeline's
+    /// background jobs are running otherwise they will be launched when the tenant is activated.
     Active,
     /// A timeline is recognized by pageserver, but not yet ready to operate.
     /// The status indicates, that the timeline could eventually go back to Active automatically:

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -19,10 +19,8 @@ pub enum TenantState {
     Loading,
     // This tenant is being downloaded from cloud storage.
     Attaching,
-    /// Tenant is fully operational, its background jobs might be running or not.
-    Active {
-        background_jobs_running: bool,
-    },
+    /// Tenant is fully operational
+    Active,
     /// A tenant is recognized by pageserver, but it is being detached or the system is being
     /// shut down.
     Paused,
@@ -36,9 +34,7 @@ impl TenantState {
         match self {
             Self::Loading => true,
             Self::Attaching => true,
-            Self::Active {
-                background_jobs_running: _,
-            } => false,
+            Self::Active => false,
             Self::Paused => false,
             Self::Broken => false,
         }

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -604,13 +604,7 @@ components:
         id:
           type: string
         state:
-            oneOf:
-              - type: string
-              - type: object
-                properties:
-                  background_jobs_running:
-                    type: boolean
-
+          type: string
         current_physical_size:
           type: integer
         has_in_progress_downloads:

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -2556,7 +2556,7 @@ pub mod harness {
             let walredo_mgr = Arc::new(TestRedoManager);
 
             let tenant = Arc::new(Tenant::new(
-                TenantState::Active,
+                TenantState::Loading,
                 self.conf,
                 TenantConfOpt::from(self.tenant_conf),
                 walredo_mgr,

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -640,9 +640,7 @@ impl Tenant {
         crashsafe::fsync(marker_file.parent().expect("marker file has parent dir"))
             .context("fsync tenant directory after unlinking attach marker file")?;
 
-        fail::fail_point!("attach-before-activate", |_| {
-            anyhow::bail!("failpoint attach-beore-activate");
-        });
+        utils::failpoint_sleep_millis_async!("attach-before-activate");
 
         // Start background operations and open the tenant for business.
         // The loops will shut themselves down when they notice that the tenant is inactive.

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -724,10 +724,7 @@ impl Tenant {
     }
 
     /// Create a placeholder Tenant object for a broken tenant
-    pub fn create_broken_tenant(
-        conf: &'static PageServerConf,
-        tenant_id: TenantId,
-    ) -> Arc<Tenant> {
+    pub fn create_broken_tenant(conf: &'static PageServerConf, tenant_id: TenantId) -> Arc<Tenant> {
         let wal_redo_manager = Arc::new(PostgresRedoManager::new(conf, tenant_id));
         let tenant = Arc::new(Tenant::new(
             TenantState::Broken,
@@ -739,7 +736,7 @@ impl Tenant {
         ));
         tenant
     }
-    
+
     ///
     /// Load a tenant that's available on local disk
     ///
@@ -1281,14 +1278,16 @@ impl Tenant {
                 }
                 TenantState::Broken => {
                     // This shouldn't happen either
-                    result = Err(anyhow::anyhow!("Could not activate tenant because it is in broken state"));
+                    result = Err(anyhow::anyhow!(
+                        "Could not activate tenant because it is in broken state"
+                    ));
                 }
                 TenantState::Paused => {
                     // The tenant was detached, or system shutdown was requested, while we were
                     // loading or attaching the tenant.
                     info!("Tenant is already in Paused state, skipping activation");
                 }
-                TenantState::Loading | TenantState::Attaching  => {
+                TenantState::Loading | TenantState::Attaching => {
                     *current_state = TenantState::Active;
 
                     let timelines_accessor = self.timelines.lock().unwrap();
@@ -1308,7 +1307,6 @@ impl Tenant {
         });
         result
     }
-
 
     /// Change tenant status to paused, to mark that it is being shut down
     pub fn set_paused(&self) {
@@ -1361,7 +1359,7 @@ impl Tenant {
                     *current_state = TenantState::Broken;
                     warn!("Marking Paused tenant as Broken");
                 }
-                TenantState::Loading | TenantState::Attaching  => {
+                TenantState::Loading | TenantState::Attaching => {
                     *current_state = TenantState::Broken;
                 }
             }
@@ -2228,7 +2226,6 @@ fn remove_timeline_and_uninit_mark(timeline_dir: &Path, uninit_mark: &Path) -> a
 
     Ok(())
 }
-
 
 fn create_tenant_files(
     conf: &'static PageServerConf,

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -640,6 +640,10 @@ impl Tenant {
         crashsafe::fsync(marker_file.parent().expect("marker file has parent dir"))
             .context("fsync tenant directory after unlinking attach marker file")?;
 
+        fail::fail_point!("attach-before-activate", |_| {
+            anyhow::bail!("failpoint attach-beore-activate");
+        });
+
         // FIXME: Check if the state has changed to Stopping while we were downloading stuff
         // We're ready for business.
         // Change to active state under the hood spawns background loops

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -726,15 +726,14 @@ impl Tenant {
     /// Create a placeholder Tenant object for a broken tenant
     pub fn create_broken_tenant(conf: &'static PageServerConf, tenant_id: TenantId) -> Arc<Tenant> {
         let wal_redo_manager = Arc::new(PostgresRedoManager::new(conf, tenant_id));
-        let tenant = Arc::new(Tenant::new(
+        Arc::new(Tenant::new(
             TenantState::Broken,
             conf,
             TenantConfOpt::default(),
             wal_redo_manager,
             tenant_id,
             None,
-        ));
-        tenant
+        ))
     }
 
     ///

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -168,7 +168,7 @@ pub async fn shutdown_all_tenants() {
         for (_, tenant) in m.drain() {
             if tenant.is_active() {
                 // updates tenant state, forbidding new GC and compaction iterations from starting
-                tenant.set_state(TenantState::Paused);
+                tenant.set_paused();
                 tenants_to_shut_down.push(tenant)
             }
         }
@@ -294,7 +294,7 @@ pub async fn detach_tenant(
         None => anyhow::bail!("Tenant not found for id {tenant_id}"),
     };
 
-    tenant.set_state(TenantState::Paused);
+    tenant.set_paused();
     // shutdown all tenant and timeline tasks: gc, compaction, page service)
     task_mgr::shutdown_tasks(None, Some(tenant_id), None).await;
 

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -213,10 +213,9 @@ pub fn create_tenant(
         hash_map::Entry::Vacant(v) => {
             // Hold the write_tenants() lock, since all of this is local IO.
             // If this section ever becomes contentious, introduce a new `TenantState::Creating`.
-            let tenant_directory = super::tenant::create_tenant_files(conf, tenant_conf, tenant_id)
-                .context("create tenant files")?;
-            let created_tenant = load_local_tenant(conf, &tenant_directory, remote_storage)
-                .context("load created tenant")?;
+            let tenant_directory =
+                super::tenant::create_tenant_files(conf, tenant_conf, tenant_id)?;
+            let created_tenant = load_local_tenant(conf, &tenant_directory, remote_storage)?;
             match created_tenant {
                 None => {
                     // We get None in case the directory is empty.

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -209,12 +209,8 @@ pub fn create_tenant(
             Ok(None)
         }
         hash_map::Entry::Vacant(v) => {
-            let tenant = Tenant::create_tenant(
-                conf,
-                tenant_conf,
-                tenant_id,
-                remote_storage.cloned(),
-            )?;
+            let tenant =
+                Tenant::create_tenant(conf, tenant_conf, tenant_id, remote_storage.cloned())?;
             v.insert(tenant);
             Ok(Some(tenant_id))
         }
@@ -285,7 +281,6 @@ pub async fn detach_tenant(
     conf: &'static PageServerConf,
     tenant_id: TenantId,
 ) -> anyhow::Result<()> {
-
     let tenant = match {
         let mut tenants_accessor = tenants_state::write_tenants();
         tenants_accessor.remove(&tenant_id)

--- a/pageserver/src/tenant_tasks.rs
+++ b/pageserver/src/tenant_tasks.rs
@@ -154,7 +154,7 @@ async fn wait_for_active_tenant(
     };
 
     // if the tenant has a proper status already, no need to wait for anything
-    if tenant.should_run_tasks() {
+    if tenant.current_state() == TenantState::Active {
         ControlFlow::Continue(tenant)
     } else {
         let mut tenant_state_updates = tenant.subscribe_for_state_updates();
@@ -163,14 +163,12 @@ async fn wait_for_active_tenant(
                 Ok(()) => {
                     let new_state = *tenant_state_updates.borrow();
                     match new_state {
-                        TenantState::Active {
-                            background_jobs_running: true,
-                        } => {
-                            debug!("Tenant state changed to active with background jobs enabled, continuing the task loop");
+                        TenantState::Active => {
+                            debug!("Tenant state changed to active, continuing the task loop");
                             return ControlFlow::Continue(tenant);
                         }
                         state => {
-                            debug!("Not running the task loop, tenant is not active with background jobs enabled: {state:?}");
+                            debug!("Not running the task loop, tenant is not active: {state:?}");
                             continue;
                         }
                     }

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -312,7 +312,7 @@ def test_remote_storage_upload_queue_retries(
         all_states = client.tenant_list()
         [tenant] = [t for t in all_states if TenantId(t["id"]) == tenant_id]
         assert tenant["has_in_progress_downloads"] is False
-        assert tenant["state"] == {"Active": {"background_jobs_running": True}}
+        assert tenant["state"] == "Active"
 
     wait_until(30, 1, tenant_active)
 

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -120,8 +120,6 @@ def test_detach_while_attaching(
     tenant_id = TenantId(pg.safe_psql("show neon.tenant_id")[0][0])
     timeline_id = TimelineId(pg.safe_psql("show neon.timeline_id")[0][0])
 
-    checkpoint_numbers = range(1, 3)
-
     # Create table, and insert some rows. Make it big enough that it doesn't fit in
     # shared_buffers, otherwise the SELECT after restart will just return answer
     # from shared_buffers without hitting the page server, which defeats the point
@@ -143,11 +141,11 @@ def test_detach_while_attaching(
     # run checkpoint manually to be sure that data landed in remote storage
     pageserver_http.timeline_checkpoint(tenant_id, timeline_id)
 
-    log.info(f"waiting for upload")
+    log.info("waiting for upload")
 
     # wait until pageserver successfully uploaded a checkpoint to remote storage
     wait_for_upload(client, tenant_id, timeline_id, current_lsn)
-    log.info(f"upload is done")
+    log.info("upload is done")
 
     # Detach it
     pageserver_http.tenant_detach(tenant_id)
@@ -166,6 +164,6 @@ def test_detach_while_attaching(
     # Attach it again. If the GC and compaction loops from the previous attach/detach
     # cycle are still running, things could get really confusing..
     pageserver_http.tenant_attach(tenant_id)
-    
+
     with pg.cursor() as cur:
-        cur.execute("SELECT COUNT(*) FROM foo");
+        cur.execute("SELECT COUNT(*) FROM foo")

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -153,7 +153,7 @@ def test_detach_while_attaching(
     pageserver_http.tenant_detach(tenant_id)
 
     # And re-attach
-    pageserver_http.configure_failpoints([("attach-before-activate", "sleep(5000)")])
+    pageserver_http.configure_failpoints([("attach-before-activate", "return(5000)")])
 
     pageserver_http.tenant_attach(tenant_id)
 

--- a/test_runner/regress/test_tenant_tasks.py
+++ b/test_runner/regress/test_tenant_tasks.py
@@ -41,16 +41,10 @@ def test_tenant_tasks(neon_env_builder: NeonEnvBuilder):
         for t in timelines:
             client.timeline_delete(tenant, t)
 
-    def assert_active_without_jobs(tenant):
-        assert get_state(tenant) == {"Active": {"background_jobs_running": False}}
-
     # Create tenant, start compute
     tenant, _ = env.neon_cli.create_tenant()
     env.neon_cli.create_timeline(name, tenant_id=tenant)
     pg = env.postgres.create_start(name, tenant_id=tenant)
-    assert get_state(tenant) == {
-        "Active": {"background_jobs_running": True}
-    }, "Pageserver should activate a tenant and start background jobs if timelines are loaded"
 
     # Stop compute
     pg.stop()
@@ -59,7 +53,6 @@ def test_tenant_tasks(neon_env_builder: NeonEnvBuilder):
     for tenant_info in client.tenant_list():
         tenant_id = TenantId(tenant_info["id"])
         delete_all_timelines(tenant_id)
-        wait_until(10, 0.2, lambda: assert_active_without_jobs(tenant_id))
 
     # Assert that all tasks finish quickly after tenant is detached
     assert get_metric_value('pageserver_tenant_task_events{event="start"}') > 0

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -259,6 +259,4 @@ def test_pageserver_with_empty_tenants(
     ), f"Tenant {tenant_without_timelines_dir} without timelines dir should be broken"
 
     [loaded_tenant] = [t for t in tenants if t["id"] == str(tenant_with_empty_timelines_dir)]
-    assert loaded_tenant["state"] == {
-        "Active": {"background_jobs_running": False}
-    }, "Tenant {tenant_with_empty_timelines_dir} with empty timelines dir should be active and ready for timeline creation"
+    assert loaded_tenant["state"] == "Active", "Tenant {tenant_with_empty_timelines_dir} with empty timelines dir should be active and ready for timeline creation"

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -259,4 +259,6 @@ def test_pageserver_with_empty_tenants(
     ), f"Tenant {tenant_without_timelines_dir} without timelines dir should be broken"
 
     [loaded_tenant] = [t for t in tenants if t["id"] == str(tenant_with_empty_timelines_dir)]
-    assert loaded_tenant["state"] == "Active", "Tenant {tenant_with_empty_timelines_dir} with empty timelines dir should be active and ready for timeline creation"
+    assert (
+        loaded_tenant["state"] == "Active"
+    ), "Tenant {tenant_with_empty_timelines_dir} with empty timelines dir should be active and ready for timeline creation"


### PR DESCRIPTION
1. Remove the `background_jobs_enabled' flag from TenantState::Active. The background jobs are now always running if tenant is in Active state, even if the tenant has zero timelines. The GC and compaction just won't have any work to do in that case. (see also @alexstanovoy's comments on this in the recent RFC: https://github.com/neondatabase/neon/pull/2899/files#diff-8c333f960108d15bc17b630d5a0c2daf48e1c7ffa16c50de9ad3a76fb055a5a2R47-R55)

 2. At the end of loading or attaching a tenant, we call activate() to change the state to Active. Change the activate() function so that if the tenant is already in Paused state, it stays Paused and we don't start the background jobs. That addresses the FIXME comment from PR 2785 that wondered what happens if you detach a tenant that's still Loading or Attaching. Also add a test case for that.
