### PR TITLE
test_runner/performance: fix flush for NeonCompare

### DIFF
--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -115,7 +115,7 @@ class NeonCompare(PgCompare):
         return self._pg_bin
 
     def flush(self):
-        self.pageserver_http.timeline_checkpoint(self.env.initial_tenant, self.timeline)
+        self.pageserver_http_client.timeline_checkpoint(self.env.initial_tenant, self.timeline)
         self.pageserver_http_client.timeline_gc(self.env.initial_tenant, self.timeline, 0)
 
     def compact(self):


### PR DESCRIPTION
Fix performance tests:
```
AttributeError: 'NeonCompare' object has no attribute 'pageserver_http'
```

https://neon-github-public-dev.s3.amazonaws.com/reports/main/release/3713487584/index.html#categories/dcb49b9953ce76b182e54e96e1454755/b68ee72a188c0b38/