### PR TITLE
Fix production deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -183,14 +183,7 @@ jobs:
           export DOCKER_TAG=${{ inputs.dockerTag }}
           cd "$(pwd)/.github/ansible"
 
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            ./get_binaries.sh
-          elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
-            RELEASE=true ./get_binaries.sh
-          else
-            echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
-            exit 1
-          fi
+          ./get_binaries.sh
 
           eval $(ssh-agent)
           echo "${{ secrets.TELEPORT_SSH_KEY }}"  | tr -d '\n'| base64 --decode >ssh-key


### PR DESCRIPTION
`get_binaries.sh` no longer use `RELEASE` environmental variable, it just use `DOCKER_TAG`