### PR TITLE
fix: initial logical size timer and caching

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1780,7 +1780,7 @@ impl Timeline {
             // need to return something
             Ok(0)
         });
-        let timer = if up_to_lsn == self.initdb_lsn {
+        let timer = if Some(up_to_lsn) == self.current_logical_size.initial_part_end {
             if let Some(size) = self.current_logical_size.initialized_size() {
                 if size != 0 {
                     // non-zero size means that the size has already been calculated by this method


### PR DESCRIPTION
initially added sometime ago, introduced in earlier PR of mine #2714. then there was confusion about for which lsn logical size was initially calculated for, and now it appears it is not the initdb_lsn but disk_consistent_lsn.

I don't think this is any correctness change, except for the used histogram, which also means that the other histogram has been seeing all of the use except for tenants which have never been touched after creation.