### PR TITLE
Safekeeper, Pageserver: simplify auth code and get rid of MD5 auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,6 +2401,7 @@ dependencies = [
  "crc32c",
  "criterion",
  "crossbeam-utils",
+ "derivative",
  "fail",
  "futures",
  "git-version",

--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -106,7 +106,9 @@ impl PageServerNode {
             self.env.pg_distrib_dir_raw().display()
         );
 
-        let authg_type_param = format!("auth_type='{}'", self.env.pageserver.auth_type);
+        // TODO: for forward compatibility only, remove after a while
+        let auth_type_param = format!("auth_type='{}'", self.env.pageserver.auth_type);
+
         let listen_http_addr_param = format!(
             "listen_http_addr='{}'",
             self.env.pageserver.listen_http_addr
@@ -118,15 +120,18 @@ impl PageServerNode {
         let mut overrides = vec![
             id,
             pg_distrib_dir_param,
-            authg_type_param,
+            auth_type_param,
             listen_http_addr_param,
             listen_pg_addr_param,
             broker_endpoint_param,
         ];
 
-        if self.env.pageserver.auth_type != AuthType::Trust {
-            overrides.push("auth_validation_public_key_path='auth_public_key.pem'".to_owned());
-        }
+        match self.env.pageserver.auth_type {
+            AuthType::Trust => {}
+            AuthType::NeonJWT => {
+                overrides.push("auth_validation_public_key_path='auth_public_key.pem'".to_owned());
+            }
+        };
         overrides
     }
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -102,13 +102,13 @@ Each compute should present a token valid for the timeline's tenant.
 Pageserver also has HTTP API: some parts are per-tenant,
 some parts are server-wide, these are different scopes.
 
-The `auth_type` configuration variable in Pageserver's config may have
-either of three values:
+The `auth_validation_public_key_path` config option, if present, enables JWT validation.
+Tokens are validated using the public key which lies in a PEM file specified in the option.
+If the option is not present, there is no authentication and pageserver trusts everyone.
 
-* `Trust` removes all authentication. The outdated `MD5` value does likewise
-* `NeonJWT` enables JWT validation.
-   Tokens are validated using the public key which lies in a PEM file
-   specified in the `auth_validation_public_key_path` config.
+Note that `neon_local`/`control_panel` use a separate pageserver config file,
+which uses the `auth_type` option instead (either `Trust` or `NeonJWT`)
+and generates the public key itself.
 
 #### Outgoing connections
 Pageserver makes a connection to a Safekeeper for each active timeline.

--- a/libs/utils/src/postgres_backend.rs
+++ b/libs/utils/src/postgres_backend.rs
@@ -52,6 +52,9 @@ pub enum ProtoState {
     Established,
 }
 
+/// Type of authentication which is required by the corresponding `PostgresBackend`
+/// for all clients. One should override `check_auth_jwt` to actually authorize client
+/// after authentication.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum AuthType {
     Trust,

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -73,6 +73,7 @@ reqwest = "0.11.13"
 
 [dev-dependencies]
 criterion = "0.4"
+derivative = "2.2.0"
 hex-literal = "0.3"
 tempfile = "3.2"
 

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -255,7 +255,7 @@ fn start_pageserver(conf: &'static PageServerConf) -> anyhow::Result<()> {
 
     // Initialize authentication for incoming connections
     let auth = match &conf.auth_type {
-        AuthType::Trust | AuthType::MD5 => None,
+        AuthType::Trust => None,
         AuthType::NeonJWT => {
             // unwrap is ok because check is performed when creating config, so path is set and file exists
             let key_path = conf.auth_validation_public_key_path.as_ref().unwrap();

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -4,7 +4,9 @@
 //! file, or on the command line.
 //! See also `settings.md` for better description on every parameter.
 
-use anyhow::{anyhow, bail, ensure, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
+#[cfg(test)]
+use derivative::Derivative;
 use remote_storage::{RemotePath, RemoteStorageConfig};
 use std::env;
 use storage_broker::Uri;
@@ -21,6 +23,7 @@ use std::time::Duration;
 use toml_edit;
 use toml_edit::{Document, Item};
 
+use utils::auth::JwtAuth;
 use utils::{
     id::{NodeId, TenantId, TimelineId},
     logging::LogFormat,
@@ -102,7 +105,13 @@ pub mod defaults {
     );
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+// Comparing `PageServerConf`s with each other is not useful in general: there may
+// be some processing during loading, e.g. creation of the `auth` field. However,
+// we still want to compare remaining fields in tests, so we derive `PartialEq`,
+// but only in the `test` configuration. A special `derivative` crate is used to ignore
+// uncomparable fields.
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Derivative), derivative(PartialEq))]
 pub struct PageServerConf {
     // Identifier of that particular pageserver so e g safekeepers
     // can safely distinguish different pageservers
@@ -133,9 +142,8 @@ pub struct PageServerConf {
 
     pub pg_distrib_dir: PathBuf,
 
-    pub auth_type: AuthType,
-
-    pub auth_validation_public_key_path: Option<PathBuf>,
+    #[cfg_attr(test, derivative(PartialEq = "ignore"))]
+    pub auth: Option<Arc<JwtAuth>>,
     pub remote_storage_config: Option<RemoteStorageConfig>,
 
     pub profiling: ProfilingConfig,
@@ -218,10 +226,8 @@ struct PageServerConfigBuilder {
 
     pg_distrib_dir: BuilderValue<PathBuf>,
 
-    auth_type: BuilderValue<AuthType>,
-
     //
-    auth_validation_public_key_path: BuilderValue<Option<PathBuf>>,
+    auth: BuilderValue<Option<Arc<JwtAuth>>>,
     remote_storage_config: BuilderValue<Option<RemoteStorageConfig>>,
 
     id: BuilderValue<NodeId>,
@@ -258,8 +264,7 @@ impl Default for PageServerConfigBuilder {
             pg_distrib_dir: Set(env::current_dir()
                 .expect("cannot access current directory")
                 .join("pg_install")),
-            auth_type: Set(AuthType::Trust),
-            auth_validation_public_key_path: Set(None),
+            auth: Set(None),
             remote_storage_config: Set(None),
             id: NotSet,
             profiling: Set(ProfilingConfig::Disabled),
@@ -321,15 +326,8 @@ impl PageServerConfigBuilder {
         self.pg_distrib_dir = BuilderValue::Set(pg_distrib_dir)
     }
 
-    pub fn auth_type(&mut self, auth_type: AuthType) {
-        self.auth_type = BuilderValue::Set(auth_type)
-    }
-
-    pub fn auth_validation_public_key_path(
-        &mut self,
-        auth_validation_public_key_path: Option<PathBuf>,
-    ) {
-        self.auth_validation_public_key_path = BuilderValue::Set(auth_validation_public_key_path)
+    pub fn auth(&mut self, auth: Option<Arc<JwtAuth>>) {
+        self.auth = BuilderValue::Set(auth)
     }
 
     pub fn remote_storage_config(&mut self, remote_storage_config: Option<RemoteStorageConfig>) {
@@ -397,10 +395,7 @@ impl PageServerConfigBuilder {
             pg_distrib_dir: self
                 .pg_distrib_dir
                 .ok_or(anyhow!("missing pg_distrib_dir"))?,
-            auth_type: self.auth_type.ok_or(anyhow!("missing auth_type"))?,
-            auth_validation_public_key_path: self
-                .auth_validation_public_key_path
-                .ok_or(anyhow!("missing auth_validation_public_key_path"))?,
+            auth: self.auth.ok_or(anyhow!("missing auth information"))?,
             remote_storage_config: self
                 .remote_storage_config
                 .ok_or(anyhow!("missing remote_storage_config"))?,
@@ -563,6 +558,11 @@ impl PageServerConf {
 
         let mut t_conf = TenantConfOpt::default();
 
+        // For backward compatibility, see https://github.com/neondatabase/neon/pull/3139
+        // TODO: remove after a while
+        let mut auth_type: Option<AuthType> = None;
+        let mut auth_validation_public_key_path: Option<PathBuf> = None;
+
         for (key, item) in toml.iter() {
             match key {
                 "listen_pg_addr" => builder.listen_pg_addr(parse_toml_string(key, item)?),
@@ -577,10 +577,8 @@ impl PageServerConf {
                 "pg_distrib_dir" => {
                     builder.pg_distrib_dir(PathBuf::from(parse_toml_string(key, item)?))
                 }
-                "auth_validation_public_key_path" => builder.auth_validation_public_key_path(Some(
-                    PathBuf::from(parse_toml_string(key, item)?),
-                )),
-                "auth_type" => builder.auth_type(parse_toml_from_str(key, item)?),
+                "auth_type" => auth_type = Some(parse_toml_from_str(key, item)?),
+                "auth_validation_public_key_path" => auth_validation_public_key_path = Some(PathBuf::from(parse_toml_string(key, item)?)),
                 "remote_storage" => {
                     builder.remote_storage_config(RemoteStorageConfig::from_toml(item)?)
                 }
@@ -611,20 +609,26 @@ impl PageServerConf {
             }
         }
 
-        let mut conf = builder.build().context("invalid config")?;
-
-        if conf.auth_type == AuthType::NeonJWT {
-            let auth_validation_public_key_path = conf
-                .auth_validation_public_key_path
-                .get_or_insert_with(|| workdir.join("auth_public_key.pem"));
-            ensure!(
-                auth_validation_public_key_path.exists(),
-                format!(
-                    "Can't find auth_validation_public_key at '{}'",
-                    auth_validation_public_key_path.display()
-                )
-            );
+        // For backward compatibility only
+        match (auth_type, auth_validation_public_key_path) {
+            (None, None) => {}
+            (Some(AuthType::Trust), None) => {}
+            (Some(AuthType::Trust), Some(_)) => {
+                // Old behavior: ignore the public key file, it may even be missing.
+            }
+            (None, Some(path)) | (Some(AuthType::NeonJWT), Some(path)) => {
+                builder.auth(Some(Arc::new(
+                    JwtAuth::from_key_path(&workdir.join(path)).context(
+                        "unable to load public key from auth_validation_public_key_path",
+                    )?,
+                )))
+            }
+            (Some(AuthType::NeonJWT), None) => {
+                bail!("invalid config: auth_type = NeonJWT, but there is no auth_validation_public_key_path")
+            }
         }
+
+        let mut conf = builder.build().context("invalid config")?;
 
         conf.default_tenant_conf = t_conf.merge(TenantConf::default());
 
@@ -719,8 +723,7 @@ impl PageServerConf {
             superuser: "cloud_admin".to_string(),
             workdir: repo_dir,
             pg_distrib_dir,
-            auth_type: AuthType::Trust,
-            auth_validation_public_key_path: None,
+            auth: None,
             remote_storage_config: None,
             profiling: ProfilingConfig::Disabled,
             default_tenant_conf: TenantConf::default(),
@@ -895,8 +898,7 @@ log_format = 'json'
                 max_file_descriptors: defaults::DEFAULT_MAX_FILE_DESCRIPTORS,
                 workdir,
                 pg_distrib_dir,
-                auth_type: AuthType::Trust,
-                auth_validation_public_key_path: None,
+                auth: None,
                 remote_storage_config: None,
                 profiling: ProfilingConfig::Disabled,
                 default_tenant_conf: TenantConf::default(),
@@ -946,8 +948,7 @@ log_format = 'json'
                 max_file_descriptors: 333,
                 workdir,
                 pg_distrib_dir,
-                auth_type: AuthType::Trust,
-                auth_validation_public_key_path: None,
+                auth: None,
                 remote_storage_config: None,
                 profiling: ProfilingConfig::Disabled,
                 default_tenant_conf: TenantConf::default(),

--- a/safekeeper/src/http/routes.rs
+++ b/safekeeper/src/http/routes.rs
@@ -277,12 +277,9 @@ async fn record_safekeeper_info(mut request: Request<Body>) -> Result<Response<B
 }
 
 /// Safekeeper http router.
-pub fn make_router(
-    conf: SafeKeeperConf,
-    auth: Option<Arc<JwtAuth>>,
-) -> RouterBuilder<hyper::Body, ApiError> {
+pub fn make_router(conf: SafeKeeperConf) -> RouterBuilder<hyper::Body, ApiError> {
     let mut router = endpoint::make_router();
-    if auth.is_some() {
+    if conf.auth.is_some() {
         router = router.middleware(auth_middleware(|request| {
             #[allow(clippy::mutable_key_type)]
             static ALLOWLIST_ROUTES: Lazy<HashSet<Uri>> =
@@ -298,6 +295,7 @@ pub fn make_router(
 
     // NB: on any changes do not forget to update the OpenAPI spec
     // located nearby (/safekeeper/src/http/openapi_spec.yaml).
+    let auth = conf.auth.clone();
     router
         .data(Arc::new(conf))
         .data(auth)

--- a/safekeeper/src/lib.rs
+++ b/safekeeper/src/lib.rs
@@ -24,7 +24,9 @@ pub mod wal_service;
 pub mod wal_storage;
 
 mod timelines_global_map;
+use std::sync::Arc;
 pub use timelines_global_map::GlobalTimelines;
+use utils::auth::JwtAuth;
 
 pub mod defaults {
     pub use safekeeper_api::{
@@ -57,7 +59,7 @@ pub struct SafeKeeperConf {
     pub max_offloader_lag_bytes: u64,
     pub backup_runtime_threads: Option<usize>,
     pub wal_backup_enabled: bool,
-    pub auth_validation_public_key_path: Option<PathBuf>,
+    pub auth: Option<Arc<JwtAuth>>,
 }
 
 impl SafeKeeperConf {
@@ -87,7 +89,7 @@ impl SafeKeeperConf {
             broker_keepalive_interval: Duration::from_secs(5),
             backup_runtime_threads: None,
             wal_backup_enabled: true,
-            auth_validation_public_key_path: None,
+            auth: None,
             heartbeat_timeout: Duration::new(5, 0),
             max_offloader_lag_bytes: defaults::DEFAULT_MAX_OFFLOADER_LAG_BYTES,
         }

--- a/safekeeper/src/wal_service.rs
+++ b/safekeeper/src/wal_service.rs
@@ -5,32 +5,25 @@
 use anyhow::Result;
 use regex::Regex;
 use std::net::{TcpListener, TcpStream};
-use std::sync::Arc;
 use std::thread;
 use tracing::*;
-use utils::auth::JwtAuth;
 
 use crate::handler::SafekeeperPostgresHandler;
 use crate::SafeKeeperConf;
 use utils::postgres_backend::{AuthType, PostgresBackend};
 
 /// Accept incoming TCP connections and spawn them into a background thread.
-pub fn thread_main(
-    conf: SafeKeeperConf,
-    listener: TcpListener,
-    auth: Option<Arc<JwtAuth>>,
-) -> Result<()> {
+pub fn thread_main(conf: SafeKeeperConf, listener: TcpListener) -> Result<()> {
     loop {
         match listener.accept() {
             Ok((socket, peer_addr)) => {
                 debug!("accepted connection from {}", peer_addr);
                 let conf = conf.clone();
 
-                let auth = auth.clone();
                 let _ = thread::Builder::new()
                     .name("WAL service thread".into())
                     .spawn(move || {
-                        if let Err(err) = handle_socket(socket, conf, auth) {
+                        if let Err(err) = handle_socket(socket, conf) {
                             error!("connection handler exited: {}", err);
                         }
                     })
@@ -51,25 +44,17 @@ fn get_tid() -> u64 {
 
 /// This is run by `thread_main` above, inside a background thread.
 ///
-fn handle_socket(
-    socket: TcpStream,
-    conf: SafeKeeperConf,
-    auth: Option<Arc<JwtAuth>>,
-) -> Result<()> {
+fn handle_socket(socket: TcpStream, conf: SafeKeeperConf) -> Result<()> {
     let _enter = info_span!("", tid = ?get_tid()).entered();
 
     socket.set_nodelay(true)?;
 
-    let mut conn_handler = SafekeeperPostgresHandler::new(conf, auth.clone());
-    let pgbackend = PostgresBackend::new(
-        socket,
-        match auth {
-            None => AuthType::Trust,
-            Some(_) => AuthType::NeonJWT,
-        },
-        None,
-        false,
-    )?;
+    let auth_type = match conf.auth {
+        None => AuthType::Trust,
+        Some(_) => AuthType::NeonJWT,
+    };
+    let mut conn_handler = SafekeeperPostgresHandler::new(conf);
+    let pgbackend = PostgresBackend::new(socket, auth_type, None, false)?;
     // libpq replication protocol between safekeeper and replicas/pagers
     pgbackend.run(&mut conn_handler)?;
 


### PR DESCRIPTION
Follow-up of #2455

There is still significant code duplication between Pageserver and Safekeeper; see `check_auth_jwt`. However, moving that functionality inside `PostgresBackend` does not seem right, as it's a more generic class that should not be forced to use a single `Claims`/`Scope` enum for authorization. For example, Pageserver and Safekeeper will probably have different scopes in the future. Maybe making `PostgresBackend` generic on the JWT scope it's using is a good idea (with default to `()` or something similar).

There is a preparation for a breaking configuration change: `auth_type` in Pageserver's config will be eradicated and replaced by `auth_validation_public_key_path`. Previously it was mandatory; now it's optional but is still generated by `neon_local` for compatibility. In the future, it'd be good to remove corresponding lines from `pageserver/src/config.rs` (everything with `auth_type`) and `control_plane/src/pageserver.src` (in the `match self.env.pageserver.auth_type`). However, one will have to exercise caution during deployment and check existing configs.