### PR TITLE
fix some anyhow::Context::context calls that should use with_context(format!(...))

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -282,7 +282,7 @@ async fn timeline_detail_handler(request: Request<Body>) -> Result<Response<Body
 
         let timeline_info = build_timeline_info(&timeline, include_non_incremental_logical_size)
             .await
-            .context("Failed to get local timeline info: {e:#}")
+            .context("get local timeline info")
             .map_err(ApiError::InternalServerError)?;
 
         Ok::<_, ApiError>(timeline_info)

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -488,7 +488,7 @@ impl Timeline {
                 let mut buf = self
                     .get(relsize_key, lsn)
                     .await
-                    .context("read relation size of {rel:?}")?;
+                    .with_context(|| format!("read relation size of {rel:?}"))?;
                 let relsize = buf.get_u32_le();
 
                 total_size += relsize as u64;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2285,7 +2285,7 @@ impl Timeline {
             let metadata = timeline_path
                 .join(path.file_name())
                 .metadata()
-                .context("reading metadata of layer file {path}")?;
+                .with_context(|| format!("reading metadata of layer file {}", path.file_name()))?;
 
             layer_paths_to_upload.insert(path, LayerFileMetadata::new(metadata.len()));
 


### PR DESCRIPTION
Noticed this while combing through some production logs.