### PR TITLE
Remove redundant RemoteStorage parts

### DIFF
--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -33,6 +33,7 @@ fn remote_object_id_from_path(path: &Path) -> anyhow::Result<RemoteObjectId> {
     ))
 }
 
+#[derive(Debug, Clone)]
 pub struct LocalFs {
     working_directory: PathBuf,
     storage_root: PathBuf,

--- a/pageserver/src/storage_sync2.rs
+++ b/pageserver/src/storage_sync2.rs
@@ -217,7 +217,7 @@ use crate::metrics::RemoteOpKind;
 use crate::metrics::REMOTE_UPLOAD_QUEUE_UNFINISHED_TASKS;
 use crate::{
     config::PageServerConf,
-    storage_sync::index::{LayerFileMetadata, RelativePath},
+    storage_sync::index::{LayerFileMetadata, RemotePath},
     task_mgr,
     task_mgr::TaskKind,
     task_mgr::BACKGROUND_RUNTIME,
@@ -287,7 +287,7 @@ struct UploadQueueInitialized {
 
     /// All layer files stored in the remote storage, taking into account all
     /// in-progress and queued operations
-    latest_files: HashMap<RelativePath, LayerFileMetadata>,
+    latest_files: HashMap<RemotePath, LayerFileMetadata>,
 
     /// Metadata stored in the remote storage, taking into account all
     /// in-progress and queued operations.
@@ -510,7 +510,7 @@ impl RemoteTimelineClient {
     /// On success, returns the size of the downloaded file.
     pub async fn download_layer_file(
         &self,
-        path: &RelativePath,
+        path: &RemotePath,
         layer_metadata: &LayerFileMetadata,
     ) -> anyhow::Result<u64> {
         let downloaded_size = download::download_layer_file(
@@ -612,7 +612,7 @@ impl RemoteTimelineClient {
             "file size not initialized in metadata"
         );
 
-        let relative_path = RelativePath::strip_base_path(
+        let relative_path = RemotePath::strip_base_path(
             &self.conf.timeline_path(&self.timeline_id, &self.tenant_id),
             path,
         )?;
@@ -644,7 +644,7 @@ impl RemoteTimelineClient {
         // Convert the paths into RelativePaths, and gather other information we need.
         let mut relative_paths = Vec::with_capacity(paths.len());
         for path in paths {
-            relative_paths.push(RelativePath::strip_base_path(
+            relative_paths.push(RemotePath::strip_base_path(
                 &self.conf.timeline_path(&self.timeline_id, &self.tenant_id),
                 path,
             )?);
@@ -1093,7 +1093,7 @@ mod tests {
         TimelineMetadata::from_bytes(&metadata.to_bytes().unwrap()).unwrap()
     }
 
-    fn assert_file_list(a: &HashSet<RelativePath>, b: &[&str]) {
+    fn assert_file_list(a: &HashSet<RemotePath>, b: &[&str]) {
         let xx = PathBuf::from("");
         let mut avec: Vec<String> = a
             .iter()

--- a/pageserver/src/storage_sync2.rs
+++ b/pageserver/src/storage_sync2.rs
@@ -612,7 +612,7 @@ impl RemoteTimelineClient {
             "file size not initialized in metadata"
         );
 
-        let relative_path = RelativePath::from_local_path(
+        let relative_path = RelativePath::strip_base_path(
             &self.conf.timeline_path(&self.timeline_id, &self.tenant_id),
             path,
         )?;
@@ -644,7 +644,7 @@ impl RemoteTimelineClient {
         // Convert the paths into RelativePaths, and gather other information we need.
         let mut relative_paths = Vec::with_capacity(paths.len());
         for path in paths {
-            relative_paths.push(RelativePath::from_local_path(
+            relative_paths.push(RelativePath::strip_base_path(
                 &self.conf.timeline_path(&self.timeline_id, &self.tenant_id),
                 path,
             )?);

--- a/pageserver/src/storage_sync2/download.rs
+++ b/pageserver/src/storage_sync2/download.rs
@@ -15,7 +15,7 @@ use utils::crashsafe::path_with_suffix_extension;
 use utils::id::{TenantId, TimelineId};
 
 use super::index::IndexPart;
-use super::RelativePath;
+use super::RemotePath;
 
 async fn fsync_path(path: impl AsRef<std::path::Path>) -> Result<(), std::io::Error> {
     fs::File::open(path).await?.sync_all().await
@@ -31,7 +31,7 @@ pub async fn download_layer_file<'a>(
     storage: &'a GenericRemoteStorage,
     tenant_id: TenantId,
     timeline_id: TimelineId,
-    path: &'a RelativePath,
+    path: &'a RemotePath,
     layer_metadata: &'a LayerFileMetadata,
 ) -> anyhow::Result<u64> {
     let timeline_path = conf.timeline_path(&timeline_id, &tenant_id);

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1013,7 +1013,7 @@ impl Timeline {
         local_filenames.retain(|path| {
             let layer_metadata = index_part
                 .layer_metadata
-                .get(&RelativePath::from_filename(path))
+                .get(&RelativePath::new(path))
                 .map(LayerFileMetadata::from)
                 .unwrap_or(LayerFileMetadata::MISSING);
 
@@ -1062,7 +1062,7 @@ impl Timeline {
 
             let layer_metadata = index_part
                 .layer_metadata
-                .get(&RelativePath::from_filename(path))
+                .get(&RelativePath::new(path))
                 .map(LayerFileMetadata::from)
                 .unwrap_or(LayerFileMetadata::MISSING);
 
@@ -1077,7 +1077,7 @@ impl Timeline {
 
                 trace!("downloading image file: {}", path.display());
                 let sz = remote_client
-                    .download_layer_file(&RelativePath::from_filename(path), &layer_metadata)
+                    .download_layer_file(&RelativePath::new(path), &layer_metadata)
                     .await
                     .context("download image layer")?;
                 trace!("done");
@@ -1107,7 +1107,7 @@ impl Timeline {
 
                 trace!("downloading delta file: {}", path.display());
                 let sz = remote_client
-                    .download_layer_file(&RelativePath::from_filename(path), &layer_metadata)
+                    .download_layer_file(&RelativePath::new(path), &layer_metadata)
                     .await
                     .context("download delta layer")?;
                 trace!("done");

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicBool, AtomicI64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 use std::time::{Duration, Instant, SystemTime};
 
-use crate::storage_sync::index::{IndexPart, RelativePath};
+use crate::storage_sync::index::{IndexPart, RemotePath};
 use crate::storage_sync::RemoteTimelineClient;
 use crate::tenant::{
     delta_layer::{DeltaLayer, DeltaLayerWriter},
@@ -1013,7 +1013,7 @@ impl Timeline {
         local_filenames.retain(|path| {
             let layer_metadata = index_part
                 .layer_metadata
-                .get(&RelativePath::new(path))
+                .get(&RemotePath::new(path))
                 .map(LayerFileMetadata::from)
                 .unwrap_or(LayerFileMetadata::MISSING);
 
@@ -1062,7 +1062,7 @@ impl Timeline {
 
             let layer_metadata = index_part
                 .layer_metadata
-                .get(&RelativePath::new(path))
+                .get(&RemotePath::new(path))
                 .map(LayerFileMetadata::from)
                 .unwrap_or(LayerFileMetadata::MISSING);
 
@@ -1077,7 +1077,7 @@ impl Timeline {
 
                 trace!("downloading image file: {}", path.display());
                 let sz = remote_client
-                    .download_layer_file(&RelativePath::new(path), &layer_metadata)
+                    .download_layer_file(&RemotePath::new(path), &layer_metadata)
                     .await
                     .context("download image layer")?;
                 trace!("done");
@@ -1107,7 +1107,7 @@ impl Timeline {
 
                 trace!("downloading delta file: {}", path.display());
                 let sz = remote_client
-                    .download_layer_file(&RelativePath::new(path), &layer_metadata)
+                    .download_layer_file(&RemotePath::new(path), &layer_metadata)
                     .await
                     .context("download delta layer")?;
                 trace!("done");


### PR DESCRIPTION
Part of a bigger simplification refactoring: https://github.com/neondatabase/neon/pull/2993