### PR TITLE
DEBUG investigate synthetic_tenant_size calculation

### DIFF
--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -705,6 +705,14 @@ fn investigation_test() {
 
     println!("calculated synthetic size: {}", res);
 
+    use utils::lsn::Lsn;
+    let latest_gc_cutoff_lsn: Lsn = "47/240A5860".parse().unwrap();
+    let last_lsn: Lsn = "47/280A5860".parse().unwrap();
+    println!(
+        "latest_gc_cutoff lsn 47/240A5860 is {}, last_lsn lsn 47/280A5860 is {}",
+        u64::from(latest_gc_cutoff_lsn),
+        u64::from(last_lsn)
+    );
     assert_eq!(res, 220054675456);
 }
 

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -696,6 +696,19 @@ fn verify_size_for_multiple_branches() {
 }
 
 #[test]
+fn investigation_test() {
+    let doc = r#"{"updates":[{"lsn":"0/0","command":{"branch_from":null},"timeline_id":"f15ae0cf21cce2ba27e4d80c6709a6cd"},{"lsn":"47/240A5860","command":{"update":220054675456},"timeline_id":"f15ae0cf21cce2ba27e4d80c6709a6cd"},{"lsn":"47/280A5860","command":"end_of_branch","timeline_id":"f15ae0cf21cce2ba27e4d80c6709a6cd"}],"retention_period":67108864}"#;
+
+    let inputs: ModelInputs = serde_json::from_str(doc).unwrap();
+
+    let res = inputs.calculate().unwrap();
+
+    println!("calculated synthetic size: {}", res);
+
+    assert_eq!(res, 220054675456);
+}
+
+#[test]
 fn updates_sort_with_branches_at_same_lsn() {
     use std::str::FromStr;
     use Command::{BranchFrom, EndOfBranch};


### PR DESCRIPTION
Don't merge!
This is just a brain dump of investigation process.

run test
`cargo test tenant::size::investigation_test`

debug output:

```
---- tenant::size::investigation_test stdout ----
insert_point: lastseg_id 0 , newseg_id 1
insert_point: lastseg Segment { parent: None, op: "", start_lsn: 0, end_lsn: 0, start_size: 0, end_size: Some(0), children_after: [1], needed: false } , newseg Segment { parent: Some(0), op: "", start_lsn: 0, end_lsn: 305547335776, start_size: 0, end_size: Some(220054675456), children_after: [], needed: false }
insert_point: lastseg_id 1 , newseg_id 2
insert_point: lastseg Segment { parent: Some(0), op: "", start_lsn: 0, end_lsn: 305547335776, start_size: 0, end_size: Some(220054675456), children_after: [2], needed: false } , newseg Segment { parent: Some(1), op: "", start_lsn: 305547335776, end_lsn: 305614444640, start_size: 220054675456, end_size: None, children_after: [], needed: false }
calculate loop
last_seg_id 0 last_seg: Segment { parent: None, op: "", start_lsn: 0, end_lsn: 0, start_size: 0, end_size: Some(0), children_after: [1], needed: false } retention_period 67108864
cutoff_lsn: 0
seg: Segment { parent: None, op: "", start_lsn: 0, end_lsn: 0, start_size: 0, end_size: Some(0), children_after: [1], needed: false }
seg.needed = true
breaking because no parent
calculate loop
last_seg_id 2 last_seg: Segment { parent: Some(1), op: "", start_lsn: 305547335776, end_lsn: 305614444640, start_size: 220054675456, end_size: None, children_after: [], needed: false } retention_period 67108864
cutoff_lsn: 305480226912
seg: Segment { parent: Some(1), op: "", start_lsn: 305547335776, end_lsn: 305614444640, start_size: 220054675456, end_size: None, children_after: [], needed: false }
seg.needed = true
prev_seg_id = 1
seg: Segment { parent: Some(0), op: "", start_lsn: 0, end_lsn: 305547335776, start_size: 0, end_size: Some(220054675456), children_after: [2], needed: false }
seg.needed = true
prev_seg_id = 0
seg: Segment { parent: None, op: "", start_lsn: 0, end_lsn: 0, start_size: 0, end_size: Some(0), children_after: [1], needed: true }
breaking because seg.end_lsn 0 < cutoff_lsn 305480226912
size_from_snapshot_later: seg0: 1 needed: true
size_from_wal: seg_id 1: this_size 305547335776 = 305547335776 - 0
size_from_wal: seg_id 2: this_size 67108864 = 305614444640 - 305547335776
size_from_snapshot_later: child.needed use p1 children loop child_id 1: size_from_wal(child_id = 1) = 305547335776
size_from_snapshot_later: WalNeeded seg_id 0: seg.start_size 0
method WalNeeded 0:t this_size=0 , ch=305614444640
calculated synthetic size: 305614444640
latest_gc_cutoff lsn 47/240A5860 is 305547335776, last_lsn lsn 47/280A5860 is 305614444640
```


human-readable interpretation:

0) We have some inputs.

1) `calculate()` function converts inputs to Storage->Segments and Storage->Branches.
_Why do we even need it?_ We already have inputs in a nice sorted format...

we have 3 segments
- seg 0 is trivial, _Why do we even need it?_
- seg 1 represents history from 0 to `latest_gc_cutoff`. We don't care about this history, we only need to know 
size at the end of the segment (this size is `220054675456`) to use it as the start_size of the next segment.
- seg 2 represents PITR window.

So far so good.

2) Let's compute the synthetic size.

What algorithm must do? 
`seg2.start_size + (seg2.end_lsn -seg2.start_lsn)`

What it really does?
`seg0.end_size + (seg1.end_lsn -seg1.start_lsn) + (seg2.end_lsn -seg2.start_lsn)`
