### PR TITLE
test_seqscans: increase table size for remote test

### DIFF
--- a/test_runner/performance/test_seqscans.py
+++ b/test_runner/performance/test_seqscans.py
@@ -24,12 +24,12 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore
 @pytest.mark.parametrize(
     "env, scale",
     [
-        # Run on all envs. Use 50x larger table on remote cluster to make sure
+        # Run on all envs. Use 200x larger table on remote cluster to make sure
         # it doesn't fit in shared buffers, which are larger on remote than local.
         pytest.param(lazy_fixture("neon_compare"), 1, id="neon"),
         pytest.param(lazy_fixture("vanilla_compare"), 1, id="vanilla"),
         pytest.param(
-            lazy_fixture("remote_compare"), 50, id="remote", marks=pytest.mark.remote_cluster
+            lazy_fixture("remote_compare"), 200, id="remote", marks=pytest.mark.remote_cluster
         ),
     ],
 )


### PR DESCRIPTION
Increase table size four times to fix the following error:

```
______________________ test_seqscans[remote-100000-100-0] ______________________
test_runner/performance/test_seqscans.py:57: in test_seqscans
    assert int(shared_buffers) < int(table_size)
E   assert 536870912 < 181239808
E    +  where 536870912 = int(536870912)
E    +  and   181239808 = int(181239808)
```

536870912 / 181239808 ≈ 2.96

Similar fix before: https://github.com/neondatabase/neon/pull/2878
Ref https://github.com/neondatabase/neon/actions/runs/3662372640/jobs/6194694846#step:6:320


