### PR TITLE
build: Use `curl -f` on vm-informant download

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -610,7 +610,7 @@ jobs:
 
       - name: Downloading VM informant version ${{ env.VM_INFORMANT_VERSION }}
         run: |
-          curl -L https://github.com/neondatabase/autoscaling/releases/download/${{ env.VM_INFORMANT_VERSION }}/vm-informant -o vm-informant
+          curl -fL https://github.com/neondatabase/autoscaling/releases/download/${{ env.VM_INFORMANT_VERSION }}/vm-informant -o vm-informant
           chmod +x vm-informant
 
       - name: Adding VM informant to compute-node image


### PR DESCRIPTION
Without this, we can silently fail (as seems to have happened in the latest deployment).