### PR TITLE
tone down error log for successful process termination

### DIFF
--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -922,8 +922,7 @@ impl NoLeakChild {
 
         match child.wait() {
             Ok(exit_status) => {
-                // log at error level since .kill() is something we only do on errors ATM
-                error!(exit_status = %exit_status, "wait successful");
+                info!(exit_status = %exit_status, "wait successful");
             }
             Err(e) => {
                 error!(error = %e, "wait error; might leak the child process; it will show as zombie (defunct)");


### PR DESCRIPTION
> // log at error level since .kill() is something we only do on errors ATM

Since it is called on drop it is expected to be called from detach which is ok

Found it while looking through logs on staging. There are messages with exit status 0 or by signal 9