### PR TITLE
Support "kick" callback from console in the HTTP API.

### DIFF
--- a/proxy/src/http/server.rs
+++ b/proxy/src/http/server.rs
@@ -1,5 +1,7 @@
-use anyhow::anyhow;
-use hyper::{Body, Request, Response, StatusCode};
+use crate::waiters::NotifyError;
+use crate::{auth, console::messages::KickSession};
+use anyhow::{anyhow, Context};
+use hyper::{body, Body, Request, Response, StatusCode};
 use std::net::TcpListener;
 use tracing::info;
 use utils::http::{endpoint, error::ApiError, json::json_response, RouterBuilder, RouterService};
@@ -8,9 +10,30 @@ async fn status_handler(_: Request<Body>) -> Result<Response<Body>, ApiError> {
     json_response(StatusCode::OK, "")
 }
 
+/// Process a session kick callback from the control plane. The body is a
+/// KickSession as a JSON document.
+///
+/// TODO: authentication
+async fn kick_session_handler(req: Request<Body>) -> Result<Response<Body>, ApiError> {
+    let body = &body::to_bytes(req.into_body())
+        .await
+        .context("Failed to get request body")
+        .map_err(ApiError::BadRequest)?;
+    let kick_session_json: KickSession = serde_json::from_slice(body)
+        .context("Failed to parse query as json")
+        .map_err(ApiError::BadRequest)?;
+
+    match auth::backend::notify(kick_session_json.session_id, Ok(kick_session_json.result)) {
+        Ok(()) => json_response(StatusCode::OK, ""),
+        Err(NotifyError::NotFound(s)) => Err(ApiError::NotFound(anyhow::anyhow!(s))),
+        Err(e @ NotifyError::Hangup) => Err(ApiError::NotFound(anyhow::anyhow!(e))),
+    }
+}
+
 fn make_router() -> RouterBuilder<hyper::Body, ApiError> {
-    let router = endpoint::make_router();
-    router.get("/v1/status", status_handler)
+    endpoint::make_router()
+        .get("/v1/status", status_handler)
+        .post("/v1/kick_session", kick_session_handler)
 }
 
 pub async fn task_main(http_listener: TcpListener) -> anyhow::Result<()> {

--- a/proxy/src/mgmt.rs
+++ b/proxy/src/mgmt.rs
@@ -1,3 +1,14 @@
+//!
+//! This provides a listener for connections using the libpq protocol, for the
+//! purposes of "kick callback" from proxy, for link authentication. The
+//!
+//! The protocol is the libpq protocol, but the only "query" we accept is a JSON
+//! document. The JSON document is a KickSession serialized to JSON.
+//!
+//! This is considered legacy now. The preferred way to deliver "kick callbacks"
+//! is now via the HTTP API. See `server.rs`. Once the control plane has switched
+//! to using the HTTP API, this can be removed.
+
 use crate::{
     auth,
     console::messages::{DatabaseInfo, KickSession},
@@ -58,7 +69,6 @@ fn handle_connection(socket: TcpStream) -> Result<(), QueryError> {
 /// A message received by `mgmt` when a compute node is ready.
 pub type ComputeReady = Result<DatabaseInfo, String>;
 
-// TODO: replace with an http-based protocol.
 struct MgmtHandler;
 impl postgres_backend::Handler for MgmtHandler {
     fn process_query(&mut self, pgb: &mut PostgresBackend, query: &str) -> Result<(), QueryError> {


### PR DESCRIPTION
We cannot remove the "mgmt" interface until the control plane has been changed to use the new HTTP API, and it has been deployed to all the environments. But this gets us started with the migration to the HTTP API.


If --mgmt option is not given, don't start the mgmt listener. The mgmt listener is only used for the "kick" callbacks from control plan in link authentication. If you're not using link authentication, it's not needed. Let's make it optional.
