### PR TITLE
Lazy calculation of traversal_id which is needed only for error repoting

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1588,7 +1588,7 @@ trait TraversalLayerExt {
 }
 
 impl TraversalLayerExt for Arc<dyn PersistentLayer> {
-    fn traversal_id(&self) -> String {
+    fn traversal_id(&self) -> TraversalId {
         match self.local_path() {
             Some(local_path) => {
                 debug_assert!(local_path.to_str().unwrap().contains(&format!("{}", self.get_timeline_id())),
@@ -1608,12 +1608,26 @@ impl TraversalLayerExt for Arc<dyn PersistentLayer> {
 }
 
 impl TraversalLayerExt for Arc<InMemoryLayer> {
-    fn traversal_id(&self) -> String {
+    fn traversal_id(&self) -> TraversalId {
         format!(
             "timeline {} in-memory {}",
             self.get_timeline_id(),
             self.short_id()
         )
+    }
+}
+
+enum AnyLayer {
+    Memory(Arc<InMemoryLayer>),
+    Persistent(Arc<dyn PersistentLayer>),
+}
+
+impl AnyLayer {
+    fn traversal_id(&self) -> String {
+        match self {
+            AnyLayer::Memory(layer) => layer.traversal_id(),
+            AnyLayer::Persistent(layer) => layer.traversal_id(),
+        }
     }
 }
 
@@ -1638,7 +1652,7 @@ impl Timeline {
 
         // For debugging purposes, collect the path of layers that we traversed
         // through. It's included in the error message if we fail to find the key.
-        let mut traversal_path = Vec::<(ValueReconstructResult, Lsn, TraversalId)>::new();
+        let mut traversal_path = Vec::<(ValueReconstructResult, Lsn, AnyLayer)>::new();
 
         let cached_lsn = if let Some((cached_lsn, _)) = &reconstruct_state.img {
             *cached_lsn
@@ -1726,7 +1740,7 @@ impl Timeline {
                         Err(e) => return PageReconstructResult::from(e),
                     };
                     cont_lsn = lsn_floor;
-                    traversal_path.push((result, cont_lsn, open_layer.traversal_id()));
+                    traversal_path.push((result, cont_lsn, AnyLayer::Memory(open_layer.clone())));
                     continue;
                 }
             }
@@ -1744,7 +1758,7 @@ impl Timeline {
                         Err(e) => return PageReconstructResult::from(e),
                     };
                     cont_lsn = lsn_floor;
-                    traversal_path.push((result, cont_lsn, frozen_layer.traversal_id()));
+                    traversal_path.push((result, cont_lsn, AnyLayer::Memory(frozen_layer.clone())));
                     continue 'outer;
                 }
             }
@@ -1771,7 +1785,7 @@ impl Timeline {
                     Err(e) => return PageReconstructResult::from(e),
                 };
                 cont_lsn = lsn_floor;
-                traversal_path.push((result, cont_lsn, layer.traversal_id()));
+                traversal_path.push((result, cont_lsn, AnyLayer::Persistent(layer.clone())));
             } else if timeline.ancestor_timeline.is_some() {
                 // Nothing on this timeline. Traverse to parent
                 result = ValueReconstructResult::Continue;
@@ -3344,7 +3358,7 @@ where
 /// to an error, as anyhow context information.
 fn layer_traversal_error(
     msg: String,
-    path: Vec<(ValueReconstructResult, Lsn, TraversalId)>,
+    path: Vec<(ValueReconstructResult, Lsn, AnyLayer)>,
 ) -> PageReconstructResult<()> {
     // We want the original 'msg' to be the outermost context. The outermost context
     // is the most high-level information, which also gets propagated to the client.
@@ -3353,7 +3367,9 @@ fn layer_traversal_error(
         .map(|(r, c, l)| {
             format!(
                 "layer traversal: result {:?}, cont_lsn {}, layer: {}",
-                r, c, l,
+                r,
+                c,
+                l.traversal_id(),
             )
         })
         .chain(std::iter::once(msg));


### PR DESCRIPTION
See 
https://neondb.slack.com/archives/C0277TKAJCA/p1672245908989789
and 
https://neondb.slack.com/archives/C033RQ5SPDH/p1671885245981359