### PR TITLE
Rename Paused states to Stopping.

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -23,7 +23,7 @@ pub enum TenantState {
     Active,
     /// A tenant is recognized by pageserver, but it is being detached or the
     /// system is being shut down.
-    Paused,
+    Stopping,
     /// A tenant is recognized by the pageserver, but can no longer be used for
     /// any operations, because it failed to be activated.
     Broken,
@@ -35,7 +35,7 @@ impl TenantState {
             Self::Loading => true,
             Self::Attaching => true,
             Self::Active => false,
-            Self::Paused => false,
+            Self::Stopping => false,
             Self::Broken => false,
         }
     }
@@ -53,7 +53,7 @@ pub enum TimelineState {
     Suspended,
     /// A timeline is recognized by pageserver, but not yet ready to operate and not allowed to
     /// automatically become Active after certain events: only a management call can change this status.
-    Paused,
+    Stopping,
     /// A timeline is recognized by the pageserver, but can no longer be used for
     /// any operations, because it failed to be activated.
     Broken,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -555,8 +555,8 @@ impl Timeline {
         let _layer_removal_cs = self.layer_removal_cs.lock().await;
         // Is the timeline being deleted?
         let state = *self.state.borrow();
-        if state == TimelineState::Paused {
-            anyhow::bail!("timeline is paused: {:?}", state);
+        if state == TimelineState::Stopping {
+            anyhow::bail!("timeline is Stopping");
         }
 
         let target_file_size = self.get_checkpoint_distance();
@@ -668,8 +668,8 @@ impl Timeline {
             (TimelineState::Broken, _) => {
                 error!("Ignoring state update {new_state:?} for broken tenant");
             }
-            (TimelineState::Paused, TimelineState::Active) => {
-                debug!("Not activating a paused timeline");
+            (TimelineState::Stopping, TimelineState::Active) => {
+                debug!("Not activating a Stopping timeline");
             }
             (_, new_state) => {
                 self.state.send_replace(new_state);
@@ -1251,7 +1251,7 @@ impl Timeline {
                                         match new_state {
                                             // we're running this job for active timelines only
                                             TimelineState::Active => continue,
-                                            TimelineState::Broken | TimelineState::Paused | TimelineState::Suspended => return Some(new_state),
+                                            TimelineState::Broken | TimelineState::Stopping | TimelineState::Suspended => return Some(new_state),
                                         }
                                     }
                                     Err(_sender_dropped_error) => return None,
@@ -2393,8 +2393,8 @@ impl Timeline {
         let _layer_removal_cs = self.layer_removal_cs.lock().await;
         // Is the timeline being deleted?
         let state = *self.state.borrow();
-        if state == TimelineState::Paused {
-            anyhow::bail!("timeline is paused: {:?}", state);
+        if state == TimelineState::Stopping {
+            anyhow::bail!("timeline is Stopping");
         }
 
         let (horizon_cutoff, pitr_cutoff, retain_lsns) = {

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -170,7 +170,7 @@ pub async fn shutdown_all_tenants() {
         for (_, tenant) in m.drain() {
             if tenant.is_active() {
                 // updates tenant state, forbidding new GC and compaction iterations from starting
-                tenant.set_paused();
+                tenant.set_stopping();
                 tenants_to_shut_down.push(tenant)
             }
         }
@@ -310,7 +310,7 @@ pub async fn detach_tenant(
         None => anyhow::bail!("Tenant not found for id {tenant_id}"),
     };
 
-    tenant.set_paused();
+    tenant.set_stopping();
     // shutdown all tenant and timeline tasks: gc, compaction, page service)
     task_mgr::shutdown_tasks(None, Some(tenant_id), None).await;
 

--- a/pageserver/src/walreceiver/connection_manager.rs
+++ b/pageserver/src/walreceiver/connection_manager.rs
@@ -214,7 +214,7 @@ async fn connection_manager_loop_step(
                             match new_state {
                                 // we're already active as walreceiver, no need to reactivate
                                 TimelineState::Active => continue,
-                                TimelineState::Broken | TimelineState::Paused | TimelineState::Suspended => return ControlFlow::Continue(new_state),
+                                TimelineState::Broken | TimelineState::Stopping | TimelineState::Suspended => return ControlFlow::Continue(new_state),
                             }
                         }
                         Err(_sender_dropped_error) => return ControlFlow::Break(()),

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1765,8 +1765,8 @@ class NeonPageserver(PgProtocol):
             # FIXME: we shouldn't be considering it an error: https://github.com/neondatabase/neon/issues/2946
             ".*could not flush frozen layer.*queue is in state Stopped",  # when schedule layer upload fails because queued got closed before compaction got killed
             ".*wait for layer upload ops to complete.*",  # .*Caused by:.*wait_completion aborted because upload queue was stopped
-            ".*gc_loop.*Gc failed, retrying in.*timeline is paused: Paused",  # When gc checks timeline state after acquiring layer_removal_cs
-            ".*compaction_loop.*Compaction failed, retrying in.*timeline is paused: Paused",  # When compaction checks timeline state after acquiring layer_removal_cs
+            ".*gc_loop.*Gc failed, retrying in.*timeline is Stopping",  # When gc checks timeline state after acquiring layer_removal_cs
+            ".*compaction_loop.*Compaction failed, retrying in.*timeline is Stopping",  # When compaction checks timeline state after acquiring layer_removal_cs
             ".*query handler for 'pagestream.*failed: Timeline .* was not found",  # postgres reconnects while timeline_delete doesn't hold the tenant's timelines.lock()
         ]
 


### PR DESCRIPTION
I'm not a fan of "Paused", for two reasons:

- Paused implies that the tenant/timeline with no activity on it. That's not true; the tenant/timeline can still have active tasks working on it.

- Paused implies that it can be resumed later. It can not. A tenant or timeline in this state cannot be switched back to Active state anymore. A completely new Tenant or Timeline struct can be constructed for the same tenant or timeline later, e.g. if you detach and later re-attach the same tenant, but that's a different thing.

Stopping describes the state better. I also considered "ShuttingDown", but Stopping is simpler as it's a single word.