### PR TITLE
storage_sync2: storage_sync: handle task_mgr::is_shutdown_requested()

### DIFF
--- a/pageserver/src/storage_sync.rs
+++ b/pageserver/src/storage_sync.rs
@@ -839,10 +839,7 @@ impl RemoteTimelineClient {
                     self_rc.update_upload_queue_unfinished_metric(-1, &task_clone.op);
                     Ok(())
                 }
-                // FIXME this captures the parent span, i.e. log messages inside the task will look like so:
-                // 2022-11-24T17:34:35.707155Z  INFO layer flush task{tenant=81892ec7b59f9ac3f06f5ab5d8c1fe3d timeline=82f9c121ee5778016485e775550e8c61}:flush_frozen_layer{tenant_id=81892ec7b59f9ac3f06f5ab5d8c1fe3d timeline_id=82f9c121ee5778016485e775550e8c61 layer=inmem-0000000001696629-00000000016AFA39}:remote_upload{tenant=81892ec7b59f9ac3f06f5ab5d8c1fe3d timeline=82f9c121ee5778016485e775550e8c61 upload_task_id=1556}: shutting down
-                // How to avoid this?
-                .instrument(info_span!("remote_upload", tenant = %self.tenant_id, timeline = %self.timeline_id, upload_task_id = %task_id)),
+                .instrument(info_span!(parent: None, "remote_upload", tenant = %self.tenant_id, timeline = %self.timeline_id, upload_task_id = %task_id)),
             );
 
             // Loop back to process next task

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -320,3 +320,82 @@ def test_remote_storage_upload_queue_retries(
     pg = env.postgres.create_start("main", tenant_id=tenant_id)
     with pg.cursor() as cur:
         assert query_scalar(cur, "SELECT COUNT(*) FROM foo WHERE val = 'd'") == 10000
+
+
+# Test that we correctly handle timeline with layers stuck in upload queue
+@pytest.mark.parametrize("remote_storage_kind", [RemoteStorageKind.LOCAL_FS])
+def test_timeline_deletion_with_files_stuck_in_upload_queue(
+    neon_env_builder: NeonEnvBuilder,
+    remote_storage_kind: RemoteStorageKind,
+):
+    neon_env_builder.enable_remote_storage(
+        remote_storage_kind=remote_storage_kind,
+        test_name="test_remote_storage_backup_and_restore",
+    )
+
+    env = neon_env_builder.init_start()
+
+    # create tenant with config that will determinstically allow
+    # compaction and gc
+    tenant_id, timeline_id = env.neon_cli.create_tenant(
+        conf={
+            # small checkpointing and compaction targets to ensure we generate many operations
+            "checkpoint_distance": f"{32 * 1024}",
+            "compaction_threshold": "1",
+            "compaction_target_size": f"{32 * 1024}",
+            # large horizon to avoid automatic GC (our assert on gc_result below relies on that)
+            "gc_horizon": f"{1024 ** 4}",
+            "gc_period": "1h",
+            # disable PITR so that GC considers just gc_horizon
+            "pitr_interval": "0s",
+        }
+    )
+
+    client = env.pageserver.http_client()
+
+    pg = env.postgres.create_start("main", tenant_id=tenant_id)
+
+    client.configure_failpoints(("before-upload-layer", "return"))
+
+    pg.safe_psql_many(
+        [
+            "CREATE TABLE foo (x INTEGER)",
+            "INSERT INTO foo SELECT g FROM generate_series(1, 10000) g",
+        ]
+    )
+    wait_for_last_flush_lsn(env, pg, tenant_id, timeline_id)
+    client.timeline_checkpoint(tenant_id, timeline_id)
+
+    timeline_path = env.repo_dir / "tenants" / str(tenant_id) / "timelines" / str(timeline_id)
+    assert timeline_path.exists()
+    assert len(list(timeline_path.glob("*"))) >= 8
+
+    def get_queued_count(file_kind, op_kind):
+        metrics = client.get_metrics()
+        matches = re.search(
+            f'^pageserver_remote_upload_queue_unfinished_tasks{{file_kind="{file_kind}",op_kind="{op_kind}",tenant_id="{tenant_id}",timeline_id="{timeline_id}"}} (\\S+)$',
+            metrics,
+            re.MULTILINE,
+        )
+        assert matches
+        return int(matches[1])
+
+    assert get_queued_count(file_kind="index", op_kind="upload") > 0
+
+    # timeline delete should work despite layer files stuck in upload
+    log.info("sending delete request")
+    client.timeline_delete(tenant_id, timeline_id)
+
+    assert not timeline_path.exists()
+
+    # timeline deletion should kill ongoing uploads
+    assert get_queued_count(file_kind="index", op_kind="upload") == 0
+
+    # Just to be sure, unblock ongoing uploads. If the previous assert was incorrect, or the prometheus metric broken,
+    # this would likely generate some ERROR level log entries that the NeonEnvBuilder would detect
+    client.configure_failpoints(("before-upload-layer", "off"))
+    # XXX force retry, currently we have to wait for exponential backoff
+    time.sleep(10)
+
+
+# TODO Test that we correctly handle GC of files that are stuck in upload queue.


### PR DESCRIPTION
storage_sync: handle task_mgr::is_shutdown_requested()                      
                                                                            
- Introduce another UploadQueue::ShutDown enum variant to indicate the state
  where the UploadQueue is shut down.                                       
- In perform_upload_task, check for task_mgr::is_shutdown_requested()       
  before going into expoential backoff.                                     
  If we are requested to shut down, the first in-progress tasks that        
  notices the shutdown request transitions the queue from                   
  UploadQueue::Initialized to UploadQueue::ShutDown.                        
  This involves dropping all the queued ops that are not yet                
  in progress, which conveniently unblocks wait_completion() calls          
  that are waiting for their barrier to be executed.                        
  They will receive an Err(), and do something sensible.                    
                                                                            
Right now, wait_completion() is only used by tests, but I                   
suspect that we should be using it in wherever we                           
delete layer files, e.g., GC and compaction, as explained                   
in the storage_sync.rs block comment section "Consistency".                 
                                                                            
This change als fixes                                                       
test_timeline_deletion_with_files_stuck_in_upload_queue                     
which I added in the previous commit.                                       
Before, timeline delete would wait until all in-progress                    
tasks and queued tasks were done.                                           
If, like in the test, a task was stuck due to upload error,                 
timeline deletion would wait forever                                        
Hence, handling task_mgr::is_shutdown_requested() is sufficient             
to resolve this particular problem.                                         
