### PR TITLE
test_tenant_detach_smoke now does not do compaction before GC

### DIFF
--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -24,7 +24,6 @@ def do_gc_target(
     """Hack to unblock main, see https://github.com/neondatabase/neon/issues/2211"""
     try:
         log.info("sending gc http request")
-        pageserver_http.timeline_checkpoint(tenant_id, timeline_id)
         pageserver_http.timeline_gc(tenant_id, timeline_id, 0)
     except Exception as e:
         log.error("do_gc failed: %s", e)


### PR DESCRIPTION
The test started failing after 6dec85b19d63fd18b7f64d65d131fae6842f39f0 because a single call to a gc HTTP endpoint was prepended with a compaction endpoint. The former does create a task which detachment waits for, the latter does not.

This test does not seem to care about gc outcome at all, so removing compaction seems safe. The underlying issue is still there: the compaction HTTP endpoint can race with tenant detachment. We only use the endpoint in testing, so it may be worth checking other tests altered in the aforementioned commit.

Fixes #3136