### PR TITLE
Run Python tests in 8 threads

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -123,8 +123,8 @@ runs:
           exit 1
         fi
         if [[ "${{ inputs.run_in_parallel }}" == "true" ]]; then
-          # -n4 uses four processes to run tests via pytest-xdist
-          EXTRA_PARAMS="-n4 $EXTRA_PARAMS"
+          # -n8 uses eight processes to run tests via pytest-xdist
+          EXTRA_PARAMS="-n8 $EXTRA_PARAMS"
 
           # --dist=loadgroup points tests marked with @pytest.mark.xdist_group
           # to the same worker to make @pytest.mark.order work with xdist


### PR DESCRIPTION
I have experimented with the runner threads number, and looks like 8 threads win us a few seconds.
[Before](https://github.com/neondatabase/neon/actions/runs/3801158803) (4 threads): 
<img width="322" alt="image" src="https://user-images.githubusercontent.com/2690773/209994003-3bb25f87-0a74-42ec-a943-a4b628d63f83.png">

[After](https://github.com/neondatabase/neon/actions/runs/3801868792) (8 threads):
<img width="321" alt="image" src="https://user-images.githubusercontent.com/2690773/209993716-81f392c4-bf67-4612-bf63-4ecbccfe152c.png">

Bumping the thread count more did not improve the situation much:
* 20 threads were not allowed by pytest
* 16 threads were flacking quite notably

My guess would be that all pageservers, safekeepers, and other nodes we start occupy quite much of the CPU and other resources to make this approach more scalable.