### PR TITLE
Add synthetic layer map bench

### DIFF
--- a/pageserver/benches/bench_layer_map.rs
+++ b/pageserver/benches/bench_layer_map.rs
@@ -5,6 +5,7 @@ use pageserver::tenant::layer_map::LayerMap;
 use pageserver::tenant::storage_layer::Layer;
 use pageserver::tenant::storage_layer::ValueReconstructResult;
 use pageserver::tenant::storage_layer::ValueReconstructState;
+use rand::prelude::{SeedableRng, SliceRandom, StdRng};
 use std::cmp::{max, min};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -12,6 +13,7 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Instant;
 use utils::id::{TenantId, TimelineId};
 use utils::lsn::Lsn;
 
@@ -257,11 +259,18 @@ fn bench_from_real_project(c: &mut Criterion) {
 // Benchmark using synthetic data. Arrange image layers on stacked diagonal lines.
 fn bench_sequential(c: &mut Criterion) {
     let mut layer_map = LayerMap::default();
+
+    // Init layer map. Create 100_000 layers arranged in 1000 diagonal lines.
+    //
+    // TODO This code is pretty slow and runs even if we're only running other
+    //      benchmarks. It needs to be somewhere else, but it's not clear where.
+    //      Putting it inside the `bench_function` closure is not a solution
+    //      because then it runs multiple times during warmup.
+    let now = Instant::now();
     for i in 0..100_000 {
-        // % 100 => 17 sec (very bad, should be way under 1 sec. 20x room for improvement)
-        // % 1000 => 1.6 sec
-        // % 10_000 =>
-        // TODO try inserting a super-wide layer in between every 10
+        // TODO try inserting a super-wide layer in between every 10 to reflect
+        //      what often happens with L1 layers that include non-rel changes.
+        //      Maybe do that as a separate test.
         let i32 = (i as u32) % 100;
         let zero = Key::from_hex("000000000000000000000000000000000000").unwrap();
         let layer = DummyImage {
@@ -271,10 +280,20 @@ fn bench_sequential(c: &mut Criterion) {
         layer_map.insert_historic(Arc::new(layer));
     }
 
-    let queries: Vec<(Key, Lsn)> = uniform_query_pattern(&layer_map);
+    // Manually measure runtime without criterion because criterion
+    // has a minimum sample size of 10 and I don't want to run it 10 times.
+    println!("Finished init in {:?}", now.elapsed());
 
-    // Test with uniform query pattern
+    // Choose 100 uniformly random queries
+    let mut rng = &mut StdRng::seed_from_u64(1);
+    let queries: Vec<(Key, Lsn)> = uniform_query_pattern(&layer_map)
+        .choose_multiple(rng, 1)
+        .map(|x| x.clone())
+        .collect();
+
+    // Define and name the benchmark function
     c.bench_function("sequential_uniform_queries", |b| {
+        // Run the search queries
         b.iter(|| {
             for q in queries.clone().into_iter() {
                 layer_map.search(q.0, q.1).unwrap();
@@ -283,5 +302,7 @@ fn bench_sequential(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_sequential);
-criterion_main!(benches);
+criterion_group!(group_1, bench_from_captest_env);
+criterion_group!(group_2, bench_from_real_project);
+criterion_group!(group_3, bench_sequential);
+criterion_main!(group_1, group_2, group_3);

--- a/pageserver/benches/bench_layer_map.rs
+++ b/pageserver/benches/bench_layer_map.rs
@@ -285,10 +285,10 @@ fn bench_sequential(c: &mut Criterion) {
     println!("Finished init in {:?}", now.elapsed());
 
     // Choose 100 uniformly random queries
-    let mut rng = &mut StdRng::seed_from_u64(1);
+    let rng = &mut StdRng::seed_from_u64(1);
     let queries: Vec<(Key, Lsn)> = uniform_query_pattern(&layer_map)
         .choose_multiple(rng, 1)
-        .map(|x| x.clone())
+        .copied()
         .collect();
 
     // Define and name the benchmark function


### PR DESCRIPTION
I was experimenting with the most trivial synthetic (but realistic) tests for layer map search and found some of them perform really bad, at least 20x worse than I'd expect. For example, it took 17 sec to answer 100k queries on a layer map with 100k layers in it (on my laptop).

I'm sharing this as a draft PR so people can run the code if they wish. I don't intend to merge the code as is. TODO:
- randomly sample search queries so benchmark can run much faster
- experiment more
- settle on 3-4 representative test cases

Relevant https://github.com/neondatabase/neon/pull/2515