### PR TITLE
Fix named_arguments_used_positionally warnings

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1105,7 +1105,7 @@ impl Timeline {
                     continue;
                 }
 
-                trace!("downloading image file: {}", path.display());
+                trace!("downloading delta file: {}", path.display());
                 let sz = remote_client
                     .download_layer_file(&RelativePath::from_filename(path), &layer_metadata)
                     .await

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1075,7 +1075,7 @@ impl Timeline {
                     continue;
                 }
 
-                trace!("downloading image file: {}", file = path.display());
+                trace!("downloading image file: {}", path.display());
                 let sz = remote_client
                     .download_layer_file(&RelativePath::from_filename(path), &layer_metadata)
                     .await
@@ -1105,7 +1105,7 @@ impl Timeline {
                     continue;
                 }
 
-                trace!("downloading image file: {}", file = path.display());
+                trace!("downloading image file: {}", path.display());
                 let sz = remote_client
                     .download_layer_file(&RelativePath::from_filename(path), &layer_metadata)
                     .await


### PR DESCRIPTION
```
warning: named argument `file` is not used by name
    --> pageserver/src/tenant/timeline.rs:1078:54
     |
1078 |                 trace!("downloading image file: {}", file = path.display());
     |                                                 --   ^^^^ this named argument is referred to by position in formatting string
     |                                                 |
     |                                                 this formatting argument uses named argument `file` by position
     |
     = note: `#[warn(named_arguments_used_positionally)]` on by default
help: use the named argument by name to avoid ambiguity
     |
1078 |                 trace!("downloading image file: {file}", file = path.display());
     |                                                  ++++

```