### PR TITLE
two logical size calculation improvements & test coverage

### DIFF
--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -3,7 +3,10 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Context;
+use tokio::sync::oneshot::error::RecvError;
 use tokio::sync::Semaphore;
+
+use crate::pgdatadir_mapping::CalculateLogicalSizeError;
 
 use super::Tenant;
 use utils::id::TimelineId;
@@ -212,11 +215,30 @@ pub(super) async fn gather_inputs(
     let mut have_any_error = false;
 
     while let Some(res) = joinset.join_next().await {
-        // each of these come with Result<Result<_, JoinError>, JoinError>
+        // each of these come with Result<anyhow::Result<_>, JoinError>
         // because of spawn + spawn_blocking
-        let res = res.and_then(|inner| inner);
         match res {
-            Ok(TimelineAtLsnSizeResult(timeline, lsn, Ok(size))) => {
+            Err(join_error) if join_error.is_cancelled() => {
+                unreachable!("we are not cancelling any of the futures, nor should be");
+            }
+            Err(join_error) => {
+                // cannot really do anything, as this panic is likely a bug
+                error!("task that calls spawn_ondemand_logical_size_calculation panicked: {join_error:#}");
+                have_any_error = true;
+            }
+            Ok(Err(recv_result_error)) => {
+                // cannot really do anything, as this panic is likely a bug
+                error!("failed to receive logical size query result: {recv_result_error:#}");
+                have_any_error = true;
+            }
+            Ok(Ok(TimelineAtLsnSizeResult(timeline, lsn, Err(error)))) => {
+                warn!(
+                    timeline_id=%timeline.timeline_id,
+                    "failed to calculate logical size at {lsn}: {error:#}"
+                );
+                have_any_error = true;
+            }
+            Ok(Ok(TimelineAtLsnSizeResult(timeline, lsn, Ok(size)))) => {
                 debug!(timeline_id=%timeline.timeline_id, %lsn, size, "size calculated");
 
                 logical_size_cache.insert((timeline.timeline_id, lsn), size);
@@ -227,21 +249,6 @@ pub(super) async fn gather_inputs(
                     timeline_id: timeline.timeline_id,
                     command: Command::Update(size),
                 });
-            }
-            Ok(TimelineAtLsnSizeResult(timeline, lsn, Err(error))) => {
-                warn!(
-                    timeline_id=%timeline.timeline_id,
-                    "failed to calculate logical size at {lsn}: {error:#}"
-                );
-                have_any_error = true;
-            }
-            Err(join_error) if join_error.is_cancelled() => {
-                unreachable!("we are not cancelling any of the futures, nor should be");
-            }
-            Err(join_error) => {
-                // cannot really do anything, as this panic is likely a bug
-                error!("logical size query panicked: {join_error:#}");
-                have_any_error = true;
             }
         }
     }
@@ -351,7 +358,7 @@ enum LsnKind {
 struct TimelineAtLsnSizeResult(
     Arc<crate::tenant::Timeline>,
     utils::lsn::Lsn,
-    anyhow::Result<u64>,
+    Result<u64, CalculateLogicalSizeError>,
 );
 
 #[instrument(skip_all, fields(timeline_id=%timeline.timeline_id, lsn=%lsn))]
@@ -359,17 +366,15 @@ async fn calculate_logical_size(
     limit: Arc<tokio::sync::Semaphore>,
     timeline: Arc<crate::tenant::Timeline>,
     lsn: utils::lsn::Lsn,
-) -> Result<TimelineAtLsnSizeResult, tokio::task::JoinError> {
-    let permit = tokio::sync::Semaphore::acquire_owned(limit)
+) -> Result<TimelineAtLsnSizeResult, RecvError> {
+    let _permit = tokio::sync::Semaphore::acquire_owned(limit)
         .await
         .expect("global semaphore should not had been closed");
 
-    tokio::task::spawn_blocking(move || {
-        let _permit = permit;
-        let size_res = timeline.calculate_logical_size(lsn);
-        TimelineAtLsnSizeResult(timeline, lsn, size_res)
-    })
-    .await
+    let size_res = timeline
+        .spawn_ondemand_logical_size_calculation(lsn)
+        .await?;
+    Ok(TimelineAtLsnSizeResult(timeline, lsn, size_res))
 }
 
 #[test]

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1290,6 +1290,9 @@ impl Timeline {
                 }
                 Ok(())
             },
+            _ = task_mgr::shutdown_watcher() => {
+                anyhow::bail!("aborted because task_mgr shutdown requested");
+            }
             new_event = async {
                 loop {
                     match timeline_state_updates.changed().await {

--- a/test_runner/regress/test_timeline_size.py
+++ b/test_runner/regress/test_timeline_size.py
@@ -265,10 +265,6 @@ def test_timeline_initial_logical_size_calculation_cancellation(
     log.info(
         f"try to delete the timeline using {deletion_method}, this should cancel size computation tasks and wait for them to finish"
     )
-    if deletion_method == "timeline_delete":
-        env.pageserver.allowed_errors.append(
-            f".*initial size calculation.*{tenant_id}.*{timeline_id}.*aborted because task_mgr shutdown requested"
-        )
     delete_timeline_success: queue.Queue[bool] = queue.Queue(maxsize=1)
 
     def delete_timeline_thread_fn():


### PR DESCRIPTION
~~Before this patch, if the task fails, we would not reset
self.initial_size_computation_started.
So, if it fails, we will return the approximate value forever.
In practice, it probably never failed because the local filesystem
is quite reliable.
But with on-demand download, the logical size calculation may need
to download layers, which is more likely to fail at times.
There will be internal retires with a timeout, but eventually,
the downloads will give up.
We want to retry in those cases.~~

This PR expanded in scope because I noticed problems with `spawn_blocking`

New commits:

```
commit 083fa3091ee5710690a37c6e00a324fe4dfb37a9
Author: Christian Schwarz <christian@neon.tech>
Date:   Thu Dec 15 12:15:23 2022 +0100

    [1/4] initial logical size calculation: if it fails, retry on next call
    
    Before this patch, if the task fails, we would not reset
    self.initial_size_computation_started.
    So, if it fails, we will return the approximate value forever.
    
    In practice, it probably never failed because the local filesystem
    is quite reliable.
    
    But with on-demand download, the logical size calculation may need
    to download layers, which is more likely to fail at times.
    There will be internal retires with a timeout, but eventually,
    the downloads will give up.
    We want to retry in those cases.
    
    While we're at it, also change the handling of the timeline state
    watch so that we treat it as an error. Most likely, we'll not be
    called again, but if we are, retrying is the right thing.

commit b278b0f0b6a13b09271f05900ba862ce3886806c
Author: Christian Schwarz <christian@neon.tech>
Date:   Thu Dec 15 15:17:13 2022 +0100

    [2/4] add test to show that tenant detach makes us leak running size calculation task

commit eb1ae57ea61ddd6e30f2ac0f7908e0abde7c2e88
Author: Christian Schwarz <christian@neon.tech>
Date:   Thu Dec 15 15:16:25 2022 +0100

    [3/4] make initial size estimation task sensitive to task_mgr shutdown requests
    
    This exacerbates the problem pointed out in the previous commit.
    Why? Because with this patch, deleting a timeline also exposes the issue.
    
    Extend the test to expose the problem.

commit b0a4a1177da76ad04f1224c6f701da6e47261c26
Author: Christian Schwarz <christian@neon.tech>
Date:   Thu Dec 15 17:20:38 2022 +0100

    [4/4] the fix: do not leak spawn_blocking() tasks from logical size calculation code
    
    - Refactor logical_size_calculation_task, moving the pieces that are
      specific to try_spawn_size_init_task into that function.
      This allows us to spawn additional size calculation tasks that are not
      init size calculation tasks.
    
      - As part of this refactoring, stop logging cancellations as errors.
        They are part of regular operations.
        Logging them as errors was inadvertently introduced in earlier commit
    
          427c1b2e9661161439e65aabc173d695cfc03ab4
          initial logical size calculation: if it fails, retry on next call
    
    - Change tenant size model request code to spawn task_mgr tasks using
      the refactored logical_size_calculation_task function.
      Using a task_mgr task ensures that the calculation cannot outlive
      the timeline.
      - There are presumably still some subtle race conditions if a size
        requests comes in at exactly the same time as a detach / delete
        request.
      - But that's the concern of diferent area of the code (e.g., tenant_mgr)
        and requires holistic solutions, such as the proposed TenantGuard.
    
    - Make size calculation cancellable using CancellationToken.
      This is more of a cherry on top.
      NB: the test code doesn't use this because we _must_ return from
      the failpoint, because the failpoint lib doesn't allow to just
      continue execution in combination with executing the closure.
    
    This commit fixes the tests introduced earlier in this patch series.
```
