### PR TITLE
avoid unchanged metadata uploads during compaction

### DIFF
--- a/pageserver/src/storage_sync2.rs
+++ b/pageserver/src/storage_sync2.rs
@@ -767,7 +767,7 @@ impl RemoteTimelineClient {
             self.update_upload_queue_unfinished_metric(1, &op);
             upload_queue.queued_operations.push_back(op);
             info!(
-                "scheduled metadata file upload after scheduling {} layer file deletions",
+                "scheduled metadata file upload before {} layer file deletions",
                 names.len()
             );
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2309,8 +2309,7 @@ impl Timeline {
             layers.insert_historic(x);
         }
 
-        // Now that we've successfully scheduled all the layer uploads,
-        // point the IndexPart to them as well.
+        // Upload all the layer files & update remote IndexPart.
         // If we crash before that is done, the pageserver startup procedure
         // will re-schedule the uploads.
         if let Some(remote_client) = &self.remote_client {


### PR DESCRIPTION
Commits are intended to remain separate.