### PR TITLE
Put e2e tag back.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -506,7 +506,7 @@ jobs:
           --user "${{ secrets.CI_ACCESS_TOKEN }}" \
           --data \
             "{
-              \"ref\": \"replace-etcd\",
+              \"ref\": \"main\",
               \"inputs\": {
                 \"ci_job_name\": \"neon-cloud-e2e\",
                 \"commit_hash\": \"$COMMIT_SHA\",


### PR DESCRIPTION
32662ff1c42a1f required running e2e tests on patched branch of cloud repo; now that it is merged, put the tag back.