### PR TITLE
Rework Cargo.toml dependencies

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -4,7 +4,7 @@
 hakari-package = "workspace_hack"
 
 # Format for `workspace-hack = ...` lines in other Cargo.tomls. Requires cargo-hakari 0.9.8 or above.
-dep-format-version = "2"
+dep-format-version = "3"
 
 # Setting workspace.resolver = "2" in the root Cargo.toml is HIGHLY recommended.
 # Hakari works much better with the new feature resolver.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4619,9 +4619,9 @@ checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
 name = "yasna"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
+checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
 dependencies = [
  "time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 [[package]]
 name = "amplify_num"
 version = "0.4.1"
-source = "git+https://github.com/hlinnaka/rust-amplify.git?branch=unsigned-int-perf#bd49b737c2e6e623ab8e9ba5ceaed5712d3a3940"
+source = "git+https://github.com/rust-amplify/rust-amplify.git?tag=v4.0.0-beta.1#3ad006cf2804e1862ec7725a7684a493f3023523"
 
 [[package]]
 name = "android_system_properties"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,17 +19,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
@@ -1518,9 +1507,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.6",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1528,7 +1514,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.2",
+ "ahash",
 ]
 
 [[package]]
@@ -4537,8 +4523,8 @@ dependencies = [
  "futures-channel",
  "futures-task",
  "futures-util",
- "hashbrown 0.12.3",
  "indexmap",
+ "itertools",
  "libc",
  "log",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if",
  "once_cell",
  "version_check",
 ]
@@ -128,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.59"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -492,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
+checksum = "1304eab461cf02bd70b083ed8273388f9724c549b316ba3d1e213ce0e9e7fb7e"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -521,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
+checksum = "f487e40dc9daee24d8a1779df88522f159a54a980f99cfbe43db0be0bd3444a8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -538,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -562,6 +573,12 @@ name = "base64"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bincode"
@@ -611,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
+checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
 dependencies = [
  "memchr",
  "once_cell",
@@ -660,9 +677,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cexpr"
@@ -691,12 +708,6 @@ dependencies = [
  "serde",
  "winapi",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "ciborium"
@@ -750,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.29"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -815,20 +826,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "comfy-table"
-version = "6.1.3"
+version = "6.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e621e7e86c46fd8a14c32c6ae3cb95656621b4743a27d0cffedb831d46e7ad21"
+checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
 dependencies = [
  "crossterm",
  "strum",
@@ -842,7 +843,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.0.29",
+ "clap 4.0.32",
  "env_logger",
  "futures",
  "hyper",
@@ -884,7 +885,7 @@ name = "control_plane"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.29",
+ "clap 4.0.32",
  "comfy-table",
  "git-version",
  "nix",
@@ -1072,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1084,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1099,15 +1100,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1218,12 +1219,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1278,14 +1279,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1446,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "git-version"
@@ -1474,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1518,7 +1519,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.2",
 ]
 
 [[package]]
@@ -1675,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
@@ -1702,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-tungstenite"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d62004bcd4f6f85d9e2aa4206f1466ee67031f5ededcb6c6e62d48f9306ad879"
+checksum = "880b8b1c98a5ec2a505c7c90db6d3f6f1f480af5655d9c5b55facc9382a5a5b5"
 dependencies = [
  "hyper",
  "pin-project",
@@ -1760,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -1800,25 +1810,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1832,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -1893,9 +1903,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -1915,18 +1925,18 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1992,18 +2002,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -2032,9 +2042,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -2048,7 +2058,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2059,26 +2069,35 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nix"
-version = "0.25.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
 dependencies = [
- "autocfg",
  "bitflags",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset 0.7.1",
  "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2142,37 +2161,37 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "oid-registry"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4bda43fd1b844cbc6e6e54b5444e2b1bc7838bce59ad205902cccbb26d6761"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
  "asn1-rs",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oorandom"
@@ -2220,7 +2239,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "clap 4.0.29",
+ "clap 4.0.32",
  "close_fds",
  "const_format",
  "crc32c",
@@ -2301,15 +2320,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2320,9 +2339,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
 ]
@@ -2487,7 +2506,7 @@ dependencies = [
  "env_logger",
  "hex",
  "log",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "once_cell",
  "postgres",
  "rand",
@@ -2523,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2557,15 +2576,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -2601,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2611,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
+checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
 dependencies = [
  "bytes",
  "heck",
@@ -2633,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.2"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2646,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.2"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
  "bytes",
  "prost",
@@ -2664,10 +2683,10 @@ dependencies = [
  "base64 0.13.1",
  "bstr",
  "bytes",
- "clap 4.0.29",
+ "clap 4.0.32",
  "futures",
  "git-version",
- "hashbrown",
+ "hashbrown 0.13.2",
  "hex",
  "hmac",
  "hyper",
@@ -2710,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2759,11 +2778,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -2803,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2940,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2952,15 +2970,16 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2995,23 +3014,23 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -3033,11 +3052,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -3051,15 +3070,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "safekeeper"
@@ -3070,7 +3089,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "clap 4.0.29",
+ "clap 4.0.32",
  "const_format",
  "crc32c",
  "fs2",
@@ -3127,12 +3146,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3143,9 +3161,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -3182,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "sentry"
@@ -3272,18 +3290,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3292,9 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -3315,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
+checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -3331,25 +3349,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
+checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -3484,13 +3491,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "storage_broker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
  "bytes",
- "clap 4.0.29",
+ "clap 4.0.32",
  "const_format",
  "futures",
  "futures-core",
@@ -3560,9 +3573,9 @@ checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3637,18 +3650,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3718,9 +3731,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tls-listener"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d4ff21187d434ac7709bfc7441ca88f63681247e5ad99f0f08c8c91ddc103d"
+checksum = "97abcaa5d5850d3b469898d1e0939b57c3afb4475122e792cdd1c82b07f5de06"
 dependencies = [
  "futures-util",
  "hyper",
@@ -3746,7 +3759,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3845,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
@@ -3871,23 +3884,33 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.14.4"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+checksum = "a34cc558345efd7e88b9eda9626df2138b80bb46a7606f695e751c892bc7dac6"
 dependencies = [
- "combine",
  "indexmap",
  "itertools",
+ "nom8",
  "serde",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -4077,15 +4100,15 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -4094,7 +4117,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
@@ -4123,9 +4146,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -4156,12 +4179,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
+checksum = "733b5ad78377302af52c0dbcb2623d78fe50e4b3bf215948ff29e9ee031d8566"
 dependencies = [
  "base64 0.13.1",
- "chunked_transfer",
  "log",
  "once_cell",
  "rustls",
@@ -4261,7 +4283,7 @@ name = "wal_craft"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.29",
+ "clap 4.0.32",
  "env_logger",
  "log",
  "once_cell",
@@ -4386,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
@@ -4437,103 +4459,60 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"
@@ -4551,14 +4530,14 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
- "clap 4.0.29",
+ "clap 4.0.32",
  "crossbeam-utils",
  "either",
  "fail",
  "futures-channel",
  "futures-task",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.12.3",
  "indexmap",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
+license = "Apache-2.0"
 
 ## All dependency versions, used in the project, grouped in some arbitrary order.
 [workspace.dependencies]
@@ -120,8 +121,8 @@ walkdir = "2.3.2"
 log = "0.4"
 env_logger = "0.10"
 
-# TODO fork this and use similar `rev` hash 
-amplify_num = { git = "https://github.com/hlinnaka/rust-amplify.git", branch = "unsigned-int-perf" }
+## TODO switch when the new release is made
+amplify_num = { git = "https://github.com/rust-amplify/rust-amplify.git", tag = "v4.0.0-beta.1" }
 
 ## Libraries from neondatabase/ git forks, ideally with changes to be upstreamed
 postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
     "libs/*",
 ]
 
+[workspace.package]
+edition = "2021"
+
 [profile.release]
 # This is useful for profiling and, to some extent, debug.
 # Besides, debug info should not affect the performance.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,122 @@ members = [
 [workspace.package]
 edition = "2021"
 
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+serde_with = "2.0"
+humantime-serde = "1.1.1"
+anyhow = { version = "1.0", features = ["backtrace"] }
+thiserror = "1.0"
+once_cell = "1.13"
+nix = "0.25"
+bytes = "1.0"
+byteorder = "1.4"
+rand = "0.8"
+futures = "0.3"
+async-stream = "0.3"
+async-trait = "0.1"
+routerify = "3"
+signal-hook = "0.3"
+rustls = "0.20"
+pin-project-lite = "0.2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+regex = "1.4"
+clap = "4.0"
+git-version = "0.3"
+tar = "0.4"
+url = "2.2"
+const_format = "0.2"
+parking_lot = "0.12"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+humantime = "2.1"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+hyper = "0.14"
+hyper-tungstenite = "0.8.1"
+toml_edit = { version = "0.14", features = ["easy"] }
+postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+tokio-util = { version = "0.7", features = ["io"] }
+tokio-stream = "0.1"
+tokio-rustls = "0.23"
+tokio-tar = { git = "https://github.com/neondatabase/tokio-tar.git", rev="404df61437de0feef49ba2ccdbdd94eb8ad6e142" }
+hex = "0.4"
+hex-literal = "0.3"
+rustls-split = "0.3"
+crc32c = "0.6"
+itertools = "0.10"
+rustls-pemfile = "1"
+###
+log = "0.4"
+env_logger = "0.9"
+###
+sentry = { version = "0.29", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest" ] }
+prometheus = {version = "0.13", default_features=false, features = ["process"]} # removes protobuf dependency
+bincode = "1.3"
+jsonwebtoken = "8"
+strum = "0.24"
+strum_macros = "0.24"
+libc = "0.2"
+memoffset = "0.7"
+notify = "5.0.0"
+tokio = { version = "1.17", features = ["macros"] }
+tokio-postgres-rustls = "0.9.0"
+futures-core = "0.3"
+futures-util = "0.3"
+tonic = {version = "0.8", features = ["tls", "tls-roots"]}
+prost = "0.11"
+fs2 = "0.4.3"
+bindgen = "0.61"
+toml = "0.5"
+comfy-table = "6.1"
+md5 = "0.7.0"
+hmac = "0.12.1"
+hashbrown = "0.12"
+bstr = "1.0"
+atty = "0.2.14"
+base64 = "0.13.0"
+close_fds = "0.3.2"
+fail = "0.5.0"
+crossbeam-utils = "0.8.5"
+num-traits = "0.2.15"
+rstar = "0.9.3"
+scopeguard = "1.1.0"
+sha2 = "0.10.2"
+socket2 = "0.4.4"
+uuid = { version = "1.2", features = ["v4", "serde"] }
+webpki-roots = "0.22.5"
+x509-parser = "0.14"
+tls-listener = { version = "0.5.1", features = ["rustls", "hyper-h1"] }
+walkdir = "2.3.2"
+aws-smithy-http = "0.51.0"
+aws-types = "0.51.0"
+aws-config = { version = "0.51.0", default-features = false, features=["rustls"] }
+aws-sdk-s3 = "0.21.0"
+svg_fmt = "0.4.1"
+
+metrics = { version = "0.1", path = "./libs/metrics/" }
+pageserver_api = { version = "0.1", path = "./libs/pageserver_api/" }
+safekeeper_api = { version = "0.1", path = "./libs/safekeeper_api" }
+postgres_connection = { version = "0.1", path = "./libs/postgres_connection/" }
+postgres_ffi = { version = "0.1", path = "./libs/postgres_ffi/" }
+pq_proto = { version = "0.1", path = "./libs/pq_proto/" }
+remote_storage = { version = "0.1", path = "./libs/remote_storage/" }
+# Note: main broker code is inside the binary crate, so linking with the library shouldn't be heavy.
+storage_broker = { version = "0.1", path = "./storage_broker/" }
+tenant_size_model = { version = "0.1", path = "./libs/tenant_size_model/" }
+utils = { version = "0.1", path = "./libs/utils/" }
+
+workspace_hack = { version = "0.1", path = "./workspace_hack/" }
+
+tempfile = "3.2"
+tonic-build = "0.8"
+criterion = "0.4"
+rcgen = "0.10"
+rstest = "0.15"
+
 [profile.release]
 # This is useful for profiling and, to some extent, debug.
 # Besides, debug info should not affect the performance.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,121 +13,149 @@ members = [
 [workspace.package]
 edition = "2021"
 
+## All dependency versions, used in the project, grouped in some arbitrary order.
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
 serde_with = "2.0"
+
+once_cell = "1.13"
+parking_lot = "0.12"
+scopeguard = "1.1"
+rand = "0.8"
+regex = "1.4"
+itertools = "0.10"
+num-traits = "0.2.15"
+signal-hook = "0.3"
+pin-project-lite = "0.2"
+git-version = "0.3"
+const_format = "0.2"
+crc32c = "0.6"
+hashbrown = "0.13"
+uuid = { version = "1.2", features = ["v4", "serde"] }
+atty = "0.2.14"
+
+humantime = "2.1"
 humantime-serde = "1.1.1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+
 anyhow = { version = "1.0", features = ["backtrace"] }
 thiserror = "1.0"
-once_cell = "1.13"
-nix = "0.25"
-bytes = "1.0"
-byteorder = "1.4"
-rand = "0.8"
+
+futures-core = "0.3"
+futures-util = "0.3"
 futures = "0.3"
 async-stream = "0.3"
 async-trait = "0.1"
-routerify = "3"
-signal-hook = "0.3"
-rustls = "0.20"
-pin-project-lite = "0.2"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-regex = "1.4"
-clap = "4.0"
-git-version = "0.3"
-tar = "0.4"
-url = "2.2"
-const_format = "0.2"
-parking_lot = "0.12"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-humantime = "2.1"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-hyper = "0.14"
-hyper-tungstenite = "0.8.1"
-toml_edit = { version = "0.14", features = ["easy"] }
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+tokio = { version = "1.17", features = ["macros"] }
+tokio-postgres-rustls = "0.9.0"
 tokio-util = { version = "0.7", features = ["io"] }
 tokio-stream = "0.1"
 tokio-rustls = "0.23"
-tokio-tar = { git = "https://github.com/neondatabase/tokio-tar.git", rev="404df61437de0feef49ba2ccdbdd94eb8ad6e142" }
+
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+toml = "0.5"
+toml_edit = { version = "0.17", features = ["easy"] }
+base64 = "0.13.0"
+md5 = "0.7.0"
+svg_fmt = "0.4.1"
 hex = "0.4"
 hex-literal = "0.3"
+
+clap = "4.0"
+
+tar = "0.4"
+rstar = "0.9.3"
+
+rustls = "0.20"
 rustls-split = "0.3"
-crc32c = "0.6"
-itertools = "0.10"
 rustls-pemfile = "1"
-###
-log = "0.4"
-env_logger = "0.9"
-###
-sentry = { version = "0.29", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest" ] }
-prometheus = {version = "0.13", default_features=false, features = ["process"]} # removes protobuf dependency
-bincode = "1.3"
+
+url = "2.2"
+serde_json = "1"
+routerify = "3"
 jsonwebtoken = "8"
-strum = "0.24"
-strum_macros = "0.24"
-libc = "0.2"
-memoffset = "0.7"
-notify = "5.0.0"
-tokio = { version = "1.17", features = ["macros"] }
-tokio-postgres-rustls = "0.9.0"
-futures-core = "0.3"
-futures-util = "0.3"
+tls-listener = { version = "0.6", features = ["rustls", "hyper-h1"] }
+
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+hyper = "0.14"
+socket2 = "0.4.4"
+hyper-tungstenite = "0.9"
 tonic = {version = "0.8", features = ["tls", "tls-roots"]}
 prost = "0.11"
-fs2 = "0.4.3"
-bindgen = "0.61"
-toml = "0.5"
-comfy-table = "6.1"
-md5 = "0.7.0"
-hmac = "0.12.1"
-hashbrown = "0.12"
-bstr = "1.0"
-atty = "0.2.14"
-base64 = "0.13.0"
-close_fds = "0.3.2"
-fail = "0.5.0"
-crossbeam-utils = "0.8.5"
-num-traits = "0.2.15"
-rstar = "0.9.3"
-scopeguard = "1.1.0"
-sha2 = "0.10.2"
-socket2 = "0.4.4"
-uuid = { version = "1.2", features = ["v4", "serde"] }
-webpki-roots = "0.22.5"
-x509-parser = "0.14"
-tls-listener = { version = "0.5.1", features = ["rustls", "hyper-h1"] }
-walkdir = "2.3.2"
+
 aws-smithy-http = "0.51.0"
 aws-types = "0.51.0"
 aws-config = { version = "0.51.0", default-features = false, features=["rustls"] }
 aws-sdk-s3 = "0.21.0"
-svg_fmt = "0.4.1"
 
-metrics = { version = "0.1", path = "./libs/metrics/" }
+sentry = { version = "0.29", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest" ] }
+prometheus = {version = "0.13", default_features=false, features = ["process"]} # removes protobuf dependency
+
+bindgen = "0.61"
+libc = "0.2"
+memoffset = "0.8"
+bincode = "1.3"
+nix = "0.26"
+bytes = "1.0"
+byteorder = "1.4"
+
+strum = "0.24"
+strum_macros = "0.24"
+notify = "5.0.0"
+fs2 = "0.4.3"
+comfy-table = "6.1"
+hmac = "0.12.1"
+bstr = "1.0"
+close_fds = "0.3.2"
+fail = "0.5.0"
+crossbeam-utils = "0.8.5"
+sha2 = "0.10.2"
+webpki-roots = "0.22.5"
+x509-parser = "0.14"
+walkdir = "2.3.2"
+
+## TODO replace this with tracing
+log = "0.4"
+env_logger = "0.10"
+
+## Libraries from neondatabase/ git forks, ideally with changes to be upstreamed
+postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+tokio-tar = { git = "https://github.com/neondatabase/tokio-tar.git", rev="404df61437de0feef49ba2ccdbdd94eb8ad6e142" }
+
+## Local libraries
 pageserver_api = { version = "0.1", path = "./libs/pageserver_api/" }
 safekeeper_api = { version = "0.1", path = "./libs/safekeeper_api" }
+# Note: main broker code is inside the binary crate, so linking with the library shouldn't be heavy.
+storage_broker = { version = "0.1", path = "./storage_broker/" }
+metrics = { version = "0.1", path = "./libs/metrics/" }
 postgres_connection = { version = "0.1", path = "./libs/postgres_connection/" }
 postgres_ffi = { version = "0.1", path = "./libs/postgres_ffi/" }
 pq_proto = { version = "0.1", path = "./libs/pq_proto/" }
 remote_storage = { version = "0.1", path = "./libs/remote_storage/" }
-# Note: main broker code is inside the binary crate, so linking with the library shouldn't be heavy.
-storage_broker = { version = "0.1", path = "./storage_broker/" }
 tenant_size_model = { version = "0.1", path = "./libs/tenant_size_model/" }
 utils = { version = "0.1", path = "./libs/utils/" }
 
+## Common library dependency
 workspace_hack = { version = "0.1", path = "./workspace_hack/" }
 
+## Build dependencies
 tempfile = "3.2"
 tonic-build = "0.8"
 criterion = "0.4"
 rcgen = "0.10"
-rstest = "0.15"
+rstest = "0.16"
+
+# This is only needed for proxy's tests.
+# TODO: we should probably fork `tokio-postgres-rustls` instead.
+[patch.crates-io]
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+
+################# Binary contents sections
 
 [profile.release]
 # This is useful for profiling and, to some extent, debug.
@@ -189,9 +217,3 @@ inherits = "release"
 debug = false # true = 2 = all symbols, 1 = line only
 opt-level = "z"
 lto = true
-
-
-# This is only needed for proxy's tests.
-# TODO: we should probably fork `tokio-postgres-rustls` instead.
-[patch.crates-io]
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,133 +14,117 @@ members = [
 edition = "2021"
 license = "Apache-2.0"
 
-## All dependency versions, used in the project, grouped in some arbitrary order.
+## All dependency versions, used in the project
 [workspace.dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "2.0"
-
-once_cell = "1.13"
-parking_lot = "0.12"
-scopeguard = "1.1"
-rand = "0.8"
-regex = "1.4"
-itertools = "0.10"
-num-traits = "0.2.15"
-signal-hook = "0.3"
-pin-project-lite = "0.2"
-git-version = "0.3"
-const_format = "0.2"
-crc32c = "0.6"
-hashbrown = "0.13"
-uuid = { version = "1.2", features = ["v4", "serde"] }
-atty = "0.2.14"
-
-humantime = "2.1"
-humantime-serde = "1.1.1"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-
 anyhow = { version = "1.0", features = ["backtrace"] }
-thiserror = "1.0"
-
-futures-core = "0.3"
-futures-util = "0.3"
-futures = "0.3"
 async-stream = "0.3"
 async-trait = "0.1"
-tokio = { version = "1.17", features = ["macros"] }
-tokio-postgres-rustls = "0.9.0"
-tokio-util = { version = "0.7", features = ["io"] }
-tokio-stream = "0.1"
-tokio-rustls = "0.23"
-
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-toml = "0.5"
-toml_edit = { version = "0.17", features = ["easy"] }
-base64 = "0.13.0"
-md5 = "0.7.0"
-svg_fmt = "0.4.1"
-hex = "0.4"
-hex-literal = "0.3"
-
-clap = "4.0"
-
-tar = "0.4"
-rstar = "0.9.3"
-
-rustls = "0.20"
-rustls-split = "0.3"
-rustls-pemfile = "1"
-
-url = "2.2"
-serde_json = "1"
-routerify = "3"
-jsonwebtoken = "8"
-tls-listener = { version = "0.6", features = ["rustls", "hyper-h1"] }
-
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-hyper = "0.14"
-socket2 = "0.4.4"
-hyper-tungstenite = "0.9"
-tonic = {version = "0.8", features = ["tls", "tls-roots"]}
-prost = "0.11"
-
-aws-smithy-http = "0.51.0"
-aws-types = "0.51.0"
+atty = "0.2.14"
 aws-config = { version = "0.51.0", default-features = false, features=["rustls"] }
 aws-sdk-s3 = "0.21.0"
-
-sentry = { version = "0.29", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest" ] }
-prometheus = {version = "0.13", default_features=false, features = ["process"]} # removes protobuf dependency
-
-bindgen = "0.61"
-libc = "0.2"
-memoffset = "0.8"
+aws-smithy-http = "0.51.0"
+aws-types = "0.51.0"
+base64 = "0.13.0"
 bincode = "1.3"
-nix = "0.26"
-bytes = "1.0"
+bindgen = "0.61"
+bstr = "1.0"
 byteorder = "1.4"
-
+bytes = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+clap = "4.0"
+close_fds = "0.3.2"
+comfy-table = "6.1"
+const_format = "0.2"
+crc32c = "0.6"
+crossbeam-utils = "0.8.5"
+fail = "0.5.0"
+fs2 = "0.4.3"
+futures = "0.3"
+futures-core = "0.3"
+futures-util = "0.3"
+git-version = "0.3"
+hashbrown = "0.13"
+hex = "0.4"
+hex-literal = "0.3"
+hmac = "0.12.1"
+humantime = "2.1"
+humantime-serde = "1.1.1"
+hyper = "0.14"
+hyper-tungstenite = "0.9"
+itertools = "0.10"
+jsonwebtoken = "8"
+libc = "0.2"
+md5 = "0.7.0"
+memoffset = "0.8"
+nix = "0.26"
+notify = "5.0.0"
+num-traits = "0.2.15"
+once_cell = "1.13"
+parking_lot = "0.12"
+pin-project-lite = "0.2"
+prometheus = {version = "0.13", default_features=false, features = ["process"]} # removes protobuf dependency
+prost = "0.11"
+rand = "0.8"
+regex = "1.4"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+routerify = "3"
+rstar = "0.9.3"
+rustls = "0.20"
+rustls-pemfile = "1"
+rustls-split = "0.3"
+scopeguard = "1.1"
+sentry = { version = "0.29", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest" ] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+serde_with = "2.0"
+sha2 = "0.10.2"
+signal-hook = "0.3"
+socket2 = "0.4.4"
 strum = "0.24"
 strum_macros = "0.24"
-notify = "5.0.0"
-fs2 = "0.4.3"
-comfy-table = "6.1"
-hmac = "0.12.1"
-bstr = "1.0"
-close_fds = "0.3.2"
-fail = "0.5.0"
-crossbeam-utils = "0.8.5"
-sha2 = "0.10.2"
+svg_fmt = "0.4.1"
+tar = "0.4"
+thiserror = "1.0"
+tls-listener = { version = "0.6", features = ["rustls", "hyper-h1"] }
+tokio = { version = "1.17", features = ["macros"] }
+tokio-postgres-rustls = "0.9.0"
+tokio-rustls = "0.23"
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["io"] }
+toml = "0.5"
+toml_edit = { version = "0.17", features = ["easy"] }
+tonic = {version = "0.8", features = ["tls", "tls-roots"]}
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+url = "2.2"
+uuid = { version = "1.2", features = ["v4", "serde"] }
+walkdir = "2.3.2"
 webpki-roots = "0.22.5"
 x509-parser = "0.14"
-walkdir = "2.3.2"
 
 ## TODO replace this with tracing
-log = "0.4"
 env_logger = "0.10"
+log = "0.4"
 
 ## TODO switch when the new release is made
 amplify_num = { git = "https://github.com/rust-amplify/rust-amplify.git", tag = "v4.0.0-beta.1" }
 
 ## Libraries from neondatabase/ git forks, ideally with changes to be upstreamed
 postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
 postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
 postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
 tokio-tar = { git = "https://github.com/neondatabase/tokio-tar.git", rev="404df61437de0feef49ba2ccdbdd94eb8ad6e142" }
 
 ## Local libraries
-pageserver_api = { version = "0.1", path = "./libs/pageserver_api/" }
-safekeeper_api = { version = "0.1", path = "./libs/safekeeper_api" }
-# Note: main broker code is inside the binary crate, so linking with the library shouldn't be heavy.
-storage_broker = { version = "0.1", path = "./storage_broker/" }
 metrics = { version = "0.1", path = "./libs/metrics/" }
+pageserver_api = { version = "0.1", path = "./libs/pageserver_api/" }
 postgres_connection = { version = "0.1", path = "./libs/postgres_connection/" }
 postgres_ffi = { version = "0.1", path = "./libs/postgres_ffi/" }
 pq_proto = { version = "0.1", path = "./libs/pq_proto/" }
 remote_storage = { version = "0.1", path = "./libs/remote_storage/" }
+safekeeper_api = { version = "0.1", path = "./libs/safekeeper_api" }
+storage_broker = { version = "0.1", path = "./storage_broker/" } # Note: main broker code is inside the binary crate, so linking with the library shouldn't be heavy.
 tenant_size_model = { version = "0.1", path = "./libs/tenant_size_model/" }
 utils = { version = "0.1", path = "./libs/utils/" }
 
@@ -148,11 +132,11 @@ utils = { version = "0.1", path = "./libs/utils/" }
 workspace_hack = { version = "0.1", path = "./workspace_hack/" }
 
 ## Build dependencies
-tempfile = "3.2"
-tonic-build = "0.8"
 criterion = "0.4"
 rcgen = "0.10"
 rstest = "0.16"
+tempfile = "3.2"
+tonic-build = "0.8"
 
 # This is only needed for proxy's tests.
 # TODO: we should probably fork `tokio-postgres-rustls` instead.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,9 @@ walkdir = "2.3.2"
 log = "0.4"
 env_logger = "0.10"
 
+# TODO fork this and use similar `rev` hash 
+amplify_num = { git = "https://github.com/hlinnaka/rust-amplify.git", branch = "unsigned-int-perf" }
+
 ## Libraries from neondatabase/ git forks, ideally with changes to be upstreamed
 postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
 tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }

--- a/compute_tools/Cargo.toml
+++ b/compute_tools/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compute_tools"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/compute_tools/Cargo.toml
+++ b/compute_tools/Cargo.toml
@@ -5,20 +5,21 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-clap = "4.0"
-env_logger = "0.9"
-futures = "0.3.13"
-hyper = { version = "0.14", features = ["full"] }
-log = { version = "0.4", features = ["std", "serde"] }
-notify = "5.0.0"
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-regex = "1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-tar = "0.4"
-tokio = { version = "1.17", features = ["macros", "rt", "rt-multi-thread"] }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-url = "2.2.2"
-workspace_hack = { version = "0.1", path = "../workspace_hack" }
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
+env_logger.workspace = true
+futures.workspace = true
+hyper = { workspace = true, features = ["full"] }
+log = { workspace = true, features = ["std", "serde"] }
+notify.workspace = true
+postgres.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tar.workspace = true
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tokio-postgres.workspace = true
+url.workspace = true
+
+workspace_hack.workspace = true

--- a/compute_tools/Cargo.toml
+++ b/compute_tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "compute_tools"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -5,28 +5,28 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
-clap = "4.0"
-comfy-table = "6.1"
-git-version = "0.3.5"
-nix = "0.25"
-once_cell = "1.13.0"
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev = "43e6db254a97fdecbce33d8bc0890accfd74495e" }
-regex = "1"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "2.0"
-tar = "0.4.38"
-thiserror = "1"
-toml = "0.5"
-url = "2.2.2"
+anyhow.workspace = true
+clap.workspace = true
+comfy-table.workspace = true
+git-version.workspace = true
+nix.workspace = true
+once_cell.workspace = true
+postgres.workspace = true
+regex.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json"] }
+serde.workspace = true
+serde_with.workspace = true
+tar.workspace = true
+thiserror.workspace = true
+toml.workspace = true
+url.workspace = true
 
 # Note: Do not directly depend on pageserver or safekeeper; use pageserver_api or safekeeper_api
 # instead, so that recompile times are better.
-pageserver_api = { path = "../libs/pageserver_api" }
-postgres_connection = { path = "../libs/postgres_connection" }
-safekeeper_api = { path = "../libs/safekeeper_api" }
-# Note: main broker code is inside the binary crate, so linking with the library shouldn't be heavy.
-storage_broker = { version = "0.1", path = "../storage_broker" }
-utils = { path = "../libs/utils" }
-workspace_hack = { version = "0.1", path = "../workspace_hack" }
+pageserver_api.workspace = true
+safekeeper_api.workspace = true
+postgres_connection.workspace = true
+storage_broker.workspace = true
+utils.workspace = true
+
+workspace_hack.workspace = true

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -2,7 +2,7 @@
 name = "control_plane"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "control_plane"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -20,7 +20,6 @@ tar.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 url.workspace = true
-
 # Note: Do not directly depend on pageserver or safekeeper; use pageserver_api or safekeeper_api
 # instead, so that recompile times are better.
 pageserver_api.workspace = true

--- a/libs/metrics/Cargo.toml
+++ b/libs/metrics/Cargo.toml
@@ -2,7 +2,7 @@
 name = "metrics"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 prometheus.workspace = true

--- a/libs/metrics/Cargo.toml
+++ b/libs/metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "metrics"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/libs/metrics/Cargo.toml
+++ b/libs/metrics/Cargo.toml
@@ -5,7 +5,8 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-prometheus = {version = "0.13", default_features=false, features = ["process"]} # removes protobuf dependency
-libc = "0.2"
-once_cell = "1.13.0"
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
+prometheus.workspace = true
+libc.workspace = true
+once_cell.workspace = true
+
+workspace_hack.workspace = true

--- a/libs/pageserver_api/Cargo.toml
+++ b/libs/pageserver_api/Cargo.toml
@@ -5,13 +5,14 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "2.0"
-const_format = "0.2.21"
-anyhow = { version = "1.0", features = ["backtrace"] }
-bytes = "1.0.1"
-byteorder = "1.4.3"
+serde.workspace = true
+serde_with.workspace = true
+const_format.workspace = true
+anyhow.workspace = true
+bytes.workspace = true
+byteorder.workspace = true
 
-utils = { path = "../utils" }
-postgres_ffi = { path = "../postgres_ffi" }
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
+utils.workspace = true
+postgres_ffi.workspace = true
+
+workspace_hack.workspace = true

--- a/libs/pageserver_api/Cargo.toml
+++ b/libs/pageserver_api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pageserver_api"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/libs/pageserver_api/Cargo.toml
+++ b/libs/pageserver_api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pageserver_api"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/libs/pageserver_api/Cargo.toml
+++ b/libs/pageserver_api/Cargo.toml
@@ -11,7 +11,6 @@ const_format.workspace = true
 anyhow.workspace = true
 bytes.workspace = true
 byteorder.workspace = true
-
 utils.workspace = true
 postgres_ffi.workspace = true
 

--- a/libs/postgres_connection/Cargo.toml
+++ b/libs/postgres_connection/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "postgres_connection"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0"

--- a/libs/postgres_connection/Cargo.toml
+++ b/libs/postgres_connection/Cargo.toml
@@ -5,12 +5,13 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
-itertools = "0.10.3"
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev = "43e6db254a97fdecbce33d8bc0890accfd74495e" }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-url = "2.2.2"
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
+anyhow.workspace = true
+itertools.workspace = true
+postgres.workspace = true
+tokio-postgres.workspace = true
+url.workspace = true
+
+workspace_hack.workspace = true
 
 [dev-dependencies]
-once_cell = "1.13.0"
+once_cell.workspace = true

--- a/libs/postgres_connection/Cargo.toml
+++ b/libs/postgres_connection/Cargo.toml
@@ -2,7 +2,7 @@
 name = "postgres_connection"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/libs/postgres_ffi/Cargo.toml
+++ b/libs/postgres_ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "postgres_ffi"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 rand.workspace = true

--- a/libs/postgres_ffi/Cargo.toml
+++ b/libs/postgres_ffi/Cargo.toml
@@ -17,7 +17,6 @@ log.workspace = true
 memoffset.workspace = true
 thiserror.workspace = true
 serde.workspace = true
-
 utils.workspace = true
 
 workspace_hack.workspace = true

--- a/libs/postgres_ffi/Cargo.toml
+++ b/libs/postgres_ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "postgres_ffi"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/libs/postgres_ffi/Cargo.toml
+++ b/libs/postgres_ffi/Cargo.toml
@@ -5,26 +5,28 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-rand = "0.8.3"
-regex = "1.4.5"
-bytes = "1.0.1"
-byteorder = "1.4.3"
-anyhow = "1.0"
-crc32c = "0.6.0"
-hex = "0.4.3"
-once_cell = "1.13.0"
-log = "0.4.14"
-memoffset = "0.7"
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-utils = { path = "../utils" }
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
+rand.workspace = true
+regex.workspace = true
+bytes.workspace = true
+byteorder.workspace = true
+anyhow.workspace = true
+crc32c.workspace = true
+hex.workspace = true
+once_cell.workspace = true
+log.workspace = true
+memoffset.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+
+utils.workspace = true
+
+workspace_hack.workspace = true
 
 [dev-dependencies]
-env_logger = "0.9"
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
+env_logger.workspace = true
+postgres.workspace = true
 wal_craft = { path = "wal_craft" }
 
 [build-dependencies]
-anyhow = "1.0"
-bindgen = "0.61"
+anyhow.workspace = true
+bindgen.workspace = true

--- a/libs/postgres_ffi/wal_craft/Cargo.toml
+++ b/libs/postgres_ffi/wal_craft/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "wal_craft"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0"

--- a/libs/postgres_ffi/wal_craft/Cargo.toml
+++ b/libs/postgres_ffi/wal_craft/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wal_craft"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/libs/postgres_ffi/wal_craft/Cargo.toml
+++ b/libs/postgres_ffi/wal_craft/Cargo.toml
@@ -5,12 +5,13 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
-clap = "4.0"
-env_logger = "0.9"
-log = "0.4"
-once_cell = "1.13.0"
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-postgres_ffi = { path = "../" }
-tempfile = "3.2"
-workspace_hack = { version = "0.1", path = "../../../workspace_hack" }
+anyhow.workspace = true
+clap.workspace = true
+env_logger.workspace = true
+log.workspace = true
+once_cell.workspace = true
+postgres.workspace = true
+postgres_ffi.workspace = true
+tempfile.workspace = true
+
+workspace_hack.workspace = true

--- a/libs/pq_proto/Cargo.toml
+++ b/libs/pq_proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pq_proto"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/libs/pq_proto/Cargo.toml
+++ b/libs/pq_proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pq_proto"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/libs/pq_proto/Cargo.toml
+++ b/libs/pq_proto/Cargo.toml
@@ -5,14 +5,14 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
-bytes = "1.0.1"
-pin-project-lite = "0.2.7"
-postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-rand = "0.8.3"
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.17", features = ["macros"] }
-tracing = "0.1"
-thiserror = "1.0"
+anyhow.workspace = true
+bytes.workspace = true
+pin-project-lite.workspace = true
+postgres-protocol.workspace = true
+rand.workspace = true
+serde.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
 
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
+workspace_hack.workspace = true

--- a/libs/remote_storage/Cargo.toml
+++ b/libs/remote_storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "remote_storage"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/libs/remote_storage/Cargo.toml
+++ b/libs/remote_storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "remote_storage"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/libs/remote_storage/Cargo.toml
+++ b/libs/remote_storage/Cargo.toml
@@ -5,24 +5,25 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = { version = "1.0", features = ["backtrace"] }
-async-trait = "0.1"
-metrics = { version = "0.1", path = "../metrics" }
-utils = { version = "0.1", path = "../utils" }
-once_cell = "1.13.0"
-aws-smithy-http = "0.51.0"
-aws-types = "0.51.0"
-aws-config = { version = "0.51.0", default-features = false, features=["rustls"] }
-aws-sdk-s3 = "0.21.0"
-hyper = { version = "0.14", features = ["stream"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1.17", features = ["sync", "macros", "fs", "io-util"] }
-tokio-util = { version = "0.7", features = ["io"] }
-toml_edit = { version = "0.14", features = ["easy"] }
-tracing = "0.1.27"
+anyhow.workspace = true
+async-trait.workspace = true
+once_cell.workspace = true
+aws-smithy-http.workspace = true
+aws-types.workspace = true
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
+hyper = { workspace = true, features = ["stream"] }
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync", "fs", "io-util"] }
+tokio-util.workspace = true
+toml_edit.workspace = true
+tracing.workspace = true
 
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
+metrics.workspace = true
+utils.workspace = true
+
+workspace_hack.workspace = true
 
 [dev-dependencies]
-tempfile = "3.2"
+tempfile.workspace = true

--- a/libs/remote_storage/Cargo.toml
+++ b/libs/remote_storage/Cargo.toml
@@ -19,7 +19,6 @@ tokio = { workspace = true, features = ["sync", "fs", "io-util"] }
 tokio-util.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true
-
 metrics.workspace = true
 utils.workspace = true
 

--- a/libs/safekeeper_api/Cargo.toml
+++ b/libs/safekeeper_api/Cargo.toml
@@ -5,9 +5,10 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "2.0"
-const_format = "0.2.21"
+serde.workspace = true
+serde_with.workspace = true
+const_format.workspace = true
 
-utils = { path = "../utils" }
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
+utils.workspace = true
+
+workspace_hack.workspace = true

--- a/libs/safekeeper_api/Cargo.toml
+++ b/libs/safekeeper_api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "safekeeper_api"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/libs/safekeeper_api/Cargo.toml
+++ b/libs/safekeeper_api/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 const_format.workspace = true
-
 utils.workspace = true
 
 workspace_hack.workspace = true

--- a/libs/safekeeper_api/Cargo.toml
+++ b/libs/safekeeper_api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "safekeeper_api"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/libs/tenant_size_model/Cargo.toml
+++ b/libs/tenant_size_model/Cargo.toml
@@ -3,7 +3,7 @@ name = "tenant_size_model"
 version = "0.1.0"
 edition.workspace = true
 publish = false
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/libs/tenant_size_model/Cargo.toml
+++ b/libs/tenant_size_model/Cargo.toml
@@ -6,5 +6,6 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
-anyhow = "1.0.68"
+anyhow.workspace = true
+
+workspace_hack.workspace = true

--- a/libs/tenant_size_model/Cargo.toml
+++ b/libs/tenant_size_model/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tenant_size_model"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 license = "Apache-2.0"
 

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "utils"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 sentry.workspace = true

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utils"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -5,44 +5,45 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-sentry = { version = "0.29.0", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest" ] }
-async-trait = "0.1"
-anyhow = "1.0"
-bincode = "1.3"
-bytes = "1.0.1"
-hyper = { version = "0.14.7", features = ["full"] }
-routerify = "3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-thiserror = "1.0"
-tokio = { version = "1.17", features = ["macros"]}
-tokio-rustls = "0.23"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-nix = "0.25"
-signal-hook = "0.3.10"
-rand = "0.8.3"
-jsonwebtoken = "8"
-hex = { version = "0.4.3", features = ["serde"] }
-rustls = "0.20.2"
-rustls-split = "0.3.0"
-git-version = "0.3.5"
-serde_with = "2.0"
-once_cell = "1.13.0"
-strum = "0.24"
-strum_macros = "0.24"
+sentry.workspace = true
+async-trait.workspace = true
+anyhow.workspace = true
+bincode.workspace = true
+bytes.workspace = true
+hyper = { workspace = true, features = ["full"] }
+routerify.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-rustls.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["json"] }
+nix.workspace = true
+signal-hook.workspace = true
+rand.workspace = true
+jsonwebtoken.workspace = true
+hex = { workspace = true, features = ["serde"] }
+rustls.workspace = true
+rustls-split.workspace = true
+git-version.workspace = true
+serde_with.workspace = true
+once_cell.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 
-metrics = { path = "../metrics" }
-pq_proto = { path = "../pq_proto" }
-workspace_hack = { version = "0.1", path = "../../workspace_hack" }
+metrics.workspace = true
+pq_proto.workspace = true
+
+workspace_hack.workspace = true
 
 [dev-dependencies]
-byteorder = "1.4.3"
-bytes = "1.0.1"
-hex-literal = "0.3"
-tempfile = "3.2"
-criterion = "0.4"
-rustls-pemfile = "1"
+byteorder.workspace = true
+bytes.workspace = true
+hex-literal.workspace = true
+tempfile.workspace = true
+criterion.workspace = true
+rustls-pemfile.workspace = true
 
 [[bench]]
 name = "benchmarks"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -56,7 +56,6 @@ toml_edit.workspace = true
 tracing.workspace = true
 url.workspace = true
 walkdir.workspace = true
-
 metrics.workspace = true
 pageserver_api.workspace = true
 postgres_connection.workspace = true

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pageserver"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [features]
 default = []

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -12,67 +12,67 @@ testing = ["fail/failpoints"]
 
 [dependencies]
 amplify_num = { git = "https://github.com/hlinnaka/rust-amplify.git", branch = "unsigned-int-perf" }
-anyhow = { version = "1.0", features = ["backtrace"] }
-async-stream = "0.3"
-async-trait = "0.1"
-byteorder = "1.4.3"
-bytes = "1.0.1"
-chrono = { version = "0.4.23", default-features = false, features = ["clock", "serde"] }
-clap = { version = "4.0", features = ["string"] }
-close_fds = "0.3.2"
-const_format = "0.2.21"
-crc32c = "0.6.0"
-crossbeam-utils = "0.8.5"
-fail = "0.5.0"
-futures = "0.3.13"
-git-version = "0.3.5"
-hex = "0.4.3"
-humantime = "2.1.0"
-humantime-serde = "1.1.1"
-hyper = "0.14"
-itertools = "0.10.3"
-nix = "0.25"
-num-traits = "0.2.15"
-once_cell = "1.13.0"
-pin-project-lite = "0.2.7"
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-rand = "0.8.3"
-regex = "1.4.5"
-rstar = "0.9.3"
-scopeguard = "1.1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
-serde_with = "2.0"
-signal-hook = "0.3.10"
-svg_fmt = "0.4.1"
-tokio-tar = { git = "https://github.com/neondatabase/tokio-tar.git", rev="404df61437de0feef49ba2ccdbdd94eb8ad6e142" }
-thiserror = "1.0"
-tokio = { version = "1.17", features = ["process", "sync", "macros", "fs", "rt", "io-util", "time"] }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-tokio-util = { version = "0.7.3", features = ["io", "io-util"] }
-toml_edit = { version = "0.14", features = ["easy"] }
-tracing = "0.1.36"
-url = "2"
-walkdir = "2.3.2"
+anyhow.workspace = true
+async-stream.workspace = true
+async-trait.workspace = true
+byteorder.workspace = true
+bytes.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+clap = { workspace = true, features = ["string"] }
+close_fds.workspace = true
+const_format.workspace = true
+crc32c.workspace = true
+crossbeam-utils.workspace = true
+fail.workspace = true
+futures.workspace = true
+git-version.workspace = true
+hex.workspace = true
+humantime.workspace = true
+humantime-serde.workspace = true
+hyper.workspace = true
+itertools.workspace = true
+nix.workspace = true
+num-traits.workspace = true
+once_cell.workspace = true
+pin-project-lite.workspace = true
+postgres.workspace = true
+postgres-protocol.workspace = true
+postgres-types.workspace = true
+rand.workspace = true
+regex.workspace = true
+rstar.workspace = true
+scopeguard.workspace = true
+serde.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
+serde_with.workspace = true
+signal-hook.workspace = true
+svg_fmt.workspace = true
+tokio-tar.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["process", "sync", "fs", "rt", "io-util", "time"] }
+tokio-postgres.workspace = true
+tokio-util.workspace = true
+toml_edit.workspace = true
+tracing.workspace = true
+url.workspace = true
+walkdir.workspace = true
 
-metrics = { path = "../libs/metrics" }
-pageserver_api = { path = "../libs/pageserver_api" }
-postgres_connection = { path = "../libs/postgres_connection" }
-postgres_ffi = { path = "../libs/postgres_ffi" }
-pq_proto = { path = "../libs/pq_proto" }
-remote_storage = { path = "../libs/remote_storage" }
-storage_broker = { version = "0.1", path = "../storage_broker" }
-tenant_size_model = { path = "../libs/tenant_size_model" }
-utils = { path = "../libs/utils" }
-workspace_hack = { version = "0.1", path = "../workspace_hack" }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+metrics.workspace = true
+pageserver_api.workspace = true
+postgres_connection.workspace = true
+postgres_ffi.workspace = true
+pq_proto.workspace = true
+remote_storage.workspace = true
+storage_broker.workspace = true
+tenant_size_model.workspace = true
+utils.workspace = true
+workspace_hack.workspace = true
+reqwest.workspace = true
 
 [dev-dependencies]
-criterion = "0.4"
-hex-literal = "0.3"
-tempfile = "3.2"
+criterion.workspace = true
+hex-literal.workspace = true
+tempfile.workspace = true
 
 [[bench]]
 name = "bench_layer_map"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pageserver"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [features]

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 testing = ["fail/failpoints"]
 
 [dependencies]
-amplify_num = { git = "https://github.com/hlinnaka/rust-amplify.git", branch = "unsigned-int-perf" }
+amplify_num.workspace = true
 anyhow.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proxy"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -45,7 +45,6 @@ url.workspace = true
 uuid.workspace = true
 webpki-roots.workspace = true
 x509-parser.workspace = true
-
 metrics.workspace = true
 pq_proto.workspace = true
 utils.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proxy"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -5,54 +5,55 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
-atty = "0.2.14"
-base64 = "0.13.0"
-bstr = "1.0"
-bytes = { version = "1.0.1", features = ['serde'] }
-clap = "4.0"
-futures = "0.3.13"
-git-version = "0.3.5"
-hashbrown = "0.12"
-hex = "0.4.3"
-hmac = "0.12.1"
-hyper = "0.14"
-hyper-tungstenite = "0.8.1"
-itertools = "0.10.3"
-md5 = "0.7.0"
-once_cell = "1.13.0"
-parking_lot = "0.12"
-pin-project-lite = "0.2.7"
-rand = "0.8.3"
-regex = "1.4.5"
-reqwest = { version = "0.11", default-features = false, features = [ "json", "rustls-tls" ] }
-routerify = "3"
-rustls = "0.20.0"
-rustls-pemfile = "1"
-scopeguard = "1.1.0"
-serde = "1"
-serde_json = "1"
-sha2 = "0.10.2"
-socket2 = "0.4.4"
-thiserror = "1.0.30"
-tokio = { version = "1.17", features = ["macros"] }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-tokio-rustls = "0.23.0"
-tls-listener = { version = "0.5.1", features = ["rustls", "hyper-h1"] }
-tracing = "0.1.36"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = "2.2.2"
-uuid = { version = "1.2", features = ["v4", "serde"] }
-webpki-roots = "0.22.5"
-x509-parser = "0.14"
+anyhow.workspace = true
+atty.workspace = true
+base64.workspace = true
+bstr.workspace = true
+bytes = {workspace = true, features = ['serde'] }
+clap.workspace = true
+futures.workspace = true
+git-version.workspace = true
+hashbrown.workspace = true
+hex.workspace = true
+hmac.workspace = true
+hyper.workspace = true
+hyper-tungstenite.workspace = true
+itertools.workspace = true
+md5.workspace = true
+once_cell.workspace = true
+parking_lot.workspace = true
+pin-project-lite.workspace = true
+rand.workspace = true
+regex.workspace = true
+reqwest = { workspace = true, features = [ "json" ] }
+routerify.workspace = true
+rustls.workspace = true
+rustls-pemfile.workspace = true
+scopeguard.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+socket2.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-postgres.workspace = true
+tokio-rustls.workspace = true
+tls-listener.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+url.workspace = true
+uuid.workspace = true
+webpki-roots.workspace = true
+x509-parser.workspace = true
 
-metrics = { path = "../libs/metrics" }
-pq_proto = { path = "../libs/pq_proto" }
-utils = { path = "../libs/utils" }
-workspace_hack = { version = "0.1", path = "../workspace_hack" }
+metrics.workspace = true
+pq_proto.workspace = true
+utils.workspace = true
+
+workspace_hack.workspace = true
 
 [dev-dependencies]
-async-trait = "0.1"
-rcgen = "0.10"
-rstest = "0.15"
-tokio-postgres-rustls = "0.9.0"
+async-trait.workspace = true
+rcgen.workspace = true
+rstest.workspace = true
+tokio-postgres-rustls.workspace = true

--- a/safekeeper/Cargo.toml
+++ b/safekeeper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "safekeeper"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]

--- a/safekeeper/Cargo.toml
+++ b/safekeeper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "safekeeper"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 async-stream.workspace = true

--- a/safekeeper/Cargo.toml
+++ b/safekeeper/Cargo.toml
@@ -34,7 +34,6 @@ tokio-postgres.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true
 url.workspace = true
-
 metrics.workspace = true
 postgres_ffi.workspace = true
 pq_proto.workspace = true

--- a/safekeeper/Cargo.toml
+++ b/safekeeper/Cargo.toml
@@ -5,44 +5,45 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
-async-stream = "0.3"
-anyhow = "1.0"
-async-trait = "0.1"
-byteorder = "1.4.3"
-bytes = "1.0.1"
-clap = { version = "4.0", features = ["derive"] }
-const_format = "0.2.21"
-crc32c = "0.6.0"
-fs2 = "0.4.3"
-git-version = "0.3.5"
-hex = "0.4.3"
-humantime = "2.1.0"
-hyper = "0.14"
-nix = "0.25"
-once_cell = "1.13.0"
-parking_lot = "0.12.1"
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-regex = "1.4.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-serde_with = "2.0"
-signal-hook = "0.3.10"
-thiserror = "1"
-tokio = { version = "1.17", features = ["macros", "fs"] }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="43e6db254a97fdecbce33d8bc0890accfd74495e" }
-toml_edit = { version = "0.14", features = ["easy"] }
-tracing = "0.1.27"
-url = "2.2.2"
+async-stream.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+byteorder.workspace = true
+bytes.workspace = true
+clap = { workspace = true, features = ["derive"] }
+const_format.workspace = true
+crc32c.workspace = true
+fs2.workspace = true
+git-version.workspace = true
+hex.workspace = true
+humantime.workspace = true
+hyper.workspace = true
+nix.workspace = true
+once_cell.workspace = true
+parking_lot.workspace = true
+postgres.workspace = true
+postgres-protocol.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+signal-hook.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs"] }
+tokio-postgres.workspace = true
+toml_edit.workspace = true
+tracing.workspace = true
+url.workspace = true
 
-metrics = { path = "../libs/metrics" }
-postgres_ffi = { path = "../libs/postgres_ffi" }
-pq_proto = { path = "../libs/pq_proto" }
-remote_storage = { path = "../libs/remote_storage" }
-safekeeper_api = { path = "../libs/safekeeper_api" }
-storage_broker = { version = "0.1", path = "../storage_broker" }
-utils = { path = "../libs/utils" }
-workspace_hack = { version = "0.1", path = "../workspace_hack" }
+metrics.workspace = true
+postgres_ffi.workspace = true
+pq_proto.workspace = true
+remote_storage.workspace = true
+safekeeper_api.workspace = true
+storage_broker.workspace = true
+utils.workspace = true
+
+workspace_hack.workspace = true
 
 [dev-dependencies]
-tempfile = "3.2"
+tempfile.workspace = true

--- a/storage_broker/Cargo.toml
+++ b/storage_broker/Cargo.toml
@@ -8,31 +8,32 @@ license = "Apache-2.0"
 bench = []
 
 [dependencies]
-anyhow = "1.0"
-async-stream = "0.3"
-bytes = "1.0"
-clap = { version = "4.0", features = ["derive"] }
-const_format = "0.2.21"
-futures = "0.3"
-futures-core = "0.3"
-futures-util = "0.3"
-git-version = "0.3.5"
-humantime = "2.1.0"
-hyper = {version = "0.14.14", features = ["full"]}
-once_cell = "1.13.0"
-parking_lot = "0.12"
-prost = "0.11"
-tonic = {version = "0.8", features = ["tls", "tls-roots"]}
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1"
-tracing = "0.1.27"
+anyhow.workspace = true
+async-stream.workspace = true
+bytes.workspace = true
+clap = { workspace = true, features = ["derive"] }
+const_format.workspace = true
+futures.workspace = true
+futures-core.workspace = true
+futures-util.workspace = true
+git-version.workspace = true
+humantime.workspace = true
+hyper = { workspace = true, features = ["full"] }
+once_cell.workspace = true
+parking_lot.workspace = true
+prost.workspace = true
+tonic.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio-stream.workspace = true
+tracing.workspace = true
 
-metrics = { path = "../libs/metrics" }
-utils = { path = "../libs/utils" }
-workspace_hack = { version = "0.1", path = "../workspace_hack" }
+metrics.workspace = true
+utils.workspace = true
+
+workspace_hack.workspace = true
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build.workspace = true
 
 [[bench]]
 name = "rps"

--- a/storage_broker/Cargo.toml
+++ b/storage_broker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "storage_broker"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license.workspace = true
 
 [features]
 bench = []

--- a/storage_broker/Cargo.toml
+++ b/storage_broker/Cargo.toml
@@ -26,7 +26,6 @@ tonic.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tracing.workspace = true
-
 metrics.workspace = true
 utils.workspace = true
 

--- a/storage_broker/Cargo.toml
+++ b/storage_broker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "storage_broker"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0"
 
 [features]

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -13,54 +13,54 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
-anyhow = { version = "1", features = ["backtrace", "std"] }
-bytes = { version = "1", features = ["serde", "std"] }
-chrono = { version = "0.4", default-features = false, features = ["clock", "iana-time-zone", "serde", "std", "winapi"] }
-clap = { version = "4", features = ["color", "derive", "error-context", "help", "std", "string", "suggestions", "usage"] }
-crossbeam-utils = { version = "0.8", features = ["once_cell", "std"] }
-either = { version = "1", features = ["use_std"] }
+anyhow = { version = "1", features = ["backtrace"] }
+bytes = { version = "1", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+clap = { version = "4", features = ["derive", "string"] }
+crossbeam-utils = { version = "0.8" }
+either = { version = "1" }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
-futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
-futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 indexmap = { version = "1", default-features = false, features = ["std"] }
-itertools = { version = "0.10", features = ["use_alloc", "use_std"] }
-libc = { version = "0.2", features = ["extra_traits", "std"] }
+itertools = { version = "0.10" }
+libc = { version = "0.2", features = ["extra_traits"] }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
-memchr = { version = "2", features = ["std"] }
-nom = { version = "7", features = ["alloc", "std"] }
-num-bigint = { version = "0.4", features = ["std"] }
-num-integer = { version = "0.1", features = ["i128", "std"] }
-num-traits = { version = "0.2", features = ["i128", "libm", "std"] }
-prost = { version = "0.11", features = ["prost-derive", "std"] }
-rand = { version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "rand_hc", "small_rng", "std", "std_rng"] }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-scopeguard = { version = "1", features = ["use_std"] }
-serde = { version = "1", features = ["alloc", "derive", "serde_derive", "std"] }
-serde_json = { version = "1", features = ["raw_value", "std"] }
+memchr = { version = "2" }
+nom = { version = "7" }
+num-bigint = { version = "0.4" }
+num-integer = { version = "0.1", features = ["i128"] }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
+prost = { version = "0.11" }
+rand = { version = "0.8", features = ["small_rng"] }
+regex = { version = "1" }
+regex-syntax = { version = "0.6" }
+scopeguard = { version = "1" }
+serde = { version = "1", features = ["alloc", "derive"] }
+serde_json = { version = "1", features = ["raw_value"] }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
-tokio = { version = "1", features = ["bytes", "fs", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "process", "rt", "rt-multi-thread", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
-tokio-util = { version = "0.7", features = ["codec", "io", "tracing"] }
-tower = { version = "0.4", features = ["__common", "balance", "buffer", "discover", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "retry", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
-tracing = { version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
-tracing-core = { version = "0.1", features = ["once_cell", "std"] }
+tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tower = { version = "0.4", features = ["balance", "buffer", "limit", "retry", "timeout", "util"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-core = { version = "0.1" }
 url = { version = "2", features = ["serde"] }
 
 [build-dependencies]
-anyhow = { version = "1", features = ["backtrace", "std"] }
-bytes = { version = "1", features = ["serde", "std"] }
-either = { version = "1", features = ["use_std"] }
+anyhow = { version = "1", features = ["backtrace"] }
+bytes = { version = "1", features = ["serde"] }
+either = { version = "1" }
 indexmap = { version = "1", default-features = false, features = ["std"] }
-itertools = { version = "0.10", features = ["use_alloc", "use_std"] }
-libc = { version = "0.2", features = ["extra_traits", "std"] }
+itertools = { version = "0.10" }
+libc = { version = "0.2", features = ["extra_traits"] }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
-memchr = { version = "2", features = ["std"] }
-nom = { version = "7", features = ["alloc", "std"] }
-prost = { version = "0.11", features = ["prost-derive", "std"] }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-serde = { version = "1", features = ["alloc", "derive", "serde_derive", "std"] }
-syn = { version = "1", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+memchr = { version = "2" }
+nom = { version = "7" }
+prost = { version = "0.11" }
+regex = { version = "1" }
+regex-syntax = { version = "0.6" }
+serde = { version = "1", features = ["alloc", "derive"] }
+syn = { version = "1", features = ["extra-traits", "full", "visit", "visit-mut"] }
 
 ### END HAKARI SECTION

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -23,8 +23,8 @@ fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
 futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
 futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
-hashbrown = { version = "0.12", features = ["ahash", "inline-more", "raw"] }
 indexmap = { version = "1", default-features = false, features = ["std"] }
+itertools = { version = "0.10", features = ["use_alloc", "use_std"] }
 libc = { version = "0.2", features = ["extra_traits", "std"] }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
 memchr = { version = "2", features = ["std"] }
@@ -41,7 +41,7 @@ serde = { version = "1", features = ["alloc", "derive", "serde_derive", "std"] }
 serde_json = { version = "1", features = ["raw_value", "std"] }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
 tokio = { version = "1", features = ["bytes", "fs", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "process", "rt", "rt-multi-thread", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
-tokio-util = { version = "0.7", features = ["codec", "io", "io-util", "tracing"] }
+tokio-util = { version = "0.7", features = ["codec", "io", "tracing"] }
 tower = { version = "0.4", features = ["__common", "balance", "buffer", "discover", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "retry", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
 tracing = { version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1", features = ["once_cell", "std"] }
@@ -51,8 +51,8 @@ url = { version = "2", features = ["serde"] }
 anyhow = { version = "1", features = ["backtrace", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
 either = { version = "1", features = ["use_std"] }
-hashbrown = { version = "0.12", features = ["ahash", "inline-more", "raw"] }
 indexmap = { version = "1", default-features = false, features = ["std"] }
+itertools = { version = "0.10", features = ["use_alloc", "use_std"] }
 libc = { version = "0.2", features = ["extra_traits", "std"] }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
 memchr = { version = "2", features = ["std"] }


### PR DESCRIPTION
* Use workspace variables from cargo, coming with rustc [1.64](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1640-2022-09-22)

See https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-package-table and https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-dependencies-table sections.

Now, all dependencies in all non-root `Cargo.toml` files are defined as 
```
clap.workspace = true
```

sometimes, when extra features are needed, as 
```
bytes = {workspace = true, features = ['serde'] }
```

With the actual declarations (with shared features and version numbers/file paths/etc.) in the root Cargo.toml.
Features are additive:
https://doc.rust-lang.org/nightly/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace

* Uses the mechanism above to set common, 2021, edition across the workspace

* Mechanically bumps a few dependencies

* Updates hakari format, as it suggested:
```
work/neon/neon kb/cargo-templated ❯ cargo hakari generate
info: no changes detected
info: new hakari format version available: 3 (current: 2)
(add or update `dep-format-version = "3"` in hakari.toml, then run `cargo hakari generate && cargo hakari manage-deps`)
```