### PR TITLE
Use static dispatch for various layer types

### DIFF
--- a/pageserver/benches/bench_layer_map.rs
+++ b/pageserver/benches/bench_layer_map.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
+use utils::id::{TenantId, TimelineId};
 
 use utils::lsn::Lsn;
 
@@ -50,6 +51,14 @@ impl Layer for DummyDelta {
     fn short_id(&self) -> String {
         unimplemented!()
     }
+
+    fn get_tenant_id(&self) -> TenantId {
+        unimplemented!()
+    }
+
+    fn get_timeline_id(&self) -> TimelineId {
+        unimplemented!()
+    }
 }
 
 struct DummyImage {
@@ -85,6 +94,14 @@ impl Layer for DummyImage {
     }
 
     fn short_id(&self) -> String {
+        unimplemented!()
+    }
+
+    fn get_tenant_id(&self) -> TenantId {
+        unimplemented!()
+    }
+
+    fn get_timeline_id(&self) -> TimelineId {
         unimplemented!()
     }
 }

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -20,8 +20,8 @@ use num_traits::{Bounded, Num, Signed};
 use rstar::{RTree, RTreeObject, AABB};
 use std::cmp::Ordering;
 use std::collections::VecDeque;
-use std::ops::Range;
 use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
+use std::ops::{Deref, Range};
 use std::sync::Arc;
 use tracing::*;
 use utils::lsn::Lsn;
@@ -31,7 +31,7 @@ use super::storage_layer::{InMemoryLayer, Layer, PersistentLayer};
 ///
 /// LayerMap tracks what layers exist on a timeline.
 ///
-pub struct LayerMap {
+pub struct LayerMap<L = PersistentLayer> {
     //
     // 'open_layer' holds the current InMemoryLayer that is accepting new
     // records. If it is None, 'next_open_layer_at' will be set instead, indicating
@@ -52,14 +52,14 @@ pub struct LayerMap {
     pub frozen_layers: VecDeque<Arc<InMemoryLayer>>,
 
     /// All the historic layers are kept here
-    historic_layers: RTree<LayerRTreeObject>,
+    historic_layers: RTree<LayerRTreeObject<L>>,
 
     /// L0 layers have key range Key::MIN..Key::MAX, and locating them using R-Tree search is very inefficient.
     /// So L0 layers are held in l0_delta_layers vector, in addition to the R-tree.
-    l0_delta_layers: Vec<PersistentLayer>,
+    l0_delta_layers: Vec<L>,
 }
 
-impl Default for LayerMap {
+impl<L> Default for LayerMap<L> {
     fn default() -> Self {
         Self {
             open_layer: None,
@@ -71,8 +71,8 @@ impl Default for LayerMap {
     }
 }
 
-struct LayerRTreeObject {
-    layer: PersistentLayer,
+struct LayerRTreeObject<L> {
+    layer: L,
 
     envelope: AABB<[IntKey; 2]>,
 }
@@ -196,21 +196,24 @@ impl Num for IntKey {
     }
 }
 
-impl PartialEq for LayerRTreeObject {
+impl<L: PartialEq> PartialEq for LayerRTreeObject<L> {
     fn eq(&self, other: &Self) -> bool {
         self.layer == other.layer
     }
 }
 
-impl RTreeObject for LayerRTreeObject {
+impl<L> RTreeObject for LayerRTreeObject<L> {
     type Envelope = AABB<[IntKey; 2]>;
     fn envelope(&self) -> Self::Envelope {
         self.envelope
     }
 }
 
-impl LayerRTreeObject {
-    fn new(layer: PersistentLayer) -> Self {
+impl<L> LayerRTreeObject<L>
+where
+    L: Deref<Target = dyn Layer>,
+{
+    fn new(layer: L) -> Self {
         let key_range = layer.get_key_range();
         let lsn_range = layer.get_lsn_range();
 
@@ -229,12 +232,15 @@ impl LayerRTreeObject {
 }
 
 /// Return value of LayerMap::search
-pub struct SearchResult {
-    pub layer: PersistentLayer,
+pub struct SearchResult<L> {
+    pub layer: L,
     pub lsn_floor: Lsn,
 }
 
-impl LayerMap {
+impl<L> LayerMap<L>
+where
+    L: Deref<Target = dyn Layer> + Clone + PartialEq,
+{
     ///
     /// Find the latest layer that covers the given 'key', with lsn <
     /// 'end_lsn'.
@@ -246,10 +252,10 @@ impl LayerMap {
     /// contain the version, even if it's missing from the returned
     /// layer.
     ///
-    pub fn search(&self, key: Key, end_lsn: Lsn) -> Option<SearchResult> {
+    pub fn search(&self, key: Key, end_lsn: Lsn) -> Option<SearchResult<L>> {
         // linear search
         // Find the latest image layer that covers the given key
-        let mut latest_img: Option<PersistentLayer> = None;
+        let mut latest_img: Option<L> = None;
         let mut latest_img_lsn: Option<Lsn> = None;
         let envelope = AABB::from_corners(
             [IntKey::from(key.to_i128()), IntKey::from(0i128)],
@@ -283,7 +289,7 @@ impl LayerMap {
         }
 
         // Search the delta layers
-        let mut latest_delta: Option<PersistentLayer> = None;
+        let mut latest_delta: Option<L> = None;
         for e in self
             .historic_layers
             .locate_in_envelope_intersecting(&envelope)
@@ -352,7 +358,7 @@ impl LayerMap {
     ///
     /// Insert an on-disk layer
     ///
-    pub fn insert_historic(&mut self, layer: PersistentLayer) {
+    pub fn insert_historic(&mut self, layer: L) {
         if layer.get_key_range() == (Key::MIN..Key::MAX) {
             self.l0_delta_layers.push(layer.clone());
         }
@@ -365,15 +371,10 @@ impl LayerMap {
     ///
     /// This should be called when the corresponding file on disk has been deleted.
     ///
-    pub fn remove_historic(&mut self, layer_to_remove: PersistentLayer) {
+    pub fn remove_historic(&mut self, layer_to_remove: L) {
         if layer_to_remove.get_key_range() == (Key::MIN..Key::MAX) {
             let len_before = self.l0_delta_layers.len();
 
-            // FIXME: ptr_eq might fail to return true for 'dyn'
-            // references.  Clippy complains about this. In practice it
-            // seems to work, the assertion below would be triggered
-            // otherwise but this ought to be fixed.
-            #[allow(clippy::vtable_address_comparisons)]
             self.l0_delta_layers
                 .retain(|other| other != &layer_to_remove);
             assert_eq!(self.l0_delta_layers.len(), len_before - 1);
@@ -434,13 +435,13 @@ impl LayerMap {
         }
     }
 
-    pub fn iter_historic_layers(&self) -> impl '_ + Iterator<Item = PersistentLayer> {
+    pub fn iter_historic_layers(&self) -> impl '_ + Iterator<Item = L> {
         self.historic_layers.iter().map(|e| e.layer.clone())
     }
 
     /// Find the last image layer that covers 'key', ignoring any image layers
     /// newer than 'lsn'.
-    fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<PersistentLayer> {
+    fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<L> {
         let mut candidate_lsn = Lsn(0);
         let mut candidate = None;
         let envelope = AABB::from_corners(
@@ -482,7 +483,7 @@ impl LayerMap {
         &self,
         key_range: &Range<Key>,
         lsn: Lsn,
-    ) -> Result<Vec<(Range<Key>, Option<PersistentLayer>)>> {
+    ) -> Result<Vec<(Range<Key>, Option<L>)>> {
         let mut points = vec![key_range.start];
         let envelope = AABB::from_corners(
             [IntKey::from(key_range.start.to_i128()), IntKey::from(0)],
@@ -567,7 +568,7 @@ impl LayerMap {
     }
 
     /// Return all L0 delta layers
-    pub fn get_level0_deltas(&self) -> Result<Vec<PersistentLayer>> {
+    pub fn get_level0_deltas(&self) -> Result<Vec<L>> {
         Ok(self.l0_delta_layers.clone())
     }
 

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -26,12 +26,12 @@ use std::sync::Arc;
 use tracing::*;
 use utils::lsn::Lsn;
 
-use super::storage_layer::{InMemoryLayer, Layer};
+use super::storage_layer::{InMemoryLayer, Layer, PersistentLayer};
 
 ///
 /// LayerMap tracks what layers exist on a timeline.
 ///
-pub struct LayerMap<L: ?Sized> {
+pub struct LayerMap {
     //
     // 'open_layer' holds the current InMemoryLayer that is accepting new
     // records. If it is None, 'next_open_layer_at' will be set instead, indicating
@@ -52,14 +52,14 @@ pub struct LayerMap<L: ?Sized> {
     pub frozen_layers: VecDeque<Arc<InMemoryLayer>>,
 
     /// All the historic layers are kept here
-    historic_layers: RTree<LayerRTreeObject<L>>,
+    historic_layers: RTree<LayerRTreeObject>,
 
     /// L0 layers have key range Key::MIN..Key::MAX, and locating them using R-Tree search is very inefficient.
     /// So L0 layers are held in l0_delta_layers vector, in addition to the R-tree.
-    l0_delta_layers: Vec<Arc<L>>,
+    l0_delta_layers: Vec<PersistentLayer>,
 }
 
-impl<L: ?Sized> Default for LayerMap<L> {
+impl Default for LayerMap {
     fn default() -> Self {
         Self {
             open_layer: None,
@@ -71,8 +71,8 @@ impl<L: ?Sized> Default for LayerMap<L> {
     }
 }
 
-struct LayerRTreeObject<L: ?Sized> {
-    layer: Arc<L>,
+struct LayerRTreeObject {
+    layer: PersistentLayer,
 
     envelope: AABB<[IntKey; 2]>,
 }
@@ -196,32 +196,21 @@ impl Num for IntKey {
     }
 }
 
-impl<T: ?Sized> PartialEq for LayerRTreeObject<T> {
+impl PartialEq for LayerRTreeObject {
     fn eq(&self, other: &Self) -> bool {
-        // FIXME: ptr_eq might fail to return true for 'dyn'
-        // references.  Clippy complains about this. In practice it
-        // seems to work, the assertion below would be triggered
-        // otherwise but this ought to be fixed.
-        #[allow(clippy::vtable_address_comparisons)]
-        Arc::ptr_eq(&self.layer, &other.layer)
+        self.layer == other.layer
     }
 }
 
-impl<L> RTreeObject for LayerRTreeObject<L>
-where
-    L: ?Sized,
-{
+impl RTreeObject for LayerRTreeObject {
     type Envelope = AABB<[IntKey; 2]>;
     fn envelope(&self) -> Self::Envelope {
         self.envelope
     }
 }
 
-impl<L> LayerRTreeObject<L>
-where
-    L: ?Sized + Layer,
-{
-    fn new(layer: Arc<L>) -> Self {
+impl LayerRTreeObject {
+    fn new(layer: PersistentLayer) -> Self {
         let key_range = layer.get_key_range();
         let lsn_range = layer.get_lsn_range();
 
@@ -240,15 +229,12 @@ where
 }
 
 /// Return value of LayerMap::search
-pub struct SearchResult<L: ?Sized> {
-    pub layer: Arc<L>,
+pub struct SearchResult {
+    pub layer: PersistentLayer,
     pub lsn_floor: Lsn,
 }
 
-impl<L> LayerMap<L>
-where
-    L: ?Sized + Layer,
-{
+impl LayerMap {
     ///
     /// Find the latest layer that covers the given 'key', with lsn <
     /// 'end_lsn'.
@@ -260,10 +246,10 @@ where
     /// contain the version, even if it's missing from the returned
     /// layer.
     ///
-    pub fn search(&self, key: Key, end_lsn: Lsn) -> Option<SearchResult<L>> {
+    pub fn search(&self, key: Key, end_lsn: Lsn) -> Option<SearchResult> {
         // linear search
         // Find the latest image layer that covers the given key
-        let mut latest_img: Option<Arc<L>> = None;
+        let mut latest_img: Option<PersistentLayer> = None;
         let mut latest_img_lsn: Option<Lsn> = None;
         let envelope = AABB::from_corners(
             [IntKey::from(key.to_i128()), IntKey::from(0i128)],
@@ -286,18 +272,18 @@ where
             if Lsn(img_lsn.0 + 1) == end_lsn {
                 // found exact match
                 return Some(SearchResult {
-                    layer: Arc::clone(l),
+                    layer: l.clone(),
                     lsn_floor: img_lsn,
                 });
             }
             if img_lsn > latest_img_lsn.unwrap_or(Lsn(0)) {
-                latest_img = Some(Arc::clone(l));
+                latest_img = Some(l.clone());
                 latest_img_lsn = Some(img_lsn);
             }
         }
 
         // Search the delta layers
-        let mut latest_delta: Option<Arc<L>> = None;
+        let mut latest_delta: Option<PersistentLayer> = None;
         for e in self
             .historic_layers
             .locate_in_envelope_intersecting(&envelope)
@@ -323,7 +309,7 @@ where
                     "found layer {} for request on {key} at {end_lsn}",
                     l.short_id(),
                 );
-                latest_delta.replace(Arc::clone(l));
+                latest_delta.replace(l.clone());
                 break;
             }
             if l.get_lsn_range().end > latest_img_lsn.unwrap_or(Lsn(0)) {
@@ -331,10 +317,10 @@ where
                 // nothing newer, this is what we need to return. Remember this.
                 if let Some(old_candidate) = &latest_delta {
                     if l.get_lsn_range().end > old_candidate.get_lsn_range().end {
-                        latest_delta.replace(Arc::clone(l));
+                        latest_delta.replace(l.clone());
                     }
                 } else {
-                    latest_delta.replace(Arc::clone(l));
+                    latest_delta.replace(l.clone());
                 }
             }
         }
@@ -366,7 +352,7 @@ where
     ///
     /// Insert an on-disk layer
     ///
-    pub fn insert_historic(&mut self, layer: Arc<L>) {
+    pub fn insert_historic(&mut self, layer: PersistentLayer) {
         if layer.get_key_range() == (Key::MIN..Key::MAX) {
             self.l0_delta_layers.push(layer.clone());
         }
@@ -379,8 +365,8 @@ where
     ///
     /// This should be called when the corresponding file on disk has been deleted.
     ///
-    pub fn remove_historic(&mut self, layer: Arc<L>) {
-        if layer.get_key_range() == (Key::MIN..Key::MAX) {
+    pub fn remove_historic(&mut self, layer_to_remove: PersistentLayer) {
+        if layer_to_remove.get_key_range() == (Key::MIN..Key::MAX) {
             let len_before = self.l0_delta_layers.len();
 
             // FIXME: ptr_eq might fail to return true for 'dyn'
@@ -389,12 +375,12 @@ where
             // otherwise but this ought to be fixed.
             #[allow(clippy::vtable_address_comparisons)]
             self.l0_delta_layers
-                .retain(|other| !Arc::ptr_eq(other, &layer));
+                .retain(|other| other != &layer_to_remove);
             assert_eq!(self.l0_delta_layers.len(), len_before - 1);
         }
         assert!(self
             .historic_layers
-            .remove(&LayerRTreeObject::new(layer))
+            .remove(&LayerRTreeObject::new(layer_to_remove))
             .is_some());
         NUM_ONDISK_LAYERS.dec();
     }
@@ -448,13 +434,13 @@ where
         }
     }
 
-    pub fn iter_historic_layers(&self) -> impl '_ + Iterator<Item = Arc<L>> {
+    pub fn iter_historic_layers(&self) -> impl '_ + Iterator<Item = PersistentLayer> {
         self.historic_layers.iter().map(|e| e.layer.clone())
     }
 
     /// Find the last image layer that covers 'key', ignoring any image layers
     /// newer than 'lsn'.
-    fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<Arc<L>> {
+    fn find_latest_image(&self, key: Key, lsn: Lsn) -> Option<PersistentLayer> {
         let mut candidate_lsn = Lsn(0);
         let mut candidate = None;
         let envelope = AABB::from_corners(
@@ -478,7 +464,7 @@ where
                 continue;
             }
             candidate_lsn = this_lsn;
-            candidate = Some(Arc::clone(l));
+            candidate = Some(l.clone());
         }
 
         candidate
@@ -496,7 +482,7 @@ where
         &self,
         key_range: &Range<Key>,
         lsn: Lsn,
-    ) -> Result<Vec<(Range<Key>, Option<Arc<L>>)>> {
+    ) -> Result<Vec<(Range<Key>, Option<PersistentLayer>)>> {
         let mut points = vec![key_range.start];
         let envelope = AABB::from_corners(
             [IntKey::from(key_range.start.to_i128()), IntKey::from(0)],
@@ -581,7 +567,7 @@ where
     }
 
     /// Return all L0 delta layers
-    pub fn get_level0_deltas(&self) -> Result<Vec<Arc<L>>> {
+    pub fn get_level0_deltas(&self) -> Result<Vec<PersistentLayer>> {
         Ok(self.l0_delta_layers.clone())
     }
 

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -177,7 +177,7 @@ impl PersistentLayer {
         match self {
             Self::Delta(delta) => Some(delta.path()),
             Self::Image(image) => Some(image.path()),
-            Self::Remote(_remote) => None, // TODO kb is this method needed?
+            Self::Remote(_remote) => None,
         }
     }
 
@@ -186,7 +186,7 @@ impl PersistentLayer {
         match self {
             Self::Delta(delta) => delta.iter(),
             Self::Image(_image) => unimplemented!(),
-            Self::Remote(_remote) => anyhow::bail!("cannot iterate a remote layer"), // TODO kb is this method needed?
+            Self::Remote(_remote) => anyhow::bail!("cannot iterate a remote layer"),
         }
     }
 
@@ -196,7 +196,7 @@ impl PersistentLayer {
         match self {
             Self::Delta(delta) => delta.key_iter(),
             Self::Image(_image) => panic!("Not implemented"),
-            Self::Remote(_remote) => anyhow::bail!("cannot iterate a remote layer"), // TODO kb is this method needed?
+            Self::Remote(_remote) => anyhow::bail!("cannot iterate a remote layer"),
         }
     }
 
@@ -213,7 +213,7 @@ impl PersistentLayer {
                 fs::remove_file(image.path())?;
                 Ok(())
             }
-            Self::Remote(_remote) => Ok(()), // TODO kb is this method needed?
+            Self::Remote(_remote) => Ok(()),
         }
     }
 
@@ -229,7 +229,7 @@ impl PersistentLayer {
         match self {
             Self::Delta(delta) => Some(delta.file_size),
             Self::Image(image) => Some(image.file_size),
-            Self::Remote(remote) => remote.layer_metadata.file_size(), // TODO kb is this method needed?
+            Self::Remote(remote) => remote.layer_metadata.file_size(),
         }
     }
 }

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -83,6 +83,11 @@ pub enum ValueReconstructResult {
 /// Supertrait of the [`Layer`] trait that captures the bare minimum interface
 /// required by [`LayerMap`].
 pub trait Layer: Send + Sync {
+    fn get_tenant_id(&self) -> TenantId;
+
+    /// Identify the timeline this layer belongs to
+    fn get_timeline_id(&self) -> TimelineId;
+
     /// Range of keys that this layer covers
     fn get_key_range(&self) -> Range<Key>;
 
@@ -147,11 +152,6 @@ pub type LayerKeyIter<'i> = Box<dyn Iterator<Item = (Key, Lsn, u64)> + 'i>;
 /// LSN
 ///
 pub trait PersistentLayer: Layer {
-    fn get_tenant_id(&self) -> TenantId;
-
-    /// Identify the timeline this layer belongs to
-    fn get_timeline_id(&self) -> TimelineId;
-
     /// File name used for this layer, both in the pageserver's local filesystem
     /// state as well as in the remote storage.
     fn filename(&self) -> LayerFileName;

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -235,11 +235,6 @@ impl PersistentLayer {
 }
 
 impl PartialEq for PersistentLayer {
-    // // FIXME: ptr_eq might fail to return true for 'dyn'
-    // // references.  Clippy complains about this. In practice it
-    // // seems to work, the assertion below would be triggered
-    // // otherwise but this ought to be fixed.
-    // #[allow(clippy::vtable_address_comparisons)]
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Delta(d0), Self::Delta(d1)) => Arc::ptr_eq(d0, d1),

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -199,6 +199,14 @@ pub struct DeltaLayerInner {
 }
 
 impl Layer for DeltaLayer {
+    fn get_tenant_id(&self) -> TenantId {
+        self.tenant_id
+    }
+
+    fn get_timeline_id(&self) -> TimelineId {
+        self.timeline_id
+    }
+
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -375,14 +383,6 @@ impl Layer for DeltaLayer {
 }
 
 impl PersistentLayer for DeltaLayer {
-    fn get_tenant_id(&self) -> TenantId {
-        self.tenant_id
-    }
-
-    fn get_timeline_id(&self) -> TimelineId {
-        self.timeline_id
-    }
-
     fn filename(&self) -> LayerFileName {
         self.layer_name().into()
     }

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -126,6 +126,14 @@ pub struct ImageLayerInner {
 }
 
 impl Layer for ImageLayer {
+    fn get_tenant_id(&self) -> TenantId {
+        self.tenant_id
+    }
+
+    fn get_timeline_id(&self) -> TimelineId {
+        self.timeline_id
+    }
+
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -213,13 +221,6 @@ impl PersistentLayer for ImageLayer {
         Some(self.path())
     }
 
-    fn get_tenant_id(&self) -> TenantId {
-        self.tenant_id
-    }
-
-    fn get_timeline_id(&self) -> TimelineId {
-        self.timeline_id
-    }
     fn iter(&self) -> Result<LayerIter<'_>> {
         unimplemented!();
     }

--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -75,13 +75,15 @@ impl InMemoryLayerInner {
     }
 }
 
-impl InMemoryLayer {
-    pub fn get_timeline_id(&self) -> TimelineId {
+impl Layer for InMemoryLayer {
+    fn get_tenant_id(&self) -> TenantId {
+        self.tenant_id
+    }
+
+    fn get_timeline_id(&self) -> TimelineId {
         self.timeline_id
     }
-}
 
-impl Layer for InMemoryLayer {
     fn get_key_range(&self) -> Range<Key> {
         Key::MIN..Key::MAX
     }

--- a/pageserver/src/tenant/storage_layer/remote_layer.rs
+++ b/pageserver/src/tenant/storage_layer/remote_layer.rs
@@ -21,8 +21,8 @@ use super::{DeltaLayer, LayerIter, LayerKeyIter, PersistentLayer};
 
 #[derive(Debug)]
 pub struct RemoteLayer {
-    tenantid: TenantId,
-    timelineid: TimelineId,
+    tenant_id: TenantId,
+    timeline_id: TimelineId,
     key_range: Range<Key>,
     lsn_range: Range<Lsn>,
 
@@ -38,6 +38,14 @@ pub struct RemoteLayer {
 }
 
 impl Layer for RemoteLayer {
+    fn get_tenant_id(&self) -> TenantId {
+        self.tenant_id
+    }
+
+    fn get_timeline_id(&self) -> TimelineId {
+        self.timeline_id
+    }
+
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -66,8 +74,8 @@ impl Layer for RemoteLayer {
     fn dump(&self, _verbose: bool) -> Result<()> {
         println!(
             "----- remote layer for ten {} tli {} keys {}-{} lsn {}-{} ----",
-            self.tenantid,
-            self.timelineid,
+            self.tenant_id,
+            self.timeline_id,
             self.key_range.start,
             self.key_range.end,
             self.lsn_range.start,
@@ -83,14 +91,6 @@ impl Layer for RemoteLayer {
 }
 
 impl PersistentLayer for RemoteLayer {
-    fn get_tenant_id(&self) -> TenantId {
-        self.tenantid
-    }
-
-    fn get_timeline_id(&self) -> TimelineId {
-        self.timelineid
-    }
-
     fn filename(&self) -> LayerFileName {
         if self.is_delta {
             DeltaFileName {
@@ -144,8 +144,8 @@ impl RemoteLayer {
         layer_metadata: &LayerFileMetadata,
     ) -> RemoteLayer {
         RemoteLayer {
-            tenantid,
-            timelineid,
+            tenant_id: tenantid,
+            timeline_id: timelineid,
             key_range: fname.key_range.clone(),
             lsn_range: fname.lsn..(fname.lsn + 1),
             is_delta: false,
@@ -163,8 +163,8 @@ impl RemoteLayer {
         layer_metadata: &LayerFileMetadata,
     ) -> RemoteLayer {
         RemoteLayer {
-            tenantid,
-            timelineid,
+            tenant_id: tenantid,
+            timeline_id: timelineid,
             key_range: fname.key_range.clone(),
             lsn_range: fname.lsn_range.clone(),
             is_delta: true,
@@ -188,8 +188,8 @@ impl RemoteLayer {
             };
             Arc::new(DeltaLayer::new(
                 conf,
-                self.timelineid,
-                self.tenantid,
+                self.timeline_id,
+                self.tenant_id,
                 &fname,
                 file_size,
             ))
@@ -200,8 +200,8 @@ impl RemoteLayer {
             };
             Arc::new(ImageLayer::new(
                 conf,
-                self.timelineid,
-                self.tenantid,
+                self.timeline_id,
+                self.tenant_id,
                 &fname,
                 file_size,
             ))


### PR DESCRIPTION
Remove various `downcast_remote_layer` and other odd `&dyn Layer` manipulations, replacing them with matching over the enum.

I think, that should be split further, but first version is created to discuss https://github.com/neondatabase/neon/pull/3260