### PR TITLE
task_mgr: use CancellationToken instead of shutdown_rx

### DIFF
--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -225,7 +225,7 @@ struct PageServerTask {
 
     name: String,
 
-    // To request task shutdown, send 'true' to the channel to notify the task.
+    // To request task shutdown, just cancel this token.
     cancel: CancellationToken,
 
     mutable: Mutex<MutableTaskState>,

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -25,7 +25,6 @@
 //! the current task has been requested to shut down. You can use that with
 //! Tokio select!().
 //!
-//!
 //! TODO: This would be a good place to also handle panics in a somewhat sane way.
 //! Depending on what task panics, we might want to kill the whole server, or
 //! only a single tenant or timeline.
@@ -458,7 +457,7 @@ pub fn shutdown_token() -> CancellationToken {
 
 /// Has the current task been requested to shut down?
 pub fn is_shutdown_requested() -> bool {
-    if let Ok(cancel) = SHUTDOWN_TOKEN.try_with(|rx| rx.clone()) {
+    if let Ok(cancel) = SHUTDOWN_TOKEN.try_with(|t| t.clone()) {
         cancel.is_cancelled()
     } else {
         if !cfg!(test) {


### PR DESCRIPTION
this should help us in the future to have more freedom with spawning tasks and cancelling things, most importantly blocking tasks (assuming the CancellationToken::is_cancelled is performant enough). CancellationToken allows creation of hierarchical cancellations, which would also simplify the task_mgr shutdown operation, rendering it unnecessary.

think of a hierarachy where in the root you have a tenant, leafs are the operations we want to cancel for one or more reasons (tenant detach, or per operation).

```
Tenant
 |- timeline1
 |   \- timeline1 initial size calc
 |- timeline2
 |   \- timeline2 foobar operation
 \- timeline3
     \- yet another operation
     \- http request requesting long to calculate information (w/ dropguard, cancelled when http request is cancelled)
```

All of these need to shutdown when tenant is shutdown, and the cancellation token hierarchy would support this, allowing phasing out of the task_mgr.

Alternative approaches:
- expose the `tokio::sync::watch::Receiver<()>` as is; I think it would be suboptimal, because then:
    - we wouldn't get the hierarchical nature
    - we would not get the drop_guard functionality (easy to do if receivers were able to close the channel, didn't check)

- [ ] add todo comment about actually using the hierarchy in task_mgr