### PR TITLE
Set last written LSN for prefetched pages to avoid false invalidation of prefetch results

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -681,7 +681,26 @@ prefetch_do_request(PrefetchRequest *slot, bool *force_latest, XLogRecPtr *force
 	Assert(slot->my_ring_index == MyPState->ring_unused);
 	page_server->send((NeonRequest *) &request);
 
-	/* Remember request LSN for the prefetched page to avoid false pefetch invalidations */
+	/*
+	 * Remember request LSN in the last-written LSN cache to avoid false
+	 * prefetch invalidations.
+	 *
+	 * Imagine what would happen without this, when you perform a large
+	 * sequential scan with UPDATE. The sequential scan issues a prefetch
+	 * request for each page in order, and every page is also dirtied. On
+	 * each page, the oldest page in the last-written LSN cache is evicted,
+	 * which advances the global last-written LSN. The pages being scanned are
+	 * not in the last-written cache, so each prefetch request will use the
+	 * global last-written LSN in the request and memorize that in the
+	 * slot. However, when we receive the response to the prefetch request,
+	 * the global last-written LSN has already moved forwards, and the
+	 * cross-check we make that the last-written LSN matches will fail, and we
+	 * discard the prefetched response unnecessary.
+	 *
+	 * Inserting the LSN we use in the prefetch request to the last-written LSN 
+	 * cache avoids that problem. With that, we will use the cached value in
+	 * the cross-check, instead of the more recent global last-written LSN value.
+	 */
 	SetLastWrittenLSNForBlock(
 		request.req.lsn,
 		slot->buftag.rnode,

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -681,6 +681,14 @@ prefetch_do_request(PrefetchRequest *slot, bool *force_latest, XLogRecPtr *force
 	Assert(slot->my_ring_index == MyPState->ring_unused);
 	page_server->send((NeonRequest *) &request);
 
+	/* Remember request LSN for the prefetched page to avoid false pefetch invalidations */
+	SetLastWrittenLSNForBlock(
+		request.req.lsn,
+		slot->buftag.rnode,
+		slot->buftag.forkNum,
+		slot->buftag.blockNum
+	);
+
 	/* update prefetch state */
 	MyPState->n_requests_inflight += 1;
 	MyPState->n_unused -= 1;


### PR DESCRIPTION
In case of prefetching large table size of last written LSN cache is not enough to keep information about all pages, this is why we are using global last written LSN which is intensively updated by vacuum because of setting ALL_VISIBLE bit in page header. It cause invalidation of prefetch results because prefetch_lsn < request_lsn