### PR TITLE
merge-allure-report: create report even if benchmarks is skipped

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -305,7 +305,7 @@ jobs:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
       options: --init
     needs: [ regress-tests, benchmarks ]
-    if: success() || failure()
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The logic `if: success() || failure()` was added in https://github.com/neondatabase/neon/pull/2813, but the job also got skipped if `benchmarks` jobs is skipped.