### PR TITLE
Fix panics at compute_ctl:monitor

### DIFF
--- a/compute_tools/src/monitor.rs
+++ b/compute_tools/src/monitor.rs
@@ -52,10 +52,16 @@ fn watch_compute_activity(compute: &ComputeNode) {
                     let mut idle_backs: Vec<DateTime<Utc>> = vec![];
 
                     for b in backs.into_iter() {
-                        let state: String = b.get("state");
-                        let change: String = b.get("state_change");
+                        let state: String = match b.try_get("state") {
+                            Ok(state) => state,
+                            Err(_) => continue,
+                        };
 
                         if state == "idle" {
+                            let change: String = match b.try_get("state_change") {
+                                Ok(state_change) => state_change,
+                                Err(_) => continue,
+                            };
                             let change = DateTime::parse_from_rfc3339(&change);
                             match change {
                                 Ok(t) => idle_backs.push(t.with_timezone(&Utc)),


### PR DESCRIPTION
Closes #1513

It's possible to receive `NULL` values. I've removed the conditions to test it:

```
main=> SELECT state, to_char(state_change, 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"') AS state_change
                         FROM pg_stat_activity;
 state  |          state_change
--------+---------------------------------
        |
        |
        |
 active | 2023-01-03"T"10:37:41.498769"Z"
        |
        |
        |
(7 rows)
```

to check that values are `NULL`s

```
main=> SELECT state is null, to_char(state_change, 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"') is null AS state_change
                         FROM pg_stat_activity;
 ?column? | state_change
----------+--------------
 t        | t
 t        | t
 t        | t
 f        | f
 t        | t
 t        | t
 t        | t
(7 rows)
```