### PR TITLE
Fix tenant config parsing

### DIFF
--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -492,7 +492,7 @@ impl PageServerConf {
         let mut builder = PageServerConfigBuilder::default();
         builder.workdir(workdir.to_owned());
 
-        let mut t_conf: TenantConfOpt = Default::default();
+        let mut t_conf = TenantConfOpt::default();
 
         for (key, item) in toml.iter() {
             match key {
@@ -622,6 +622,12 @@ impl PageServerConf {
         }
         if let Some(max_lsn_wal_lag) = item.get("max_lsn_wal_lag") {
             t_conf.max_lsn_wal_lag = Some(parse_toml_from_str("max_lsn_wal_lag", max_lsn_wal_lag)?);
+        }
+        if let Some(trace_read_requests) = item.get("trace_read_requests") {
+            t_conf.trace_read_requests =
+                Some(trace_read_requests.as_bool().with_context(|| {
+                    "configure option trace_read_requests is not a bool".to_string()
+                })?);
         }
 
         Ok(t_conf)
@@ -1019,6 +1025,35 @@ broker_endpoints = ['{broker_endpoint}']
                 "Remote storage config should correctly parse the S3 config"
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn parse_tenant_config() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let (workdir, pg_distrib_dir) = prepare_fs(&tempdir)?;
+
+        let broker_endpoint = "http://127.0.0.1:7777";
+        let trace_read_requests = true;
+
+        let config_string = format!(
+            r#"{ALL_BASE_VALUES_TOML}
+pg_distrib_dir='{}'
+broker_endpoints = ['{broker_endpoint}']
+
+[tenant_config]
+trace_read_requests = {trace_read_requests}"#,
+            pg_distrib_dir.display(),
+        );
+
+        let toml = config_string.parse()?;
+
+        let conf = PageServerConf::parse_and_validate(&toml, &workdir)?;
+        assert_eq!(
+            conf.default_tenant_conf.trace_read_requests, trace_read_requests,
+            "Tenant config from pageserver config file should be parsed and udpated values used as defaults for all tenants",
+        );
+
         Ok(())
     }
 

--- a/test_runner/regress/test_read_trace.py
+++ b/test_runner/regress/test_read_trace.py
@@ -1,10 +1,14 @@
 from contextlib import closing
 
-from fixtures.neon_fixtures import NeonEnvBuilder
+from fixtures.neon_fixtures import NeonEnvBuilder, wait_for_last_record_lsn
+from fixtures.types import Lsn, TenantId, TimelineId
+from fixtures.utils import query_scalar
 
 
 # This test demonstrates how to collect a read trace. It's useful until
 # it gets replaced by a test that actually does stuff with the trace.
+#
+# Additionally, tests that pageserver is able to create tenants with custom configs.
 def test_read_request_tracing(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.num_safekeepers = 1
     env = neon_env_builder.init_start()
@@ -23,6 +27,12 @@ def test_read_request_tracing(neon_env_builder: NeonEnvBuilder):
             cur.execute("create table t (i integer);")
             cur.execute(f"insert into t values (generate_series(1,{10000}));")
             cur.execute("select count(*) from t;")
+            tenant_id = TenantId(pg.safe_psql("show neon.tenant_id")[0][0])
+            timeline_id = TimelineId(pg.safe_psql("show neon.timeline_id")[0][0])
+            current_lsn = Lsn(query_scalar(cur, "SELECT pg_current_wal_flush_lsn()"))
+    # wait until pageserver receives that data
+    pageserver_http = env.pageserver.http_client()
+    wait_for_last_record_lsn(pageserver_http, tenant_id, timeline_id, current_lsn)
 
     # Stop pg so we drop the connection and flush the traces
     pg.stop()


### PR DESCRIPTION
Adds missing `trace_read_requests` field parsing to the tenant config code, this fixing recent benchmark failures, example of the CI run:
https://github.com/neondatabase/neon/actions/runs/3631064366

I've moved the test to the regression suite, since it's very short and turned to be useful.

Generally, the whole tenant config code would benefit from further improvements, but let's keep the fixes first and small.