### PR TITLE
Tone down http error printing

### DIFF
--- a/libs/utils/src/http/error.rs
+++ b/libs/utils/src/http/error.rs
@@ -81,6 +81,7 @@ pub async fn handler(err: routerify::RouteError) -> Response<Body> {
         .downcast::<ApiError>()
         .expect("handler should always return api error");
 
+    // Print a stack trace for Internal Server errors
     if let ApiError::InternalServerError(_) = api_error.as_ref() {
         error!("Error processing HTTP request: {api_error:?}");
     } else {

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -237,7 +237,7 @@ def test_tenant_detach_smoke(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
 
-    env.pageserver.allowed_errors.append(".*NotFound\\(Tenant .* not found")
+    env.pageserver.allowed_errors.append(".*NotFound: Tenant .* not found")
 
     # first check for non existing tenant
     tenant_id = TenantId.generate()


### PR DESCRIPTION
Only print backtraces for internal server error variants of the API error.

Before:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/2690773/214390217-8b7c8668-77f7-41fd-a730-0103039df4f6.png">

After:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/2690773/214390227-fe8bf3e0-09a1-400a-8cf1-81fa980a1e94.png">

