### PR TITLE
Allow creating config for attached tenant

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1854,19 +1854,7 @@ impl Tenant {
         // before this was done conditionally on first_save, but these management actions are rare
         // enough to just fsync it always.
 
-        File::open(target_config_parent)
-            .context("Failed to open config parent")
-            .and_then(|tenant_dir| {
-                tenant_dir
-                    .sync_all()
-                    .context("Failed to fsync config parent")
-            })
-            .with_context(|| {
-                format!(
-                    "Failed to fsync on first save for config {}",
-                    target_config_path.display()
-                )
-            })?;
+        crashsafe::fsync(target_config_parent)?;
 
         Ok(())
     }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1823,7 +1823,10 @@ impl Tenant {
             OpenOptions::new()
                 .truncate(true) // This needed for overwriting with small config files
                 .write(true)
-                .create_new(first_save),
+                .create_new(first_save)
+                // when initializing a new tenant, first_save will be true, thus this flag will be
+                // ignored (per rust std docs). later, don't care.
+                .create(true),
         )?;
 
         target_config_file

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1844,7 +1844,7 @@ impl Tenant {
             .and_then(|_| {
                 target_config_file
                     .sync_all()
-                    .context("Faile to fsync config file")
+                    .context("Failed to fsync config file")
             })
             .with_context(|| {
                 format!(

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1843,26 +1843,26 @@ impl Tenant {
                 )
             })?;
 
-        // fsync the parent directory to ensure the directory entry is durable
-        if first_save {
-            target_config_path
-                .parent()
-                .context("Config file does not have a parent")
-                .and_then(|target_config_parent| {
-                    File::open(target_config_parent).context("Failed to open config parent")
-                })
-                .and_then(|tenant_dir| {
-                    tenant_dir
-                        .sync_all()
-                        .context("Failed to fsync config parent")
-                })
-                .with_context(|| {
-                    format!(
-                        "Failed to fsync on first save for config {}",
-                        target_config_path.display()
-                    )
-                })?;
-        }
+        // fsync the parent directory to ensure the directory entry is durable.
+        // before this was done conditionally on first_save, but these management actions are rare
+        // enough to just fsync it always.
+        target_config_path
+            .parent()
+            .context("Config file does not have a parent")
+            .and_then(|target_config_parent| {
+                File::open(target_config_parent).context("Failed to open config parent")
+            })
+            .and_then(|tenant_dir| {
+                tenant_dir
+                    .sync_all()
+                    .context("Failed to fsync config parent")
+            })
+            .with_context(|| {
+                format!(
+                    "Failed to fsync on first save for config {}",
+                    target_config_path.display()
+                )
+            })?;
 
         Ok(())
     }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1840,18 +1840,9 @@ impl Tenant {
 
         target_config_file
             .write(conf_content.as_bytes())
-            .context("Failed to write toml bytes into file")
-            .and_then(|_| {
-                target_config_file
-                    .sync_all()
-                    .context("Failed to fsync config file")
-            })
-            .with_context(|| {
-                format!(
-                    "Failed to write config file into path '{}'",
-                    target_config_path.display()
-                )
-            })?;
+            .context("write toml bytes into file")
+            .and_then(|_| target_config_file.sync_all().context("fsync config file"))
+            .context("write config file")?;
 
         // fsync the parent directory to ensure the directory entry is durable.
         // before this was done conditionally on creating_tenant, but these management actions are rare

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1807,7 +1807,7 @@ impl Tenant {
     ) -> anyhow::Result<()> {
         let _enter = info_span!("saving tenantconf").entered();
 
-        // imitiate try-block with a closure
+        // imitate a try-block with a closure
         let do_persist = |target_config_path: &Path| -> anyhow::Result<()> {
             let target_config_parent = target_config_path.parent().with_context(|| {
                 format!(

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1802,7 +1802,7 @@ impl Tenant {
     pub(super) fn persist_tenant_config(
         target_config_path: &Path,
         tenant_conf: TenantConfOpt,
-        first_save: bool,
+        creating_tenant: bool,
     ) -> anyhow::Result<()> {
         let _enter = info_span!("saving tenantconf").entered();
         let target_config_parent = target_config_path.parent().with_context(|| {
@@ -1829,7 +1829,7 @@ impl Tenant {
             OpenOptions::new()
                 .truncate(true) // This needed for overwriting with small config files
                 .write(true)
-                .create_new(first_save)
+                .create_new(creating_tenant)
                 // when creating a new tenant, first_save will be true and `.create(true)` will be
                 // ignored (per rust std docs).
                 //
@@ -1854,7 +1854,7 @@ impl Tenant {
             })?;
 
         // fsync the parent directory to ensure the directory entry is durable.
-        // before this was done conditionally on first_save, but these management actions are rare
+        // before this was done conditionally on creating_tenant, but these management actions are rare
         // enough to just fsync it always.
 
         crashsafe::fsync(target_config_parent)?;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1830,8 +1830,11 @@ impl Tenant {
                 .truncate(true) // This needed for overwriting with small config files
                 .write(true)
                 .create_new(first_save)
-                // when initializing a new tenant, first_save will be true, thus this flag will be
-                // ignored (per rust std docs). later, don't care.
+                // when creating a new tenant, first_save will be true and `.create(true)` will be
+                // ignored (per rust std docs).
+                //
+                // later when updating the config of created tenant, or persisting config for the
+                // first time for attached tenant, the `.create(true)` is used.
                 .create(true),
         )?;
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -2513,19 +2513,19 @@ fn try_create_target_tenant_dir(
         target_tenant_directory,
         temporary_tenant_dir,
     )
-    .with_context(|| format!("Failed to resolve tenant {tenant_id} temporary timelines dir"))?;
+    .with_context(|| format!("resolve tenant {tenant_id} temporary timelines dir"))?;
     let temporary_tenant_config_path = rebase_directory(
         &conf.tenant_config_path(tenant_id),
         target_tenant_directory,
         temporary_tenant_dir,
     )
-    .with_context(|| format!("Failed to resolve tenant {tenant_id} temporary config path"))?;
+    .with_context(|| format!("resolve tenant {tenant_id} temporary config path"))?;
 
     Tenant::persist_tenant_config(&tenant_id, &temporary_tenant_config_path, tenant_conf, true)?;
 
     crashsafe::create_dir(&temporary_tenant_timelines_dir).with_context(|| {
         format!(
-            "could not create tenant {} temporary timelines directory {}",
+            "create tenant {} temporary timelines directory {}",
             tenant_id,
             temporary_tenant_timelines_dir.display()
         )
@@ -2536,7 +2536,7 @@ fn try_create_target_tenant_dir(
 
     fs::rename(temporary_tenant_dir, target_tenant_directory).with_context(|| {
         format!(
-            "failed to move tenant {} temporary directory {} into the permanent one {}",
+            "move tenant {} temporary directory {} into the permanent one {}",
             tenant_id,
             temporary_tenant_dir.display(),
             target_tenant_directory.display()
@@ -2544,14 +2544,14 @@ fn try_create_target_tenant_dir(
     })?;
     let target_dir_parent = target_tenant_directory.parent().with_context(|| {
         format!(
-            "Failed to get tenant {} dir parent for {}",
+            "get tenant {} dir parent for {}",
             tenant_id,
             target_tenant_directory.display()
         )
     })?;
     crashsafe::fsync(target_dir_parent).with_context(|| {
         format!(
-            "Failed to fsync renamed directory's parent {} for tenant {}",
+            "fsync renamed directory's parent {} for tenant {}",
             target_dir_parent.display(),
             tenant_id,
         )

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1807,7 +1807,6 @@ impl Tenant {
         let _enter = info_span!("saving tenantconf").entered();
         info!("persisting tenantconf to {}", target_config_path.display());
 
-        // TODO this will prepend comments endlessly ?
         let mut conf_content = r#"# This file contains a specific per-tenant's config.
 #  It is read in case of pageserver restart.
 

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -242,17 +242,11 @@ pub async fn update_tenant_config(
     tenant_id: TenantId,
 ) -> anyhow::Result<()> {
     info!("configuring tenant {tenant_id}");
-    get_tenant(tenant_id, true)
-        .await?
-        .update_tenant_config(tenant_conf);
+    let tenant = get_tenant(tenant_id, true).await?;
+
+    tenant.update_tenant_config(tenant_conf);
     let tenant_config_path = conf.tenant_config_path(tenant_id);
-    Tenant::persist_tenant_config(&tenant_config_path, tenant_conf, false).with_context(|| {
-        format!(
-            "Failed to write tenant {} config to {}",
-            tenant_id,
-            tenant_config_path.display()
-        )
-    })?;
+    Tenant::persist_tenant_config(&tenant.tenant_id(), &tenant_config_path, tenant_conf, false)?;
     Ok(())
 }
 

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -245,7 +245,14 @@ pub async fn update_tenant_config(
     get_tenant(tenant_id, true)
         .await?
         .update_tenant_config(tenant_conf);
-    Tenant::persist_tenant_config(&conf.tenant_config_path(tenant_id), tenant_conf, false)?;
+    let tenant_config_path = conf.tenant_config_path(tenant_id);
+    Tenant::persist_tenant_config(&tenant_config_path, tenant_conf, false).with_context(|| {
+        format!(
+            "Failed to write tenant {} config to {}",
+            tenant_id,
+            tenant_config_path.display()
+        )
+    })?;
     Ok(())
 }
 

--- a/test_runner/regress/test_tenant_conf.py
+++ b/test_runner/regress/test_tenant_conf.py
@@ -202,9 +202,9 @@ def test_creating_tenant_conf_after_attach(neon_env_builder: NeonEnvBuilder):
     )
 
     env.neon_cli.config_tenant(tenant_id, {"gc_horizon": "1000000"})
-    contents_first = config_path.read_text("utf-8")
+    contents_first = config_path.read_text()
     env.neon_cli.config_tenant(tenant_id, {"gc_horizon": "0"})
-    contents_later = config_path.read_text("utf-8")
+    contents_later = config_path.read_text()
 
     # dont test applying the setting here, we have that another test case to show it
     # we just care about being able to create the file


### PR DESCRIPTION
This might be a bit controversial change but I thought to write the code takes about as much as writing a proper issue.

Currently `attach` doesn't write a tenant config, because we don't back it up in the first place. The current implementation of `Tenant::persist_tenant_config` does not allow changing tenant's configuration through the http api which will fail because the file wasn't created on attach and `OpenOptions::truncate(true).write(true).create_new(false)` is used.

I think this patch allows for least controversial middle ground which *enables* changing tenant configuration even for attached tenants (not just created tenants).

I also removed the conditional fsync on the directory because it's now a hazard because the file might be created when `!first_save`.

See also:
- #1555

Does not address:
- #3062

Found while trying to reproduce #3387.