### PR TITLE
ignore metadata_backup files in index_part

### DIFF
--- a/pageserver/src/storage_sync2/index.rs
+++ b/pageserver/src/storage_sync2/index.rs
@@ -135,7 +135,7 @@ impl<'de> serde::de::Visitor<'de> for UncleanLayerFileNameVisitor {
         match maybe_clean {
             Ok(clean) => Ok(UncleanLayerFileName::Clean(clean)),
             Err(e) => {
-                if v.ends_with(".old") {
+                if v.ends_with(".old") || v == "metadata_backup" {
                     Ok(UncleanLayerFileName::BackupFile(v.to_owned()))
                 } else {
                     Err(E::custom(e))


### PR DESCRIPTION
It turns out we had other unexpected types of files on the remote storage. Namely metadata_backup which is preventing tenants from loading.

The root cause is the same as here https://github.com/neondatabase/neon/issues/3024