### PR TITLE
Avoid `dyn PersistentLayer` interface usage in LayerMap.

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -59,9 +59,7 @@ use crate::task_mgr::TaskKind;
 use crate::tenant::config::TenantConfOpt;
 use crate::tenant::metadata::load_metadata;
 use crate::tenant::remote_timeline_client::index::IndexPart;
-use crate::tenant::storage_layer::DeltaLayer;
-use crate::tenant::storage_layer::ImageLayer;
-use crate::tenant::storage_layer::Layer;
+use crate::tenant::storage_layer::{DeltaLayer, ImageLayer, LayerContent};
 
 use crate::virtual_file::VirtualFile;
 use crate::walredo::PostgresRedoManager;

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -29,16 +29,14 @@ use crate::repository::{Key, Value, KEY_SIZE};
 use crate::tenant::blob_io::{BlobCursor, BlobWriter, WriteBlobWriter};
 use crate::tenant::block_io::{BlockBuf, BlockCursor, BlockReader, FileBlockReader};
 use crate::tenant::disk_btree::{DiskBtreeBuilder, DiskBtreeReader, VisitDirection};
-use crate::tenant::storage_layer::{
-    PersistentLayer, ValueReconstructResult, ValueReconstructState,
-};
+use crate::tenant::storage_layer::{ValueReconstructResult, ValueReconstructState};
 use crate::virtual_file::VirtualFile;
 use crate::{walrecord, TEMP_FILE_SUFFIX};
 use crate::{DELTA_FILE_MAGIC, STORAGE_FORMAT_VERSION};
 use anyhow::{bail, ensure, Context, Result};
 use rand::{distributions::Alphanumeric, Rng};
 use serde::{Deserialize, Serialize};
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::io::{Seek, SeekFrom};
 use std::ops::Range;
@@ -53,7 +51,10 @@ use utils::{
     lsn::Lsn,
 };
 
-use super::{DeltaFileName, Layer, LayerFileName, LayerIter, LayerKeyIter, PathOrConf};
+use super::{
+    DeltaFileName, LayerContent, LayerFile, LayerFileName, LayerIter, LayerKeyIter, LayerRange,
+    PathOrConf,
+};
 
 ///
 /// Header stored in the beginning of the file
@@ -198,7 +199,7 @@ pub struct DeltaLayerInner {
     file: Option<FileBlockReader<VirtualFile>>,
 }
 
-impl Layer for DeltaLayer {
+impl LayerRange for DeltaLayer {
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -211,8 +212,11 @@ impl Layer for DeltaLayer {
     }
 
     fn short_id(&self) -> String {
-        self.filename().file_name()
+        self.delta_layer_name().to_string()
     }
+}
+
+impl LayerContent for DeltaLayer {
     /// debugging function to print out the contents of the layer
     fn dump(&self, verbose: bool) -> Result<()> {
         println!(
@@ -374,46 +378,17 @@ impl Layer for DeltaLayer {
     }
 }
 
-impl PersistentLayer for DeltaLayer {
-    fn get_tenant_id(&self) -> TenantId {
-        self.tenant_id
+impl LayerFile for DeltaLayer {
+    fn layer_name(&self) -> LayerFileName {
+        LayerFileName::Delta(self.delta_layer_name())
     }
 
-    fn get_timeline_id(&self) -> TimelineId {
-        self.timeline_id
+    fn local_path(&self) -> PathBuf {
+        self.path()
     }
 
-    fn filename(&self) -> LayerFileName {
-        self.layer_name().into()
-    }
-
-    fn local_path(&self) -> Option<PathBuf> {
-        Some(self.path())
-    }
-
-    fn iter(&self) -> Result<LayerIter<'_>> {
-        let inner = self.load().context("load delta layer")?;
-        Ok(match DeltaValueIter::new(inner) {
-            Ok(iter) => Box::new(iter),
-            Err(err) => Box::new(std::iter::once(Err(err))),
-        })
-    }
-
-    fn key_iter(&self) -> Result<LayerKeyIter<'_>> {
-        let inner = self.load()?;
-        Ok(Box::new(
-            DeltaKeyIter::new(inner).context("Layer index is corrupted")?,
-        ))
-    }
-
-    fn delete(&self) -> Result<()> {
-        // delete underlying file
-        fs::remove_file(self.path())?;
-        Ok(())
-    }
-
-    fn file_size(&self) -> Option<u64> {
-        Some(self.file_size)
+    fn file_size(&self) -> u64 {
+        self.file_size
     }
 }
 
@@ -512,7 +487,7 @@ impl DeltaLayer {
             }
             PathOrConf::Path(path) => {
                 let actual_filename = path.file_name().unwrap().to_str().unwrap().to_owned();
-                let expected_filename = self.filename().file_name();
+                let expected_filename = self.delta_layer_name().to_string();
 
                 if actual_filename != expected_filename {
                     println!(
@@ -586,7 +561,7 @@ impl DeltaLayer {
         })
     }
 
-    fn layer_name(&self) -> DeltaFileName {
+    fn delta_layer_name(&self) -> DeltaFileName {
         DeltaFileName {
             key_range: self.key_range.clone(),
             lsn_range: self.lsn_range.clone(),
@@ -599,8 +574,23 @@ impl DeltaLayer {
             &self.path_or_conf,
             self.timeline_id,
             self.tenant_id,
-            &self.layer_name(),
+            &self.delta_layer_name(),
         )
+    }
+
+    pub fn iter(&self) -> Result<LayerIter<'_>> {
+        let inner = self.load().context("load delta layer")?;
+        Ok(match DeltaValueIter::new(inner) {
+            Ok(iter) => Box::new(iter),
+            Err(err) => Box::new(std::iter::once(Err(err))),
+        })
+    }
+
+    pub fn key_iter(&self) -> anyhow::Result<LayerKeyIter<'_>> {
+        let inner = self.load()?;
+        Ok(Box::new(
+            DeltaKeyIter::new(inner).context("Layer index is corrupted")?,
+        ))
     }
 }
 

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -578,12 +578,9 @@ impl DeltaLayer {
         )
     }
 
-    pub fn iter(&self) -> Result<LayerIter<'_>> {
+    pub fn iter(&self) -> anyhow::Result<LayerIter<'_>> {
         let inner = self.load().context("load delta layer")?;
-        Ok(match DeltaValueIter::new(inner) {
-            Ok(iter) => Box::new(iter),
-            Err(err) => Box::new(std::iter::once(Err(err))),
-        })
+        Ok(Box::new(DeltaValueIter::new(inner)?))
     }
 
     pub fn key_iter(&self) -> anyhow::Result<LayerKeyIter<'_>> {
@@ -896,7 +893,7 @@ impl<'a> Iterator for DeltaValueIter<'a> {
 }
 
 impl<'a> DeltaValueIter<'a> {
-    fn new(inner: RwLockReadGuard<'a, DeltaLayerInner>) -> Result<Self> {
+    fn new(inner: RwLockReadGuard<'a, DeltaLayerInner>) -> anyhow::Result<Self> {
         let file = inner.file.as_ref().unwrap();
         let tree_reader = DiskBtreeReader::<_, DELTA_KEY_SIZE>::new(
             inner.index_start_blk,

--- a/pageserver/src/tenant/storage_layer/filename.rs
+++ b/pageserver/src/tenant/storage_layer/filename.rs
@@ -184,26 +184,26 @@ pub enum LayerFileName {
 impl LayerFileName {
     pub fn file_name(&self) -> String {
         match self {
-            LayerFileName::Image(fname) => format!("{fname}"),
-            LayerFileName::Delta(fname) => format!("{fname}"),
+            Self::Image(fname) => fname.to_string(),
+            Self::Delta(fname) => fname.to_string(),
             #[cfg(test)]
-            LayerFileName::Test(fname) => fname.to_string(),
+            Self::Test(fname) => fname.clone(),
         }
     }
     #[cfg(test)]
     pub(crate) fn new_test(name: &str) -> LayerFileName {
-        LayerFileName::Test(name.to_owned())
+        Self::Test(name.to_owned())
     }
 }
 
 impl From<ImageFileName> for LayerFileName {
     fn from(fname: ImageFileName) -> Self {
-        LayerFileName::Image(fname)
+        Self::Image(fname)
     }
 }
 impl From<DeltaFileName> for LayerFileName {
     fn from(fname: DeltaFileName) -> Self {
-        LayerFileName::Delta(fname)
+        Self::Delta(fname)
     }
 }
 
@@ -218,7 +218,7 @@ impl FromStr for LayerFileName {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         #[cfg(test)]
         if let Some(value) = value.strip_prefix(LAYER_FILE_NAME_TEST_PREFIX) {
-            return Ok(LayerFileName::Test(value.to_owned()));
+            return Ok(Self::Test(value.to_owned()));
         }
         let delta = DeltaFileName::parse_str(value);
         let image = ImageFileName::parse_str(value);
@@ -228,8 +228,8 @@ impl FromStr for LayerFileName {
                     "neither delta nor image layer file name: {value:?}"
                 ))
             }
-            (Some(delta), None) => LayerFileName::Delta(delta),
-            (None, Some(image)) => LayerFileName::Image(image),
+            (Some(delta), None) => Self::Delta(delta),
+            (None, Some(image)) => Self::Image(image),
             (Some(_), Some(_)) => unreachable!(),
         };
         Ok(ok)
@@ -242,12 +242,10 @@ impl serde::Serialize for LayerFileName {
         S: serde::Serializer,
     {
         match self {
-            LayerFileName::Image(fname) => serializer.serialize_str(&format!("{}", fname)),
-            LayerFileName::Delta(fname) => serializer.serialize_str(&format!("{}", fname)),
+            Self::Image(fname) => serializer.serialize_str(&format!("{}", fname)),
+            Self::Delta(fname) => serializer.serialize_str(&format!("{}", fname)),
             #[cfg(test)]
-            LayerFileName::Test(t) => {
-                serializer.serialize_str(&format!("{LAYER_FILE_NAME_TEST_PREFIX}{t}"))
-            }
+            Self::Test(t) => serializer.serialize_str(&format!("{LAYER_FILE_NAME_TEST_PREFIX}{t}")),
         }
     }
 }

--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -27,7 +27,7 @@ use std::fmt::Write as _;
 use std::ops::Range;
 use std::sync::RwLock;
 
-use super::{DeltaLayer, DeltaLayerWriter, Layer};
+use super::{DeltaLayer, DeltaLayerWriter, LayerContent, LayerRange};
 
 thread_local! {
     /// A buffer for serializing object during [`InMemoryLayer::put_value`].
@@ -38,7 +38,7 @@ thread_local! {
 pub struct InMemoryLayer {
     conf: &'static PageServerConf,
     tenant_id: TenantId,
-    timeline_id: TimelineId,
+    pub timeline_id: TimelineId,
 
     ///
     /// This layer contains all the changes from 'start_lsn'. The
@@ -75,13 +75,7 @@ impl InMemoryLayerInner {
     }
 }
 
-impl InMemoryLayer {
-    pub fn get_timeline_id(&self) -> TimelineId {
-        self.timeline_id
-    }
-}
-
-impl Layer for InMemoryLayer {
+impl LayerRange for InMemoryLayer {
     fn get_key_range(&self) -> Range<Key> {
         Key::MIN..Key::MAX
     }
@@ -108,7 +102,9 @@ impl Layer for InMemoryLayer {
         let end_lsn = inner.end_lsn.unwrap_or(Lsn(u64::MAX));
         format!("inmem-{:016X}-{:016X}", self.start_lsn.0, end_lsn.0)
     }
+}
 
+impl LayerContent for InMemoryLayer {
     /// debugging function to print out the contents of the layer
     fn dump(&self, verbose: bool) -> Result<()> {
         let inner = self.inner.read().unwrap();

--- a/pageserver/src/tenant/storage_layer/remote_layer.rs
+++ b/pageserver/src/tenant/storage_layer/remote_layer.rs
@@ -4,10 +4,8 @@
 use crate::config::PageServerConf;
 use crate::repository::Key;
 use crate::tenant::remote_timeline_client::index::LayerFileMetadata;
-use crate::tenant::storage_layer::{Layer, ValueReconstructResult, ValueReconstructState};
-use anyhow::{bail, Result};
+use crate::tenant::storage_layer::LayerRange;
 use std::ops::Range;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use utils::{
@@ -17,12 +15,12 @@ use utils::{
 
 use super::filename::{DeltaFileName, ImageFileName, LayerFileName};
 use super::image_layer::ImageLayer;
-use super::{DeltaLayer, LayerIter, LayerKeyIter, PersistentLayer};
+use super::{DeltaLayer, HistoricLayer};
 
 #[derive(Debug)]
 pub struct RemoteLayer {
-    tenantid: TenantId,
-    timelineid: TimelineId,
+    tenant_id: TenantId,
+    timeline_id: TimelineId,
     key_range: Range<Key>,
     lsn_range: Range<Lsn>,
 
@@ -37,7 +35,7 @@ pub struct RemoteLayer {
     pub(crate) ongoing_download: Arc<tokio::sync::Semaphore>,
 }
 
-impl Layer for RemoteLayer {
+impl LayerRange for RemoteLayer {
     fn get_key_range(&self) -> Range<Key> {
         self.key_range.clone()
     }
@@ -46,106 +44,29 @@ impl Layer for RemoteLayer {
         self.lsn_range.clone()
     }
 
-    fn get_value_reconstruct_data(
-        &self,
-        _key: Key,
-        _lsn_range: Range<Lsn>,
-        _reconstruct_state: &mut ValueReconstructState,
-    ) -> Result<ValueReconstructResult> {
-        bail!(
-            "layer {} needs to be downloaded",
-            self.filename().file_name()
-        );
-    }
-
     fn is_incremental(&self) -> bool {
         self.is_incremental
     }
 
-    /// debugging function to print out the contents of the layer
-    fn dump(&self, _verbose: bool) -> Result<()> {
-        println!(
-            "----- remote layer for ten {} tli {} keys {}-{} lsn {}-{} ----",
-            self.tenantid,
-            self.timelineid,
-            self.key_range.start,
-            self.key_range.end,
-            self.lsn_range.start,
-            self.lsn_range.end
-        );
-
-        Ok(())
-    }
-
     fn short_id(&self) -> String {
-        self.filename().file_name()
-    }
-}
-
-impl PersistentLayer for RemoteLayer {
-    fn get_tenant_id(&self) -> TenantId {
-        self.tenantid
-    }
-
-    fn get_timeline_id(&self) -> TimelineId {
-        self.timelineid
-    }
-
-    fn filename(&self) -> LayerFileName {
-        if self.is_delta {
-            DeltaFileName {
-                key_range: self.key_range.clone(),
-                lsn_range: self.lsn_range.clone(),
-            }
-            .into()
-        } else {
-            ImageFileName {
-                key_range: self.key_range.clone(),
-                lsn: self.lsn_range.start,
-            }
-            .into()
-        }
-    }
-
-    fn local_path(&self) -> Option<PathBuf> {
-        None
-    }
-
-    fn iter(&self) -> Result<LayerIter<'_>> {
-        bail!("cannot iterate a remote layer");
-    }
-
-    fn key_iter(&self) -> Result<LayerKeyIter<'_>> {
-        bail!("cannot iterate a remote layer");
-    }
-
-    fn delete(&self) -> Result<()> {
-        Ok(())
-    }
-
-    fn downcast_remote_layer<'a>(self: Arc<Self>) -> Option<std::sync::Arc<RemoteLayer>> {
-        Some(self)
-    }
-
-    fn is_remote_layer(&self) -> bool {
-        true
-    }
-
-    fn file_size(&self) -> Option<u64> {
-        self.layer_metadata.file_size()
+        self.layer_name().file_name()
     }
 }
 
 impl RemoteLayer {
+    pub fn timeline_id(&self) -> TimelineId {
+        self.timeline_id
+    }
+
     pub fn new_img(
-        tenantid: TenantId,
-        timelineid: TimelineId,
+        tenant_id: TenantId,
+        timeline_id: TimelineId,
         fname: &ImageFileName,
         layer_metadata: &LayerFileMetadata,
     ) -> RemoteLayer {
         RemoteLayer {
-            tenantid,
-            timelineid,
+            tenant_id,
+            timeline_id,
             key_range: fname.key_range.clone(),
             lsn_range: fname.lsn..(fname.lsn + 1),
             is_delta: false,
@@ -157,14 +78,14 @@ impl RemoteLayer {
     }
 
     pub fn new_delta(
-        tenantid: TenantId,
-        timelineid: TimelineId,
+        tenant_id: TenantId,
+        timeline_id: TimelineId,
         fname: &DeltaFileName,
         layer_metadata: &LayerFileMetadata,
     ) -> RemoteLayer {
         RemoteLayer {
-            tenantid,
-            timelineid,
+            tenant_id,
+            timeline_id,
             key_range: fname.key_range.clone(),
             lsn_range: fname.lsn_range.clone(),
             is_delta: true,
@@ -180,16 +101,16 @@ impl RemoteLayer {
         &self,
         conf: &'static PageServerConf,
         file_size: u64,
-    ) -> Arc<dyn PersistentLayer> {
+    ) -> HistoricLayer {
         if self.is_delta {
             let fname = DeltaFileName {
                 key_range: self.key_range.clone(),
                 lsn_range: self.lsn_range.clone(),
             };
-            Arc::new(DeltaLayer::new(
+            HistoricLayer::from(DeltaLayer::new(
                 conf,
-                self.timelineid,
-                self.tenantid,
+                self.timeline_id,
+                self.tenant_id,
                 &fname,
                 file_size,
             ))
@@ -198,13 +119,40 @@ impl RemoteLayer {
                 key_range: self.key_range.clone(),
                 lsn: self.lsn_range.start,
             };
-            Arc::new(ImageLayer::new(
+            HistoricLayer::from(ImageLayer::new(
                 conf,
-                self.timelineid,
-                self.tenantid,
+                self.timeline_id,
+                self.tenant_id,
                 &fname,
                 file_size,
             ))
         }
+    }
+
+    pub fn layer_name(&self) -> LayerFileName {
+        if self.is_delta {
+            LayerFileName::from(DeltaFileName {
+                key_range: self.key_range.clone(),
+                lsn_range: self.lsn_range.clone(),
+            })
+        } else {
+            LayerFileName::from(ImageFileName {
+                key_range: self.key_range.clone(),
+                lsn: self.lsn_range.start,
+            })
+        }
+    }
+
+    /// Debugging function to print out the contents of the layer.
+    pub fn dump(&self) {
+        println!(
+            "----- remote layer for ten {} tli {} keys {}-{} lsn {}-{} ----",
+            self.tenant_id,
+            self.timeline_id,
+            self.key_range.start,
+            self.key_range.end,
+            self.lsn_range.start,
+            self.lsn_range.end
+        );
     }
 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1742,7 +1742,7 @@ impl Timeline {
                     // Check the open and frozen in-memory layers first, in order from newest
                     // to oldest.
                     if let Some(open_layer) = &layers.open_layer {
-                        let start_lsn = open_layer.get_lsn_range().start;
+                        let start_lsn = open_layer.get_current_lsn_range().start;
                         if cont_lsn > start_lsn {
                             //info!("CHECKING for {} at {} on open layer {}", key, cont_lsn, open_layer.filename().display());
                             // Get all the data needed to reconstruct the page version from this layer.
@@ -1769,7 +1769,7 @@ impl Timeline {
                         }
                     }
                     for frozen_layer in layers.frozen_layers.iter().rev() {
-                        let start_lsn = frozen_layer.get_lsn_range().start;
+                        let start_lsn = frozen_layer.get_current_lsn_range().start;
                         if cont_lsn > start_lsn {
                             //info!("CHECKING for {} at {} on frozen layer {}", key, cont_lsn, frozen_layer.filename().display());
                             let lsn_floor = max(cached_lsn + 1, start_lsn);
@@ -1925,7 +1925,7 @@ impl Timeline {
         // Do we have a layer open for writing already?
         let layer;
         if let Some(open_layer) = &layers.open_layer {
-            if open_layer.get_lsn_range().start > lsn {
+            if open_layer.get_current_lsn_range().start > lsn {
                 bail!("unexpected open layer in the future");
             }
 
@@ -2101,7 +2101,7 @@ impl Timeline {
         // instead of writing out a L0 delta layer, we directly write out image layer
         // files instead. This is possible as long as *all* the data imported into the
         // repository have the same LSN.
-        let lsn_range = frozen_layer.get_lsn_range();
+        let lsn_range = frozen_layer.get_current_lsn_range();
         let layer_paths_to_upload =
             if lsn_range.start == self.initdb_lsn && lsn_range.end == Lsn(self.initdb_lsn.0 + 1) {
                 // Note: The 'ctx' in use here has DownloadBehavior::Error. We should not


### PR DESCRIPTION
Follow-up of https://github.com/neondatabase/neon/pull/3263

This PR proposes more type-based checking of Delta, Image and Remote layers via enums and generics.

* Traits are now are used without `dyn` in almost every place except `impl Deref` for a few enums with different kinds of layers.

* `InMemoryLayer` handling is unchanged.

* `LayerMap`, instead of collections of arbitrary interfaces as 

```rust
historic: BufferedHistoricLayerCoverage<Arc<L>>,
...
l0_delta_layers: Vec<Arc<L>>,
```

became

```rust
historic: BufferedHistoricLayerCoverage<HistoricLayer<D, I>>,
...
l0_delta_layers: Vec<LocalOrRemote<D>>,
```

all related code handling is adjusted

* Layer traits got shrinked and renamed



## Motivation for change.

Old `LayerMap` relied on traits to provide the functionality it has:

```rust 
impl<L> LayerMap<L>
where
    L: ?Sized + Layer,
```

and did not distinguish layers between each other.
Similarly, old `Timeline` did the same, by also placing stricter type boundaries on the layers:

```rust
pub struct Timeline {
    ...
    pub layers: RwLock<LayerMap<dyn PersistentLayer>>,
    ...
```
Due to `pub trait PersistentLayer: Layer`, that means that both traits have to be implemented for every kind of layer behind it.

Inside the `LayerMap`, there are 4.5 kinds of layers:

1. open layer (InMemory kind)
2. frozen layers (InMemory kind)
3. image layers (PersistentLayer kind)
4. delta layers (PersistentLayer kind)
4.5 remote delta or image layers, not present on the local disk


* Generics in layer map cover only the latest 3 categories of layers, but not all the methods in the traits are applicable for every one.
One good example is `impl PersistentLayer for RemoteLayer` and the whole `PersistentLayer` per se, that becomes too much of a god trait with methods like 

```rust
/// Iterate through all keys stored in the layer. Returns key, lsn and value size
/// It is used only for compaction and so is currently implemented only for DeltaLayer
fn key_iter(&self) -> Result<LayerKeyIter<'_>> {
    panic!("Not implemented")
}

/// Permanently remove this layer from disk.
fn delete(&self) -> Result<()>;

fn downcast_remote_layer(self: Arc<Self>) -> Option<std::sync::Arc<RemoteLayer>> {
    None
}

fn is_remote_layer(&self) -> bool {
    false
}
```

Similar mock implementations are used for a specific benchmarking type that's used in the `LayerMap` separately.

* All `Arc<dyn PersistentLayer>` layers inside the `LayerMap` are not distinguishable from each other on the type level, hence delta, image and remote layers could be placed into the wrong places or slip unnoticed, since they all duck type.

* Last but not least, `dyn` support in Rust is generally lacking compared to the generics.
As an example, current nightly async traits feature does not support `dyn` objects.

## Comments on the new version

Due to stricter typisation, big part of the original traits is either not needed at all, or could be moved into certain struct/enum impl instead. Still, they are providing a public, generic API, there's multiple impls on `LayerMap` and `HistoricLayer` that base on that, not on specific generic values for delta and image types.

More specific impls on `DeltaLayer` and `ImageLayer` structs can use whatever exposed fields/methods without extra traits, thus providing "less generic" features: for instance, the methods that compaction uses are now only implemented in `impl LocalOrRemote<DeltaLayer>` section.
No `todo!` or `unimplemented!` trait methods are left.

`InMemoryLayer` could be generified similar way now, by adding another generic to the `LayerMap`.

Further improvements are possible, for instance, `TraversalId` could be changed from `String` to a `Copy` type and no 

```rust
Box::new({
    let layer = layer.clone();
    move || layer.traversal_id()
}),
```

would be needed.