### PR TITLE
neon_local init: properly stop & wait for pageserver child process to exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "regex",
  "reqwest",
  "safekeeper_api",
+ "scopeguard",
  "serde",
  "serde_with",
  "tar",

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -27,3 +27,4 @@ postgres_connection = { path = "../libs/postgres_connection" }
 safekeeper_api = { path = "../libs/safekeeper_api" }
 utils = { path = "../libs/utils" }
 workspace_hack = { version = "0.1", path = "../workspace_hack" }
+scopeguard = "1.1.0"

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -324,7 +324,7 @@ fn handle_init(init_match: &ArgMatches) -> anyhow::Result<LocalEnv> {
             pg_version,
         )
         .unwrap_or_else(|e| {
-            eprintln!("pageserver init failed: {e}");
+            eprintln!("pageserver init failed: {e:?}");
             exit(1);
         });
 


### PR DESCRIPTION
Before this patch, we would SIGKILL but not wait for the child to exit, but still remove its pidfile.

If a `neon_local start` command follows, that would then successfully spawn a pageserver process, but the pageserver process would fail to bind the listener ports because the old child child (from neon_local init) was still around.
The error returned by the kernel in that case is EADDRNOTAVAIL. We've encountered it frequently in CI:

    2022-11-29T18:14:38.495970Z  INFO Starting pageserver http handler on localhost:15041
    Error: Failed to start pageserver

    Caused by:
        Cannot assign requested address (os error 99)

refs https://github.com/neondatabase/neon/issues/2968