### PR TITLE
Add test that importing an empty file fails.

### DIFF
--- a/test_runner/regress/test_import.py
+++ b/test_runner/regress/test_import.py
@@ -120,6 +120,12 @@ def test_import_from_vanilla(test_output_dir, pg_bin, vanilla_pg, neon_env_build
             ]
         )
 
+    # Importing empty file fails
+    empty_file = os.path.join(test_output_dir, "empty_file")
+    with open(empty_file, "w") as _:
+        with pytest.raises(Exception):
+            import_tar(empty_file, empty_file)
+
     # Importing corrupt backup fails
     with pytest.raises(Exception):
         import_tar(corrupt_base_tar, wal_tar)


### PR DESCRIPTION
We used to have a bug where the pageserver just got stuck if the client sent a CopyDone message before reaching end of tar stream. That showed up with an empty tar file, as one example. That was inadvertently fixed by code refactorings, but let's add a regression test for it, so that we don't accidentally re-introduce the bug later.

Co-authored-by: Heikki Linnakangas <heikki@neon.tech>