### PR TITLE
Collect core dump backtraces in compute_ctl.

### DIFF
--- a/Dockerfile.compute-node-v14
+++ b/Dockerfile.compute-node-v14
@@ -207,7 +207,8 @@ RUN apt update &&  \
         libgeos-c1v5 \
         libgdal28 \
         libproj19 \
-        libprotobuf-c1 && \
+        libprotobuf-c1 \
+        gdb && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 USER postgres

--- a/Dockerfile.compute-node-v15
+++ b/Dockerfile.compute-node-v15
@@ -207,7 +207,8 @@ RUN apt update &&  \
         libgeos-c1v5 \
         libgdal28 \
         libproj19 \
-        libprotobuf-c1 && \
+        libprotobuf-c1 \
+        gdb && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 USER postgres


### PR DESCRIPTION
Scan core dumps directory on exit. In case of existing core dumps call gdb/lldb to get a backtrace and log it. By default look for core dumps in postgres data directory as core.<pid>. That is how core collection is configured in our k8s nodes (and a reasonable convention in general).