### PR TITLE
LayerMap::replace

### DIFF
--- a/pageserver/benches/bench_layer_map.rs
+++ b/pageserver/benches/bench_layer_map.rs
@@ -28,22 +28,12 @@ fn build_layer_map(filename_dump: PathBuf) -> LayerMap<LayerDescriptor> {
     for fname in filenames {
         let fname = &fname.unwrap();
         if let Some(imgfilename) = ImageFileName::parse_str(fname) {
-            let layer = LayerDescriptor {
-                key: imgfilename.key_range,
-                lsn: imgfilename.lsn..(imgfilename.lsn + 1),
-                is_incremental: false,
-                short_id: fname.to_string(),
-            };
+            let layer = LayerDescriptor::from(imgfilename);
             updates.insert_historic(Arc::new(layer));
             min_lsn = min(min_lsn, imgfilename.lsn);
             max_lsn = max(max_lsn, imgfilename.lsn);
         } else if let Some(deltafilename) = DeltaFileName::parse_str(fname) {
-            let layer = LayerDescriptor {
-                key: deltafilename.key_range.clone(),
-                lsn: deltafilename.lsn_range.clone(),
-                is_incremental: true,
-                short_id: fname.to_string(),
-            };
+            let layer = LayerDescriptor::from(deltafilename);
             updates.insert_historic(Arc::new(layer));
             min_lsn = min(min_lsn, deltafilename.lsn_range.start);
             max_lsn = max(max_lsn, deltafilename.lsn_range.end);

--- a/pageserver/benches/bench_layer_map.rs
+++ b/pageserver/benches/bench_layer_map.rs
@@ -1,8 +1,7 @@
 use pageserver::keyspace::{KeyPartitioning, KeySpace};
 use pageserver::repository::Key;
 use pageserver::tenant::layer_map::LayerMap;
-use pageserver::tenant::storage_layer::Layer;
-use pageserver::tenant::storage_layer::{DeltaFileName, ImageFileName, LayerDescriptor};
+use pageserver::tenant::storage_layer::{Layer, LayerDescriptor, LayerFileName};
 use rand::prelude::{SeedableRng, SliceRandom, StdRng};
 use std::cmp::{max, min};
 use std::fs::File;
@@ -26,20 +25,15 @@ fn build_layer_map(filename_dump: PathBuf) -> LayerMap<LayerDescriptor> {
 
     let mut updates = layer_map.batch_update();
     for fname in filenames {
-        let fname = &fname.unwrap();
-        if let Some(imgfilename) = ImageFileName::parse_str(fname) {
-            let layer = LayerDescriptor::from(imgfilename);
-            updates.insert_historic(Arc::new(layer));
-            min_lsn = min(min_lsn, imgfilename.lsn);
-            max_lsn = max(max_lsn, imgfilename.lsn);
-        } else if let Some(deltafilename) = DeltaFileName::parse_str(fname) {
-            let layer = LayerDescriptor::from(deltafilename);
-            updates.insert_historic(Arc::new(layer));
-            min_lsn = min(min_lsn, deltafilename.lsn_range.start);
-            max_lsn = max(max_lsn, deltafilename.lsn_range.end);
-        } else {
-            panic!("unexpected filename {fname}");
-        }
+        let fname = fname.unwrap();
+        let fname = LayerFileName::from_str(&fname).unwrap();
+        let layer = LayerDescriptor::from(fname);
+
+        let lsn_range = layer.get_lsn_range();
+        min_lsn = min(min_lsn, lsn_range.start);
+        max_lsn = max(max_lsn, Lsn(lsn_range.end.0 - 1));
+
+        updates.insert_historic(Arc::new(layer));
     }
 
     println!("min: {min_lsn}, max: {max_lsn}");

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -316,15 +316,20 @@ where
         let key = historic_layer_coverage::LayerKey::from(&**expected);
         let other = historic_layer_coverage::LayerKey::from(&*new);
 
-        let was_l0 = Self::is_l0(expected);
+        let expected_l0 = Self::is_l0(expected);
+        let new_l0 = Self::is_l0(&new);
 
         anyhow::ensure!(
-            was_l0 == Self::is_l0(&new),
-            "replaced must both be l0 deltas or neither"
+            key == other,
+            "expected and new must have equal LayerKeys: {key:?} != {other:?}"
         );
-        anyhow::ensure!(key == other, "replaced must have same layerkeys");
 
-        let l0_index = if was_l0 {
+        anyhow::ensure!(
+            expected_l0 == new_l0,
+            "expected and new must both be l0 deltas or neither should be: {expected_l0} != {new_l0}"
+        );
+
+        let l0_index = if expected_l0 {
             // find the index in case replace worked, we need to replace that as well
             Some(
                 self.l0_delta_layers

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -146,11 +146,11 @@ where
     /// Returns `true` if the layer map was changed, `false` otherwise. Errors are returned for
     /// precondition failures, such as trying to replace two different kind of layers with each
     /// other, and no modification is done in the case of precondition failure.
-    pub fn replace_historic<'a>(
-        &'a mut self,
+    pub fn replace_historic(
+        &mut self,
         expected: &Arc<L>,
         new: Arc<L>,
-    ) -> anyhow::Result<Replacement<'a, Arc<L>>> {
+    ) -> anyhow::Result<Replacement<Arc<L>>> {
         self.layer_map.replace_historic_noflush(expected, new)
     }
 
@@ -308,11 +308,11 @@ where
         NUM_ONDISK_LAYERS.dec();
     }
 
-    pub(self) fn replace_historic_noflush<'a>(
-        &'a mut self,
+    pub(self) fn replace_historic_noflush(
+        &mut self,
         expected: &Arc<L>,
         new: Arc<L>,
-    ) -> anyhow::Result<Replacement<'a, Arc<L>>> {
+    ) -> anyhow::Result<Replacement<Arc<L>>> {
         let key = historic_layer_coverage::LayerKey::from(&**expected);
         let other = historic_layer_coverage::LayerKey::from(&*new);
 

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -746,8 +746,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use utils::lsn::Lsn;
-
     use super::{LayerMap, Replacement};
     use crate::tenant::storage_layer::{DeltaFileName, ImageFileName, Layer, LayerDescriptor};
     use std::sync::Arc;
@@ -776,7 +774,6 @@ mod tests {
 
         #[test]
         fn for_image() {
-            // has minimal uncovered areas compared to l0_delta_layers_updated_on_insert_replace_remove_for_full_range_delta
             l0_delta_layers_updated_scenario(
                 "000000000000000000000000000000000000-000000000000000000000000000000010000__0000000053424D69",
                 // code only checks if it is a full range layer, doesn't care about images, which must
@@ -787,22 +784,10 @@ mod tests {
 
         fn l0_delta_layers_updated_scenario(layer_name: &str, expected_l0: bool) {
             let skeleton = {
-                // TODO: add from impls for LayerDescriptor
                 if let Some(name) = DeltaFileName::parse_str(layer_name) {
-                    LayerDescriptor {
-                        key: name.key_range,
-                        lsn: name.lsn_range,
-                        is_incremental: true,
-                        short_id: layer_name.to_owned(),
-                    }
+                    LayerDescriptor::from(name)
                 } else if let Some(name) = ImageFileName::parse_str(layer_name) {
-                    LayerDescriptor {
-                        key: name.key_range,
-                        // TODO: having this spread around the codebase doesn't make sense
-                        lsn: name.lsn..Lsn(name.lsn.0 + 1),
-                        is_incremental: true,
-                        short_id: layer_name.to_owned(),
-                    }
+                    LayerDescriptor::from(name)
                 } else {
                     unreachable!(
                         "failed to parse as either DeltaFileName or ImageFileName: {layer_name}"

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -146,6 +146,10 @@ where
     /// Returns `true` if the layer map was changed, `false` otherwise. Errors are returned for
     /// precondition failures, such as trying to replace two different kind of layers with each
     /// other, and no modification is done in the case of precondition failure.
+    ///
+    /// TODO replacement can be done without buffering and rebuilding layer map updates.
+    ///      One way to do that is to add a layer of indirection for returned values, so
+    ///      that we can replace values only by updating a hashmap.
     pub fn replace_historic(
         &mut self,
         expected: &Arc<L>,

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -142,7 +142,9 @@ where
     ///
     /// If the expected layer has been removed it will not be inserted by this function.
     ///
-    /// Returns `true` if the layer map was changed, `false` otherwise.
+    /// Returns `true` if the layer map was changed, `false` otherwise. Errors are returned for
+    /// precondition failures, such as trying to replace two different kind of layers with each
+    /// other, and no modification is done in the case of precondition failure.
     pub fn replace_historic(&mut self, expected: &Arc<L>, new: Arc<L>) -> anyhow::Result<bool> {
         self.layer_map.replace_historic_noflush(expected, new)
     }

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -747,10 +747,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::{LayerMap, Replacement};
-    use crate::tenant::storage_layer::{DeltaFileName, ImageFileName, Layer, LayerDescriptor};
+    use crate::tenant::storage_layer::{Layer, LayerDescriptor, LayerFileName};
+    use std::str::FromStr;
     use std::sync::Arc;
 
     mod l0_delta_layers_updated {
+
         use super::*;
 
         #[test]
@@ -783,17 +785,8 @@ mod tests {
         }
 
         fn l0_delta_layers_updated_scenario(layer_name: &str, expected_l0: bool) {
-            let skeleton = {
-                if let Some(name) = DeltaFileName::parse_str(layer_name) {
-                    LayerDescriptor::from(name)
-                } else if let Some(name) = ImageFileName::parse_str(layer_name) {
-                    LayerDescriptor::from(name)
-                } else {
-                    unreachable!(
-                        "failed to parse as either DeltaFileName or ImageFileName: {layer_name}"
-                    )
-                }
-            };
+            let name = LayerFileName::from_str(layer_name).unwrap();
+            let skeleton = LayerDescriptor::from(name);
 
             let remote: Arc<dyn Layer> = Arc::new(skeleton.clone());
             let downloaded: Arc<dyn Layer> = Arc::new(skeleton);

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -254,14 +254,8 @@ where
     /// Helper function for BatchedUpdates::insert_historic
     ///
     pub(self) fn insert_historic_noflush(&mut self, layer: Arc<L>) {
-        let kr = layer.get_key_range();
-        let lr = layer.get_lsn_range();
         self.historic.insert(
-            historic_layer_coverage::LayerKey {
-                key: kr.start.to_i128()..kr.end.to_i128(),
-                lsn: lr.start.0..lr.end.0,
-                is_image: !layer.is_incremental(),
-            },
+            historic_layer_coverage::LayerKey::from(&*layer),
             Arc::clone(&layer),
         );
 
@@ -278,13 +272,8 @@ where
     /// Helper function for BatchedUpdates::remove_historic
     ///
     pub fn remove_historic_noflush(&mut self, layer: Arc<L>) {
-        let kr = layer.get_key_range();
-        let lr = layer.get_lsn_range();
-        self.historic.remove(historic_layer_coverage::LayerKey {
-            key: kr.start.to_i128()..kr.end.to_i128(),
-            lsn: lr.start.0..lr.end.0,
-            is_image: !layer.is_incremental(),
-        });
+        self.historic
+            .remove(historic_layer_coverage::LayerKey::from(&*layer));
 
         if Self::is_l0(&layer) {
             let len_before = self.l0_delta_layers.len();

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -288,7 +288,14 @@ where
             let len_before = self.l0_delta_layers.len();
             self.l0_delta_layers
                 .retain(|other| !Self::compare_arced_layers(other, &layer));
-            assert_eq!(self.l0_delta_layers.len(), len_before - 1);
+            // this assertion is related to use of Arc::ptr_eq in Self::compare_arced_layers,
+            // there's a chance that the comparison fails at runtime due to it comparing (pointer,
+            // vtable) pairs.
+            assert_eq!(
+                self.l0_delta_layers.len(),
+                len_before - 1,
+                "failed to locate removed historic layer from l0_delta_layers"
+            );
         }
 
         NUM_ONDISK_LAYERS.dec();
@@ -716,7 +723,7 @@ where
     fn compare_arced_layers(left: &Arc<L>, right: &Arc<L>) -> bool {
         // FIXME: ptr_eq might fail to return true for 'dyn' references because of multiple vtables
         // can be created in compilation. Clippy complains about this. In practice it seems to
-        // work, the assertion below would be triggered otherwise but this ought to be fixed.
+        // work.
         //
         // In future rust versions this might become Arc::as_ptr(left) as *const () ==
         // Arc::as_ptr(right) as *const (), we could change to that before.

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -138,6 +138,11 @@ where
         self.layer_map.remove_historic_noflush(layer)
     }
 
+    /// Replaces existing layer iff it is the `expected`.
+    ///
+    /// If the expected layer has been removed it will not be inserted by this function.
+    ///
+    /// Returns `true` if the layer map was changed, `false` otherwise.
     pub fn replace_historic(&mut self, expected: &Arc<L>, new: Arc<L>) -> anyhow::Result<bool> {
         self.layer_map.replace_historic_noflush(expected, new)
     }

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -143,9 +143,8 @@ where
     ///
     /// If the expected layer has been removed it will not be inserted by this function.
     ///
-    /// Returns `true` if the layer map was changed, `false` otherwise. Errors are returned for
-    /// precondition failures, such as trying to replace two different kind of layers with each
-    /// other, and no modification is done in the case of precondition failure.
+    /// Returned `Replacement` describes succeeding in replacement or the reason why it could not
+    /// be done.
     ///
     /// TODO replacement can be done without buffering and rebuilding layer map updates.
     ///      One way to do that is to add a layer of indirection for returned values, so

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -600,7 +600,7 @@ fn test_retroactive_simple() {
         LayerKey {
             key: 2..5,
             lsn: 105..106,
-            is_image: true,
+            is_image: false,
         },
         "Delta 1".to_string(),
     );
@@ -614,7 +614,8 @@ fn test_retroactive_simple() {
     let version = map.get().unwrap().get_version(102).unwrap();
     assert_eq!(version.image_coverage.query(4), Some("Image 1".to_string()));
     let version = map.get().unwrap().get_version(107).unwrap();
-    assert_eq!(version.image_coverage.query(4), Some("Delta 1".to_string()));
+    assert_eq!(version.image_coverage.query(4), Some("Image 1".to_string()));
+    assert_eq!(version.delta_coverage.query(4), Some("Delta 1".to_string()));
     let version = map.get().unwrap().get_version(115).unwrap();
     assert_eq!(version.image_coverage.query(4), Some("Image 2".to_string()));
     let version = map.get().unwrap().get_version(125).unwrap();

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -751,24 +751,12 @@ fn missing_key_is_not_inserted_with_replace() {
 
     let ret = map.replace(&key, "should not replace", |_| true);
     assert!(matches!(ret, Replacement::NotFound), "{ret:?}");
+    map.rebuild();
     assert!(map
         .get()
         .expect("no changes to rebuild")
         .get_version(102)
         .is_none());
-
-    map.insert(key.clone(), "Image 1");
-    map.rebuild();
-
-    assert_eq!(
-        map.get()
-            .expect("rebuilt")
-            .get_version(102)
-            .unwrap()
-            .image_coverage
-            .query(4),
-        Some("Image 1")
-    );
 }
 
 #[test]

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -682,7 +682,7 @@ fn test_retroactive_replacement() {
 
         // evict
         assert!(
-            map.replace(&key, replacement.clone(), |l| l == orig_layer),
+            map.replace(key, replacement.clone(), |l| l == orig_layer),
             "replace {orig_layer}"
         );
         map.rebuild();
@@ -698,7 +698,7 @@ fn test_retroactive_replacement() {
 
         // download
         assert!(
-            map.replace(&key, orig_layer.clone(), |l| l == &replacement),
+            map.replace(key, orig_layer.clone(), |l| l == &replacement),
             "replace {orig_layer} back"
         );
         map.rebuild();

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -436,7 +436,8 @@ impl<Value: Clone> BufferedHistoricLayerCoverage<Value> {
     /// against some expectation. This allows to use `Arc::ptr_eq` or similar which would be
     /// inaccessible via `PartialEq` trait.
     ///
-    /// Returns `true` if a modification was made and rebuild will be needed, `false` otherwise.
+    /// Returns a `Replacement` value describing the outcome; only the case of
+    /// `Replacement::Replaced` modifies the map and requires a rebuild.
     pub fn replace<F>(
         &mut self,
         layer_key: &LayerKey,

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -730,6 +730,12 @@ fn missing_key_is_not_inserted_with_replace() {
     };
 
     assert!(!map.replace(&key, "should not replace", |_| true));
+    assert!(map
+        .get()
+        .expect("no changes to rebuild")
+        .get_version(102)
+        .is_none());
+
     map.insert(key.clone(), "Image 1");
     map.rebuild();
 

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -94,15 +94,13 @@ impl<Value: Clone> HistoricLayerCoverage<Value> {
         }
 
         // Insert into data structure
-        if layer_key.is_image {
-            self.head
-                .image_coverage
-                .insert(layer_key.key, layer_key.lsn.clone(), value);
+        let target = if layer_key.is_image {
+            &mut self.head.image_coverage
         } else {
-            self.head
-                .delta_coverage
-                .insert(layer_key.key, layer_key.lsn.clone(), value);
-        }
+            &mut self.head.delta_coverage
+        };
+
+        target.insert(layer_key.key, layer_key.lsn.clone(), value);
 
         // Remember history. Clone is O(1)
         self.historic.insert(layer_key.lsn.start, self.head.clone());

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -41,6 +41,18 @@ impl Ord for LayerKey {
     }
 }
 
+impl<'a, L: crate::tenant::storage_layer::Layer + ?Sized> From<&'a L> for LayerKey {
+    fn from(layer: &'a L) -> Self {
+        let kr = layer.get_key_range();
+        let lr = layer.get_lsn_range();
+        LayerKey {
+            key: kr.start.to_i128()..kr.end.to_i128(),
+            lsn: lr.start.0..lr.end.0,
+            is_image: !layer.is_incremental(),
+        }
+    }
+}
+
 /// Efficiently queryable layer coverage for each LSN.
 ///
 /// Allows answering layer map queries very efficiently,

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -608,18 +608,24 @@ fn test_retroactive_simple() {
     // Rebuild so we can start querying
     map.rebuild();
 
-    // Query key 4
-    let version = map.get().unwrap().get_version(90);
-    assert!(version.is_none());
-    let version = map.get().unwrap().get_version(102).unwrap();
-    assert_eq!(version.image_coverage.query(4), Some("Image 1".to_string()));
-    let version = map.get().unwrap().get_version(107).unwrap();
-    assert_eq!(version.image_coverage.query(4), Some("Image 1".to_string()));
-    assert_eq!(version.delta_coverage.query(4), Some("Delta 1".to_string()));
-    let version = map.get().unwrap().get_version(115).unwrap();
-    assert_eq!(version.image_coverage.query(4), Some("Image 2".to_string()));
-    let version = map.get().unwrap().get_version(125).unwrap();
-    assert_eq!(version.image_coverage.query(4), Some("Image 3".to_string()));
+    {
+        let map = map.get().expect("rebuilt");
+
+        let version = map.get_version(90);
+        assert!(version.is_none());
+        let version = map.get_version(102).unwrap();
+        assert_eq!(version.image_coverage.query(4), Some("Image 1".to_string()));
+
+        let version = map.get_version(107).unwrap();
+        assert_eq!(version.image_coverage.query(4), Some("Image 1".to_string()));
+        assert_eq!(version.delta_coverage.query(4), Some("Delta 1".to_string()));
+
+        let version = map.get_version(115).unwrap();
+        assert_eq!(version.image_coverage.query(4), Some("Image 2".to_string()));
+
+        let version = map.get_version(125).unwrap();
+        assert_eq!(version.image_coverage.query(4), Some("Image 3".to_string()));
+    }
 
     // Remove Image 3
     map.remove(LayerKey {
@@ -629,10 +635,13 @@ fn test_retroactive_simple() {
     });
     map.rebuild();
 
-    // Check deletion worked
-    let version = map.get().unwrap().get_version(125).unwrap();
-    assert_eq!(version.image_coverage.query(4), Some("Image 2".to_string()));
-    assert_eq!(version.image_coverage.query(8), Some("Image 4".to_string()));
+    {
+        // Check deletion worked
+        let map = map.get().expect("rebuilt");
+        let version = map.get_version(125).unwrap();
+        assert_eq!(version.image_coverage.query(4), Some("Image 2".to_string()));
+        assert_eq!(version.image_coverage.query(8), Some("Image 4".to_string()));
+    }
 }
 
 #[test]

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -425,7 +425,16 @@ impl<Value: Clone> BufferedHistoricLayerCoverage<Value> {
         self.buffer.insert(layer_key, None);
     }
 
-    /// Replaces a previous layer with a new layer value if it the given closure returns true.
+    /// Replaces a previous layer with a new layer value.
+    ///
+    /// The replacement is conditional on:
+    /// - there is an existing `LayerKey` record
+    /// - there is no buffered removal for the given `LayerKey`
+    /// - the given closure returns true for the current `Value`
+    ///
+    /// The closure is used to compare the latest value (buffered insert, or existing layer)
+    /// against some expectation. This allows to use `Arc::ptr_eq` or similar which would be
+    /// inaccessible via `PartialEq` trait.
     ///
     /// Returns `true` if a modification was made and rebuild will be needed, `false` otherwise.
     pub fn replace<F>(&mut self, layer_key: &LayerKey, new: Value, check_expected: F) -> bool

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -212,6 +212,7 @@ impl std::fmt::Debug for dyn Layer {
 }
 
 /// Holds metadata about a layer without any content. Used mostly for testing.
+#[derive(Clone)]
 pub struct LayerDescriptor {
     pub key: Range<Key>,
     pub lsn: Range<Lsn>,

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -212,6 +212,9 @@ impl std::fmt::Debug for dyn Layer {
 }
 
 /// Holds metadata about a layer without any content. Used mostly for testing.
+///
+/// To use filenames as fixtures, parse them as [`LayerFileName`] then convert from that to a
+/// LayerDescriptor.
 #[derive(Clone)]
 pub struct LayerDescriptor {
     pub key: Range<Key>,

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -252,6 +252,37 @@ impl Layer for LayerDescriptor {
     }
 }
 
+impl From<DeltaFileName> for LayerDescriptor {
+    fn from(value: DeltaFileName) -> Self {
+        LayerDescriptor {
+            key: value.key_range,
+            lsn: value.lsn_range,
+            is_incremental: true,
+            short_id: value.to_string(),
+        }
+    }
+}
+
+impl From<ImageFileName> for LayerDescriptor {
+    fn from(value: ImageFileName) -> Self {
+        LayerDescriptor {
+            key: value.key_range,
+            lsn: value.lsn_as_range(),
+            is_incremental: false,
+            short_id: value.to_string(),
+        }
+    }
+}
+
+impl From<LayerFileName> for LayerDescriptor {
+    fn from(value: LayerFileName) -> Self {
+        match value {
+            LayerFileName::Delta(d) => Self::from(d),
+            LayerFileName::Image(i) => Self::from(i),
+        }
+    }
+}
+
 /// Helper enum to hold a PageServerConf, or a path
 ///
 /// This is used by DeltaLayer and ImageLayer. Normally, this holds a reference to the

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -254,22 +254,25 @@ impl Layer for LayerDescriptor {
 
 impl From<DeltaFileName> for LayerDescriptor {
     fn from(value: DeltaFileName) -> Self {
+        let short_id = value.to_string();
         LayerDescriptor {
             key: value.key_range,
             lsn: value.lsn_range,
             is_incremental: true,
-            short_id: value.to_string(),
+            short_id,
         }
     }
 }
 
 impl From<ImageFileName> for LayerDescriptor {
     fn from(value: ImageFileName) -> Self {
+        let short_id = value.to_string();
+        let lsn = value.lsn_as_range();
         LayerDescriptor {
             key: value.key_range,
-            lsn: value.lsn_as_range(),
+            lsn,
             is_incremental: false,
-            short_id: value.to_string(),
+            short_id,
         }
     }
 }

--- a/pageserver/src/tenant/storage_layer/filename.rs
+++ b/pageserver/src/tenant/storage_layer/filename.rs
@@ -128,6 +128,13 @@ impl Ord for ImageFileName {
     }
 }
 
+impl ImageFileName {
+    pub fn lsn_as_range(&self) -> Range<Lsn> {
+        // Saves from having to copypaste this all over
+        self.lsn..(self.lsn + 1)
+    }
+}
+
 ///
 /// Represents the filename of an ImageLayer
 ///

--- a/pageserver/src/tenant/storage_layer/remote_layer.rs
+++ b/pageserver/src/tenant/storage_layer/remote_layer.rs
@@ -172,7 +172,7 @@ impl RemoteLayer {
             tenantid,
             timelineid,
             key_range: fname.key_range.clone(),
-            lsn_range: fname.lsn..(fname.lsn + 1),
+            lsn_range: fname.lsn_as_range(),
             is_delta: false,
             is_incremental: false,
             file_name: fname.to_owned().into(),

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3390,8 +3390,9 @@ impl Timeline {
                         match updates.replace_historic(&l, new_layer) {
                             Ok(true) => { /* expected */ }
                             Ok(false) => {
-                                // FIXME: the downloaded file should probably be removed, otherwise
-                                // it will be added to the layermap on next load?
+                                // TODO: the downloaded file should probably be removed, otherwise
+                                // it will be added to the layermap on next load? we should
+                                // probably restart any get_reconstruct_data search as well.
                                 warn!("replacing downloaded layer into layermap failed because layer was not found");
                             }
                             Err(e) => {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3387,9 +3387,14 @@ impl Timeline {
                     let mut updates = layers.batch_update();
                     {
                         let l: Arc<dyn PersistentLayer> = remote_layer.clone();
-                        updates.remove_historic(l);
+                        match updates.replace_historic(&l, new_layer) {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                todo!("what then? start the search all over again, remove downloaded file?")
+                            }
+                            Err(e) => todo!("how is this possible? {e:?}"),
+                        }
                     }
-                    updates.insert_historic(new_layer);
                     updates.flush();
                     drop(layers);
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3403,10 +3403,12 @@ impl Timeline {
                                 // if the other layer would have the same pointer value as
                                 // expected, it means they differ only on vtables.
                                 //
-                                // otherwise there's no known reason for this to happen.
+                                // otherwise there's no known reason for this to happen as
+                                // compacted layers should have different covering rectangle
+                                // leading to produce Replacement::NotFound.
                                 error!(
                                     expected = ?Arc::as_ptr(&l),
-                                    other = ?Arc::as_ptr(other),
+                                    other = ?Arc::as_ptr(&other),
                                     "replacing downloaded layer into layermap failed because another layer was found instead of expected"
                                 );
                             }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3394,7 +3394,9 @@ impl Timeline {
                                 // TODO: the downloaded file should probably be removed, otherwise
                                 // it will be added to the layermap on next load? we should
                                 // probably restart any get_reconstruct_data search as well.
-                                warn!("replacing downloaded layer into layermap failed because layer was not found");
+                                //
+                                // See: https://github.com/neondatabase/neon/issues/3533
+                                error!("replacing downloaded layer into layermap failed because layer was not found");
                             }
                             Ok(Replacement::RemovalBuffered) => {
                                 unreachable!("current implementation does not remove anything")

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3408,9 +3408,10 @@ impl Timeline {
                                 // otherwise there's no known reason for this to happen as
                                 // compacted layers should have different covering rectangle
                                 // leading to produce Replacement::NotFound.
+
                                 error!(
-                                    expected = ?Arc::as_ptr(&l),
-                                    other = ?Arc::as_ptr(&other),
+                                    expected.ptr = ?Arc::as_ptr(&l),
+                                    other.ptr = ?Arc::as_ptr(&other),
                                     "replacing downloaded layer into layermap failed because another layer was found instead of expected"
                                 );
                             }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3388,11 +3388,17 @@ impl Timeline {
                     {
                         let l: Arc<dyn PersistentLayer> = remote_layer.clone();
                         match updates.replace_historic(&l, new_layer) {
-                            Ok(true) => {}
+                            Ok(true) => { /* expected */ }
                             Ok(false) => {
-                                todo!("what then? start the search all over again, remove downloaded file?")
+                                // FIXME: the downloaded file should probably be removed, otherwise
+                                // it will be added to the layermap on next load?
+                                warn!("replacing downloaded layer into layermap failed because layer was not found");
                             }
-                            Err(e) => todo!("how is this possible? {e:?}"),
+                            Err(e) => {
+                                // this is a precondition failure, the layer filename derived
+                                // attributes didn't match up, which doesn't seem likely.
+                                error!("replacing downloaded layer into layermap failed: {e:#?}")
+                            }
                         }
                     }
                     updates.flush();


### PR DESCRIPTION
Cc: #3486

Adds a method to replace a particular layer from the LayerMap for the purposes of remote layer download and layer eviction. In those use cases read lock on layer map needs to be released after initial search, but other operations could modify layermap before replacing thread gets to run.

I don't feel too strongly about the existing code refactorings. The actual usage is not intended to be fully resolved on this PR (needs more error handling unrelated to this replace functionality).