### PR TITLE
Tracing panic hook

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -88,6 +88,13 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
+    // Initialize logging, which must be initialized before the custom panic hook is installed.
+    logging::init(conf.log_format)?;
+
+    // disable the default rust panic hook by using `set_hook`. sentry will install it's own on top
+    // of this, always processing the panic before we log it.
+    std::panic::set_hook(Box::new(tracing_panic_hook));
+
     // initialize sentry if SENTRY_DSN is provided
     let _sentry_guard = init_sentry(
         Some(GIT_VERSION.into()),
@@ -210,9 +217,6 @@ fn start_pageserver(
     launch_ts: &'static LaunchTimestamp,
     conf: &'static PageServerConf,
 ) -> anyhow::Result<()> {
-    // Initialize logging
-    logging::init(conf.log_format)?;
-
     // Print version and launch timestamp to the log,
     // and expose them as prometheus metrics.
     // A changed version string indicates changed software.
@@ -493,6 +497,38 @@ fn cli() -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Show enabled compile time features"),
         )
+}
+
+/// Named symbol for our panic hook, which logs the panic.
+fn tracing_panic_hook(info: &std::panic::PanicInfo) {
+    // following rust 1.66.1 std implementation:
+    // https://github.com/rust-lang/rust/blob/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs#L235-L288
+    let location = info.location();
+
+    let msg = match info.payload().downcast_ref::<&'static str>() {
+        Some(s) => *s,
+        None => match info.payload().downcast_ref::<String>() {
+            Some(s) => &s[..],
+            None => "Box<dyn Any>",
+        },
+    };
+
+    let thread = std::thread::current();
+    let thread = thread.name().unwrap_or("<unnamed>");
+    let backtrace = std::backtrace::Backtrace::capture();
+
+    let _entered = if let Some(location) = location {
+            tracing::error_span!("panic", %thread, panic.file = location.file(), panic.line = location.line(), panic.column = location.column())
+        } else {
+            // very unlikely to hit here, but the guarantees of std could change
+            tracing::error_span!("panic", %thread)
+        }.entered();
+
+    if backtrace.status() == std::backtrace::BacktraceStatus::Captured {
+        tracing::error!("{msg}\n\nStack backtrace:\n{backtrace}");
+    } else {
+        tracing::error!("{msg}");
+    }
 }
 
 #[test]

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1029,12 +1029,13 @@ async fn active_timeline_of_active_tenant(
         .map_err(ApiError::NotFound)
 }
 
-async fn always_panic_handler(_: Request<Body>) -> Result<Response<Body>, ApiError> {
+async fn always_panic_handler(req: Request<Body>) -> Result<Response<Body>, ApiError> {
     // Deliberately cause a panic to exercise the panic hook registered via std::panic::set_hook().
     // For pageserver, the relevant panic hook is `tracing_panic_hook` , and the `sentry` crate's wrapper around it.
     // Use catch_unwind to ensure that tokio nor hyper are distracted by our panic.
+    let query = req.uri().query();
     let _ = std::panic::catch_unwind(|| {
-        panic!("unconditional panic for testing panic hook integration")
+        panic!("unconditional panic for testing panic hook integration; request query: {query:?}")
     });
     json_response(StatusCode::NO_CONTENT, ())
 }

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1030,9 +1030,9 @@ async fn active_timeline_of_active_tenant(
 }
 
 async fn always_panic_handler(_: Request<Body>) -> Result<Response<Body>, ApiError> {
-    // catch_unwind ensures that tokio nor hyper are distracted by our panic, but panic hooks
-    // (at least sentry) will report the issue. if tested across fleet, this should be a good test
-    // case for panic deduplication as well per version.
+    // Deliberately cause a panic to exercise the panic hook registered via std::panic::set_hook().
+    // For pageserver, the relevant panic hook is `tracing_panic_hook` , and the `sentry` crate's wrapper around it.
+    // Use catch_unwind to ensure that tokio nor hyper are distracted by our panic.
     let _ = std::panic::catch_unwind(|| {
         panic!("unconditional panic for testing panic hook integration")
     });


### PR DESCRIPTION
Fixes #3468.

This does change how the panics look, and most importantly, make sure they are not interleaved with other messages. Adds a `GET /v1/panic` endpoint for panic testing (useful for sentry dedup and this hook testing).

The panics are now logged within a new error level span called `panic` which separates it from other error level events. The panic info is unpacked similar to in tracing example with fields:
- thread=mgmt request worker
- location="pageserver/src/http/routes.rs:898:9"
  - instead of:
      - panic.file="pageserver/src/http/routes.rs"
      - panic.line=898
      - panic.column=9

Much interest was not sparked, I am thinking of deciding the below as:
- no frame filtering until std supports it (same for head, tail)
- no getting rid of trailing `\n` (splitting should not care -- lets try this on staging)
- location formatting changed (both are above)
- try first on pageserver on staging because we can test this (added http route)

Decision points:
- [x] should we filter the first frames up to `rust_begin_unwind`?
- [x] should we filter the last frames up with same heuristics as anyhow? (I haven't checked what those are)
- [x] should we get rid of the trailing `\n` on the message? (re: message splitting for promtail)
- [x] should we change the location formatting?
- [x] move directly to utils under logging?
- [x] apply to all binaries directly or first test with `pageserver`?