### PR TITLE
Remove redundant once_cell usages

### DIFF
--- a/libs/postgres_ffi/wal_craft/src/lib.rs
+++ b/libs/postgres_ffi/wal_craft/src/lib.rs
@@ -1,7 +1,6 @@
 use anyhow::*;
 use core::time::Duration;
 use log::*;
-use once_cell::sync::Lazy;
 use postgres::types::PgLsn;
 use postgres::Client;
 use postgres_ffi::{WAL_SEGMENT_SIZE, XLOG_BLCKSZ};
@@ -26,15 +25,13 @@ pub struct PostgresServer {
     client_config: postgres::Config,
 }
 
-pub static REQUIRED_POSTGRES_CONFIG: Lazy<Vec<&'static str>> = Lazy::new(|| {
-    vec![
-        "wal_keep_size=50MB",            // Ensure old WAL is not removed
-        "shared_preload_libraries=neon", // can only be loaded at startup
-        // Disable background processes as much as possible
-        "wal_writer_delay=10s",
-        "autovacuum=off",
-    ]
-});
+pub static REQUIRED_POSTGRES_CONFIG: [&str; 4] = [
+    "wal_keep_size=50MB",            // Ensure old WAL is not removed
+    "shared_preload_libraries=neon", // can only be loaded at startup
+    // Disable background processes as much as possible
+    "wal_writer_delay=10s",
+    "autovacuum=off",
+];
 
 impl Conf {
     pub fn pg_distrib_dir(&self) -> anyhow::Result<PathBuf> {

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -139,7 +139,7 @@ pub struct PageserverTaskId(u64);
 
 /// Each task that we track is associated with a "task ID". It's just an
 /// increasing number that we assign. Note that it is different from tokio::task::Id.
-static NEXT_TASK_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(1));
+static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Global registry of tasks
 static TASKS: Lazy<Mutex<HashMap<u64, Arc<PageServerTask>>>> =

--- a/pageserver/src/tenant/block_io.rs
+++ b/pageserver/src/tenant/block_io.rs
@@ -5,7 +5,6 @@
 use crate::page_cache;
 use crate::page_cache::{ReadBufResult, PAGE_SZ};
 use bytes::Bytes;
-use once_cell::sync::Lazy;
 use std::ops::{Deref, DerefMut};
 use std::os::unix::fs::FileExt;
 use std::sync::atomic::AtomicU64;
@@ -117,7 +116,7 @@ where
     }
 }
 
-static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(1));
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
 /// An adapter for reading a (virtual) file using the page cache.
 ///


### PR DESCRIPTION
rustc 1.63 is now [present](https://tracker.debian.org/pkg/rustc) in Debian unstable and I wanted to check on the "const Mutex, RwLock, Condvar initialization"
[feature](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html#const-mutex-rwlock-condvar-initialization).
Tokio provides a `parking_lot` feature with similar possibilities for its lock counterparts.

Alas, current rustc, 1.65, does not have `HashMap::new` as `const`, `BTreeMap::new` as `const` is unstable, only `Vec::new` is `const` and available.
`static TEST: Mutex<Option<HashMap<String, u32>>> = Mutex::new(None);` works, but that is not much different from `once_cell` in terms of usage convenience, so seems that the whole idea is not yet easily applicable for our needs.

As a small solace, I've found a few small places where `once_cell` seems to be redundant.