### PR TITLE
Actualize the comment

### DIFF
--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -135,7 +135,7 @@
 //! - Initiate upload queue with that [`IndexPart`].
 //! - Reschedule all lost operations by comparing the local filesystem state
 //!   and remote state as per [`IndexPart`]. This is done in
-//!   [`Timeline::setup_timeline`] and [`Timeline::reconcile_with_remote`].
+//!   [`Timeline::timeline_init_and_sync`] and [`Timeline::reconcile_with_remote`].
 //!
 //! Note that if we crash during file deletion between the index update
 //! that removes the file from the list of files, and deleting the remote file,


### PR DESCRIPTION
Follow-up of https://github.com/neondatabase/neon/pull/3326#issuecomment-1384265759

Not sure if the new version is correct though, r-a does not resolve that properly:

<img width="699" alt="image" src="https://user-images.githubusercontent.com/2690773/212756538-2ea286bf-c757-4478-83ba-678d1ca5d89e.png">
