### PR TITLE
When new timeline is created, don't wait for compaction.

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1320,7 +1320,7 @@ impl Tenant {
             format!("Failed to import pgdatadir for timeline {tenant_id}/{timeline_id}")
         })?;
 
-        // Flush the new layer files to disk, before we mark the timelne as available to
+        // Flush the new layer files to disk, before we mark the timeline as available to
         // the outside world.
         //
         // Thus spawn flush loop manually and skip flush_loop setup in initialize_with_lock

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1320,9 +1320,10 @@ impl Tenant {
             format!("Failed to import pgdatadir for timeline {tenant_id}/{timeline_id}")
         })?;
 
-        // Flush loop needs to be spawned in order for checkpoint to be able to flush.
-        // We want to run proper checkpoint before we mark timeline as available to outside world
-        // Thus spawning flush loop manually and skipping flush_loop setup in initialize_with_lock
+        // Flush the new layer files to disk, before we mark the timelne as available to
+        // the outside world.
+        //
+        // Thus spawn flush loop manually and skip flush_loop setup in initialize_with_lock
         unfinished_timeline.maybe_spawn_flush_loop();
 
         fail::fail_point!("before-checkpoint-new-timeline", |_| {
@@ -1330,7 +1331,7 @@ impl Tenant {
         });
 
         unfinished_timeline
-            .checkpoint(CheckpointConfig::Forced).await
+            .checkpoint(CheckpointConfig::Flush).await
             .with_context(|| format!("Failed to checkpoint after pgdatadir import for timeline {tenant_id}/{timeline_id}"))?;
 
         let timeline = {


### PR DESCRIPTION
When a new root timeline is created, we want to flush all the data to disk before we return success to the caller. We were using checkpoint(CheckpointConfig::Forced) for that, but that also performs compaction. With the default settings, compaction will have no work after we have imported an empty database, as the image of that is too small to require compaction. However, with very small checkpoint_distance and compaction_target_size, compaction will run, and it can take a while.

PR #2785 adds new tests that use very small checkpoint_distance and compaction_target_size settings, and the test sometimes failed with "operation timed out" error in the client, when the create_timeline step took too long.