### PR TITLE
Change storage brokers to internal subdomain

### DIFF
--- a/.github/helm-values/dev-eu-west-1-zeta.neon-storage-broker.yaml
+++ b/.github/helm-values/dev-eu-west-1-zeta.neon-storage-broker.yaml
@@ -13,13 +13,13 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker.zeta.eu-west-1.aws.neon.build
+    - host: storage-broker.zeta.eu-west-1.internal.aws.neon.build
       paths:
         - path: /
           pathType: Prefix
   tls:
     - hosts:
-        - storage-broker.zeta.eu-west-1.aws.neon.build
+        - storage-broker.zeta.eu-west-1.internal.aws.neon.build
       secretName: storage-broker-tls
 
 

--- a/.github/helm-values/dev-eu-west-1-zeta.neon-storage-broker.yaml
+++ b/.github/helm-values/dev-eu-west-1-zeta.neon-storage-broker.yaml
@@ -13,13 +13,13 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker-zeta.eu-west-1.aws.neon.build
+    - host: storage-broker.zeta.eu-west-1.aws.neon.build
       paths:
         - path: /
           pathType: Prefix
   tls:
     - hosts:
-        - storage-broker-zeta.eu-west-1.aws.neon.build
+        - storage-broker.zeta.eu-west-1.aws.neon.build
       secretName: storage-broker-tls
 
 

--- a/.github/helm-values/dev-us-east-2-beta.neon-storage-broker.yaml
+++ b/.github/helm-values/dev-us-east-2-beta.neon-storage-broker.yaml
@@ -13,13 +13,13 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker-beta.us-east-2.aws.neon.build
+    - host: storage-broker.beta.us-east-2.aws.neon.build
       paths:
         - path: /
           pathType: Prefix
   tls:
     - hosts:
-        - storage-broker-beta.us-east-2.aws.neon.build
+        - storage-broker.beta.us-east-2.aws.neon.build
       secretName: storage-broker-tls
 
 

--- a/.github/helm-values/dev-us-east-2-beta.neon-storage-broker.yaml
+++ b/.github/helm-values/dev-us-east-2-beta.neon-storage-broker.yaml
@@ -13,13 +13,13 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker.beta.us-east-2.aws.neon.build
+    - host: storage-broker.beta.us-east-2.internal.aws.neon.build
       paths:
         - path: /
           pathType: Prefix
   tls:
     - hosts:
-        - storage-broker.beta.us-east-2.aws.neon.build
+        - storage-broker.beta.us-east-2.internal.aws.neon.build
       secretName: storage-broker-tls
 
 

--- a/.github/helm-values/prod-ap-southeast-1-epsilon.neon-storage-broker.yaml
+++ b/.github/helm-values/prod-ap-southeast-1-epsilon.neon-storage-broker.yaml
@@ -13,7 +13,7 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker-epsilon.ap-southeast-1.aws.neon.tech
+    - host: storage-broker.epsilon.ap-southeast-1.aws.neon.tech
       paths:
         - path: /
           pathType: Prefix

--- a/.github/helm-values/prod-ap-southeast-1-epsilon.neon-storage-broker.yaml
+++ b/.github/helm-values/prod-ap-southeast-1-epsilon.neon-storage-broker.yaml
@@ -13,13 +13,13 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker.epsilon.ap-southeast-1.aws.neon.tech
+    - host: storage-broker.epsilon.ap-southeast-1.internal.aws.neon.tech
       paths:
         - path: /
           pathType: Prefix
   tls:
     - hosts:
-        - storage-broker-epsilon.ap-southeast-1.aws.neon.tech
+        - storage-broker.epsilon.ap-southeast-1.internal.aws.neon.tech
       secretName: storage-broker-tls
 
 

--- a/.github/helm-values/prod-eu-central-1-gamma.neon-storage-broker.yaml
+++ b/.github/helm-values/prod-eu-central-1-gamma.neon-storage-broker.yaml
@@ -13,7 +13,7 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker-gamma.eu-central-1.aws.neon.tech
+    - host: storage-broker.gamma.eu-central-1.aws.neon.tech
       paths:
         - path: /
           pathType: Prefix

--- a/.github/helm-values/prod-eu-central-1-gamma.neon-storage-broker.yaml
+++ b/.github/helm-values/prod-eu-central-1-gamma.neon-storage-broker.yaml
@@ -13,13 +13,13 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker.gamma.eu-central-1.aws.neon.tech
+    - host: storage-broker.gamma.eu-central-1.internal.aws.neon.tech
       paths:
         - path: /
           pathType: Prefix
   tls:
     - hosts:
-        - storage-broker-gamma.eu-central-1.aws.neon.tech
+        - storage-broker.gamma.eu-central-1.internal.aws.neon.tech
       secretName: storage-broker-tls
 
 

--- a/.github/helm-values/prod-us-east-2-delta.neon-storage-broker.yaml
+++ b/.github/helm-values/prod-us-east-2-delta.neon-storage-broker.yaml
@@ -13,13 +13,13 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker.delta.us-east-2.aws.neon.tech
+    - host: storage-broker.delta.us-east-2.internal.aws.neon.tech
       paths:
         - path: /
           pathType: Prefix
   tls:
     - hosts:
-        - storage-broker-delta.us-east-2.aws.neon.tech
+        - storage-broker.delta.us-east-2.internal.aws.neon.tech
       secretName: storage-broker-tls
 
 

--- a/.github/helm-values/prod-us-east-2-delta.neon-storage-broker.yaml
+++ b/.github/helm-values/prod-us-east-2-delta.neon-storage-broker.yaml
@@ -13,7 +13,7 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker-delta.us-east-2.aws.neon.tech
+    - host: storage-broker.delta.us-east-2.aws.neon.tech
       paths:
         - path: /
           pathType: Prefix

--- a/.github/helm-values/prod-us-west-2-eta.neon-storage-broker.yaml
+++ b/.github/helm-values/prod-us-west-2-eta.neon-storage-broker.yaml
@@ -13,13 +13,13 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker.eta.us-west-2.aws.neon.tech
+    - host: storage-broker.eta.us-west-2.internal.aws.neon.tech
       paths:
         - path: /
           pathType: Prefix
   tls:
     - hosts:
-        - storage-broker-eta.us-west-2.aws.neon.tech
+        - storage-broker.eta.us-west-2.internal.aws.neon.tech
       secretName: storage-broker-tls
 
 

--- a/.github/helm-values/prod-us-west-2-eta.neon-storage-broker.yaml
+++ b/.github/helm-values/prod-us-west-2-eta.neon-storage-broker.yaml
@@ -13,7 +13,7 @@ ingress:
     cert-manager.io/cluster-issuer: "cert-manager-clusterissuer"
 
   hosts:
-    - host: storage-broker-eta.us-west-2.aws.neon.tech
+    - host: storage-broker.eta.us-west-2.aws.neon.tech
       paths:
         - path: /
           pathType: Prefix


### PR DESCRIPTION
There's a bit of a clash with the naming, so dedicate a subdomain for storage brokers. Back to subdomain separation just to be consistent.