### PR TITLE
Rename billing_metrics to consumption_metrics.

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -338,7 +338,7 @@ fn start_pageserver(conf: &'static PageServerConf) -> anyhow::Result<()> {
                 "consumption metrics collection",
                 true,
                 async move {
-                    pageserver::billing_metrics::collect_metrics(
+                    pageserver::consumption_metrics::collect_metrics(
                         metric_collection_endpoint,
                         conf.metric_collection_interval,
                         conf.id,

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -1,7 +1,7 @@
 mod auth;
 pub mod basebackup;
-pub mod billing_metrics;
 pub mod config;
+pub mod consumption_metrics;
 pub mod http;
 pub mod import_datadir;
 pub mod keyspace;


### PR DESCRIPTION
Use more appropriate term, because not all of these metrics are used for billing.
