### PR TITLE
Use neondatabase/ library changes for tokio-tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4076,7 +4076,7 @@ dependencies = [
 [[package]]
 name = "tokio-tar"
 version = "0.3.0"
-source = "git+https://github.com/hlinnaka/tokio-tar.git?branch=no-termination-on-drop#59824bfdc42f42b039fb9e3bcb35f43e02fbe63f"
+source = "git+https://github.com/neondatabase/tokio-tar.git?rev=404df61437de0feef49ba2ccdbdd94eb8ad6e142#404df61437de0feef49ba2ccdbdd94eb8ad6e142"
 dependencies = [
  "filetime",
  "futures-core",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 serde_with = "2.0"
 signal-hook = "0.3.10"
 svg_fmt = "0.4.1"
-tokio-tar = { git = "https://github.com/hlinnaka/tokio-tar.git", branch="no-termination-on-drop" }
+tokio-tar = { git = "https://github.com/neondatabase/tokio-tar.git", rev="404df61437de0feef49ba2ccdbdd94eb8ad6e142" }
 thiserror = "1.0"
 tokio = { version = "1.17", features = ["process", "sync", "macros", "fs", "rt", "io-util", "time"] }
 tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -117,7 +117,7 @@ where
         );
 
         Ok(Basebackup {
-            ar: Builder::new(AbortableWrite::new(write)),
+            ar: Builder::new_non_terminated(AbortableWrite::new(write)),
             timeline,
             lsn: backup_lsn,
             prev_record_lsn: prev_lsn,


### PR DESCRIPTION
Based on https://github.com/neondatabase/tokio-tar/pull/1

If the tokio-tar approach is right, for the library management, we can merge it in master there and use `rev=$SHA` here instead of the branch.