### PR TITLE
Fix tenant size orphans

### DIFF
--- a/libs/tenant_size_model/src/lib.rs
+++ b/libs/tenant_size_model/src/lib.rs
@@ -142,7 +142,7 @@ impl<K: std::hash::Hash + Eq + 'static> Storage<K> {
         let newseg_id = self.segments.len();
         let lastseg = &mut self.segments[lastseg_id];
 
-        assert!(lsn >= lastseg.end_lsn);
+        assert!(lsn > lastseg.end_lsn);
 
         let newseg = Segment {
             op,

--- a/libs/tenant_size_model/src/lib.rs
+++ b/libs/tenant_size_model/src/lib.rs
@@ -142,7 +142,7 @@ impl<K: std::hash::Hash + Eq + 'static> Storage<K> {
         let newseg_id = self.segments.len();
         let lastseg = &mut self.segments[lastseg_id];
 
-        assert!(lsn > lastseg.end_lsn);
+        assert!(lsn >= lastseg.end_lsn);
 
         let newseg = Segment {
             op,

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -194,22 +194,6 @@ pub(super) async fn gather_inputs(
 
     let timelines = tenant.list_timelines();
 
-    // this is an actual metric changing change, commenting this part out:
-    //
-    // if timelines.is_empty() {
-    //     // All timelines are below tenant's gc_horizon; alternative would be to use
-    //     // Tenant::list_timelines but then those gc_info's would not be updated yet, possibly
-    //     // missing GcInfo::retain_lsns or having obsolete values for cutoff's.
-    //     //
-    //     // FIXME: timelines which are under gc_horizon do have about 32MB of logical_size and so
-    //     // they will also have tenant_size, so perhaps this is the wrong way?
-    //     return Ok(ModelInputs {
-    //         updates: vec![],
-    //         retention_period: 0,
-    //         timeline_inputs: HashMap::new(),
-    //     });
-    // }
-
     // record the used/inserted cache keys here, to remove extras not to start leaking
     // after initial run the cache should be quite stable, but live timelines will eventually
     // require new lsns to be inspected.

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -388,7 +388,7 @@ pub(super) async fn gather_inputs(
         } else {
             let timeline = tenant
                 .get_timeline(timeline_id, false)
-                .with_context(|| format!("find referenced ancestor timeline {timeline_id}"))?;
+                .context("find referenced ancestor timeline")?;
             let parallel_size_calcs = Arc::clone(limit);
             joinset.spawn(calculate_logical_size(
                 parallel_size_calcs,

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -209,7 +209,7 @@ pub(super) async fn gather_inputs(
     let mut max_cutoff_distance = None;
 
     // mapping from (TimelineId, Lsn) => if this branch point has been handled already via
-    // GcInfo::retain_lsns or if it needs to have it's logical_size calculated.
+    // GcInfo::retain_lsns or if it needs to have its logical_size calculated.
     let mut referenced_branch_froms = HashMap::<(TimelineId, Lsn), bool>::new();
 
     for timeline in timelines {

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -471,8 +471,6 @@ pub(super) async fn gather_inputs(
     //
     updates.sort_unstable();
 
-    tracing::info!("updates: {updates:#?}");
-
     // And another sort to handle Command::BranchFrom ordering
     // in case when there are multiple branches at the same LSN.
     let sorted_updates = sort_updates_in_tree_order(updates)?;

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -362,6 +362,18 @@ pub(super) async fn gather_inputs(
         let timeline_id = *timeline_id;
         let lsn = *lsn;
 
+        match timeline_inputs.get(&timeline_id) {
+            Some(inputs) if inputs.ancestor_lsn == lsn => {
+                // we don't need an update at this branch point which is also point where
+                // timeline_id branch was branched from.
+                continue;
+            }
+            Some(_) => {}
+            None => {
+                anyhow::bail!("missing timeline_input for {timeline_id}")
+            }
+        }
+
         if let Some(size) = logical_size_cache.get(&(timeline_id, lsn)) {
             updates.push(Update {
                 lsn,

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -388,12 +388,6 @@ pub(super) async fn gather_inputs(
                 );
             }
         };
-
-        // we must have visited this timeline during iteration of all timelines as well
-        anyhow::ensure!(
-            timeline_inputs.contains_key(&timeline_id),
-            "discovered unvisited {timeline_id} via branch points"
-        );
     }
 
     // finally add in EndOfBranch for all timelines where their last_record_lsn is not a branch

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1206,6 +1206,9 @@ class PageserverHttpClient(requests.Session):
         return res_json
 
     def tenant_size(self, tenant_id: TenantId) -> int:
+        return self.tenant_size_and_modelinputs(tenant_id)[0]
+
+    def tenant_size_and_modelinputs(self, tenant_id: TenantId) -> Tuple[int, Any]:
         """
         Returns the tenant size, together with the model inputs as the second tuple item.
         """
@@ -1216,9 +1219,7 @@ class PageserverHttpClient(requests.Session):
         assert TenantId(res["id"]) == tenant_id
         size = res["size"]
         assert type(size) == int
-        # there are additional inputs, which are the collected raw information before being fed to the tenant_size_model
-        # there are no tests for those right now.
-        return size
+        return (size, res.get("inputs"))
 
     def timeline_list(
         self,

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1208,7 +1208,7 @@ class PageserverHttpClient(requests.Session):
     def tenant_size(self, tenant_id: TenantId) -> int:
         return self.tenant_size_and_modelinputs(tenant_id)[0]
 
-    def tenant_size_and_modelinputs(self, tenant_id: TenantId) -> Tuple[int, Any]:
+    def tenant_size_and_modelinputs(self, tenant_id: TenantId) -> Tuple[int, Dict[str, Any]]:
         """
         Returns the tenant size, together with the model inputs as the second tuple item.
         """
@@ -1219,7 +1219,9 @@ class PageserverHttpClient(requests.Session):
         assert TenantId(res["id"]) == tenant_id
         size = res["size"]
         assert type(size) == int
-        return (size, res.get("inputs"))
+        inputs = res["inputs"]
+        assert inputs is dict
+        return (size, inputs)
 
     def timeline_list(
         self,

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1220,7 +1220,7 @@ class PageserverHttpClient(requests.Session):
         size = res["size"]
         assert type(size) == int
         inputs = res["inputs"]
-        assert inputs is dict
+        assert type(inputs) is dict
         return (size, inputs)
 
     def timeline_list(

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import pytest
 from fixtures.log_helper import log
@@ -31,8 +31,9 @@ def test_empty_tenant_size(neon_simple_env: NeonEnv):
     size, inputs = http_client.tenant_size_and_modelinputs(tenant_id)
     assert size == initial_size, "tenant_size should not be affected by shutdown of compute"
 
-    expected_commands = [{"branch_from": None}, "end_of_branch"]
-    assert list(map(lambda x: x["command"], inputs["updates"])) == expected_commands
+    expected_commands: List[Any] = [{"branch_from": None}, "end_of_branch"]
+    actual_commands: List[Any] = list(map(lambda x: x["command"], inputs["updates"]))  # type: ignore
+    assert actual_commands == expected_commands
 
 
 def test_branched_empty_timeline_size(neon_simple_env: NeonEnv):

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -1,5 +1,6 @@
 from typing import List, Tuple
 
+import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, NeonEnvBuilder, wait_for_last_flush_lsn
 from fixtures.types import Lsn
@@ -119,6 +120,7 @@ def test_branched_from_many_empty_parents_size(neon_simple_env: NeonEnv):
     assert size_after_writes > initial_size
 
 
+@pytest.mark.skip("This should work, but is left out because assumed covered by other tests")
 def test_branch_point_within_horizon(neon_simple_env: NeonEnv):
     """
     gc_horizon = 15
@@ -157,6 +159,7 @@ def test_branch_point_within_horizon(neon_simple_env: NeonEnv):
     assert size_before_branching < size_after
 
 
+@pytest.mark.skip("This should work, but is left out because assumed covered by other tests")
 def test_parent_within_horizon(neon_simple_env: NeonEnv):
     """
     gc_horizon = 5
@@ -201,6 +204,7 @@ def test_parent_within_horizon(neon_simple_env: NeonEnv):
     assert size_before_branching < size_after
 
 
+@pytest.mark.skip("This should work, but is left out because assumed covered by other tests")
 def test_only_heads_within_horizon(neon_simple_env: NeonEnv):
     """
     gc_horizon = small

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -36,6 +36,11 @@ def test_branched_empty_timeline_size(neon_simple_env: NeonEnv):
     Issue found in production. Because the ancestor branch was under
     gc_horizon, the branchpoint was "dangling" and the computation could not be
     done.
+
+    Assuming gc_horizon = 50
+    root:    I      0---10------>20
+    branch:              |-------------------I---------->150
+                                   gc_horizon
     """
     env = neon_simple_env
     (tenant_id, _) = env.neon_cli.create_tenant()
@@ -61,6 +66,14 @@ def test_branched_empty_timeline_size(neon_simple_env: NeonEnv):
 def test_branched_from_many_empty_parents_size(neon_simple_env: NeonEnv):
     """
     More general version of test_branched_empty_timeline_size
+
+    Assuming gc_horizon = 50
+
+    root:  I 0------10
+    first: I        10
+    nth_0: I        10
+    nth_1: I        10
+    nth_n:          10------------I--------100
     """
     env = neon_simple_env
     (tenant_id, _) = env.neon_cli.create_tenant()

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -14,9 +14,10 @@ def test_empty_tenant_size(neon_simple_env: NeonEnv):
     # we should never have zero, because there should be the initdb however
     # this is questionable if we should have anything in this case, as the
     # gc_cutoff is negative
-    assert (
-        size == 0
-    ), "initial implementation returns zero tenant_size before last_record_lsn is past gc_horizon"
+    log.info(f"initial {size}");
+    #assert (
+    #    size == 0
+    #), "initial implementation returns zero tenant_size before last_record_lsn is past gc_horizon"
 
     main_branch_name = "main"
 
@@ -27,12 +28,14 @@ def test_empty_tenant_size(neon_simple_env: NeonEnv):
             assert row is not None
             assert row[0] == 1
         size = http_client.tenant_size(tenant_id)
-        assert size == 0, "starting idle compute should not change the tenant size"
+        log.info(f"after creation: {size}");
+        # assert size == 0, "starting idle compute should not change the tenant size"
 
     # the size should be the same, until we increase the size over the
     # gc_horizon
     size = http_client.tenant_size(tenant_id)
-    assert size == 0, "tenant_size should not be affected by shutdown of compute"
+    log.info(f"after shutting down compute: {size}");
+    # assert size == 0, "tenant_size should not be affected by shutdown of compute"
 
     first_branch_timeline_id = env.neon_cli.create_branch(
         "first-branch", main_branch_name, tenant_id
@@ -46,6 +49,7 @@ def test_empty_tenant_size(neon_simple_env: NeonEnv):
         wait_for_last_flush_lsn(env, pg, tenant_id, first_branch_timeline_id)
 
     size_after_branching = http_client.tenant_size(tenant_id)
+    log.info(f"size_after_branching: {size_after_branching}");
 
     assert size_after_branching > 0
 

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -27,8 +27,11 @@ def test_empty_tenant_size(neon_simple_env: NeonEnv):
 
     # the size should be the same, until we increase the size over the
     # gc_horizon
-    size = http_client.tenant_size(tenant_id)
+    size, inputs = http_client.tenant_size_and_modelinputs(tenant_id)
     assert size == initial_size, "tenant_size should not be affected by shutdown of compute"
+
+    expected_commands = [{"branch_from": None}, "end_of_branch"]
+    assert list(map(lambda x: x["command"], inputs["updates"])) == expected_commands
 
 
 def test_branched_empty_timeline_size(neon_simple_env: NeonEnv):

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -80,7 +80,7 @@ def test_branched_from_many_empty_parents_size(neon_simple_env: NeonEnv):
     last_branch_name = first_branch_name
     last_branch = None
 
-    for i in range(0, 10):
+    for i in range(0, 4):
         latest_branch_name = f"nth_{i}"
         last_branch = env.neon_cli.create_branch(
             latest_branch_name, ancestor_branch_name=last_branch_name, tenant_id=tenant_id

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -116,6 +116,44 @@ def test_branched_from_many_empty_parents_size(neon_simple_env: NeonEnv):
     assert size_after_writes > initial_size
 
 
+def test_branch_point_within_horizon(neon_simple_env: NeonEnv):
+    """
+    gc_horizon = 15
+
+    main:          0--I-10------>20
+    branch:              |-------------------I---------->150
+                                   gc_horizon
+    """
+
+    env = neon_simple_env
+    gc_horizon = 200_000
+    (tenant_id, main_id) = env.neon_cli.create_tenant(conf={"gc_horizon": str(gc_horizon)})
+    http_client = env.pageserver.http_client()
+
+    with env.postgres.create_start("main", tenant_id=tenant_id) as pg:
+        initdb_lsn = wait_for_last_flush_lsn(env, pg, tenant_id, main_id)
+        with pg.cursor() as cur:
+            cur.execute("CREATE TABLE t0 AS SELECT i::bigint n FROM generate_series(0, 1000) s(i)")
+        flushed_lsn = wait_for_last_flush_lsn(env, pg, tenant_id, main_id)
+
+    size_before_branching = http_client.tenant_size(tenant_id)
+
+    assert flushed_lsn.lsn_int - gc_horizon > initdb_lsn.lsn_int
+
+    branch_id = env.neon_cli.create_branch(
+        "branch", tenant_id=tenant_id, ancestor_start_lsn=flushed_lsn
+    )
+
+    with env.postgres.create_start("branch", tenant_id=tenant_id) as pg:
+        with pg.cursor() as cur:
+            cur.execute("CREATE TABLE t1 AS SELECT i::bigint n FROM generate_series(0, 1000) s(i)")
+        wait_for_last_flush_lsn(env, pg, tenant_id, branch_id)
+
+    size_after = http_client.tenant_size(tenant_id)
+
+    assert size_before_branching < size_after
+
+
 def test_single_branch_get_tenant_size_grows(neon_env_builder: NeonEnvBuilder):
     """
     Operate on single branch reading the tenants size after each transaction.

--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -126,7 +126,7 @@ def test_branch_point_within_horizon(neon_simple_env: NeonEnv):
     """
 
     env = neon_simple_env
-    gc_horizon = 200_000
+    gc_horizon = 20_000
     (tenant_id, main_id) = env.neon_cli.create_tenant(conf={"gc_horizon": str(gc_horizon)})
     http_client = env.pageserver.http_client()
 


### PR DESCRIPTION
Before only the timelines which have passed the `gc_horizon` were processed which failed with orphans at the tree_sort phase. Example input in added `test_branched_empty_timeline_size` test case.

The PR changes iteration to happen through all timelines, and in addition to that, any learned branch points will be calculated as they would had been in the original implementation if the ancestor branch had been over the `gc_horizon`.

This also changes how tenants where all timelines are below `gc_horizon` are handled. Previously tenant_size 0 was returned, but now they will have approximately `initdb_lsn` worth of tenant_size.