### PR TITLE
Output coloured pageserver logs for tty stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4157,6 +4157,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "atty",
  "bincode",
  "byteorder",
  "bytes",

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+atty.workspace = true
 sentry.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -34,7 +34,7 @@ pub fn init(log_format: LogFormat) -> anyhow::Result<()> {
     let base_logger = tracing_subscriber::fmt()
         .with_env_filter(env_filter)
         .with_target(false)
-        .with_ansi(false)
+        .with_ansi(atty::is(atty::Stream::Stdout))
         .with_writer(std::io::stdout);
 
     match log_format {


### PR DESCRIPTION
Similar to https://github.com/neondatabase/neon/blob/5c865f46bae28532ebe0ff6ed5317ba2b30e9892/proxy/src/main.rs#L47 

Before:
<img width="1526" alt="Screenshot 2023-01-23 at 14 41 46" src="https://user-images.githubusercontent.com/2690773/214043226-c1a1ad4c-636f-487f-9182-d2093e39d16f.png">

After:
<img width="1533" alt="Screenshot 2023-01-23 at 14 41 01" src="https://user-images.githubusercontent.com/2690773/214043210-4326f147-716a-4a7d-8c7b-cbbd614ab7e2.png">

