### PR TITLE
Make 'branch_timeline' function more clear.

### DIFF
--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -1653,7 +1653,7 @@ mod tests {
         assert!(tline.list_rels(0, TESTDB, Lsn(0x30))?.contains(&TESTREL_A));
 
         // Create a branch, check that the relation is visible there
-        repo.branch_timeline(TIMELINE_ID, NEW_TIMELINE_ID, Lsn(0x30))?;
+        repo.branch_timeline(&tline, NEW_TIMELINE_ID, Lsn(0x30))?;
         let newtline = match repo.get_timeline(NEW_TIMELINE_ID)?.local_timeline() {
             Some(timeline) => timeline,
             None => panic!("Should have a local timeline"),


### PR DESCRIPTION
Change the signature so that it takes an Arc<Timeline> reference to the source timeline, instead of just the ID. All the callers have an Arc reference at hand, so this is more convenient for everyone.

Reorder the code a bit and improve the comments, to make it more clear what it does and why.