### PR TITLE
download_all_remote_layers API: require client to specify max_concurr…

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU64;
+use std::num::{NonZeroU64, NonZeroUsize};
 
 use byteorder::{BigEndian, ReadBytesExt};
 use serde::{Deserialize, Serialize};
@@ -208,6 +208,11 @@ pub struct TimelineInfo {
     pub pg_version: u32,
 
     pub state: TimelineState,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DownloadRemoteLayersTaskSpawnRequest {
+    pub max_concurrent_downloads: NonZeroUsize,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1350,11 +1350,18 @@ class PageserverHttpClient(requests.Session):
         assert res_json is None
 
     def timeline_spawn_download_remote_layers(
-        self, tenant_id: TenantId, timeline_id: TimelineId
+        self,
+        tenant_id: TenantId,
+        timeline_id: TimelineId,
+        max_concurrent_downloads: int,
     ) -> dict[str, Any]:
 
+        body = {
+            "max_concurrent_downloads": max_concurrent_downloads,
+        }
         res = self.post(
             f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/download_remote_layers",
+            json=body,
         )
         self.verbose_error(res)
         res_json = res.json()
@@ -1388,10 +1395,13 @@ class PageserverHttpClient(requests.Session):
         self,
         tenant_id: TenantId,
         timeline_id: TimelineId,
+        max_concurrent_downloads: int,
         errors_ok=False,
         at_least_one_download=True,
     ):
-        res = self.timeline_spawn_download_remote_layers(tenant_id, timeline_id)
+        res = self.timeline_spawn_download_remote_layers(
+            tenant_id, timeline_id, max_concurrent_downloads
+        )
         while True:
             completed = self.timeline_poll_download_remote_layers_status(
                 tenant_id, timeline_id, res, poll_state="Completed"

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -392,7 +392,12 @@ def test_download_remote_layers_api(
 
     # issue downloads that we know will fail
     info = client.timeline_download_remote_layers(
-        tenant_id, timeline_id, errors_ok=True, at_least_one_download=False
+        tenant_id,
+        timeline_id,
+        # allow some concurrency to unveil potential concurrency bugs
+        max_concurrent_downloads=10,
+        errors_ok=True,
+        at_least_one_download=False,
     )
     log.info(f"info={info}")
     assert info["state"] == "Completed"
@@ -413,7 +418,13 @@ def test_download_remote_layers_api(
 
     ##### Retry, this time without failpoints
     client.configure_failpoints(("remote-storage-download-pre-rename", "off"))
-    info = client.timeline_download_remote_layers(tenant_id, timeline_id, errors_ok=False)
+    info = client.timeline_download_remote_layers(
+        tenant_id,
+        timeline_id,
+        # allow some concurrency to unveil potential concurrency bugs
+        max_concurrent_downloads=10,
+        errors_ok=False,
+    )
     log.info(f"info={info}")
 
     assert info["state"] == "Completed"


### PR DESCRIPTION
…ent_downloads

Before this patch, we would start all layer downloads simultaneously.

There is at most one download_all_remote_layers task per timeline. Hence, the specified limit is per timeline.

There is still no global concurrency limit for layer downloads. We'll have to revisit that at some point and also prioritize on-demand initiated downloads over download_all_remote_layers downloads. But that's for another day.