### PR TITLE
Use the same runners/container for old prod deployments as for new prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -162,8 +162,8 @@ jobs:
   # Deploy to old account below          
 
   deploy:
-    runs-on: [ self-hosted, gen3, small ]
-    container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/ansible:pinned
+    runs-on: prod
+    container: 093970136003.dkr.ecr.eu-central-1.amazonaws.com/ansible:latest
     if: inputs.deployStorage
     defaults:
       run:


### PR DESCRIPTION
docker doesn't work on the new runners yet: https://github.com/neondatabase/neon/actions/runs/4054496885/jobs/6976395557