### PR TITLE
storage_sync2: `wait_completion()` MVP

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -749,7 +749,10 @@ async fn timeline_compact_handler(request: Request<Body>) -> Result<Response<Bod
     let timeline = tenant
         .get_timeline(timeline_id, true)
         .map_err(ApiError::NotFound)?;
-    timeline.compact().map_err(ApiError::InternalServerError)?;
+    timeline
+        .compact()
+        .await
+        .map_err(ApiError::InternalServerError)?;
 
     json_response(StatusCode::OK, ())
 }

--- a/pageserver/src/storage_sync.rs
+++ b/pageserver/src/storage_sync.rs
@@ -999,7 +999,8 @@ impl RemoteTimelineClient {
             UploadOp::UploadMetadata(_, _) => (RemoteOpFileKind::Index, RemoteOpKind::Upload),
             UploadOp::Delete(file_kind, _) => (*file_kind, RemoteOpKind::Delete),
             UploadOp::Barrier(_) => {
-                unreachable!("we execute barriers synchronously")
+                // we do not account these
+                return;
             }
         };
         REMOTE_UPLOAD_QUEUE_UNFINISHED_TASKS

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -290,7 +290,7 @@ pub async fn delete_timeline(tenant_id: TenantId, timeline_id: TimelineId) -> an
     info!("timeline task shutdown completed");
     match get_tenant(tenant_id, true) {
         Ok(tenant) => {
-            tenant.delete_timeline(timeline_id)?;
+            tenant.delete_timeline(timeline_id).await?;
         }
         Err(e) => anyhow::bail!("Cannot access tenant {tenant_id} in local tenant state: {e:?}"),
     }

--- a/pageserver/src/tenant_tasks.rs
+++ b/pageserver/src/tenant_tasks.rs
@@ -84,7 +84,7 @@ async fn compaction_loop(tenant_id: TenantId) {
 
             // Run compaction
             let mut sleep_duration = tenant.get_compaction_period();
-            if let Err(e) = tenant.compaction_iteration() {
+            if let Err(e) = tenant.compaction_iteration().await {
                 sleep_duration = wait_duration;
                 error!("Compaction failed, retrying in {:?}: {e:?}", sleep_duration);
             }

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2534,6 +2534,7 @@ class SafekeeperTimelineStatus:
     acceptor_epoch: int
     pg_version: int
     flush_lsn: Lsn
+    commit_lsn: Lsn
     timeline_start_lsn: Lsn
     backup_lsn: Lsn
     remote_consistent_lsn: Lsn
@@ -2583,6 +2584,7 @@ class SafekeeperHttpClient(requests.Session):
             acceptor_epoch=resj["acceptor_state"]["epoch"],
             pg_version=resj["pg_info"]["pg_version"],
             flush_lsn=Lsn(resj["flush_lsn"]),
+            commit_lsn=Lsn(resj["commit_lsn"]),
             timeline_start_lsn=Lsn(resj["timeline_start_lsn"]),
             backup_lsn=Lsn(resj["backup_lsn"]),
             remote_consistent_lsn=Lsn(resj["remote_consistent_lsn"]),

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1761,6 +1761,12 @@ class NeonPageserver(PgProtocol):
             ".*Removing intermediate uninit mark file.*",
             # FIXME: known race condition in TaskHandle: https://github.com/neondatabase/neon/issues/2885
             ".*sender is dropped while join handle is still alive.*",
+            # Tenant::delete_timeline() can cause any of the four following errors.
+            # FIXME: we shouldn't be considering it an error: https://github.com/neondatabase/neon/issues/2946
+            ".*could not flush frozen layer.*queue is in state Stopped",  # when schedule layer upload fails because queued got closed before compaction got killed
+            ".*wait for layer upload ops to complete.*",  # .*Caused by:.*wait_completion aborted because upload queue was stopped
+            ".*gc_loop.*Gc failed, retrying in.*timeline is paused: Paused",  # When gc checks timeline state after acquiring layer_removal_cs
+            ".*compaction_loop.*Compaction failed, retrying in.*timeline is paused: Paused",  # When compaction checks timeline state after acquiring layer_removal_cs
         ]
 
     def start(

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -202,9 +202,9 @@ def test_remote_storage_upload_queue_retries(
     tenant_id, timeline_id = env.neon_cli.create_tenant(
         conf={
             # small checkpointing and compaction targets to ensure we generate many operations
-            "checkpoint_distance": f"{32 * 1024}",
+            "checkpoint_distance": f"{128 * 1024}",
             "compaction_threshold": "1",
-            "compaction_target_size": f"{32 * 1024}",
+            "compaction_target_size": f"{128 * 1024}",
             # large horizon to avoid automatic GC (our assert on gc_result below relies on that)
             "gc_horizon": f"{1024 ** 4}",
             "gc_period": "1h",

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -1,13 +1,7 @@
-import time
 from typing import List, Tuple
 
 from fixtures.log_helper import log
-from fixtures.neon_fixtures import (
-    NeonEnv,
-    NeonEnvBuilder,
-    PageserverApiException,
-    wait_for_last_flush_lsn,
-)
+from fixtures.neon_fixtures import NeonEnv, NeonEnvBuilder, wait_for_last_flush_lsn
 from fixtures.types import Lsn
 
 
@@ -256,22 +250,7 @@ def test_get_tenant_size_with_multiple_branches(neon_env_builder: NeonEnvBuilder
     assert size_after == size_after_thinning_branch
 
     # teardown, delete branches, and the size should be going down
-    deleted = False
-    for _ in range(10):
-        try:
-            http_client.timeline_delete(tenant_id, first_branch_timeline_id)
-            deleted = True
-            break
-        except PageserverApiException as e:
-            # compaction is ok but just retry if this fails; related to #2442
-            if "cannot lock compaction critical section" in str(e):
-                # also ignore it in the log
-                env.pageserver.allowed_errors.append(".*cannot lock compaction critical section.*")
-                time.sleep(1)
-                continue
-            raise
-
-    assert deleted
+    http_client.timeline_delete(tenant_id, first_branch_timeline_id)
 
     size_after_deleting_first = http_client.tenant_size(tenant_id)
     assert size_after_deleting_first < size_after_thinning_branch


### PR DESCRIPTION
Commit 1:

```
 refactor: turn compaction code async

We need this to insert remote_client.wait_completion() calls.
That'll happen in the next commit.

The major wrinkle in this change is Tenant::timeline_delete().
Before this change, Tenant::timeline_delete() does the following:
1 Acquire timelines.lock()
2 get a ref to the timelines map
3 Set it to `TimelineState::Paused`
4 Get Tenant::layer_removal_guard()
  (Internally, this is a Tenant::layer_removal_cs.try_lock().expect())
5 Remove timeline directory and all its files.
6 drop the guard
7 Remove the timeline from the timelines map
8 drop timelines lock (implicit drop)

Couple of odd things about that:

- I think (3) is supposed to lock out any more timeline ops and and
  (4) is supposed to drain any existing timeline ops, namely, GC & Compactions.
  So that (5) can then remove the layer files, knowing that nobody
  references the corresponding Layer structs anymore, except us.
- If that assumption is correct, I think there are several flaws with
  that approach:
  1. The layer_remvoal_guard() is a try_lock() that will panic if we
     can't get it. The caller only shuts down timeline tasks before
     calling us, but GC & Compaction is a per-tenant loop, so, I think
     we could reach the case where the try_lock() fails. In that case,
     timeline_delete() panicks.
  2. The `layer_removal_guard()` only waits for concurrent GC & Compaction.
     Once we have it, we delete the layer files (5).
     We need to be 100% sure that nobody else will be accessing these layer
     files anymore.
     The caller has killed WAL receiver, that's good.
     But the timeline is still reachable via PS HTTP API.
     So, if there's any HTTP op that started before (3), we haven't
     yet waited for it to finish.

This PR doesn't address those problems.
And possible, it makes things worse because layer_removal_cs needs to
become a tokio::sync::Mutex, so that the next commit's
can hold it across the remote_client.wait_completion().await points
that it adds.

So, the solution in delete_timeline() is to drop the timelines.lock()
after setting the `TimelineState::Paused`.
Then do compaction while holding `layer_removal_cs()`.
Then re-aquire timelines.lock() and delete the timeline.
```

Commit 2:

```
 add remote_storage.wait_completion() calls to compaction() and gc() 
```