### PR TITLE
rework tenant attach code to share the initialization code path with tenant load

### DIFF
--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -29,7 +29,7 @@ use utils::{
 
 use crate::tenant::config::TenantConf;
 use crate::tenant::config::TenantConfOpt;
-use crate::tenant::{TENANT_ATTACHING_MARKER_FILENAME, TIMELINES_SEGMENT_NAME};
+use crate::tenant::{TENANT_ATTACHING_MARKER_SUFFIX, TIMELINES_SEGMENT_NAME};
 use crate::{
     IGNORED_TENANT_FILE_NAME, METADATA_FILE_NAME, TENANT_CONFIG_NAME, TIMELINE_UNINIT_MARK_SUFFIX,
 };
@@ -459,8 +459,7 @@ impl PageServerConf {
     }
 
     pub fn tenant_attaching_mark_file_path(&self, tenant_id: &TenantId) -> PathBuf {
-        self.tenant_path(tenant_id)
-            .join(TENANT_ATTACHING_MARKER_FILENAME)
+        path_with_suffix_extension(self.tenant_path(tenant_id), TENANT_ATTACHING_MARKER_SUFFIX)
     }
 
     pub fn tenant_ignore_mark_file_path(&self, tenant_id: TenantId) -> PathBuf {

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -238,11 +238,17 @@ pub enum TaskKind {
     // Task that downloads a file from remote storage
     RemoteDownloadTask,
 
-    // task that handles the initial downloading of all tenants
-    InitialLoad,
+    // task that handles loading of a tenant during pageserver startup
+    TenantLoadStartup,
+
+    // task that handles loading of a tenant in response to a /load HTTP API request
+    TenantLoadApi,
+
+    // task that handles loading of a tenant as part of the tenant creation procedure
+    TenantLoadCreate,
 
     // task that handles attaching a tenant
-    Attach,
+    TenantAttach,
 
     // task that handhes metrics collection
     MetricsCollection,

--- a/test_runner/regress/test_broken_timeline.py
+++ b/test_runner/regress/test_broken_timeline.py
@@ -20,7 +20,7 @@ def test_broken_timeline(neon_env_builder: NeonEnvBuilder):
             ".*is not active. Current state: Broken.*",
             ".*will not become active. Current state: Broken.*",
             ".*failed to load metadata.*",
-            ".*could not load tenant.*load local timeline.*",
+            ".*could not load tenant.*load timeline.*",
         ]
     )
 

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -579,12 +579,11 @@ def test_load_attach_negatives(
 
     pageserver_http.tenant_ignore(tenant_id)
 
-    env.pageserver.allowed_errors.append(
-        ".*Cannot attach tenant .*?, local tenant directory already exists.*"
-    )
+    expect_error_msg = f".*attach tenant {tenant_id}: some local filesystem state already exists:"
+    env.pageserver.allowed_errors.append(expect_error_msg)
     with pytest.raises(
         expected_exception=PageserverApiException,
-        match=f"Cannot attach tenant {tenant_id}, local tenant directory already exists",
+        match=expect_error_msg,
     ):
         pageserver_http.tenant_attach(tenant_id)
 
@@ -628,12 +627,11 @@ def test_ignore_while_attaching(
     pageserver_http.tenant_ignore(tenant_id)
 
     # Cannot attach it due to some local files existing
-    env.pageserver.allowed_errors.append(
-        ".*Cannot attach tenant .*?, local tenant directory already exists.*"
-    )
+    expect_error_msg = f".*attach tenant {tenant_id}: some local filesystem state already exists:"
+    env.pageserver.allowed_errors.append(expect_error_msg)
     with pytest.raises(
         expected_exception=PageserverApiException,
-        match=f"Cannot attach tenant {tenant_id}, local tenant directory already exists",
+        match=expect_error_msg,
     ):
         pageserver_http.tenant_attach(tenant_id)
 


### PR DESCRIPTION
At the time of writing, the only logical difference between Attach and Load is that Attach learns the list of timelines by querying the remote storage, whereas Load learns it by listing the timelines directory of the tenant.

This patch restructures the code such that Attach

1. prepares the on-disk state and then
2. calls into the same `load()` routine that is used by Load.

Further, this patch provides the following fixes & improvements to Attach:

1. Make Attach durable before acknowledging it to the management API client.

   Before this change, we would acknowledge after just creating the in-memory tenant.
   In the event of a crash before creating the tenant directory & fsyncing the attaching marker,
   the pageserver would come up without the tenant present (404), even though we acknowledged
   success to the client.

2. Simplified resume logic if we crash during Attach.
   Before this patch, if we crashed during Attach with some timelines downloaded and others not downloaded,
   we would combine existing metadata files with remote ones one-by-one to figure out what's missing.
   That was necessary before on-demand download because we were downloading layer files as part of Attach.
   However, with on-demand download, Attach only downloads & writes the timeline metadata files.

   After this patch, when we crash during Attach, we blow away the tenant's directory while leaving its attach marker file in place. Then, we start over.
   
   IMO this is significantly easier to reason about compared to what we had before.
   Note that we were losing the work for the downloads even before this change, so that's not a regression (the old reconcile_with_remote would still need to download the `IndexPart`s when resuming Attach after a crash).

   If we want to improve on this in the future, I think the first order of business will be to
   avoiding re-downloading the `IndexPart`'s and the initial `list_remote_timelines()`.
   However, given that crashes should be rare, and attach events also, I don't think the number
   one priority with Attach code should be to make it as simple as possible.

For (2), I changed the location of the attach marker file to be outside the tenant directory,
so that we can use standard functions for removing the tenant directory.
I even wrote a migration function for it, although in retrospect, I think it's quite unlikely that there are any tenants in attaching state deployed.
But oh well, now the code is there, and it even has unit tests.
We can delete the migration code once we've successfully rolled it out to all regions.

The remaining wrinkle with this change is that Attach needs to hint the downloaded `IndexPart`s to `load()` so that it doesn't download them twice during Attach, which would be wasteful.
The mechanism for this is the new `TenantLoadReason` and `TimelineLoadReason`.

We could eliminate this particular case by on-demand downloading the metadata.
However, that might open up another can of worms which I'd like to avoid.
If we ever want to go that route, I suggest we start tracking the attachment state of a timeline more formally, e.g., in a `timelines.json` file.

---

TODOs:

- [x] reviews
- [x] squash & update commit message
