### PR TITLE
Download on demand layers during GC info updates

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -2023,7 +2023,7 @@ impl Tenant {
                 *latest_gc_cutoff_lsn,
             ))?;
         {
-            let gc_info = src_timeline.gc_info.read().unwrap();
+            let gc_info = src_timeline.gc_info.read().await;
             let cutoff = min(gc_info.pitr_cutoff, gc_info.horizon_cutoff);
             if start_lsn < cutoff {
                 bail!(format!(

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -103,7 +103,7 @@ pub(super) async fn gather_inputs(
         let (interesting_lsns, horizon_cutoff, pitr_cutoff, next_gc_cutoff) = {
             // there's a race between the update (holding tenant.gc_lock) and this read but it
             // might not be an issue, because it's not for Timeline::gc
-            let gc_info = timeline.gc_info.read().unwrap();
+            let gc_info = timeline.gc_info.read().await;
 
             // similar to gc, but Timeline::get_latest_gc_cutoff_lsn() will not be updated before a
             // new gc run, which we have no control over. however differently from `Timeline::gc`


### PR DESCRIPTION
https://neondb.slack.com/archives/C04C55G1RHB/p1671730083417359

This one is more interesting then https://github.com/neondatabase/neon/pull/3194 ones, since std lock around `GcInfo` that was held during the whole info update operation, now needs to be broken due to `.await` happening in between to download on-demand.

I came up with some fugly CAS and had to replace the lock to the tokio one despite [the recommendations](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use), because rustc does not understand that lock is `drop`'ed, it only would understand it if the whole lock handling happened before `.await` in a dedicated block `{}`.
Now, I release the lock in case when on-demand downloads are needed and reacquire that later, comparing the data.

In general, it's again relatively odd to see that on-demand download required *after* the GC process, on GC info updates: something is odd here, but I guess we need to plug such places first before doing good refactoring and analysis later.