### PR TITLE
Fix neon_local start and stop commands

### DIFF
--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -900,6 +900,7 @@ fn cli() -> Command {
     let stop_mode_arg = Arg::new("stop-mode")
         .short('m')
         .value_parser(["fast", "immediate"])
+        .default_value("fast")
         .help("If 'immediate', don't flush repository data at shutdown")
         .required(false)
         .value_name("stop-mode");

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1742,6 +1742,12 @@ class NeonCli(AbstractNeonCli):
 
         return self.raw_cli(args, check_return_code=check_return_code)
 
+    def start(self, check_return_code=True) -> "subprocess.CompletedProcess[str]":
+        return self.raw_cli(["start"], check_return_code=check_return_code)
+
+    def stop(self, check_return_code=True) -> "subprocess.CompletedProcess[str]":
+        return self.raw_cli(["stop"], check_return_code=check_return_code)
+
 
 class WalCraft(AbstractNeonCli):
     """

--- a/test_runner/regress/test_neon_local_cli.py
+++ b/test_runner/regress/test_neon_local_cli.py
@@ -1,0 +1,10 @@
+from fixtures.neon_fixtures import NeonEnvBuilder
+
+
+# Test that neon cli is able to start and stop all processes with the user defaults.
+# def test_neon_cli_basics(neon_simple_env: NeonEnv):
+def test_neon_cli_basics(neon_env_builder: NeonEnvBuilder):
+    env = neon_env_builder.init()
+
+    env.neon_cli.start()
+    env.neon_cli.stop()


### PR DESCRIPTION
Fixes https://github.com/neondatabase/neon/issues/3088

* Adds a test to ensure `neon_local` `start` and `stop` commands work. The nodes are started on the default ports, but all other nodes in the suites are started on different ports thanks to `PortDistributor`.
The test turned out to be useless for reproducing the current case, since created the config for the nodes, which contained absolute path to the test directory. Still, the test seems useful to keep it.

* Fixes an issue when pageserver was not killed after it got started and safekeeper had failed to start.
For me on Mac, the stopping code fails to get the event that shows that the process does not run, but the processes are actually stopped. The issue is not related to this PR hence not fixed.

* Canonicalize workdir in safekeeper to ensure that it exists and avoid issues with startup: pageserver did that, but safekeeper did not and when no workdir was picked, used a relative path when created an id file:
```
Error: Failed to create id file at ".neon/safekeepers/sk1/safekeeper.id"

Caused by:
    No such file or directory (os error 2)
```
It was not visible which file was causing the issue, so some more context was added to errors.