### PR TITLE
Use LayerMap::replace in eviction

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -930,7 +930,7 @@ impl Timeline {
                 true
             }
             Replacement::NotFound => {
-                debug!(evicted=?local_layer, "lost the race to evict layer");
+                debug!(evicted=?local_layer, "layer was no longer in layer map");
                 false
             }
             Replacement::RemovalBuffered => {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3412,6 +3412,7 @@ impl Timeline {
                                 error!(
                                     expected.ptr = ?Arc::as_ptr(&l),
                                     other.ptr = ?Arc::as_ptr(&other),
+                                    ?other,
                                     "replacing downloaded layer into layermap failed because another layer was found instead of expected"
                                 );
                             }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -867,6 +867,14 @@ impl Timeline {
         Ok(Some(true))
     }
 
+    /// Evicts one layer as in replaces a downloaded layer with a remote layer
+    ///
+    /// Returns:
+    /// - `Ok(Some(true))` when the layer was replaced
+    /// - `Ok(Some(false))` when
+    ///     - the layer was not found
+    ///     - or remote storage is not configured (TODO: make error)
+    /// - `Ok(None)` when the layer is not found
     pub async fn evict_layer(&self, layer_file_name: &str) -> anyhow::Result<Option<bool>> {
         let Some(local_layer) = self.find_layer(layer_file_name) else { return Ok(None) };
         if local_layer.is_remote_layer() {


### PR DESCRIPTION
Follow-up to #3536, to actually use the new `Debug` in replacing the layers.

Turns out the two paths share a lot of handling of `Replacement` but didn't unify the two (need 3).

Related to #3486.