### PR TITLE
neon_local: allow rr recordings via env var

### DIFF
--- a/control_plane/src/etcd.rs
+++ b/control_plane/src/etcd.rs
@@ -63,6 +63,7 @@ pub fn start_etcd_process(env: &local_env::LocalEnv) -> anyhow::Result<()> {
 
             Ok(false)
         },
+        false,
     )
     .context("Failed to spawn etcd subprocess")?;
 

--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -151,7 +151,7 @@ impl PageServerNode {
         }
 
         let mut pageserver_process = self
-            .start_node(&init_config_overrides, &self.env.base_data_dir, true)
+            .start_node(&init_config_overrides, &self.env.base_data_dir, true, false)
             .with_context(|| {
                 format!(
                     "Failed to start a process for pageserver {}",
@@ -223,7 +223,7 @@ impl PageServerNode {
     }
 
     pub fn start(&self, config_overrides: &[&str]) -> anyhow::Result<Child> {
-        self.start_node(config_overrides, &self.repo_path(), false)
+        self.start_node(config_overrides, &self.repo_path(), false, true)
     }
 
     fn start_node(
@@ -231,6 +231,7 @@ impl PageServerNode {
         config_overrides: &[&str],
         datadir: &Path,
         update_config: bool,
+        allow_recording: bool,
     ) -> anyhow::Result<Child> {
         print!(
             "Starting pageserver at '{}' in '{}'",
@@ -275,6 +276,7 @@ impl PageServerNode {
                 Err(PageserverHttpError::Transport(_)) => Ok(false),
                 Err(e) => Err(anyhow::anyhow!("Failed to check node status: {e}")),
             },
+            allow_recording,
         )
     }
 

--- a/control_plane/src/safekeeper.rs
+++ b/control_plane/src/safekeeper.rs
@@ -173,6 +173,7 @@ impl SafekeeperNode {
                 Err(SafekeeperHttpError::Transport(_)) => Ok(false),
                 Err(e) => Err(anyhow::anyhow!("Failed to check node status: {e}")),
             },
+            true,
         )
     }
 


### PR DESCRIPTION
record as in 'rr record $cmd' for later playback. configured via NEON_LOCAL_RECORD_COMMANDS environment variable, for example:

```
NEON_LOCAL_RECORD_COMMANDS=pageserver ./scripts/pytest \
  test_runner/regress/test_gc_aggressive.py
```

will then show up as a new recording with `rr ls`.