### PR TITLE
refactor: use new type LayerFileName when referring to layer file names in PathBuf/RemotePath

### DIFF
--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -142,7 +142,7 @@ impl std::fmt::Display for DownloadError {
                 write!(f, "Failed to download a remote file due to user input: {e}")
             }
             DownloadError::NotFound => write!(f, "No file found for the remote object id given"),
-            DownloadError::Other(e) => write!(f, "Failed to download a remote file: {e}"),
+            DownloadError::Other(e) => write!(f, "Failed to download a remote file: {e:?}"),
         }
     }
 }

--- a/pageserver/benches/bench_layer_map.rs
+++ b/pageserver/benches/bench_layer_map.rs
@@ -62,10 +62,6 @@ impl Layer for DummyDelta {
         true
     }
 
-    fn is_in_memory(&self) -> bool {
-        false
-    }
-
     fn iter(&self) -> Box<dyn Iterator<Item = Result<(Key, Lsn, Value)>> + '_> {
         panic!()
     }
@@ -124,10 +120,6 @@ impl Layer for DummyImage {
     }
 
     fn is_incremental(&self) -> bool {
-        false
-    }
-
-    fn is_in_memory(&self) -> bool {
         false
     }
 

--- a/pageserver/benches/bench_layer_map.rs
+++ b/pageserver/benches/bench_layer_map.rs
@@ -40,16 +40,16 @@ impl PureLayer for DummyDelta {
         panic!()
     }
 
-    fn dump(&self, _verbose: bool) -> Result<()> {
-        todo!()
-    }
-
     fn is_incremental(&self) -> bool {
         true
     }
 
+    fn dump(&self, _verbose: bool) -> Result<()> {
+        unimplemented!()
+    }
+
     fn short_id(&self) -> String {
-        todo!()
+        unimplemented!()
     }
 }
 
@@ -82,11 +82,11 @@ impl PureLayer for DummyImage {
     }
 
     fn dump(&self, _verbose: bool) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
 
     fn short_id(&self) -> String {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/pageserver/benches/bench_layer_map.rs
+++ b/pageserver/benches/bench_layer_map.rs
@@ -3,7 +3,7 @@ use pageserver::repository::Key;
 use pageserver::tenant::filename::{DeltaFileName, ImageFileName};
 use pageserver::tenant::layer_map::LayerMap;
 use pageserver::tenant::storage_layer::ValueReconstructState;
-use pageserver::tenant::storage_layer::{PureLayer, ValueReconstructResult};
+use pageserver::tenant::storage_layer::{Layer, ValueReconstructResult};
 use rand::prelude::{SeedableRng, SliceRandom, StdRng};
 use std::cmp::{max, min};
 use std::fs::File;
@@ -23,7 +23,7 @@ struct DummyDelta {
     lsn_range: Range<Lsn>,
 }
 
-impl PureLayer for DummyDelta {
+impl Layer for DummyDelta {
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -58,7 +58,7 @@ struct DummyImage {
     lsn: Lsn,
 }
 
-impl PureLayer for DummyImage {
+impl Layer for DummyImage {
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -90,8 +90,8 @@ impl PureLayer for DummyImage {
     }
 }
 
-fn build_layer_map(filename_dump: PathBuf) -> LayerMap<dyn PureLayer> {
-    let mut layer_map = LayerMap::<dyn PureLayer>::default();
+fn build_layer_map(filename_dump: PathBuf) -> LayerMap<dyn Layer> {
+    let mut layer_map = LayerMap::<dyn Layer>::default();
 
     let mut min_lsn = Lsn(u64::MAX);
     let mut max_lsn = Lsn(0);
@@ -127,7 +127,7 @@ fn build_layer_map(filename_dump: PathBuf) -> LayerMap<dyn PureLayer> {
 }
 
 /// Construct a layer map query pattern for benchmarks
-fn uniform_query_pattern(layer_map: &LayerMap<dyn PureLayer>) -> Vec<(Key, Lsn)> {
+fn uniform_query_pattern(layer_map: &LayerMap<dyn Layer>) -> Vec<(Key, Lsn)> {
     // For each image layer we query one of the pages contained, at LSN right
     // before the image layer was created. This gives us a somewhat uniform
     // coverage of both the lsn and key space because image layers have
@@ -200,7 +200,7 @@ fn bench_from_real_project(c: &mut Criterion) {
 
 // Benchmark using synthetic data. Arrange image layers on stacked diagonal lines.
 fn bench_sequential(c: &mut Criterion) {
-    let mut layer_map: LayerMap<dyn PureLayer> = LayerMap::default();
+    let mut layer_map: LayerMap<dyn Layer> = LayerMap::default();
 
     // Init layer map. Create 100_000 layers arranged in 1000 diagonal lines.
     //

--- a/pageserver/src/storage_sync2.rs
+++ b/pageserver/src/storage_sync2.rs
@@ -197,12 +197,11 @@ pub use download::{is_temp_download_file, list_remote_timelines};
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::ops::DerefMut;
-use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
 use anyhow::ensure;
-use remote_storage::{DownloadError, GenericRemoteStorage, RemotePath};
+use remote_storage::{DownloadError, GenericRemoteStorage};
 use tokio::runtime::Runtime;
 use tracing::{info, warn};
 use tracing::{info_span, Instrument};
@@ -215,6 +214,7 @@ use crate::metrics::MeasureRemoteOp;
 use crate::metrics::RemoteOpFileKind;
 use crate::metrics::RemoteOpKind;
 use crate::metrics::REMOTE_UPLOAD_QUEUE_UNFINISHED_TASKS;
+use crate::tenant::filename::LayerFileName;
 use crate::{
     config::PageServerConf,
     storage_sync::index::LayerFileMetadata,
@@ -287,7 +287,7 @@ struct UploadQueueInitialized {
 
     /// All layer files stored in the remote storage, taking into account all
     /// in-progress and queued operations
-    latest_files: HashMap<RemotePath, LayerFileMetadata>,
+    latest_files: HashMap<LayerFileName, LayerFileMetadata>,
 
     /// Metadata stored in the remote storage, taking into account all
     /// in-progress and queued operations.
@@ -357,10 +357,6 @@ impl UploadQueue {
 
     fn initialize_with_current_remote_index_part(
         &mut self,
-        conf: &'static PageServerConf,
-        tenant_id: TenantId,
-        timeline_id: TimelineId,
-
         index_part: &IndexPart,
     ) -> anyhow::Result<&mut UploadQueueInitialized> {
         match self {
@@ -371,18 +367,13 @@ impl UploadQueue {
         }
 
         let mut files = HashMap::with_capacity(index_part.timeline_layers.len());
-        let timeline_path = conf.timeline_path(&timeline_id, &tenant_id);
-        for timeline_name in &index_part.timeline_layers {
-            let local_path = timeline_path.join(timeline_name);
-            let remote_timeline_path = conf.remote_path(&local_path).expect(
-                "Remote timeline path and local timeline path were constructed form the same conf",
-            );
+        for layer_name in &index_part.timeline_layers {
             let layer_metadata = index_part
                 .layer_metadata
-                .get(timeline_name)
+                .get(&layer_name)
                 .map(LayerFileMetadata::from)
                 .unwrap_or(LayerFileMetadata::MISSING);
-            files.insert(remote_timeline_path, layer_metadata);
+            files.insert(layer_name.to_owned(), layer_metadata);
         }
 
         let index_part_metadata = index_part.parse_metadata()?;
@@ -431,13 +422,13 @@ struct UploadTask {
 #[derive(Debug)]
 enum UploadOp {
     /// Upload a layer file
-    UploadLayer(PathBuf, LayerFileMetadata),
+    UploadLayer(LayerFileName, LayerFileMetadata),
 
     /// Upload the metadata file
     UploadMetadata(IndexPart, Lsn),
 
     /// Delete a file.
-    Delete(RemoteOpFileKind, PathBuf),
+    Delete(RemoteOpFileKind, LayerFileName),
 
     /// Barrier. When the barrier operation is reached,
     Barrier(tokio::sync::watch::Sender<()>),
@@ -446,12 +437,14 @@ enum UploadOp {
 impl std::fmt::Display for UploadOp {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            UploadOp::UploadLayer(path, metadata) => write!(
-                f,
-                "UploadLayer({}, size={:?})",
-                path.display(),
-                metadata.file_size()
-            ),
+            UploadOp::UploadLayer(path, metadata) => {
+                write!(
+                    f,
+                    "UploadLayer({}, size={:?})",
+                    path.display(),
+                    metadata.file_size()
+                )
+            }
             UploadOp::UploadMetadata(_, lsn) => write!(f, "UploadMetadata(lsn: {})", lsn),
             UploadOp::Delete(_, path) => write!(f, "Delete({})", path.display()),
             UploadOp::Barrier(_) => write!(f, "Barrier"),
@@ -465,12 +458,7 @@ impl RemoteTimelineClient {
     /// The given `index_part` must be the one on the remote.
     pub fn init_upload_queue(&self, index_part: &IndexPart) -> anyhow::Result<()> {
         let mut upload_queue = self.upload_queue.lock().unwrap();
-        upload_queue.initialize_with_current_remote_index_part(
-            self.conf,
-            self.tenant_id,
-            self.timeline_id,
-            index_part,
-        )?;
+        upload_queue.initialize_with_current_remote_index_part(index_part)?;
         Ok(())
     }
 
@@ -524,13 +512,15 @@ impl RemoteTimelineClient {
     /// On success, returns the size of the downloaded file.
     pub async fn download_layer_file(
         &self,
-        remote_path: &RemotePath,
+        layer_file_name: &LayerFileName,
         layer_metadata: &LayerFileMetadata,
     ) -> anyhow::Result<u64> {
         let downloaded_size = download::download_layer_file(
             self.conf,
             &self.storage_impl,
-            remote_path,
+            self.tenant_id,
+            self.timeline_id,
+            layer_file_name,
             layer_metadata,
         )
         .measure_remote_op(
@@ -548,13 +538,13 @@ impl RemoteTimelineClient {
             let new_metadata = LayerFileMetadata::new(downloaded_size);
             let mut guard = self.upload_queue.lock().unwrap();
             let upload_queue = guard.initialized_mut()?;
-            if let Some(upgraded) = upload_queue.latest_files.get_mut(remote_path) {
+            if let Some(upgraded) = upload_queue.latest_files.get_mut(layer_file_name) {
                 upgraded.merge(&new_metadata);
             } else {
                 // The file should exist, since we just downloaded it.
                 warn!(
                     "downloaded file {:?} not found in local copy of the index file",
-                    remote_path
+                    layer_file_name
                 );
             }
         }
@@ -611,7 +601,7 @@ impl RemoteTimelineClient {
     ///
     pub fn schedule_layer_file_upload(
         self: &Arc<Self>,
-        path: &Path,
+        layer_file_name: &LayerFileName,
         layer_metadata: &LayerFileMetadata,
     ) -> anyhow::Result<()> {
         let mut guard = self.upload_queue.lock().unwrap();
@@ -626,13 +616,13 @@ impl RemoteTimelineClient {
 
         upload_queue
             .latest_files
-            .insert(self.conf.remote_path(path)?, layer_metadata.clone());
+            .insert(layer_file_name.clone(), layer_metadata.clone());
 
-        let op = UploadOp::UploadLayer(PathBuf::from(path), layer_metadata.clone());
+        let op = UploadOp::UploadLayer(layer_file_name.clone(), layer_metadata.clone());
         self.update_upload_queue_unfinished_metric(1, &op);
         upload_queue.queued_operations.push_back(op);
 
-        info!("scheduled layer file upload {}", path.display());
+        info!("scheduled layer file upload {}", layer_file_name.display());
 
         // Launch the task immediately, if possible
         self.launch_queued_tasks(upload_queue);
@@ -644,15 +634,12 @@ impl RemoteTimelineClient {
     ///
     /// The deletion won't actually be performed, until all preceding
     /// upload operations have completed succesfully.
-    pub fn schedule_layer_file_deletion(self: &Arc<Self>, paths: &[PathBuf]) -> anyhow::Result<()> {
+    pub fn schedule_layer_file_deletion(
+        self: &Arc<Self>,
+        names: &[LayerFileName],
+    ) -> anyhow::Result<()> {
         let mut guard = self.upload_queue.lock().unwrap();
         let upload_queue = guard.initialized_mut()?;
-
-        // Convert the paths into RemotePaths, and gather other information we need.
-        let mut remote_paths = Vec::with_capacity(paths.len());
-        for path in paths {
-            remote_paths.push(self.conf.remote_path(path)?);
-        }
 
         // Deleting layers doesn't affect the values stored in TimelineMetadata,
         // so we don't need update it. Just serialize it.
@@ -667,8 +654,8 @@ impl RemoteTimelineClient {
         // from latest_files, but not yet scheduled for deletion. Use a closure
         // to syntactically forbid ? or bail! calls here.
         let no_bail_here = || {
-            for remote_path in remote_paths {
-                upload_queue.latest_files.remove(&remote_path);
+            for name in names {
+                upload_queue.latest_files.remove(name);
             }
 
             let index_part = IndexPart::new(
@@ -681,11 +668,11 @@ impl RemoteTimelineClient {
             upload_queue.queued_operations.push_back(op);
 
             // schedule the actual deletions
-            for path in paths {
-                let op = UploadOp::Delete(RemoteOpFileKind::Layer, PathBuf::from(path));
+            for name in names {
+                let op = UploadOp::Delete(RemoteOpFileKind::Layer, name.clone());
                 self.update_upload_queue_unfinished_metric(1, &op);
                 upload_queue.queued_operations.push_back(op);
-                info!("scheduled layer file deletion {}", path.display());
+                info!("scheduled layer file deletion {}", name.display());
             }
 
             // Launch the tasks immediately, if possible
@@ -841,9 +828,13 @@ impl RemoteTimelineClient {
             }
 
             let upload_result: anyhow::Result<()> = match &task.op {
-                UploadOp::UploadLayer(ref path, ref layer_metadata) => {
+                UploadOp::UploadLayer(ref layer_file_name, ref layer_metadata) => {
+                    let path = &self
+                        .conf
+                        .timeline_path(&self.timeline_id, &self.tenant_id)
+                        .join(layer_file_name.file_name());
                     upload::upload_timeline_layer(
-                        self.conf,
+                        &self.conf,
                         &self.storage_impl,
                         path,
                         layer_metadata,
@@ -872,8 +863,12 @@ impl RemoteTimelineClient {
                     )
                     .await
                 }
-                UploadOp::Delete(metric_file_kind, ref path) => {
-                    delete::delete_layer(self.conf, &self.storage_impl, path)
+                UploadOp::Delete(metric_file_kind, ref layer_file_name) => {
+                    let path = &self
+                        .conf
+                        .timeline_path(&self.timeline_id, &self.tenant_id)
+                        .join(layer_file_name.file_name());
+                    delete::delete_layer(&self.conf, &self.storage_impl, path)
                         .measure_remote_op(
                             self.tenant_id,
                             self.timeline_id,
@@ -1078,7 +1073,7 @@ mod tests {
     use super::*;
     use crate::tenant::harness::{TenantHarness, TIMELINE_ID};
     use remote_storage::{RemoteStorageConfig, RemoteStorageKind};
-    use std::collections::HashSet;
+    use std::{collections::HashSet, path::Path};
     use utils::lsn::Lsn;
 
     pub(super) fn dummy_contents(name: &str) -> Vec<u8> {
@@ -1102,8 +1097,8 @@ mod tests {
         TimelineMetadata::from_bytes(&metadata.to_bytes().unwrap()).unwrap()
     }
 
-    fn assert_file_list(a: &HashSet<String>, b: &[&str]) {
-        let mut avec: Vec<&str> = a.iter().map(|a| a.as_str()).collect();
+    fn assert_file_list(a: &HashSet<LayerFileName>, b: &[&str]) {
+        let mut avec: Vec<String> = a.iter().map(|x| x.file_name()).collect();
         avec.sort();
 
         let mut bvec = b.to_vec();
@@ -1198,11 +1193,11 @@ mod tests {
         std::fs::write(timeline_path.join("bar"), &content_bar)?;
 
         client.schedule_layer_file_upload(
-            &timeline_path.join("foo"),
+            &LayerFileName::Test("foo".to_owned()),
             &LayerFileMetadata::new(content_foo.len() as u64),
         )?;
         client.schedule_layer_file_upload(
-            &timeline_path.join("bar"),
+            &LayerFileName::Test("bar".to_owned()),
             &LayerFileMetadata::new(content_bar.len() as u64),
         )?;
 
@@ -1244,10 +1239,10 @@ mod tests {
         let content_baz = dummy_contents("baz");
         std::fs::write(timeline_path.join("baz"), &content_baz)?;
         client.schedule_layer_file_upload(
-            &timeline_path.join("baz"),
+            &LayerFileName::Test("baz".to_owned()),
             &LayerFileMetadata::new(content_baz.len() as u64),
         )?;
-        client.schedule_layer_file_deletion(&[timeline_path.join("foo")])?;
+        client.schedule_layer_file_deletion(&[LayerFileName::Test("foo".to_owned())])?;
         {
             let mut guard = client.upload_queue.lock().unwrap();
             let upload_queue = guard.initialized_mut().unwrap();

--- a/pageserver/src/storage_sync2.rs
+++ b/pageserver/src/storage_sync2.rs
@@ -441,12 +441,12 @@ impl std::fmt::Display for UploadOp {
                 write!(
                     f,
                     "UploadLayer({}, size={:?})",
-                    path.display(),
+                    path.file_name(),
                     metadata.file_size()
                 )
             }
             UploadOp::UploadMetadata(_, lsn) => write!(f, "UploadMetadata(lsn: {})", lsn),
-            UploadOp::Delete(_, path) => write!(f, "Delete({})", path.display()),
+            UploadOp::Delete(_, path) => write!(f, "Delete({})", path.file_name()),
             UploadOp::Barrier(_) => write!(f, "Barrier"),
         }
     }
@@ -622,7 +622,10 @@ impl RemoteTimelineClient {
         self.update_upload_queue_unfinished_metric(1, &op);
         upload_queue.queued_operations.push_back(op);
 
-        info!("scheduled layer file upload {}", layer_file_name.display());
+        info!(
+            "scheduled layer file upload {}",
+            layer_file_name.file_name()
+        );
 
         // Launch the task immediately, if possible
         self.launch_queued_tasks(upload_queue);
@@ -672,7 +675,7 @@ impl RemoteTimelineClient {
                 let op = UploadOp::Delete(RemoteOpFileKind::Layer, name.clone());
                 self.update_upload_queue_unfinished_metric(1, &op);
                 upload_queue.queued_operations.push_back(op);
-                info!("scheduled layer file deletion {}", name.display());
+                info!("scheduled layer file deletion {}", name.file_name());
             }
 
             // Launch the tasks immediately, if possible

--- a/pageserver/src/storage_sync2.rs
+++ b/pageserver/src/storage_sync2.rs
@@ -370,7 +370,7 @@ impl UploadQueue {
         for layer_name in &index_part.timeline_layers {
             let layer_metadata = index_part
                 .layer_metadata
-                .get(&layer_name)
+                .get(layer_name)
                 .map(LayerFileMetadata::from)
                 .unwrap_or(LayerFileMetadata::MISSING);
             files.insert(layer_name.to_owned(), layer_metadata);
@@ -837,7 +837,7 @@ impl RemoteTimelineClient {
                         .timeline_path(&self.timeline_id, &self.tenant_id)
                         .join(layer_file_name.file_name());
                     upload::upload_timeline_layer(
-                        &self.conf,
+                        self.conf,
                         &self.storage_impl,
                         path,
                         layer_metadata,
@@ -871,7 +871,7 @@ impl RemoteTimelineClient {
                         .conf
                         .timeline_path(&self.timeline_id, &self.tenant_id)
                         .join(layer_file_name.file_name());
-                    delete::delete_layer(&self.conf, &self.storage_impl, path)
+                    delete::delete_layer(self.conf, &self.storage_impl, path)
                         .measure_remote_op(
                             self.tenant_id,
                             self.timeline_id,

--- a/pageserver/src/storage_sync2/download.rs
+++ b/pageserver/src/storage_sync2/download.rs
@@ -10,11 +10,12 @@ use tracing::debug;
 
 use crate::config::PageServerConf;
 use crate::storage_sync::index::LayerFileMetadata;
-use remote_storage::{DownloadError, GenericRemoteStorage, RemotePath};
+use crate::tenant::filename::LayerFileName;
+use remote_storage::{DownloadError, GenericRemoteStorage};
 use utils::crashsafe::path_with_suffix_extension;
 use utils::id::{TenantId, TimelineId};
 
-use super::index::IndexPart;
+use super::index::{IndexPart, IndexPartUnclean};
 
 async fn fsync_path(path: impl AsRef<std::path::Path>) -> Result<(), std::io::Error> {
     fs::File::open(path).await?.sync_all().await
@@ -28,10 +29,16 @@ async fn fsync_path(path: impl AsRef<std::path::Path>) -> Result<(), std::io::Er
 pub async fn download_layer_file<'a>(
     conf: &'static PageServerConf,
     storage: &'a GenericRemoteStorage,
-    remote_path: &'a RemotePath,
+    tenant_id: TenantId,
+    timeline_id: TimelineId,
+    layer_file_name: &'a LayerFileName,
     layer_metadata: &'a LayerFileMetadata,
 ) -> anyhow::Result<u64> {
-    let local_path = conf.local_path(remote_path);
+    let timeline_path = conf.timeline_path(&timeline_id, &tenant_id);
+
+    let local_path = timeline_path.join(layer_file_name.file_name());
+
+    let remote_path = conf.remote_path(&local_path)?;
 
     // Perform a rename inspired by durable_rename from file_utils.c.
     // The sequence:
@@ -52,7 +59,7 @@ pub async fn download_layer_file<'a>(
             temp_file_path.display()
         )
     })?;
-    let mut download = storage.download(remote_path).await.with_context(|| {
+    let mut download = storage.download(&remote_path).await.with_context(|| {
         format!(
             "Failed to open a download stream for layer with remote storage path '{remote_path:?}'"
         )
@@ -211,11 +218,13 @@ pub async fn download_index_part(
     .with_context(|| format!("Failed to download an index part into file {index_part_path:?}"))
     .map_err(DownloadError::Other)?;
 
-    let index_part: IndexPart = serde_json::from_slice(&index_part_bytes)
+    let index_part: IndexPartUnclean = serde_json::from_slice(&index_part_bytes)
         .with_context(|| {
             format!("Failed to deserialize index part file into file {index_part_path:?}")
         })
         .map_err(DownloadError::Other)?;
+
+    let index_part = index_part.remove_unclean_layer_file_names();
 
     Ok(index_part)
 }

--- a/pageserver/src/storage_sync2/download.rs
+++ b/pageserver/src/storage_sync2/download.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Context};
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
-use tracing::debug;
+use tracing::{debug, info_span, Instrument};
 
 use crate::config::PageServerConf;
 use crate::storage_sync::index::LayerFileMetadata;
@@ -176,7 +176,9 @@ pub async fn list_remote_timelines<'a>(
             part_downloads.push(async move {
                 (
                     timeline_id,
-                    download_index_part(conf, &storage_clone, tenant_id, timeline_id).await,
+                    download_index_part(conf, &storage_clone, tenant_id, timeline_id)
+                        .instrument(info_span!("download_index_part", timeline=%timeline_id))
+                        .await,
                 )
             });
         }

--- a/pageserver/src/storage_sync2/index.rs
+++ b/pageserver/src/storage_sync2/index.rs
@@ -4,11 +4,12 @@
 
 use std::collections::{HashMap, HashSet};
 
-use remote_storage::RemotePath;
+use std::convert::TryFrom;
+
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
-use crate::tenant::metadata::TimelineMetadata;
+use crate::tenant::{filename::LayerFileName, metadata::TimelineMetadata};
 
 use utils::lsn::Lsn;
 
@@ -62,7 +63,10 @@ impl LayerFileMetadata {
 /// remember to add a test case for the changed version.
 #[serde_as]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct IndexPart {
+pub struct IndexPartImpl<L>
+where
+    L: std::hash::Hash + PartialEq + Eq,
+{
     /// Debugging aid describing the version of this type.
     #[serde(default)]
     version: usize,
@@ -70,25 +74,115 @@ pub struct IndexPart {
     /// Layer names, which are stored on the remote storage.
     ///
     /// Additional metadata can might exist in `layer_metadata`.
-    pub timeline_layers: HashSet<String>,
+    pub timeline_layers: HashSet<L>,
 
     /// FIXME: unused field. This should be removed, but that changes the on-disk format,
     /// so we need to make sure we're backwards-` (and maybe forwards-) compatible
     /// First pass is to move it to Optional and the next would be its removal
-    missing_layers: Option<HashSet<String>>,
+    missing_layers: Option<HashSet<L>>,
 
     /// Per layer file name metadata, which can be present for a present or missing layer file.
     ///
     /// Older versions of `IndexPart` will not have this property or have only a part of metadata
     /// that latest version stores.
-    #[serde(default)]
-    pub layer_metadata: HashMap<String, IndexLayerMetadata>,
+    #[serde(default = "HashMap::default")]
+    pub layer_metadata: HashMap<L, IndexLayerMetadata>,
 
     // 'disk_consistent_lsn' is a copy of the 'disk_consistent_lsn' in the metadata.
     // It's duplicated here for convenience.
     #[serde_as(as = "DisplayFromStr")]
     pub disk_consistent_lsn: Lsn,
     metadata_bytes: Vec<u8>,
+}
+
+pub type IndexPart = IndexPartImpl<LayerFileName>;
+
+pub type IndexPartUnclean = IndexPartImpl<UncleanLayerFileName>;
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum UncleanLayerFileName {
+    Clean(LayerFileName),
+    BackupFile(String),
+}
+
+impl<'de> serde::Deserialize<'de> for UncleanLayerFileName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_string(UncleanLayerFileNameVisitor)
+    }
+}
+
+struct UncleanLayerFileNameVisitor;
+
+impl<'de> serde::de::Visitor<'de> for UncleanLayerFileNameVisitor {
+    type Value = UncleanLayerFileName;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            formatter,
+            "a string that is a valid LayerFileName or '.old' backup file name"
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match LayerFileName::try_from(v) {
+            Ok(clean) => Ok(UncleanLayerFileName::Clean(clean)),
+            Err(e) => {
+                if v.ends_with(".old") {
+                    Ok(UncleanLayerFileName::BackupFile(v.to_owned()))
+                } else {
+                    Err(E::custom(e))
+                }
+            }
+        }
+    }
+}
+
+impl UncleanLayerFileName {
+    fn into_clean(self) -> Option<LayerFileName> {
+        match self {
+            UncleanLayerFileName::Clean(clean) => Some(clean),
+            UncleanLayerFileName::BackupFile(_) => None,
+        }
+    }
+}
+
+impl IndexPartUnclean {
+    pub fn remove_unclean_layer_file_names(self) -> IndexPart {
+        let IndexPartUnclean {
+            version,
+            timeline_layers,
+            missing_layers,
+            layer_metadata,
+            disk_consistent_lsn,
+            metadata_bytes,
+        } = self;
+
+        IndexPart {
+            version,
+            timeline_layers: timeline_layers
+                .into_iter()
+                .filter_map(UncleanLayerFileName::into_clean)
+                .collect(),
+            missing_layers: missing_layers.map(|missing_layers| {
+                missing_layers
+                    .into_iter()
+                    .filter_map(UncleanLayerFileName::into_clean)
+                    .collect()
+            }),
+            layer_metadata: layer_metadata
+                .into_iter()
+                .filter_map(|(l, m)| l.into_clean().map(|l| (l, m)))
+                .collect(),
+            disk_consistent_lsn,
+            metadata_bytes,
+        }
+    }
 }
 
 impl IndexPart {
@@ -100,23 +194,17 @@ impl IndexPart {
     pub const FILE_NAME: &'static str = "index_part.json";
 
     pub fn new(
-        layers_and_metadata: HashMap<RemotePath, LayerFileMetadata>,
+        layers_and_metadata: HashMap<LayerFileName, LayerFileMetadata>,
         disk_consistent_lsn: Lsn,
         metadata_bytes: Vec<u8>,
     ) -> Self {
         let mut timeline_layers = HashSet::with_capacity(layers_and_metadata.len());
         let mut layer_metadata = HashMap::with_capacity(layers_and_metadata.len());
 
-        for (remote_path, metadata) in &layers_and_metadata {
+        for (remote_name, metadata) in &layers_and_metadata {
+            timeline_layers.insert(remote_name.to_owned());
             let metadata = IndexLayerMetadata::from(metadata);
-            match remote_path.object_name() {
-                Some(layer_name) => {
-                    timeline_layers.insert(layer_name.to_owned());
-                    layer_metadata.insert(layer_name.to_owned(), metadata);
-                }
-                // TODO move this on a type level: we know, that every layer entry does have a name
-                None => panic!("Layer {remote_path:?} has no file name, skipping"),
-            }
+            layer_metadata.insert(remote_name.to_owned(), metadata);
         }
 
         Self {
@@ -156,21 +244,22 @@ mod tests {
     fn v0_indexpart_is_parsed() {
         let example = r#"{
             "timeline_layers":["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9"],
-            "missing_layers":["not_a_real_layer_but_adding_coverage"],
+            "missing_layers":["LAYER_FILE_NAME::test/not_a_real_layer_but_adding_coverage"],
             "disk_consistent_lsn":"0/16960E8",
             "metadata_bytes":[113,11,159,210,0,54,0,4,0,0,0,0,1,105,96,232,1,0,0,0,0,1,105,96,112,0,0,0,0,0,0,0,0,0,0,0,0,0,1,105,96,112,0,0,0,0,1,105,96,112,0,0,0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
         }"#;
 
         let expected = IndexPart {
             version: 0,
-            timeline_layers: HashSet::from([String::from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9")]),
-            missing_layers: Some(HashSet::from([String::from("not_a_real_layer_but_adding_coverage")])),
+            timeline_layers: HashSet::from([LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap()]),
+            missing_layers: Some(HashSet::from([LayerFileName::new_test("not_a_real_layer_but_adding_coverage")])),
             layer_metadata: HashMap::default(),
             disk_consistent_lsn: "0/16960E8".parse::<Lsn>().unwrap(),
             metadata_bytes: [113,11,159,210,0,54,0,4,0,0,0,0,1,105,96,232,1,0,0,0,0,1,105,96,112,0,0,0,0,0,0,0,0,0,0,0,0,0,1,105,96,112,0,0,0,0,1,105,96,112,0,0,0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0].to_vec(),
         };
 
-        let part = serde_json::from_str::<IndexPart>(example).unwrap();
+        let part: IndexPartUnclean = serde_json::from_str(example).unwrap();
+        let part = part.remove_unclean_layer_file_names();
         assert_eq!(part, expected);
     }
 
@@ -179,10 +268,10 @@ mod tests {
         let example = r#"{
             "version":1,
             "timeline_layers":["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9"],
-            "missing_layers":["not_a_real_layer_but_adding_coverage"],
+            "missing_layers":["LAYER_FILE_NAME::test/not_a_real_layer_but_adding_coverage"],
             "layer_metadata":{
                 "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9": { "file_size": 25600000 },
-                "not_a_real_layer_but_adding_coverage": { "file_size": 9007199254741001 }
+                "LAYER_FILE_NAME::test/not_a_real_layer_but_adding_coverage": { "file_size": 9007199254741001 }
             },
             "disk_consistent_lsn":"0/16960E8",
             "metadata_bytes":[113,11,159,210,0,54,0,4,0,0,0,0,1,105,96,232,1,0,0,0,0,1,105,96,112,0,0,0,0,0,0,0,0,0,0,0,0,0,1,105,96,112,0,0,0,0,1,105,96,112,0,0,0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
@@ -191,13 +280,13 @@ mod tests {
         let expected = IndexPart {
             // note this is not verified, could be anything, but exists for humans debugging.. could be the git version instead?
             version: 1,
-            timeline_layers: HashSet::from([String::from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9")]),
-            missing_layers: Some(HashSet::from([String::from("not_a_real_layer_but_adding_coverage")])),
+            timeline_layers: HashSet::from([LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap()]),
+            missing_layers: Some(HashSet::from([LayerFileName::new_test("not_a_real_layer_but_adding_coverage")])),
             layer_metadata: HashMap::from([
-                (String::from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9"), IndexLayerMetadata {
+                (LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap(), IndexLayerMetadata {
                     file_size: Some(25600000),
                 }),
-                (String::from("not_a_real_layer_but_adding_coverage"), IndexLayerMetadata {
+                (LayerFileName::new_test("not_a_real_layer_but_adding_coverage"), IndexLayerMetadata {
                     // serde_json should always parse this but this might be a double with jq for
                     // example.
                     file_size: Some(9007199254741001),
@@ -218,7 +307,7 @@ mod tests {
             "timeline_layers":["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9"],
             "layer_metadata":{
                 "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9": { "file_size": 25600000 },
-                "not_a_real_layer_but_adding_coverage": { "file_size": 9007199254741001 }
+                "LAYER_FILE_NAME::test/not_a_real_layer_but_adding_coverage": { "file_size": 9007199254741001 }
             },
             "disk_consistent_lsn":"0/16960E8",
             "metadata_bytes":[112,11,159,210,0,54,0,4,0,0,0,0,1,105,96,232,1,0,0,0,0,1,105,96,112,0,0,0,0,0,0,0,0,0,0,0,0,0,1,105,96,112,0,0,0,0,1,105,96,112,0,0,0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
@@ -227,29 +316,24 @@ mod tests {
         let expected = IndexPart {
             // note this is not verified, could be anything, but exists for humans debugging.. could be the git version instead?
             version: 1,
-            timeline_layers: HashSet::from(["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".to_string()]),
+            timeline_layers: [LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap()].into_iter().collect(),
             layer_metadata: HashMap::from([
-                (
-                    "000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".to_string(),
-                    IndexLayerMetadata {
-                        file_size: Some(25600000),
-                    }
-                ),
-                (
-                    "not_a_real_layer_but_adding_coverage".to_string(),
-                    IndexLayerMetadata {
-                        // serde_json should always parse this but this might be a double with jq for
-                        // example.
-                        file_size: Some(9007199254741001),
-                    }
-                )
+                (LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap(), IndexLayerMetadata {
+                    file_size: Some(25600000),
+                }),
+                (LayerFileName::new_test("not_a_real_layer_but_adding_coverage"), IndexLayerMetadata {
+                    // serde_json should always parse this but this might be a double with jq for
+                    // example.
+                    file_size: Some(9007199254741001),
+                })
             ]),
             disk_consistent_lsn: "0/16960E8".parse::<Lsn>().unwrap(),
             metadata_bytes: [112,11,159,210,0,54,0,4,0,0,0,0,1,105,96,232,1,0,0,0,0,1,105,96,112,0,0,0,0,0,0,0,0,0,0,0,0,0,1,105,96,112,0,0,0,0,1,105,96,112,0,0,0,14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0].to_vec(),
             missing_layers: None,
         };
 
-        let part = serde_json::from_str::<IndexPart>(example).unwrap();
+        let part = serde_json::from_str::<IndexPartUnclean>(example).unwrap();
+        let part = part.remove_unclean_layer_file_names();
         assert_eq!(part, expected);
     }
 }

--- a/pageserver/src/storage_sync2/index.rs
+++ b/pageserver/src/storage_sync2/index.rs
@@ -4,8 +4,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use std::convert::TryFrom;
-
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
@@ -130,7 +128,8 @@ impl<'de> serde::de::Visitor<'de> for UncleanLayerFileNameVisitor {
     where
         E: serde::de::Error,
     {
-        match LayerFileName::try_from(v) {
+        let maybe_clean: Result<LayerFileName, _> = v.parse();
+        match maybe_clean {
             Ok(clean) => Ok(UncleanLayerFileName::Clean(clean)),
             Err(e) => {
                 if v.ends_with(".old") {
@@ -251,7 +250,7 @@ mod tests {
 
         let expected = IndexPart {
             version: 0,
-            timeline_layers: HashSet::from([LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap()]),
+            timeline_layers: HashSet::from(["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".parse().unwrap()]),
             missing_layers: Some(HashSet::from([LayerFileName::new_test("not_a_real_layer_but_adding_coverage")])),
             layer_metadata: HashMap::default(),
             disk_consistent_lsn: "0/16960E8".parse::<Lsn>().unwrap(),
@@ -280,10 +279,10 @@ mod tests {
         let expected = IndexPart {
             // note this is not verified, could be anything, but exists for humans debugging.. could be the git version instead?
             version: 1,
-            timeline_layers: HashSet::from([LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap()]),
+            timeline_layers: HashSet::from(["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".parse().unwrap()]),
             missing_layers: Some(HashSet::from([LayerFileName::new_test("not_a_real_layer_but_adding_coverage")])),
             layer_metadata: HashMap::from([
-                (LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap(), IndexLayerMetadata {
+                ("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".parse().unwrap(), IndexLayerMetadata {
                     file_size: Some(25600000),
                 }),
                 (LayerFileName::new_test("not_a_real_layer_but_adding_coverage"), IndexLayerMetadata {
@@ -316,9 +315,9 @@ mod tests {
         let expected = IndexPart {
             // note this is not verified, could be anything, but exists for humans debugging.. could be the git version instead?
             version: 1,
-            timeline_layers: [LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap()].into_iter().collect(),
+            timeline_layers: ["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".parse().unwrap()].into_iter().collect(),
             layer_metadata: HashMap::from([
-                (LayerFileName::try_from("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9").unwrap(), IndexLayerMetadata {
+                ("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".parse().unwrap(), IndexLayerMetadata {
                     file_size: Some(25600000),
                 }),
                 (LayerFileName::new_test("not_a_real_layer_but_adding_coverage"), IndexLayerMetadata {

--- a/pageserver/src/storage_sync2/index.rs
+++ b/pageserver/src/storage_sync2/index.rs
@@ -93,6 +93,8 @@ where
     metadata_bytes: Vec<u8>,
 }
 
+// TODO seems like another part of the remote storage file format
+// compatibility issue, see https://github.com/neondatabase/neon/issues/3072
 pub type IndexPart = IndexPartImpl<LayerFileName>;
 
 pub type IndexPartUnclean = IndexPartImpl<UncleanLayerFileName>;
@@ -315,7 +317,7 @@ mod tests {
         let expected = IndexPart {
             // note this is not verified, could be anything, but exists for humans debugging.. could be the git version instead?
             version: 1,
-            timeline_layers: ["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".parse().unwrap()].into_iter().collect(),
+            timeline_layers: HashSet::from(["000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".parse().unwrap()]),
             layer_metadata: HashMap::from([
                 ("000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__0000000001696070-00000000016960E9".parse().unwrap(), IndexLayerMetadata {
                     file_size: Some(25600000),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -57,6 +57,7 @@ use crate::storage_sync::RemoteTimelineClient;
 use crate::task_mgr;
 use crate::task_mgr::TaskKind;
 use crate::tenant::metadata::load_metadata;
+use crate::tenant::storage_layer::PureLayer;
 use crate::tenant_config::TenantConfOpt;
 use crate::virtual_file::VirtualFile;
 use crate::walredo::PostgresRedoManager;
@@ -88,8 +89,6 @@ pub mod storage_layer;
 mod timeline;
 
 pub mod size;
-
-use storage_layer::Layer;
 
 pub use timeline::Timeline;
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -57,7 +57,7 @@ use crate::storage_sync::RemoteTimelineClient;
 use crate::task_mgr;
 use crate::task_mgr::TaskKind;
 use crate::tenant::metadata::load_metadata;
-use crate::tenant::storage_layer::PureLayer;
+use crate::tenant::storage_layer::Layer;
 use crate::tenant_config::TenantConfOpt;
 use crate::virtual_file::VirtualFile;
 use crate::walredo::PostgresRedoManager;

--- a/pageserver/src/tenant/block_io.rs
+++ b/pageserver/src/tenant/block_io.rs
@@ -60,7 +60,7 @@ where
 ///
 /// ```no_run
 /// # use pageserver::tenant::block_io::{BlockReader, FileBlockReader};
-/// # let reader: FileBlockReader<std::fs::File> = todo!();
+/// # let reader: FileBlockReader<std::fs::File> = unimplemented!("stub");
 /// let cursor = reader.block_cursor();
 /// let buf = cursor.read_blk(1);
 /// // do stuff with 'buf'

--- a/pageserver/src/tenant/delta_layer.rs
+++ b/pageserver/src/tenant/delta_layer.rs
@@ -52,6 +52,7 @@ use utils::{
     lsn::Lsn,
 };
 
+use super::filename::LayerFileName;
 use super::storage_layer::PureLayer;
 
 ///
@@ -208,9 +209,8 @@ impl PureLayer for DeltaLayer {
     }
 
     fn short_id(&self) -> String {
-        format!("{}", self.filename().display())
+        self.filename().file_name()
     }
-
     /// debugging function to print out the contents of the layer
     fn dump(&self, verbose: bool) -> Result<()> {
         println!(
@@ -381,12 +381,12 @@ impl Layer for DeltaLayer {
         self.timeline_id
     }
 
-    fn filename(&self) -> PathBuf {
-        PathBuf::from(self.layer_name().to_string())
+    fn filename(&self) -> LayerFileName {
+        self.layer_name().into()
     }
 
-    fn local_path(&self) -> Option<PathBuf> {
-        Some(self.path())
+    fn local_path(&self) -> Option<LayerFileName> {
+        Some(self.filename())
     }
 
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = anyhow::Result<(Key, Lsn, Value)>> + 'a> {
@@ -521,8 +521,8 @@ impl DeltaLayer {
                 }
             }
             PathOrConf::Path(path) => {
-                let actual_filename = Path::new(path.file_name().unwrap());
-                let expected_filename = self.filename();
+                let actual_filename = path.file_name().unwrap().to_str().unwrap().to_owned();
+                let expected_filename = self.filename().file_name();
 
                 if actual_filename != expected_filename {
                     println!(

--- a/pageserver/src/tenant/delta_layer.rs
+++ b/pageserver/src/tenant/delta_layer.rs
@@ -52,6 +52,8 @@ use utils::{
     lsn::Lsn,
 };
 
+use super::storage_layer::PureLayer;
+
 ///
 /// Header stored in the beginning of the file
 ///
@@ -193,15 +195,7 @@ pub struct DeltaLayerInner {
     file: Option<FileBlockReader<VirtualFile>>,
 }
 
-impl Layer for DeltaLayer {
-    fn get_tenant_id(&self) -> TenantId {
-        self.tenant_id
-    }
-
-    fn get_timeline_id(&self) -> TimelineId {
-        self.timeline_id
-    }
-
+impl PureLayer for DeltaLayer {
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -209,13 +203,87 @@ impl Layer for DeltaLayer {
     fn get_lsn_range(&self) -> Range<Lsn> {
         self.lsn_range.clone()
     }
-
-    fn filename(&self) -> PathBuf {
-        PathBuf::from(self.layer_name().to_string())
+    fn is_incremental(&self) -> bool {
+        true
     }
 
-    fn local_path(&self) -> Option<PathBuf> {
-        Some(self.path())
+    fn short_id(&self) -> String {
+        format!("{}", self.filename().display())
+    }
+
+    /// debugging function to print out the contents of the layer
+    fn dump(&self, verbose: bool) -> Result<()> {
+        println!(
+            "----- delta layer for ten {} tli {} keys {}-{} lsn {}-{} ----",
+            self.tenant_id,
+            self.timeline_id,
+            self.key_range.start,
+            self.key_range.end,
+            self.lsn_range.start,
+            self.lsn_range.end
+        );
+
+        if !verbose {
+            return Ok(());
+        }
+
+        let inner = self.load()?;
+
+        println!(
+            "index_start_blk: {}, root {}",
+            inner.index_start_blk, inner.index_root_blk
+        );
+
+        let file = inner.file.as_ref().unwrap();
+        let tree_reader = DiskBtreeReader::<_, DELTA_KEY_SIZE>::new(
+            inner.index_start_blk,
+            inner.index_root_blk,
+            file,
+        );
+
+        tree_reader.dump()?;
+
+        let mut cursor = file.block_cursor();
+
+        // A subroutine to dump a single blob
+        let mut dump_blob = |blob_ref: BlobRef| -> anyhow::Result<String> {
+            let buf = cursor.read_blob(blob_ref.pos())?;
+            let val = Value::des(&buf)?;
+            let desc = match val {
+                Value::Image(img) => {
+                    format!(" img {} bytes", img.len())
+                }
+                Value::WalRecord(rec) => {
+                    let wal_desc = walrecord::describe_wal_record(&rec)?;
+                    format!(
+                        " rec {} bytes will_init: {} {}",
+                        buf.len(),
+                        rec.will_init(),
+                        wal_desc
+                    )
+                }
+            };
+            Ok(desc)
+        };
+
+        tree_reader.visit(
+            &[0u8; DELTA_KEY_SIZE],
+            VisitDirection::Forwards,
+            |delta_key, val| {
+                let blob_ref = BlobRef(val);
+                let key = DeltaKey::extract_key_from_buf(delta_key);
+                let lsn = DeltaKey::extract_lsn_from_buf(delta_key);
+
+                let desc = match dump_blob(blob_ref) {
+                    Ok(desc) => desc,
+                    Err(err) => format!("ERROR: {}", err),
+                };
+                println!("  key {} at {}: {}", key, lsn, desc);
+                true
+            },
+        )?;
+
+        Ok(())
     }
 
     fn get_value_reconstruct_data(
@@ -302,6 +370,24 @@ impl Layer for DeltaLayer {
             Ok(ValueReconstructResult::Complete)
         }
     }
+}
+
+impl Layer for DeltaLayer {
+    fn get_tenant_id(&self) -> TenantId {
+        self.tenant_id
+    }
+
+    fn get_timeline_id(&self) -> TimelineId {
+        self.timeline_id
+    }
+
+    fn filename(&self) -> PathBuf {
+        PathBuf::from(self.layer_name().to_string())
+    }
+
+    fn local_path(&self) -> Option<PathBuf> {
+        Some(self.path())
+    }
 
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = anyhow::Result<(Key, Lsn, Value)>> + 'a> {
         let inner = match self.load() {
@@ -333,83 +419,11 @@ impl Layer for DeltaLayer {
         Ok(())
     }
 
-    fn is_incremental(&self) -> bool {
-        true
-    }
-
-    /// debugging function to print out the contents of the layer
-    fn dump(&self, verbose: bool) -> Result<()> {
-        println!(
-            "----- delta layer for ten {} tli {} keys {}-{} lsn {}-{} ----",
-            self.tenant_id,
-            self.timeline_id,
-            self.key_range.start,
-            self.key_range.end,
-            self.lsn_range.start,
-            self.lsn_range.end
-        );
-
-        if !verbose {
-            return Ok(());
-        }
-
-        let inner = self.load()?;
-
-        println!(
-            "index_start_blk: {}, root {}",
-            inner.index_start_blk, inner.index_root_blk
-        );
-
-        let file = inner.file.as_ref().unwrap();
-        let tree_reader = DiskBtreeReader::<_, DELTA_KEY_SIZE>::new(
-            inner.index_start_blk,
-            inner.index_root_blk,
-            file,
-        );
-
-        tree_reader.dump()?;
-
-        let mut cursor = file.block_cursor();
-
-        // A subroutine to dump a single blob
-        let mut dump_blob = |blob_ref: BlobRef| -> anyhow::Result<String> {
-            let buf = cursor.read_blob(blob_ref.pos())?;
-            let val = Value::des(&buf)?;
-            let desc = match val {
-                Value::Image(img) => {
-                    format!(" img {} bytes", img.len())
-                }
-                Value::WalRecord(rec) => {
-                    let wal_desc = walrecord::describe_wal_record(&rec)?;
-                    format!(
-                        " rec {} bytes will_init: {} {}",
-                        buf.len(),
-                        rec.will_init(),
-                        wal_desc
-                    )
-                }
-            };
-            Ok(desc)
-        };
-
-        tree_reader.visit(
-            &[0u8; DELTA_KEY_SIZE],
-            VisitDirection::Forwards,
-            |delta_key, val| {
-                let blob_ref = BlobRef(val);
-                let key = DeltaKey::extract_key_from_buf(delta_key);
-                let lsn = DeltaKey::extract_lsn_from_buf(delta_key);
-
-                let desc = match dump_blob(blob_ref) {
-                    Ok(desc) => desc,
-                    Err(err) => format!("ERROR: {}", err),
-                };
-                println!("  key {} at {}: {}", key, lsn, desc);
-                true
-            },
-        )?;
-
-        Ok(())
+    fn as_pure_layer<'a>(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn PureLayer>
+    where
+        Self: 'a,
+    {
+        self
     }
 }
 

--- a/pageserver/src/tenant/delta_layer.rs
+++ b/pageserver/src/tenant/delta_layer.rs
@@ -337,10 +337,6 @@ impl Layer for DeltaLayer {
         true
     }
 
-    fn is_in_memory(&self) -> bool {
-        false
-    }
-
     /// debugging function to print out the contents of the layer
     fn dump(&self, verbose: bool) -> Result<()> {
         println!(

--- a/pageserver/src/tenant/delta_layer.rs
+++ b/pageserver/src/tenant/delta_layer.rs
@@ -418,13 +418,6 @@ impl Layer for DeltaLayer {
         fs::remove_file(self.path())?;
         Ok(())
     }
-
-    fn as_pure_layer<'a>(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn PureLayer>
-    where
-        Self: 'a,
-    {
-        self
-    }
 }
 
 impl DeltaLayer {

--- a/pageserver/src/tenant/delta_layer.rs
+++ b/pageserver/src/tenant/delta_layer.rs
@@ -385,8 +385,8 @@ impl Layer for DeltaLayer {
         self.layer_name().into()
     }
 
-    fn local_path(&self) -> Option<LayerFileName> {
-        Some(self.filename())
+    fn local_path(&self) -> PathBuf {
+        self.path()
     }
 
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = anyhow::Result<(Key, Lsn, Value)>> + 'a> {

--- a/pageserver/src/tenant/delta_layer.rs
+++ b/pageserver/src/tenant/delta_layer.rs
@@ -30,7 +30,9 @@ use crate::tenant::blob_io::{BlobCursor, BlobWriter, WriteBlobWriter};
 use crate::tenant::block_io::{BlockBuf, BlockCursor, BlockReader, FileBlockReader};
 use crate::tenant::disk_btree::{DiskBtreeBuilder, DiskBtreeReader, VisitDirection};
 use crate::tenant::filename::{DeltaFileName, PathOrConf};
-use crate::tenant::storage_layer::{Layer, ValueReconstructResult, ValueReconstructState};
+use crate::tenant::storage_layer::{
+    PersistentLayer, ValueReconstructResult, ValueReconstructState,
+};
 use crate::virtual_file::VirtualFile;
 use crate::{walrecord, TEMP_FILE_SUFFIX};
 use crate::{DELTA_FILE_MAGIC, STORAGE_FORMAT_VERSION};
@@ -53,7 +55,7 @@ use utils::{
 };
 
 use super::filename::LayerFileName;
-use super::storage_layer::PureLayer;
+use super::storage_layer::Layer;
 
 ///
 /// Header stored in the beginning of the file
@@ -196,7 +198,7 @@ pub struct DeltaLayerInner {
     file: Option<FileBlockReader<VirtualFile>>,
 }
 
-impl PureLayer for DeltaLayer {
+impl Layer for DeltaLayer {
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -372,7 +374,7 @@ impl PureLayer for DeltaLayer {
     }
 }
 
-impl Layer for DeltaLayer {
+impl PersistentLayer for DeltaLayer {
     fn get_tenant_id(&self) -> TenantId {
         self.tenant_id
     }

--- a/pageserver/src/tenant/filename.rs
+++ b/pageserver/src/tenant/filename.rs
@@ -236,12 +236,6 @@ impl FromStr for LayerFileName {
     }
 }
 
-impl LayerFileName {
-    pub fn display(&self) -> impl std::fmt::Display {
-        self.file_name()
-    }
-}
-
 impl serde::Serialize for LayerFileName {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/pageserver/src/tenant/filename.rs
+++ b/pageserver/src/tenant/filename.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use utils::lsn::Lsn;
 
 // Note: Timeline::load_layer_map() relies on this sort order
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct DeltaFileName {
     pub key_range: Range<Key>,
     pub lsn_range: Range<Lsn>,
@@ -101,7 +101,7 @@ impl fmt::Display for DeltaFileName {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct ImageFileName {
     pub key_range: Range<Key>,
     pub lsn: Lsn,
@@ -170,6 +170,118 @@ impl fmt::Display for ImageFileName {
             self.key_range.end,
             u64::from(self.lsn),
         )
+    }
+}
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum LayerFileName {
+    Image(ImageFileName),
+    Delta(DeltaFileName),
+    #[cfg(test)]
+    Test(String),
+}
+
+impl LayerFileName {
+    pub fn file_name(&self) -> String {
+        match self {
+            LayerFileName::Image(fname) => format!("{fname}"),
+            LayerFileName::Delta(fname) => format!("{fname}"),
+            #[cfg(test)]
+            LayerFileName::Test(fname) => fname.to_string(),
+        }
+    }
+    #[cfg(test)]
+    pub(crate) fn new_test(name: &str) -> LayerFileName {
+        LayerFileName::Test(name.to_owned())
+    }
+}
+
+impl From<ImageFileName> for LayerFileName {
+    fn from(fname: ImageFileName) -> Self {
+        LayerFileName::Image(fname)
+    }
+}
+impl From<DeltaFileName> for LayerFileName {
+    fn from(fname: DeltaFileName) -> Self {
+        LayerFileName::Delta(fname)
+    }
+}
+
+// include a `/` in the name as an additional layer of robustness
+// because `/` chars are not allowed in UNIX paths
+#[cfg(test)]
+pub const LAYER_FILE_NAME_TEST_PREFIX: &str = "LAYER_FILE_NAME::test/";
+
+impl<'a> TryFrom<&'a str> for LayerFileName {
+    type Error = String;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        #[cfg(test)]
+        if let Some(value) = value.strip_prefix(LAYER_FILE_NAME_TEST_PREFIX) {
+            return Ok(LayerFileName::Test(value.to_owned()));
+        }
+        let delta = DeltaFileName::parse_str(value);
+        let image = ImageFileName::parse_str(value);
+        let ok = match (delta, image) {
+            (None, None) => {
+                return Err(format!(
+                    "neither delta nor image layer file name: {value:?}"
+                ))
+            }
+            (Some(delta), None) => LayerFileName::Delta(delta),
+            (None, Some(image)) => LayerFileName::Image(image),
+            (Some(_), Some(_)) => unreachable!(),
+        };
+        Ok(ok)
+    }
+}
+
+impl LayerFileName {
+    pub fn display(&self) -> impl std::fmt::Display {
+        self.file_name()
+    }
+}
+
+impl serde::Serialize for LayerFileName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            LayerFileName::Image(fname) => serializer.serialize_str(&format!("{}", fname)),
+            LayerFileName::Delta(fname) => serializer.serialize_str(&format!("{}", fname)),
+            #[cfg(test)]
+            LayerFileName::Test(t) => {
+                serializer.serialize_str(&format!("{LAYER_FILE_NAME_TEST_PREFIX}{t}"))
+            }
+        }
+    }
+}
+
+struct LayerFileNameVisitor;
+
+impl<'de> serde::de::Visitor<'de> for LayerFileNameVisitor {
+    type Value = LayerFileName;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "a string that is a valid image or delta layer file name"
+        )
+    }
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        LayerFileName::try_from(v).map_err(|e| E::custom(e))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for LayerFileName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(LayerFileNameVisitor)
     }
 }
 

--- a/pageserver/src/tenant/filename.rs
+++ b/pageserver/src/tenant/filename.rs
@@ -7,6 +7,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::ops::Range;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use utils::lsn::Lsn;
 
@@ -211,10 +212,10 @@ impl From<DeltaFileName> for LayerFileName {
 #[cfg(test)]
 pub const LAYER_FILE_NAME_TEST_PREFIX: &str = "LAYER_FILE_NAME::test/";
 
-impl<'a> TryFrom<&'a str> for LayerFileName {
-    type Error = String;
+impl FromStr for LayerFileName {
+    type Err = String;
 
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         #[cfg(test)]
         if let Some(value) = value.strip_prefix(LAYER_FILE_NAME_TEST_PREFIX) {
             return Ok(LayerFileName::Test(value.to_owned()));
@@ -272,7 +273,7 @@ impl<'de> serde::de::Visitor<'de> for LayerFileNameVisitor {
     where
         E: serde::de::Error,
     {
-        LayerFileName::try_from(v).map_err(|e| E::custom(e))
+        v.parse().map_err(|e| E::custom(e))
     }
 }
 

--- a/pageserver/src/tenant/filename.rs
+++ b/pageserver/src/tenant/filename.rs
@@ -210,7 +210,7 @@ impl From<DeltaFileName> for LayerFileName {
 // include a `/` in the name as an additional layer of robustness
 // because `/` chars are not allowed in UNIX paths
 #[cfg(test)]
-pub const LAYER_FILE_NAME_TEST_PREFIX: &str = "LAYER_FILE_NAME::test/";
+const LAYER_FILE_NAME_TEST_PREFIX: &str = "LAYER_FILE_NAME::test/";
 
 impl FromStr for LayerFileName {
     type Err = String;

--- a/pageserver/src/tenant/filename.rs
+++ b/pageserver/src/tenant/filename.rs
@@ -271,15 +271,6 @@ impl<'de> serde::de::Visitor<'de> for LayerFileNameVisitor {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for LayerFileName {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        deserializer.deserialize_str(LayerFileNameVisitor)
-    }
-}
-
 /// Helper enum to hold a PageServerConf, or a path
 ///
 /// This is used by DeltaLayer and ImageLayer. Normally, this holds a reference to the

--- a/pageserver/src/tenant/image_layer.rs
+++ b/pageserver/src/tenant/image_layer.rs
@@ -206,8 +206,8 @@ impl Layer for ImageLayer {
         self.layer_name().into()
     }
 
-    fn local_path(&self) -> Option<LayerFileName> {
-        Some(self.filename())
+    fn local_path(&self) -> PathBuf {
+        self.path()
     }
 
     fn get_tenant_id(&self) -> TenantId {

--- a/pageserver/src/tenant/image_layer.rs
+++ b/pageserver/src/tenant/image_layer.rs
@@ -194,10 +194,6 @@ impl Layer for ImageLayer {
         false
     }
 
-    fn is_in_memory(&self) -> bool {
-        false
-    }
-
     /// debugging function to print out the contents of the layer
     fn dump(&self, verbose: bool) -> Result<()> {
         println!(

--- a/pageserver/src/tenant/image_layer.rs
+++ b/pageserver/src/tenant/image_layer.rs
@@ -187,7 +187,7 @@ impl PureLayer for ImageLayer {
             let blob = file.block_cursor().read_blob(offset).with_context(|| {
                 format!(
                     "failed to read value from data file {} at offset {}",
-                    self.filename().display(),
+                    self.path().display(),
                     offset
                 )
             })?;

--- a/pageserver/src/tenant/image_layer.rs
+++ b/pageserver/src/tenant/image_layer.rs
@@ -226,13 +226,6 @@ impl Layer for ImageLayer {
         fs::remove_file(self.path())?;
         Ok(())
     }
-
-    fn as_pure_layer<'a>(self: std::sync::Arc<Self>) -> std::sync::Arc<dyn PureLayer>
-    where
-        Self: 'a,
-    {
-        self
-    }
 }
 
 impl ImageLayer {

--- a/pageserver/src/tenant/image_layer.rs
+++ b/pageserver/src/tenant/image_layer.rs
@@ -48,6 +48,7 @@ use utils::{
     lsn::Lsn,
 };
 
+use super::filename::LayerFileName;
 use super::storage_layer::PureLayer;
 
 ///
@@ -135,7 +136,7 @@ impl PureLayer for ImageLayer {
     }
 
     fn short_id(&self) -> String {
-        format!("{}", self.filename().display())
+        self.filename().file_name()
     }
 
     /// debugging function to print out the contents of the layer
@@ -201,12 +202,12 @@ impl PureLayer for ImageLayer {
 }
 
 impl Layer for ImageLayer {
-    fn filename(&self) -> PathBuf {
-        PathBuf::from(self.layer_name().to_string())
+    fn filename(&self) -> LayerFileName {
+        self.layer_name().into()
     }
 
-    fn local_path(&self) -> Option<PathBuf> {
-        Some(self.path())
+    fn local_path(&self) -> Option<LayerFileName> {
+        Some(self.filename())
     }
 
     fn get_tenant_id(&self) -> TenantId {
@@ -323,8 +324,8 @@ impl ImageLayer {
                 }
             }
             PathOrConf::Path(path) => {
-                let actual_filename = Path::new(path.file_name().unwrap());
-                let expected_filename = self.filename();
+                let actual_filename = path.file_name().unwrap().to_str().unwrap().to_owned();
+                let expected_filename = self.filename().file_name();
 
                 if actual_filename != expected_filename {
                     println!(

--- a/pageserver/src/tenant/image_layer.rs
+++ b/pageserver/src/tenant/image_layer.rs
@@ -26,7 +26,9 @@ use crate::tenant::blob_io::{BlobCursor, BlobWriter, WriteBlobWriter};
 use crate::tenant::block_io::{BlockBuf, BlockReader, FileBlockReader};
 use crate::tenant::disk_btree::{DiskBtreeBuilder, DiskBtreeReader, VisitDirection};
 use crate::tenant::filename::{ImageFileName, PathOrConf};
-use crate::tenant::storage_layer::{Layer, ValueReconstructResult, ValueReconstructState};
+use crate::tenant::storage_layer::{
+    PersistentLayer, ValueReconstructResult, ValueReconstructState,
+};
 use crate::virtual_file::VirtualFile;
 use crate::{IMAGE_FILE_MAGIC, STORAGE_FORMAT_VERSION, TEMP_FILE_SUFFIX};
 use anyhow::{bail, ensure, Context, Result};
@@ -49,7 +51,7 @@ use utils::{
 };
 
 use super::filename::LayerFileName;
-use super::storage_layer::PureLayer;
+use super::storage_layer::Layer;
 
 ///
 /// Header stored in the beginning of the file
@@ -122,7 +124,7 @@ pub struct ImageLayerInner {
     file: Option<FileBlockReader<VirtualFile>>,
 }
 
-impl PureLayer for ImageLayer {
+impl Layer for ImageLayer {
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -201,7 +203,7 @@ impl PureLayer for ImageLayer {
     }
 }
 
-impl Layer for ImageLayer {
+impl PersistentLayer for ImageLayer {
     fn filename(&self) -> LayerFileName {
         self.layer_name().into()
     }

--- a/pageserver/src/tenant/image_layer.rs
+++ b/pageserver/src/tenant/image_layer.rs
@@ -218,7 +218,7 @@ impl Layer for ImageLayer {
         self.timeline_id
     }
     fn iter(&self) -> Box<dyn Iterator<Item = Result<(Key, Lsn, Value)>>> {
-        todo!();
+        unimplemented!();
     }
 
     fn delete(&self) -> Result<()> {

--- a/pageserver/src/tenant/inmemory_layer.rs
+++ b/pageserver/src/tenant/inmemory_layer.rs
@@ -10,9 +10,9 @@ use crate::tenant::blob_io::{BlobCursor, BlobWriter};
 use crate::tenant::block_io::BlockReader;
 use crate::tenant::delta_layer::{DeltaLayer, DeltaLayerWriter};
 use crate::tenant::ephemeral_file::EphemeralFile;
-use crate::tenant::storage_layer::{Layer, ValueReconstructResult, ValueReconstructState};
+use crate::tenant::storage_layer::{ValueReconstructResult, ValueReconstructState};
 use crate::walrecord;
-use anyhow::{bail, ensure, Result};
+use anyhow::{ensure, Result};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use tracing::*;
@@ -26,8 +26,9 @@ use utils::{
 // while being able to use std::fmt::Write's methods
 use std::fmt::Write as _;
 use std::ops::Range;
-use std::path::PathBuf;
 use std::sync::RwLock;
+
+use super::storage_layer::PureLayer;
 
 thread_local! {
     /// A buffer for serializing object during [`InMemoryLayer::put_value`].
@@ -75,33 +76,7 @@ impl InMemoryLayerInner {
     }
 }
 
-impl Layer for InMemoryLayer {
-    // An in-memory layer can be spilled to disk into ephemeral file,
-    // This function is used only for debugging, so we don't need to be very precise.
-    // Construct a filename as if it was a delta layer.
-    fn filename(&self) -> PathBuf {
-        let inner = self.inner.read().unwrap();
-
-        let end_lsn = inner.end_lsn.unwrap_or(Lsn(u64::MAX));
-
-        PathBuf::from(format!(
-            "inmem-{:016X}-{:016X}",
-            self.start_lsn.0, end_lsn.0
-        ))
-    }
-
-    fn local_path(&self) -> Option<PathBuf> {
-        None
-    }
-
-    fn get_tenant_id(&self) -> TenantId {
-        self.tenant_id
-    }
-
-    fn get_timeline_id(&self) -> TimelineId {
-        self.timeline_id
-    }
-
+impl PureLayer for InMemoryLayer {
     fn get_key_range(&self) -> Range<Key> {
         Key::MIN..Key::MAX
     }
@@ -116,69 +91,16 @@ impl Layer for InMemoryLayer {
         };
         self.start_lsn..end_lsn
     }
-
-    /// Look up given value in the layer.
-    fn get_value_reconstruct_data(
-        &self,
-        key: Key,
-        lsn_range: Range<Lsn>,
-        reconstruct_state: &mut ValueReconstructState,
-    ) -> anyhow::Result<ValueReconstructResult> {
-        ensure!(lsn_range.start >= self.start_lsn);
-        let mut need_image = true;
-
-        let inner = self.inner.read().unwrap();
-
-        let mut reader = inner.file.block_cursor();
-
-        // Scan the page versions backwards, starting from `lsn`.
-        if let Some(vec_map) = inner.index.get(&key) {
-            let slice = vec_map.slice_range(lsn_range);
-            for (entry_lsn, pos) in slice.iter().rev() {
-                let buf = reader.read_blob(*pos)?;
-                let value = Value::des(&buf)?;
-                match value {
-                    Value::Image(img) => {
-                        reconstruct_state.img = Some((*entry_lsn, img));
-                        return Ok(ValueReconstructResult::Complete);
-                    }
-                    Value::WalRecord(rec) => {
-                        let will_init = rec.will_init();
-                        reconstruct_state.records.push((*entry_lsn, rec));
-                        if will_init {
-                            // This WAL record initializes the page, so no need to go further back
-                            need_image = false;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        // release lock on 'inner'
-
-        // If an older page image is needed to reconstruct the page, let the
-        // caller know.
-        if need_image {
-            Ok(ValueReconstructResult::Continue)
-        } else {
-            Ok(ValueReconstructResult::Complete)
-        }
-    }
-
-    fn iter(&self) -> Box<dyn Iterator<Item = Result<(Key, Lsn, Value)>>> {
-        todo!();
-    }
-
-    /// Nothing to do here. When you drop the last reference to the layer, it will
-    /// be deallocated.
-    fn delete(&self) -> Result<()> {
-        bail!("can't delete an InMemoryLayer")
-    }
-
     fn is_incremental(&self) -> bool {
         // in-memory layer is always considered incremental.
         true
+    }
+
+    fn short_id(&self) -> String {
+        let inner = self.inner.read().unwrap();
+
+        let end_lsn = inner.end_lsn.unwrap_or(Lsn(u64::MAX));
+        format!("inmem-{:016X}-{:016X}", self.start_lsn.0, end_lsn.0)
     }
 
     /// debugging function to print out the contents of the layer
@@ -230,6 +152,55 @@ impl Layer for InMemoryLayer {
         }
 
         Ok(())
+    }
+
+    /// Look up given value in the layer.
+    fn get_value_reconstruct_data(
+        &self,
+        key: Key,
+        lsn_range: Range<Lsn>,
+        reconstruct_state: &mut ValueReconstructState,
+    ) -> anyhow::Result<ValueReconstructResult> {
+        ensure!(lsn_range.start >= self.start_lsn);
+        let mut need_image = true;
+
+        let inner = self.inner.read().unwrap();
+
+        let mut reader = inner.file.block_cursor();
+
+        // Scan the page versions backwards, starting from `lsn`.
+        if let Some(vec_map) = inner.index.get(&key) {
+            let slice = vec_map.slice_range(lsn_range);
+            for (entry_lsn, pos) in slice.iter().rev() {
+                let buf = reader.read_blob(*pos)?;
+                let value = Value::des(&buf)?;
+                match value {
+                    Value::Image(img) => {
+                        reconstruct_state.img = Some((*entry_lsn, img));
+                        return Ok(ValueReconstructResult::Complete);
+                    }
+                    Value::WalRecord(rec) => {
+                        let will_init = rec.will_init();
+                        reconstruct_state.records.push((*entry_lsn, rec));
+                        if will_init {
+                            // This WAL record initializes the page, so no need to go further back
+                            need_image = false;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // release lock on 'inner'
+
+        // If an older page image is needed to reconstruct the page, let the
+        // caller know.
+        if need_image {
+            Ok(ValueReconstructResult::Continue)
+        } else {
+            Ok(ValueReconstructResult::Complete)
+        }
     }
 }
 

--- a/pageserver/src/tenant/inmemory_layer.rs
+++ b/pageserver/src/tenant/inmemory_layer.rs
@@ -76,6 +76,12 @@ impl InMemoryLayerInner {
     }
 }
 
+impl InMemoryLayer {
+    pub fn get_timeline_id(&self) -> TimelineId {
+        self.timeline_id
+    }
+}
+
 impl PureLayer for InMemoryLayer {
     fn get_key_range(&self) -> Range<Key> {
         Key::MIN..Key::MAX

--- a/pageserver/src/tenant/inmemory_layer.rs
+++ b/pageserver/src/tenant/inmemory_layer.rs
@@ -181,10 +181,6 @@ impl Layer for InMemoryLayer {
         true
     }
 
-    fn is_in_memory(&self) -> bool {
-        true
-    }
-
     /// debugging function to print out the contents of the layer
     fn dump(&self, verbose: bool) -> Result<()> {
         let inner = self.inner.read().unwrap();

--- a/pageserver/src/tenant/inmemory_layer.rs
+++ b/pageserver/src/tenant/inmemory_layer.rs
@@ -28,7 +28,7 @@ use std::fmt::Write as _;
 use std::ops::Range;
 use std::sync::RwLock;
 
-use super::storage_layer::PureLayer;
+use super::storage_layer::Layer;
 
 thread_local! {
     /// A buffer for serializing object during [`InMemoryLayer::put_value`].
@@ -82,7 +82,7 @@ impl InMemoryLayer {
     }
 }
 
-impl PureLayer for InMemoryLayer {
+impl Layer for InMemoryLayer {
     fn get_key_range(&self) -> Range<Key> {
         Key::MIN..Key::MAX
     }

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -248,7 +248,7 @@ pub struct SearchResult<PersistentLayerT: ?Sized> {
 
 impl<PersistentLayerT> LayerMap<PersistentLayerT>
 where
-    PersistentLayerT: ?Sized + Send + Sync + PureLayer,
+    PersistentLayerT: ?Sized + PureLayer,
 {
     ///
     /// Find the latest layer that covers the given 'key', with lsn <

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -63,11 +63,11 @@ pub struct LayerMap<PersistentLayerT: ?Sized> {
 impl<T: ?Sized> Default for LayerMap<T> {
     fn default() -> Self {
         Self {
-            open_layer: Default::default(),
-            next_open_layer_at: Default::default(),
-            frozen_layers: Default::default(),
-            historic_layers: Default::default(),
-            l0_delta_layers: Default::default(),
+            open_layer: None,
+            next_open_layer_at: None,
+            frozen_layers: VecDeque::default(),
+            historic_layers: RTree::default(),
+            l0_delta_layers: Vec::default(),
         }
     }
 }

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -13,7 +13,6 @@
 use crate::metrics::NUM_ONDISK_LAYERS;
 use crate::repository::Key;
 use crate::tenant::inmemory_layer::InMemoryLayer;
-use crate::tenant::storage_layer::Layer;
 use crate::tenant::storage_layer::{range_eq, range_overlaps};
 use amplify_num::i256;
 use anyhow::Result;
@@ -28,11 +27,12 @@ use std::sync::Arc;
 use tracing::*;
 use utils::lsn::Lsn;
 
+use super::storage_layer::PureLayer;
+
 ///
 /// LayerMap tracks what layers exist on a timeline.
 ///
-#[derive(Default)]
-pub struct LayerMap {
+pub struct LayerMap<PersistentLayerT: ?Sized> {
     //
     // 'open_layer' holds the current InMemoryLayer that is accepting new
     // records. If it is None, 'next_open_layer_at' will be set instead, indicating
@@ -53,15 +53,27 @@ pub struct LayerMap {
     pub frozen_layers: VecDeque<Arc<InMemoryLayer>>,
 
     /// All the historic layers are kept here
-    historic_layers: RTree<LayerRTreeObject>,
+    historic_layers: RTree<LayerRTreeObject<PersistentLayerT>>,
 
     /// L0 layers have key range Key::MIN..Key::MAX, and locating them using R-Tree search is very inefficient.
     /// So L0 layers are held in l0_delta_layers vector, in addition to the R-tree.
-    l0_delta_layers: Vec<Arc<dyn Layer>>,
+    l0_delta_layers: Vec<Arc<PersistentLayerT>>,
 }
 
-struct LayerRTreeObject {
-    layer: Arc<dyn Layer>,
+impl<T: ?Sized> Default for LayerMap<T> {
+    fn default() -> Self {
+        Self {
+            open_layer: Default::default(),
+            next_open_layer_at: Default::default(),
+            frozen_layers: Default::default(),
+            historic_layers: Default::default(),
+            l0_delta_layers: Default::default(),
+        }
+    }
+}
+
+struct LayerRTreeObject<PersistentLayerT: ?Sized> {
+    layer: Arc<PersistentLayerT>,
 
     envelope: AABB<[IntKey; 2]>,
 }
@@ -185,7 +197,7 @@ impl Num for IntKey {
     }
 }
 
-impl PartialEq for LayerRTreeObject {
+impl<T: ?Sized> PartialEq for LayerRTreeObject<T> {
     fn eq(&self, other: &Self) -> bool {
         // FIXME: ptr_eq might fail to return true for 'dyn'
         // references.  Clippy complains about this. In practice it
@@ -196,15 +208,21 @@ impl PartialEq for LayerRTreeObject {
     }
 }
 
-impl RTreeObject for LayerRTreeObject {
+impl<PersistentLayerT> RTreeObject for LayerRTreeObject<PersistentLayerT>
+where
+    PersistentLayerT: ?Sized,
+{
     type Envelope = AABB<[IntKey; 2]>;
     fn envelope(&self) -> Self::Envelope {
         self.envelope
     }
 }
 
-impl LayerRTreeObject {
-    fn new(layer: Arc<dyn Layer>) -> Self {
+impl<PersistentLayerT> LayerRTreeObject<PersistentLayerT>
+where
+    PersistentLayerT: ?Sized + PureLayer,
+{
+    fn new(layer: Arc<PersistentLayerT>) -> Self {
         let key_range = layer.get_key_range();
         let lsn_range = layer.get_lsn_range();
 
@@ -223,12 +241,15 @@ impl LayerRTreeObject {
 }
 
 /// Return value of LayerMap::search
-pub struct SearchResult {
-    pub layer: Arc<dyn Layer>,
+pub struct SearchResult<PersistentLayerT: ?Sized> {
+    pub layer: Arc<PersistentLayerT>,
     pub lsn_floor: Lsn,
 }
 
-impl LayerMap {
+impl<PersistentLayerT> LayerMap<PersistentLayerT>
+where
+    PersistentLayerT: ?Sized + Send + Sync + PureLayer,
+{
     ///
     /// Find the latest layer that covers the given 'key', with lsn <
     /// 'end_lsn'.
@@ -240,10 +261,10 @@ impl LayerMap {
     /// contain the version, even if it's missing from the returned
     /// layer.
     ///
-    pub fn search(&self, key: Key, end_lsn: Lsn) -> Result<Option<SearchResult>> {
+    pub fn search(&self, key: Key, end_lsn: Lsn) -> Result<Option<SearchResult<PersistentLayerT>>> {
         // linear search
         // Find the latest image layer that covers the given key
-        let mut latest_img: Option<Arc<dyn Layer>> = None;
+        let mut latest_img: Option<Arc<PersistentLayerT>> = None;
         let mut latest_img_lsn: Option<Lsn> = None;
         let envelope = AABB::from_corners(
             [IntKey::from(key.to_i128()), IntKey::from(0i128)],
@@ -277,7 +298,7 @@ impl LayerMap {
         }
 
         // Search the delta layers
-        let mut latest_delta: Option<Arc<dyn Layer>> = None;
+        let mut latest_delta: Option<Arc<PersistentLayerT>> = None;
         for e in self
             .historic_layers
             .locate_in_envelope_intersecting(&envelope)
@@ -301,7 +322,7 @@ impl LayerMap {
                 // No need to search any further
                 trace!(
                     "found layer {} for request on {key} at {end_lsn}",
-                    l.filename().display(),
+                    l.short_id(),
                 );
                 latest_delta.replace(Arc::clone(l));
                 break;
@@ -319,7 +340,7 @@ impl LayerMap {
         if let Some(l) = latest_delta {
             trace!(
                 "found (old) layer {} for request on {key} at {end_lsn}",
-                l.filename().display(),
+                l.short_id(),
             );
             let lsn_floor = std::cmp::max(
                 Lsn(latest_img_lsn.unwrap_or(Lsn(0)).0 + 1),
@@ -344,7 +365,7 @@ impl LayerMap {
     ///
     /// Insert an on-disk layer
     ///
-    pub fn insert_historic(&mut self, layer: Arc<dyn Layer>) {
+    pub fn insert_historic(&mut self, layer: Arc<PersistentLayerT>) {
         if layer.get_key_range() == (Key::MIN..Key::MAX) {
             self.l0_delta_layers.push(layer.clone());
         }
@@ -357,7 +378,7 @@ impl LayerMap {
     ///
     /// This should be called when the corresponding file on disk has been deleted.
     ///
-    pub fn remove_historic(&mut self, layer: Arc<dyn Layer>) {
+    pub fn remove_historic(&mut self, layer: Arc<PersistentLayerT>) {
         if layer.get_key_range() == (Key::MIN..Key::MAX) {
             let len_before = self.l0_delta_layers.len();
 
@@ -426,13 +447,13 @@ impl LayerMap {
         }
     }
 
-    pub fn iter_historic_layers(&self) -> impl '_ + Iterator<Item = Arc<dyn Layer>> {
+    pub fn iter_historic_layers(&self) -> impl '_ + Iterator<Item = Arc<PersistentLayerT>> {
         self.historic_layers.iter().map(|e| e.layer.clone())
     }
 
     /// Find the last image layer that covers 'key', ignoring any image layers
     /// newer than 'lsn'.
-    fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<Arc<dyn Layer>> {
+    fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<Arc<PersistentLayerT>> {
         let mut candidate_lsn = Lsn(0);
         let mut candidate = None;
         let envelope = AABB::from_corners(
@@ -474,7 +495,7 @@ impl LayerMap {
         &self,
         key_range: &Range<Key>,
         lsn: Lsn,
-    ) -> Result<Vec<(Range<Key>, Option<Arc<dyn Layer>>)>> {
+    ) -> Result<Vec<(Range<Key>, Option<Arc<PersistentLayerT>>)>> {
         let mut points = vec![key_range.start];
         let envelope = AABB::from_corners(
             [IntKey::from(key_range.start.to_i128()), IntKey::from(0)],
@@ -559,7 +580,7 @@ impl LayerMap {
     }
 
     /// Return all L0 delta layers
-    pub fn get_level0_deltas(&self) -> Result<Vec<Arc<dyn Layer>>> {
+    pub fn get_level0_deltas(&self) -> Result<Vec<Arc<PersistentLayerT>>> {
         Ok(self.l0_delta_layers.clone())
     }
 

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -133,9 +133,6 @@ pub trait Layer: Send + Sync {
     /// the previous non-incremental layer.
     fn is_incremental(&self) -> bool;
 
-    /// Returns true for layers that are represented in memory.
-    fn is_in_memory(&self) -> bool;
-
     /// Iterate through all keys and values stored in the layer
     fn iter(&self) -> Box<dyn Iterator<Item = Result<(Key, Lsn, Value)>> + '_>;
 

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -7,6 +7,7 @@ use crate::walrecord::NeonWalRecord;
 use anyhow::Result;
 use bytes::Bytes;
 use std::ops::Range;
+use std::path::PathBuf;
 
 use utils::{
     id::{TenantId, TimelineId},
@@ -139,11 +140,8 @@ pub trait Layer: Send + Sync + PureLayer {
     /// state as well as in the remote storage.
     fn filename(&self) -> LayerFileName;
 
-    /// If the layer has a corresponding file on a local filesystem, return its filename.
-    /// `None` otherwise.
-    /// NB: all current implementations return `Some`, but with on-demand download,
-    /// a new `RemoteLayer` type will be added that returns `None` here.
-    fn local_path(&self) -> Option<LayerFileName>;
+    // Path to the layer file in the local filesystem.
+    fn local_path(&self) -> PathBuf;
 
     /// Iterate through all keys and values stored in the layer
     fn iter(&self) -> Box<dyn Iterator<Item = Result<(Key, Lsn, Value)>> + '_>;

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -7,7 +7,6 @@ use crate::walrecord::NeonWalRecord;
 use anyhow::Result;
 use bytes::Bytes;
 use std::ops::Range;
-use std::sync::Arc;
 
 use utils::{
     id::{TenantId, TimelineId},
@@ -157,9 +156,4 @@ pub trait Layer: Send + Sync + PureLayer {
 
     /// Permanently remove this layer from disk.
     fn delete(&self) -> Result<()>;
-
-    // https://articles.bchlr.de/traits-dynamic-dispatch-upcasting
-    fn as_pure_layer<'a>(self: Arc<Self>) -> Arc<dyn PureLayer>
-    where
-        Self: 'a;
 }

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -7,7 +7,6 @@ use crate::walrecord::NeonWalRecord;
 use anyhow::Result;
 use bytes::Bytes;
 use std::ops::Range;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use utils::{
@@ -15,6 +14,7 @@ use utils::{
     lsn::Lsn,
 };
 
+use super::filename::LayerFileName;
 pub fn range_overlaps<T>(a: &Range<T>, b: &Range<T>) -> bool
 where
     T: PartialOrd<T>,
@@ -138,13 +138,13 @@ pub trait Layer: Send + Sync + PureLayer {
 
     /// File name used for this layer, both in the pageserver's local filesystem
     /// state as well as in the remote storage.
-    fn filename(&self) -> PathBuf;
+    fn filename(&self) -> LayerFileName;
 
     /// If the layer has a corresponding file on a local filesystem, return its filename.
     /// `None` otherwise.
     /// NB: all current implementations return `Some`, but with on-demand download,
     /// a new `RemoteLayer` type will be added that returns `None` here.
-    fn local_path(&self) -> Option<PathBuf>;
+    fn local_path(&self) -> Option<LayerFileName>;
 
     /// Iterate through all keys and values stored in the layer
     fn iter(&self) -> Box<dyn Iterator<Item = Result<(Key, Lsn, Value)>> + '_>;

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -70,7 +70,8 @@ pub enum ValueReconstructResult {
     Missing,
 }
 
-/// Supertrait of the [`Layer`] trait that conta
+/// Supertrait of the [`Layer`] trait that captures the bare minimum interface
+/// required by [`LayerMap`].
 pub trait PureLayer: Send + Sync {
     /// Range of keys that this layer covers
     fn get_key_range(&self) -> Range<Key>;
@@ -135,12 +136,14 @@ pub trait Layer: Send + Sync + PureLayer {
     /// Identify the timeline this layer belongs to
     fn get_timeline_id(&self) -> TimelineId;
 
-    /// Filename used to store this layer on disk. (Even in-memory layers
-    /// implement this, to print a handy unique identifier for the layer for
-    /// log messages, even though they're never not on disk.)
+    /// File name used for this layer, both in the pageserver's local filesystem
+    /// state as well as in the remote storage.
     fn filename(&self) -> PathBuf;
 
-    /// If a layer has a corresponding file on a local filesystem, return its absolute path.
+    /// If the layer has a corresponding file on a local filesystem, return its filename.
+    /// `None` otherwise.
+    /// NB: all current implementations return `Some`, but with on-demand download,
+    /// a new `RemoteLayer` type will be added that returns `None` here.
     fn local_path(&self) -> Option<PathBuf>;
 
     /// Iterate through all keys and values stored in the layer

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use bytes::Bytes;
 use std::ops::Range;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use utils::{
     id::{TenantId, TimelineId},
@@ -69,26 +70,8 @@ pub enum ValueReconstructResult {
     Missing,
 }
 
-/// A Layer contains all data in a "rectangle" consisting of a range of keys and
-/// range of LSNs.
-///
-/// There are two kinds of layers, in-memory and on-disk layers. In-memory
-/// layers are used to ingest incoming WAL, and provide fast access to the
-/// recent page versions. On-disk layers are stored as files on disk, and are
-/// immutable. This trait presents the common functionality of in-memory and
-/// on-disk layers.
-///
-/// Furthermore, there are two kinds of on-disk layers: delta and image layers.
-/// A delta layer contains all modifications within a range of LSNs and keys.
-/// An image layer is a snapshot of all the data in a key-range, at a single
-/// LSN
-///
-pub trait Layer: Send + Sync {
-    fn get_tenant_id(&self) -> TenantId;
-
-    /// Identify the timeline this layer belongs to
-    fn get_timeline_id(&self) -> TimelineId;
-
+/// Supertrait of the [`Layer`] trait that conta
+pub trait PureLayer: Send + Sync {
     /// Range of keys that this layer covers
     fn get_key_range(&self) -> Range<Key>;
 
@@ -100,13 +83,11 @@ pub trait Layer: Send + Sync {
     /// - An image layer represents snapshot at one LSN, so end_lsn is always the snapshot LSN + 1
     fn get_lsn_range(&self) -> Range<Lsn>;
 
-    /// Filename used to store this layer on disk. (Even in-memory layers
-    /// implement this, to print a handy unique identifier for the layer for
-    /// log messages, even though they're never not on disk.)
-    fn filename(&self) -> PathBuf;
-
-    /// If a layer has a corresponding file on a local filesystem, return its absolute path.
-    fn local_path(&self) -> Option<PathBuf>;
+    /// Does this layer only contain some data for the key-range (incremental),
+    /// or does it contain a version of every page? This is important to know
+    /// for garbage collecting old layers: an incremental layer depends on
+    /// the previous non-incremental layer.
+    fn is_incremental(&self) -> bool;
 
     ///
     /// Return data needed to reconstruct given page at LSN.
@@ -127,11 +108,40 @@ pub trait Layer: Send + Sync {
         reconstruct_data: &mut ValueReconstructState,
     ) -> Result<ValueReconstructResult>;
 
-    /// Does this layer only contain some data for the key-range (incremental),
-    /// or does it contain a version of every page? This is important to know
-    /// for garbage collecting old layers: an incremental layer depends on
-    /// the previous non-incremental layer.
-    fn is_incremental(&self) -> bool;
+    /// A short ID string that uniquely identifies the given layer within a [`LayerMap`].
+    fn short_id(&self) -> String;
+
+    /// Dump summary of the contents of the layer to stdout
+    fn dump(&self, verbose: bool) -> Result<()>;
+}
+
+/// A Layer contains all data in a "rectangle" consisting of a range of keys and
+/// range of LSNs.
+///
+/// There are two kinds of layers, in-memory and on-disk layers. In-memory
+/// layers are used to ingest incoming WAL, and provide fast access to the
+/// recent page versions. On-disk layers are stored as files on disk, and are
+/// immutable. This trait presents the common functionality of in-memory and
+/// on-disk layers.
+///
+/// Furthermore, there are two kinds of on-disk layers: delta and image layers.
+/// A delta layer contains all modifications within a range of LSNs and keys.
+/// An image layer is a snapshot of all the data in a key-range, at a single
+/// LSN
+///
+pub trait Layer: Send + Sync + PureLayer {
+    fn get_tenant_id(&self) -> TenantId;
+
+    /// Identify the timeline this layer belongs to
+    fn get_timeline_id(&self) -> TimelineId;
+
+    /// Filename used to store this layer on disk. (Even in-memory layers
+    /// implement this, to print a handy unique identifier for the layer for
+    /// log messages, even though they're never not on disk.)
+    fn filename(&self) -> PathBuf;
+
+    /// If a layer has a corresponding file on a local filesystem, return its absolute path.
+    fn local_path(&self) -> Option<PathBuf>;
 
     /// Iterate through all keys and values stored in the layer
     fn iter(&self) -> Box<dyn Iterator<Item = Result<(Key, Lsn, Value)>> + '_>;
@@ -145,6 +155,8 @@ pub trait Layer: Send + Sync {
     /// Permanently remove this layer from disk.
     fn delete(&self) -> Result<()>;
 
-    /// Dump summary of the contents of the layer to stdout
-    fn dump(&self, verbose: bool) -> Result<()>;
+    // https://articles.bchlr.de/traits-dynamic-dispatch-upcasting
+    fn as_pure_layer<'a>(self: Arc<Self>) -> Arc<dyn PureLayer>
+    where
+        Self: 'a;
 }

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -72,7 +72,7 @@ pub enum ValueReconstructResult {
 
 /// Supertrait of the [`Layer`] trait that captures the bare minimum interface
 /// required by [`LayerMap`].
-pub trait PureLayer: Send + Sync {
+pub trait Layer: Send + Sync {
     /// Range of keys that this layer covers
     fn get_key_range(&self) -> Range<Key>;
 
@@ -130,7 +130,7 @@ pub trait PureLayer: Send + Sync {
 /// An image layer is a snapshot of all the data in a key-range, at a single
 /// LSN
 ///
-pub trait Layer: Send + Sync + PureLayer {
+pub trait PersistentLayer: Layer {
     fn get_tenant_id(&self) -> TenantId;
 
     /// Identify the timeline this layer belongs to

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1015,7 +1015,7 @@ impl Timeline {
         let mut local_only_layers = local_layers;
         let timeline_dir = self.conf.timeline_path(&self.timeline_id, &self.tenant_id);
         for remote_layer_name in &index_part.timeline_layers {
-            local_only_layers.remove(&remote_layer_name);
+            local_only_layers.remove(remote_layer_name);
 
             let remote_layer_metadata = index_part
                 .layer_metadata
@@ -1070,7 +1070,7 @@ impl Timeline {
 
                     trace!("downloading image file: {remote_layer_name:?}");
                     let downloaded_size = remote_client
-                        .download_layer_file(&remote_layer_name, &remote_layer_metadata)
+                        .download_layer_file(remote_layer_name, &remote_layer_metadata)
                         .await
                         .with_context(|| {
                             format!("failed to download image layer {remote_layer_name:?}")
@@ -1105,7 +1105,7 @@ impl Timeline {
 
                     trace!("downloading delta file: {remote_layer_name:?}");
                     let sz = remote_client
-                        .download_layer_file(&remote_layer_name, &remote_layer_metadata)
+                        .download_layer_file(remote_layer_name, &remote_layer_metadata)
                         .await
                         .with_context(|| {
                             format!("failed to download delta layer {remote_layer_name:?}")

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -930,7 +930,7 @@ impl Timeline {
                 let layer =
                     ImageLayer::new(self.conf, self.timeline_id, self.tenant_id, &imgfilename);
 
-                trace!("found layer {}", layer.filename().display());
+                trace!("found layer {}", layer.path().display());
                 total_physical_size += layer.path().metadata()?.len();
                 layers.insert_historic(Arc::new(layer));
                 num_layers += 1;
@@ -954,7 +954,7 @@ impl Timeline {
                 let layer =
                     DeltaLayer::new(self.conf, self.timeline_id, self.tenant_id, &deltafilename);
 
-                trace!("found layer {}", layer.filename().display());
+                trace!("found layer {}", layer.path().display());
                 total_physical_size += layer.path().metadata()?.len();
                 layers.insert_historic(Arc::new(layer));
                 num_layers += 1;
@@ -2060,7 +2060,7 @@ impl Timeline {
             level0_deltas.len()
         );
         for l in deltas_to_compact.iter() {
-            info!("compact includes {}", l.filename().display());
+            info!("compact includes {}", l.filename().file_name());
         }
         // We don't need the original list of layers anymore. Drop it so that
         // we don't accidentally use it later in the function.
@@ -2509,7 +2509,7 @@ impl Timeline {
             if l.get_lsn_range().end > horizon_cutoff {
                 debug!(
                     "keeping {} because it's newer than horizon_cutoff {}",
-                    l.filename().display(),
+                    l.filename().file_name(),
                     horizon_cutoff
                 );
                 result.layers_needed_by_cutoff += 1;
@@ -2520,7 +2520,7 @@ impl Timeline {
             if l.get_lsn_range().end > pitr_cutoff {
                 debug!(
                     "keeping {} because it's newer than pitr_cutoff {}",
-                    l.filename().display(),
+                    l.filename().file_name(),
                     pitr_cutoff
                 );
                 result.layers_needed_by_pitr += 1;
@@ -2537,7 +2537,7 @@ impl Timeline {
                 if &l.get_lsn_range().start <= retain_lsn {
                     debug!(
                         "keeping {} because it's still might be referenced by child branch forked at {} is_dropped: xx is_incremental: {}",
-                        l.filename().display(),
+                        l.filename().file_name(),
                         retain_lsn,
                         l.is_incremental(),
                     );
@@ -2570,7 +2570,7 @@ impl Timeline {
             {
                 debug!(
                     "keeping {} because it is the latest layer",
-                    l.filename().display()
+                    l.filename().file_name()
                 );
                 result.layers_not_updated += 1;
                 continue 'outer;
@@ -2579,7 +2579,7 @@ impl Timeline {
             // We didn't find any reason to keep this file, so remove it.
             debug!(
                 "garbage collecting {} is_dropped: xx is_incremental: {}",
-                l.filename().display(),
+                l.filename().file_name(),
                 l.is_incremental(),
             );
             layers_to_remove.push(Arc::clone(&l));

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2485,16 +2485,6 @@ impl Timeline {
         //
         let mut layers = self.layers.write().unwrap();
         'outer: for l in layers.iter_historic_layers() {
-            // This layer is in the process of being flushed to disk.
-            // It will be swapped out of the layer map, replaced with
-            // on-disk layers containing the same data.
-            // We can't GC it, as it's not on disk. We can't remove it
-            // from the layer map yet, as it would make its data
-            // inaccessible.
-            if l.is_in_memory() {
-                continue;
-            }
-
             result.layers_total += 1;
 
             // 1. Is it newer than GC horizon cutoff point?

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1319,11 +1319,12 @@ trait TraversalLayerExt {
 
 impl TraversalLayerExt for Arc<dyn Layer> {
     fn traversal_id(&self) -> String {
-        format!(
-            "timeline {} layer file {}",
-            self.get_timeline_id(),
-            self.filename().file_name()
-        )
+        debug_assert!(
+            self.local_path().to_str().unwrap()
+                .contains(&format!("{}", self.get_timeline_id())),
+            "need timeline ID to uniquely identify the layer when tranversal crosses ancestor boundary",
+        );
+        format!("{}", self.local_path().display())
     }
 }
 

--- a/test_runner/regress/test_tenants_with_remote_storage.py
+++ b/test_runner/regress/test_tenants_with_remote_storage.py
@@ -411,12 +411,10 @@ def test_tenant_ignores_backup_file(
     env.postgres.stop_all()
     env.pageserver.stop()
 
-    # file is still mentioned in the index. Removing it requires more hacking on remote queue initialization
-    # Will be easier to do once there will be no .download_missing so it will be only one cycle through the layers
-    # in load_layer_map
+    # the .old file is gone from newly serialized index_part
     new_index_part = local_fs_index_part(env, tenant_id, timeline_id)
     backup_layers = filter(lambda x: x.endswith(".old"), new_index_part["timeline_layers"])
-    assert len(list(backup_layers)) == 1
+    assert len(list(backup_layers)) == 0
 
 
 @pytest.mark.parametrize("remote_storage_kind", [RemoteStorageKind.LOCAL_FS])


### PR DESCRIPTION
Please use the 'review commit by commit' functionality of GitHub code review to review the three commits individually.
I can also open separate PRs for each of them if that's preferred, but they build on top of each other, so I think it's ultimately better to keep them in one PR.

If it turns out that one commit is ready to merge while others need more time, we can do that.

```
commit bd27d407d2b0f6594a2180c0aa2ad3654d0df99c
Author: Christian Schwarz <christian@neon.tech>
Date:   Wed Dec 7 09:52:48 2022 -0500

    remove Layer::is_in_memory()
    
    It's only used inside gc_timeline() and there, it always returns `false`
    because `layers.iter_historic_layers()` only returns
    ImageLayer / DeltaLayer
```
```
commit 432e8667a2be069e08ccc9a338c775dec76331e2
Author: Christian Schwarz <christian@neon.tech>
Date:   Wed Dec 7 07:40:08 2022 -0500

    refactor: split off LayerMap's needs from trait Layer into super trait PureLayer
    
    While this complicates the typings in `layer_map.rs`, it removes the
    need for most `unimplemented!()` / `todo!()` impls in the layer types
    used for benchmarking the layer map.
    
    That by itself wouldn't justify the time I put into this refactoring.
    
    But, after this change, I will remove `PathBuf`s from the `Layer` trait's interface,
    which in turn will enable a clean-up of the `storage_sync2` APIs.
```

```
commit f169a4c16862c0269e94d58887d75b8de33f1b32
Author: Christian Schwarz <christian@neon.tech>
Date:   Wed Dec 7 04:54:49 2022 -0500

    refactor: use new type LayerFileName when referring to layer file names in PathBuf/RemotePath
    
    The `RemoteTimelineClient` has all the context it needs to construct the
    local path / remote object key of the layer files.
    
    Before this patch, we would sometimes carry around plain file names in
    `Path` types and/or awkwardly "rebase" paths to have a unified
    representation of the layer file name between local and remote.
    
    This patch introduces a new type `LayerFileName` which replaces the use
    of `Path` / `PathBuf` / `RemotePath` in the `storage_sync2` APIs.
    
    Instead of holding a string, it contains the parsed representation of
    the image and delta file name.
    When we need the file name, e.g., to construct a local path or
    remote object key, we construct the name ad-hoc.
    
    `LayerFileName` is also serde {Dese,Se}rializable and hence
    is used directly in `IndexPart`, replacing `RemotePath`.
```foobar