### PR TITLE
Add build_info metric to storage broker

### DIFF
--- a/storage_broker/src/bin/storage_broker.rs
+++ b/storage_broker/src/bin/storage_broker.rs
@@ -431,6 +431,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     logging::init(LogFormat::from_config(&args.log_format)?)?;
     info!("version: {GIT_VERSION}");
+    ::metrics::set_build_info_metric(GIT_VERSION);
 
     let registry = Registry {
         shared_state: Arc::new(RwLock::new(SharedState::new(args.all_keys_chan_size))),


### PR DESCRIPTION
## Describe your changes
Add libmetrics_build_info  metrics with commit sha to storage_broken /metrics, to match behaviour of proxy, pageserver and safekeeper.
