### PR TITLE
Little cleanup around measure_remote_op calls

### DIFF
--- a/pageserver/src/storage_sync.rs
+++ b/pageserver/src/storage_sync.rs
@@ -234,10 +234,8 @@ mod download;
 pub mod index;
 mod upload;
 
-// re-export this
-pub use download::is_temp_download_file;
-pub use download::list_remote_timelines;
-use tracing::{info_span, Instrument};
+// re-export these
+pub use download::{is_temp_download_file, list_remote_timelines};
 
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
@@ -250,6 +248,7 @@ use anyhow::ensure;
 use remote_storage::{DownloadError, GenericRemoteStorage};
 use tokio::runtime::Runtime;
 use tracing::{error, info, warn};
+use tracing::{info_span, Instrument};
 
 use utils::lsn::Lsn;
 
@@ -538,6 +537,12 @@ impl RemoteTimelineClient {
             self.tenant_id,
             self.timeline_id,
         )
+        .measure_remote_op(
+            self.tenant_id,
+            self.timeline_id,
+            RemoteOpFileKind::Index,
+            RemoteOpKind::Download,
+        )
         .await
     }
 
@@ -558,6 +563,12 @@ impl RemoteTimelineClient {
             self.timeline_id,
             path,
             layer_metadata,
+        )
+        .measure_remote_op(
+            self.tenant_id,
+            self.timeline_id,
+            RemoteOpFileKind::Layer,
+            RemoteOpKind::Download,
         )
         .await?;
 

--- a/pageserver/src/storage_sync/delete.rs
+++ b/pageserver/src/storage_sync/delete.rs
@@ -12,29 +12,26 @@ pub(super) async fn delete_layer(
     fail::fail_point!("before-delete-layer", |_| {
         anyhow::bail!("failpoint before-delete-layer")
     });
-    async {
-        debug!(
-            "Deleting layer from remote storage: {:?}",
-            local_layer_path.display()
-        );
+    debug!(
+        "Deleting layer from remote storage: {:?}",
+        local_layer_path.display()
+    );
 
-        let storage_path = storage
-            .remote_object_id(local_layer_path)
-            .with_context(|| {
-                format!(
-                    "Failed to get the layer storage path for local path '{}'",
-                    local_layer_path.display()
-                )
-            })?;
-
-        // FIXME: If the deletion fails because the object already didn't exist,
-        // it would be good to just issue a warning but consider it success.
-        storage.delete(&storage_path).await.with_context(|| {
+    let storage_path = storage
+        .remote_object_id(local_layer_path)
+        .with_context(|| {
             format!(
-                "Failed to delete remote layer from storage at '{:?}'",
-                storage_path
+                "Failed to get the layer storage path for local path '{}'",
+                local_layer_path.display()
             )
-        })
-    }
-    .await
+        })?;
+
+    // FIXME: If the deletion fails because the object already didn't exist,
+    // it would be good to just issue a warning but consider it success.
+    storage.delete(&storage_path).await.with_context(|| {
+        format!(
+            "Failed to delete remote layer from storage at '{:?}'",
+            storage_path
+        )
+    })
 }

--- a/pageserver/src/storage_sync/upload.rs
+++ b/pageserver/src/storage_sync/upload.rs
@@ -22,27 +22,24 @@ pub(super) async fn upload_index_part<'a>(
     fail_point!("before-upload-index", |_| {
         bail!("failpoint before-upload-index")
     });
-    async {
-        let index_part_bytes = serde_json::to_vec(&index_part)
-            .context("Failed to serialize index part file into bytes")?;
-        let index_part_size = index_part_bytes.len();
-        let index_part_bytes = tokio::io::BufReader::new(std::io::Cursor::new(index_part_bytes));
+    let index_part_bytes = serde_json::to_vec(&index_part)
+        .context("Failed to serialize index part file into bytes")?;
+    let index_part_size = index_part_bytes.len();
+    let index_part_bytes = tokio::io::BufReader::new(std::io::Cursor::new(index_part_bytes));
 
-        let index_part_path = conf
-            .metadata_path(timeline_id, tenant_id)
-            .with_file_name(IndexPart::FILE_NAME);
-        storage
-            .upload_storage_object(
-                Box::new(index_part_bytes),
-                index_part_size,
-                &index_part_path,
-            )
-            .await
-            .with_context(|| {
-                format!("Failed to upload index part for '{tenant_id} / {timeline_id}'")
-            })
-    }
-    .await
+    let index_part_path = conf
+        .metadata_path(timeline_id, tenant_id)
+        .with_file_name(IndexPart::FILE_NAME);
+    storage
+        .upload_storage_object(
+            Box::new(index_part_bytes),
+            index_part_size,
+            &index_part_path,
+        )
+        .await
+        .with_context(|| {
+            format!("Failed to upload index part for '{tenant_id} / {timeline_id}'")
+        })
 }
 
 /// Attempts to upload given layer files.
@@ -57,54 +54,51 @@ pub(super) async fn upload_timeline_layer(
     fail_point!("before-upload-layer", |_| {
         bail!("failpoint before-upload-layer")
     });
-    async {
-        let storage_path = storage.remote_object_id(source_path).with_context(|| {
+    let storage_path = storage.remote_object_id(source_path).with_context(|| {
+        format!(
+            "Failed to get the layer storage path for local path '{}'",
+            source_path.display()
+        )
+    })?;
+
+    let source_file = fs::File::open(&source_path).await.with_context(|| {
+        format!(
+            "Failed to open a source file for layer '{}'",
+            source_path.display()
+        )
+    })?;
+
+    let fs_size = source_file
+        .metadata()
+        .await
+        .with_context(|| {
             format!(
-                "Failed to get the layer storage path for local path '{}'",
+                "Failed to get the source file metadata for layer '{}'",
                 source_path.display()
             )
-        })?;
+        })?
+        .len();
 
-        let source_file = fs::File::open(&source_path).await.with_context(|| {
-            format!(
-                "Failed to open a source file for layer '{}'",
-                source_path.display()
-            )
-        })?;
-
-        let fs_size = source_file
-            .metadata()
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to get the source file metadata for layer '{}'",
-                    source_path.display()
-                )
-            })?
-            .len();
-
-        // FIXME: this looks bad
-        if let Some(metadata_size) = known_metadata.file_size() {
-            if metadata_size != fs_size {
-                bail!("File {source_path:?} has its current FS size {fs_size} diferent from initially determined {metadata_size}");
-            }
-        } else {
-            // this is a silly state we would like to avoid
+    // FIXME: this looks bad
+    if let Some(metadata_size) = known_metadata.file_size() {
+        if metadata_size != fs_size {
+            bail!("File {source_path:?} has its current FS size {fs_size} diferent from initially determined {metadata_size}");
         }
-
-        let fs_size = usize::try_from(fs_size).with_context(|| format!("File {source_path:?} size {fs_size} could not be converted to usize"))?;
-
-        storage
-            .upload(Box::new(source_file), fs_size, &storage_path, None)
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to upload a layer from local path '{}'",
-                    source_path.display()
-                )
-            })?;
-
-        Ok(())
+    } else {
+        // this is a silly state we would like to avoid
     }
-    .await
+
+    let fs_size = usize::try_from(fs_size).with_context(|| format!("File {source_path:?} size {fs_size} could not be converted to usize"))?;
+
+    storage
+        .upload(Box::new(source_file), fs_size, &storage_path, None)
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to upload a layer from local path '{}'",
+                source_path.display()
+            )
+        })?;
+
+    Ok(())
 }


### PR DESCRIPTION
- Previously, the functions in download.rs did the measurement themselves, whereas for functions in delete.rs and upload.rs, it was the caller's responsibility. Move the measure_remote_op calls from download.rs to the callers, for consistency.
- Remove pointless async blocks in upload.rs and delete.rs. They would've been useful for inserting the measure_remote_op calls, but since the caller's are responsible for measure_remote_op now, they're not neeed.
- tiny cosmetic cleanup around imports