### PR TITLE
Add sleep after pg.stop() in check_restored_datadir_content for taking basebackup.

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2828,6 +2828,10 @@ def check_restored_datadir_content(
     # stop postgres to ensure that files won't change
     pg.stop()
 
+    # pg.stop() doesn't wait for backends termination so it can happen that there still be some transactions
+    # after returning from pg.stop(). Just make small pause to let postgres to terminate before taking basebackup
+    time.sleep(1)
+
     # Take a basebackup from pageserver
     restored_dir_path = env.repo_dir / f"{pg.node_name}_restored_datadir"
     restored_dir_path.mkdir(exist_ok=True)


### PR DESCRIPTION
pg.stop) is not waiting for  postgres backends termination, so with very small probability there can be still active tranactions after returning from pg.stop() which cause differences in pg_xacts with restored directory