### PR TITLE
Add debug information to hunt down port collisions.

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -239,6 +239,8 @@ fn start_pageserver(conf: &'static PageServerConf) -> anyhow::Result<()> {
     // we need to release the lock file only when the current process is gone
     let _ = Box::leak(Box::new(lock_file));
 
+    info!("Created PID file with PID {}", Pid::this().to_string());
+
     // TODO: Check that it looks like a valid repository before going further
 
     // bind sockets before daemonizing so we report errors early and do not return until we are listening

--- a/safekeeper/src/bin/safekeeper.rs
+++ b/safekeeper/src/bin/safekeeper.rs
@@ -165,18 +165,27 @@ fn start_safekeeper(mut conf: SafeKeeperConf, given_id: Option<NodeId>, init: bo
     // we need to release the lock file only when the current process is gone
     let _ = Box::leak(Box::new(lock_file));
 
+    info!("Created PID file with PID {}", Pid::this().to_string());
+
     // Set or read our ID.
     set_id(&mut conf, given_id)?;
     if init {
         return Ok(());
     }
 
+    info!(
+        "Starting safekeeper http handler on {}",
+        conf.listen_http_addr
+    );
     let http_listener = tcp_listener::bind(conf.listen_http_addr.clone()).map_err(|e| {
         error!("failed to bind to address {}: {}", conf.listen_http_addr, e);
         e
     })?;
 
-    info!("Starting safekeeper on {}", conf.listen_pg_addr);
+    info!(
+        "Starting safekeeper pg protocol handler on {}",
+        conf.listen_pg_addr
+    );
     let pg_listener = tcp_listener::bind(conf.listen_pg_addr.clone()).map_err(|e| {
         error!("failed to bind to address {}: {}", conf.listen_pg_addr, e);
         e


### PR DESCRIPTION
We've been seeing a lot of sporadic test failures with "Cannot assign requested address" lately. Add some debug information to help us find the cause:

- When server startup fails, print "netstat -tnlap" output to the test log. If the failure was caused by "Cannot assign requested address", this will hopefully tell us which process was occupying the port.
- In pageserver and safekeeper startup, print its PID. This way, we can correlate the PID from netstat output with the test that launched it.
- In safekeeper startup, print the HTTP port it's using to the log, in addition to the libpq port. The pageserver was already doing it.