### PR TITLE
Create initial timeline without remote storage

### DIFF
--- a/control_plane/src/background_process.rs
+++ b/control_plane/src/background_process.rs
@@ -51,21 +51,21 @@ pub enum InitialPidFile<'t> {
 }
 
 /// Start a background child process using the parameters given.
-pub fn start_process<
-    F,
-    S: AsRef<OsStr>,
-    EI: IntoIterator<Item = (String, String)>, // Not generic AsRef<OsStr>, otherwise empty `envs` prevents type inference
->(
+pub fn start_process<F, AI, A, EI>(
     process_name: &str,
     datadir: &Path,
     command: &Path,
-    args: &[S],
+    args: AI,
     envs: EI,
     initial_pid_file: InitialPidFile,
     process_status_check: F,
 ) -> anyhow::Result<Child>
 where
     F: Fn() -> anyhow::Result<bool>,
+    AI: IntoIterator<Item = A>,
+    A: AsRef<OsStr>,
+    // Not generic AsRef<OsStr>, otherwise empty `envs` prevents type inference
+    EI: IntoIterator<Item = (String, String)>,
 {
     let log_path = datadir.join(format!("{process_name}.log"));
     let process_log_file = fs::OpenOptions::new()

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -341,7 +341,7 @@ fn pageserver_config_overrides(init_match: &ArgMatches) -> Vec<&str> {
         .get_many::<String>("pageserver-config-override")
         .into_iter()
         .flatten()
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .collect()
 }
 

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -277,7 +277,7 @@ impl Debug for S3Config {
 }
 
 impl RemoteStorageConfig {
-    pub fn from_toml(toml: &toml_edit::Item) -> anyhow::Result<RemoteStorageConfig> {
+    pub fn from_toml(toml: &toml_edit::Item) -> anyhow::Result<Option<RemoteStorageConfig>> {
         let local_path = toml.get("local_path");
         let bucket_name = toml.get("bucket_name");
         let bucket_region = toml.get("bucket_region");
@@ -301,7 +301,8 @@ impl RemoteStorageConfig {
         .context("Failed to parse 'concurrency_limit' as a positive integer")?;
 
         let storage = match (local_path, bucket_name, bucket_region) {
-            (None, None, None) => bail!("no 'local_path' nor 'bucket_name' option"),
+            // no 'local_path' nor 'bucket_name' options are provided, consider this remote storage disabled
+            (None, None, None) => return Ok(None),
             (_, Some(_), None) => {
                 bail!("'bucket_region' option is mandatory if 'bucket_name' is given ")
             }
@@ -327,11 +328,11 @@ impl RemoteStorageConfig {
             (Some(_), Some(_), _) => bail!("local_path and bucket_name are mutually exclusive"),
         };
 
-        Ok(RemoteStorageConfig {
+        Ok(Some(RemoteStorageConfig {
             max_concurrent_syncs,
             max_sync_errors,
             storage,
-        })
+        }))
     }
 }
 

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -524,7 +524,7 @@ impl PageServerConf {
                 )),
                 "auth_type" => builder.auth_type(parse_toml_from_str(key, item)?),
                 "remote_storage" => {
-                    builder.remote_storage_config(Some(RemoteStorageConfig::from_toml(item)?))
+                    builder.remote_storage_config(RemoteStorageConfig::from_toml(item)?)
                 }
                 "tenant_config" => {
                     t_conf = Self::parse_toml_tenant_conf(item)?;


### PR DESCRIPTION
Sometimes, on my local machine S3 tests failed due to extra log lines present:
```
2022-12-04T11:25:13.935351Z ERROR remote_upload{tenant=b933a6c8685e3898383c94bb220779d1 timeline=ccf01aab20e4d8f34145ccf1122a5f19 upload_task_id=1}: failed to perform remote task UploadLayer(/Users/someonetoignore/work/neon/neon/test_output/test_ignored_tenant_reattach[mock_s3]/repo/tenants/b933a6c8685e3898383c94bb220779d1/timelines/ccf01aab20e4d8f34145ccf1122a5f19/000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__00000000016B59D8-00000000016B5A51, size=Some(25821184)), will retry (attempt 0): Failed to upload a layer from local path '/Users/someonetoignore/work/neon/neon/test_output/test_ignored_tenant_reattach[mock_s3]/repo/tenants/b933a6c8685e3898383c94bb220779d1/timelines/ccf01aab20e4d8f34145ccf1122a5f19/000000000000000000000000000000000000-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF__00000000016B59D8-00000000016B5A51'

Caused by:
    0: failed to construct request: No credentials in the property bag
    1: No credentials in the property bag
```
[full log](https://github.com/neondatabase/neon/files/10215688/eager_s3_init_pageserver.log)

yet the test itself was working, only the log checking assertion failed.

The failure happened on the very first pageserver start during the test, which is an initial timeline creation.
We shut down pageserver immediately after that happens, so it does not make sense to have the remote storage enabled during the procedure in the first place.

