### PR TITLE
Propagate context to spawn_blocking tasks

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1457,10 +1457,7 @@ impl Timeline {
         up_to_lsn: Lsn,
         cancel: CancellationToken,
     ) -> Result<u64, CalculateLogicalSizeError> {
-        info!(
-            "Calculating logical size for timeline {} at {}",
-            self.timeline_id, up_to_lsn
-        );
+        info!(%up_to_lsn, "Calculating logical size");
         // These failpoints are used by python tests to ensure that we don't delete
         // the timeline while the logical size computation is ongoing.
         // The first failpoint is used to make this function pause.

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1388,7 +1388,11 @@ impl Timeline {
 
         let calculation = async {
             let cancel = cancel.child_token();
+            let span = tracing::info_span!("blocking");
             tokio::task::spawn_blocking(move || {
+                // spans cannot be automatically included with spawn_blocking
+                let _entered = span.entered();
+
                 // Run in a separate thread since this can do a lot of
                 // synchronous file IO without .await inbetween
                 // if there are no RemoteLayers that would require downloading.

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1351,7 +1351,7 @@ impl Timeline {
                 // so that we prevent future callers from spawning this task
                 permit.forget();
                 Ok(())
-            },
+            }.in_current_span(),
         );
     }
 
@@ -1372,7 +1372,8 @@ impl Timeline {
                 let res = self_clone.logical_size_calculation_task(lsn).await;
                 let _ = sender.send(res).ok();
                 Ok(()) // Receiver is responsible for handling errors
-            },
+            }
+            .in_current_span(),
         );
         receiver
     }


### PR DESCRIPTION
Drafted until I test if it would be worth to add `.in_current_span` to `task_mgr`. That'd probably go against most of the expectations, so most likely this is good. And this needs to be tested as well :)

Adds context to stray info messages:

```
<timestamp> Calculating logical size for timeline Y at 0/1F3A1FA8
```

Cc: #3387 