### PR TITLE
If an error happens during consumption metrics collection, continue.

### DIFF
--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -138,7 +138,7 @@ struct EventChunk<'a> {
     events: &'a [ConsumptionMetric],
 }
 
-/// Main thread that serves metrics collection
+/// Main task that serves metrics collection
 pub async fn collect_metrics(
     metric_collection_endpoint: &Url,
     metric_collection_interval: Duration,
@@ -159,7 +159,10 @@ pub async fn collect_metrics(
                 return Ok(());
             },
             _ = ticker.tick() => {
-                collect_metrics_task(&client, &mut cached_metrics, metric_collection_endpoint, node_id).await?;
+                if let Err(err) = collect_metrics_task(&client, &mut cached_metrics, metric_collection_endpoint, node_id).await {
+                    // Log the error and continue
+                    error!("metrics collection failed: {err:?}");
+                }
             }
         }
     }


### PR DESCRIPTION
Previously, any error on any tenant would cause the whole task to exit. That's not nice, because then no more metrics will be collected for any tenant. In fact, I think we will shut down the whole pageserver if the task returns with error.

TODO: With this, if we get stuck on one tenant, we still stop the collection cycle and don't process the other tenants. That's not great.

@lubennikovaav I noticed this while working on PR #3228, and extracted this from that PR. I'm marking this as draft because of the above TODO, and because we probably should add tests for this. Do you have the time to pick up and finish this?