### PR TITLE
fix: one leftover Arc::ptr_eq

### DIFF
--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -731,6 +731,9 @@ where
         Ok(())
     }
 
+    /// Similar to `Arc::ptr_eq`, but only compares the object pointers, not vtables.
+    ///
+    /// Returns `true` if the two `Arc` point to the same layer, false otherwise.
     #[inline(always)]
     pub fn compare_arced_layers(left: &Arc<L>, right: &Arc<L>) -> bool {
         // "dyn Trait" objects are "fat pointers" in that they have two components:

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -732,7 +732,7 @@ where
     }
 
     #[inline(always)]
-    fn compare_arced_layers(left: &Arc<L>, right: &Arc<L>) -> bool {
+    pub fn compare_arced_layers(left: &Arc<L>, right: &Arc<L>) -> bool {
         // "dyn Trait" objects are "fat pointers" in that they have two components:
         // - pointer to the object
         // - pointer to the vtable

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2374,7 +2374,7 @@ impl Timeline {
             // Only one thread may call this function at a time (for this
             // timeline). If two threads tried to flush the same frozen
             // layer to disk at the same time, that would not work.
-            assert!(Arc::ptr_eq(&l.unwrap(), &frozen_layer));
+            assert!(LayerMap::compare_arced_layers(&l.unwrap(), &frozen_layer));
 
             // release lock on 'layers'
         }


### PR DESCRIPTION
@knizhnik noticed that one instance of `Arc::<dyn PersistentLayer>::ptr_eq` was missed in #3558.

Now all `ptr_eq` which remain are in comments.