### PR TITLE
fix: dont stop pageserver if we fail to calculate synthetic size

### DIFF
--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -59,7 +59,7 @@ pub async fn collect_metrics(
         None,
         None,
         "synthetic size calculation",
-        true,
+        false,
         async move {
             calculate_synthetic_size_worker(synthetic_size_calculation_interval)
                 .instrument(info_span!("synthetic_size_worker"))


### PR DESCRIPTION
Cc: #3387

Noted that the flag is still enabled for the metrics collection as a whole on: https://github.com/neondatabase/neon/blob/05c13f76c74f7dc4d281a5d1b5f6cc8328faedad/pageserver/src/bin/pageserver.rs#L327-L346