### PR TITLE
artificial lifetime of TimelineGuard bound to the lifetime of TimelineRef

### DIFF
--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -195,7 +195,7 @@ pub async fn collect_metrics_task(
         let mut tenant_resident_size = 0;
 
         // iterate through list of timelines in tenant
-        for timeline_ref in tenant.list_timelines().iter() {
+        for timeline_ref in &tenant.list_timeline_refs() {
             if let Ok(timeline) = timeline_ref.timeline() {
                 // collect per-timeline metrics only for active timelines
                 if timeline.is_active() {

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -1504,13 +1504,13 @@ fn is_slru_block_key(key: Key) -> bool {
 }
 
 #[cfg(test)]
-pub fn create_test_timeline(
+pub fn create_test_timeline_ref(
     tenant: &crate::tenant::Tenant,
     timeline_id: utils::id::TimelineId,
     pg_version: u32,
 ) -> anyhow::Result<crate::tenant::TimelineRef> {
     let tline_ref = tenant
-        .create_empty_timeline(timeline_id, Lsn(8), pg_version)?
+        .create_empty_timeline_ref(timeline_id, Lsn(8), pg_version)?
         .initialize()?;
     let tline = tline_ref.timeline()?;
     let mut m = tline.begin_modification(Lsn(8));

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -1508,15 +1508,15 @@ pub fn create_test_timeline(
     tenant: &crate::tenant::Tenant,
     timeline_id: utils::id::TimelineId,
     pg_version: u32,
-) -> anyhow::Result<crate::tenant::TimelineGuard> {
-    let tline = tenant
+) -> anyhow::Result<crate::tenant::TimelineRef> {
+    let tline_ref = tenant
         .create_empty_timeline(timeline_id, Lsn(8), pg_version)?
-        .initialize()?
-        .timeline()?;
+        .initialize()?;
+    let tline = tline_ref.timeline()?;
     let mut m = tline.begin_modification(Lsn(8));
     m.init_empty()?;
     m.commit()?;
-    Ok(tline)
+    Ok(tline_ref)
 }
 
 #[allow(clippy::bool_assert_comparison)]

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1889,7 +1889,10 @@ impl Tenant {
         for timeline_ref in gc_timelines {
             let timeline = match timeline_ref.timeline() {
                 Err(e) => {
-                    info!("skipping gc on timeline {}: {:#}", timeline_ref.id, e);
+                    info!(
+                        "skipping gc on timeline {}: {:#}",
+                        timeline_ref.id.timeline_id, e
+                    );
                     continue; // TODO review: is it ok to do this here? Should be, because we break below on shutdown request.
                 }
                 Ok(tl) => tl,

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -507,7 +507,7 @@ pub async fn immediate_compact(
         .map_err(ApiError::NotFound)?;
 
     let timeline_ref = tenant
-        .get_timeline(timeline_id)
+        .get_timeline_ref(timeline_id)
         .map_err(ApiError::NotFound)?;
 
     // Run in task_mgr to avoid race with detach operation

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -97,7 +97,15 @@ pub(super) async fn gather_inputs(
     // used to determine the `retention_period` for the size model
     let mut max_cutoff_distance = None;
 
-    for timeline in timelines {
+    for timeline_ref in timelines {
+        let timeline = match timeline_ref.timeline() {
+            Ok(tl) => tl,
+            Err(e) => {
+                info!("skipping timeline {}: {:#}", timeline_ref.id, e);
+                continue; // TODO review: OK to do this here?
+            }
+        };
+
         let last_record_lsn = timeline.get_last_record_lsn();
 
         let (interesting_lsns, horizon_cutoff, pitr_cutoff, next_gc_cutoff) = {

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -101,7 +101,7 @@ pub(super) async fn gather_inputs(
         let timeline = match timeline_ref.timeline() {
             Ok(tl) => tl,
             Err(e) => {
-                info!("skipping timeline {}: {:#}", timeline_ref.id, e);
+                info!("skipping timeline {}: {:#}", timeline_ref.id.timeline_id, e);
                 continue; // TODO review: OK to do this here?
             }
         };

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -68,12 +68,12 @@ pub(super) async fn gather_inputs(
     // our advantage with `?` error handling.
     let mut joinset = tokio::task::JoinSet::new();
 
-    let timelines = tenant
+    let timeline_refs = tenant
         .refresh_gc_info()
         .await
         .context("Failed to refresh gc_info before gathering inputs")?;
 
-    if timelines.is_empty() {
+    if timeline_refs.is_empty() {
         // All timelines are below tenant's gc_horizon; alternative would be to use
         // Tenant::list_timelines but then those gc_info's would not be updated yet, possibly
         // missing GcInfo::retain_lsns or having obsolete values for cutoff's.
@@ -92,12 +92,12 @@ pub(super) async fn gather_inputs(
     let mut updates = Vec::new();
 
     // record the per timline values used to determine `retention_period`
-    let mut timeline_inputs = HashMap::with_capacity(timelines.len());
+    let mut timeline_inputs = HashMap::with_capacity(timeline_refs.len());
 
     // used to determine the `retention_period` for the size model
     let mut max_cutoff_distance = None;
 
-    for timeline_ref in timelines {
+    for timeline_ref in timeline_refs {
         let timeline = match timeline_ref.timeline() {
             Ok(tl) => tl,
             Err(e) => {

--- a/pageserver/src/tenant/timeline/timeline_wrappers.rs
+++ b/pageserver/src/tenant/timeline/timeline_wrappers.rs
@@ -35,7 +35,7 @@ use super::Timeline;
 /// while operations that use `&Timeline` are "uninterruptable".
 #[derive(Clone)]
 pub struct TimelineRef {
-    timeline: Weak<Timeline>,
+    timeline_ref: Weak<Timeline>,
     pub id: TenantTimelineId,
 }
 
@@ -51,7 +51,7 @@ impl TimelineRef {
     // Let only Timeline module the ability to create weak references on itself.
     pub(super) fn new(timeline: &Timeline) -> Self {
         Self {
-            timeline: Weak::clone(&timeline.myself),
+            timeline_ref: Weak::clone(&timeline.myself),
             id: TenantTimelineId::new(timeline.tenant_id, timeline.timeline_id),
         }
     }
@@ -61,10 +61,10 @@ impl TimelineRef {
     pub fn timeline(&self) -> anyhow::Result<TimelineGuard<'_>> {
         Ok(TimelineGuard {
             timeline: self
-                .timeline
+                .timeline_ref
                 .upgrade()
                 .with_context(|| format!("Timeline {} is dropped", self.id))?,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         })
     }
 

--- a/pageserver/src/tenant/timeline/timeline_wrappers.rs
+++ b/pageserver/src/tenant/timeline/timeline_wrappers.rs
@@ -107,7 +107,7 @@ impl TimelineRef {
 /// By reacquiring the guard periodically, the timeline-accessing processes can stop when the timeline is being shut down.
 pub struct TimelineGuard<'a> {
     timeline: Arc<Timeline>,
-    _phantom: PhantomData<&'a Timeline>,
+    _phantom: PhantomData<&'a ()>,
 }
 
 // All `Timeline::` methods here exist because `Arc<Timeline>` is needed for them to run

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -740,7 +740,6 @@ impl WalIngest {
             },
         )?;
 
-        let timeline_read = self.timeline_ref.timeline()?;
         for xnode in &parsed.xnodes {
             for forknum in MAIN_FORKNUM..=VISIBILITYMAP_FORKNUM {
                 let rel = RelTag {
@@ -749,6 +748,7 @@ impl WalIngest {
                     dbnode: xnode.dbnode,
                     relnode: xnode.relnode,
                 };
+                let timeline_read = self.timeline_ref.timeline()?;
                 let last_lsn = timeline_read.get_last_record_lsn();
                 if with_ondemand_download(|| modification.tline.get_rel_exists(rel, last_lsn, true))
                     .await?

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1112,7 +1112,7 @@ impl WalIngest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pgdatadir_mapping::create_test_timeline;
+    use crate::pgdatadir_mapping::create_test_timeline_ref;
     use crate::tenant::harness::*;
     use crate::tenant::Timeline;
     use postgres_ffi::v14::xlog_utils::SIZEOF_CHECKPOINT;
@@ -1147,7 +1147,8 @@ mod tests {
     #[tokio::test]
     async fn test_relsize() -> Result<()> {
         let tenant = TenantHarness::create("test_relsize")?.load().await;
-        let tline = create_test_timeline(&tenant, TIMELINE_ID, DEFAULT_PG_VERSION)?;
+        let tline_ref = create_test_timeline_ref(&tenant, TIMELINE_ID, DEFAULT_PG_VERSION)?;
+        let tline = tline_ref.active_timeline()?;
         let mut walingest = init_walingest_test(&tline).await?;
 
         let mut m = tline.begin_modification(Lsn(0x20));
@@ -1363,7 +1364,8 @@ mod tests {
     #[tokio::test]
     async fn test_drop_extend() -> Result<()> {
         let tenant = TenantHarness::create("test_drop_extend")?.load().await;
-        let tline = create_test_timeline(&tenant, TIMELINE_ID, DEFAULT_PG_VERSION)?;
+        let tline_ref = create_test_timeline_ref(&tenant, TIMELINE_ID, DEFAULT_PG_VERSION)?;
+        let tline = tline_ref.active_timeline()?;
         let mut walingest = init_walingest_test(&tline).await?;
 
         let mut m = tline.begin_modification(Lsn(0x20));
@@ -1432,7 +1434,8 @@ mod tests {
     #[tokio::test]
     async fn test_truncate_extend() -> Result<()> {
         let tenant = TenantHarness::create("test_truncate_extend")?.load().await;
-        let tline = create_test_timeline(&tenant, TIMELINE_ID, DEFAULT_PG_VERSION)?;
+        let tline_ref = create_test_timeline_ref(&tenant, TIMELINE_ID, DEFAULT_PG_VERSION)?;
+        let tline = tline_ref.active_timeline()?;
         let mut walingest = init_walingest_test(&tline).await?;
 
         // Create a 20 MB relation (the size is arbitrary)
@@ -1570,7 +1573,8 @@ mod tests {
     #[tokio::test]
     async fn test_large_rel() -> Result<()> {
         let tenant = TenantHarness::create("test_large_rel")?.load().await;
-        let tline = create_test_timeline(&tenant, TIMELINE_ID, DEFAULT_PG_VERSION)?;
+        let tline_ref = create_test_timeline_ref(&tenant, TIMELINE_ID, DEFAULT_PG_VERSION)?;
+        let tline = tline_ref.active_timeline()?;
         let mut walingest = init_walingest_test(&tline).await?;
 
         let mut lsn = 0x10;

--- a/pageserver/src/walreceiver/connection_manager.rs
+++ b/pageserver/src/walreceiver/connection_manager.rs
@@ -1242,7 +1242,7 @@ mod tests {
         let timeline_ref = harness
             .load()
             .await
-            .create_empty_timeline(TIMELINE_ID, Lsn(0), crate::DEFAULT_PG_VERSION)
+            .create_empty_timeline_ref(TIMELINE_ID, Lsn(0), crate::DEFAULT_PG_VERSION)
             .expect("Failed to create an empty timeline for dummy wal connection manager")
             .initialize()
             .unwrap();


### PR DESCRIPTION
This makes it way harder to hold a TimelineGuard for long.

It adds a little more verbosity but I think it's a clean win.