### PR TITLE
Fix new deploy workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -866,9 +866,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            gh workflow run deploy-dev.yml --ref ${{ github.sha }} -f dockerTag=${{needs.tag.outputs.build-tag}}
+            gh workflow run deploy-dev.yml --ref main -f branch=${{ github.sha }} -f dockerTag=${{needs.tag.outputs.build-tag}}
           elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
-            gh workflow run deploy-prod.yml --ref ${{ github.sha }} -f dockerTag=${{needs.tag.outputs.build-tag}}
+            gh workflow run deploy-prod.yml --ref release -f branch=${{ github.sha }} -f dockerTag=${{needs.tag.outputs.build-tag}}
           else
             echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
             exit 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -7,6 +7,11 @@ on:
         description: 'Docker tag to deploy'
         required: true
         type: string
+      branch:
+        description: 'Branch or commit used for deploy scripts and configs'
+        required: true
+        type: string
+        default: 'main'
       deployStorage:
         description: 'Deploy storage'
         required: true
@@ -52,6 +57,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
 
       - name: Redeploy
         run: |
@@ -93,6 +99,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
   
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -149,6 +156,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
   
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,6 +7,11 @@ on:
         description: 'Docker tag to deploy'
         required: true
         type: string
+      branch:
+        description: 'Branch or commit used for deploy scripts and configs'
+        required: true
+        type: string
+        default: 'main'
       deployStorage:
         description: 'Deploy storage'
         required: true
@@ -46,6 +51,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
 
       - name: Redeploy
         run: |
@@ -92,6 +98,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
 
       - name: Configure environment
         run: |
@@ -141,6 +148,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
 
       - name: Configure environment
         run: |
@@ -168,6 +176,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
 
       - name: Redeploy
         run: |
@@ -214,6 +223,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
 
       - name: Store kubeconfig file
         run: |
@@ -249,6 +259,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
 
       - name: Store kubeconfig file
         run: |


### PR DESCRIPTION
Add 'branch' input to specify commit for deploy scripts/configs. Commit can't be passed to workflow as ref, and we need to pin configs to specific commit for main/release deploys
Update deploy input descriptions to match GH interface