### PR TITLE
test_bulk_update: use new prefetch settings

### DIFF
--- a/test_runner/performance/test_bulk_update.py
+++ b/test_runner/performance/test_bulk_update.py
@@ -42,7 +42,8 @@ def test_bulk_update(neon_env_builder: NeonEnvBuilder, zenbenchmark, fillfactor)
 
     cur.execute("drop table t")
     cur.execute("set enable_seqscan_prefetch=on")
-    cur.execute("set seqscan_prefetch_buffers=100")
+    cur.execute("set effective_io_concurrency=32")
+    cur.execute("set maintenance_io_concurrency=32")
 
     cur.execute(f"create table t2(x integer) WITH (fillfactor={fillfactor})")
 


### PR DESCRIPTION
Replace `seqscan_prefetch_buffers` with `effective_io_concurrency` & `maintenance_io_concurrency` in one more place (the last one!)

The settings `seqscan_prefetch_buffers` was set to 100 (instead of the usual 10) in the test. Should we also give  `effective_io_concurrency` & `maintenance_io_concurrency` larger values?