### PR TITLE
Skip largest N holes during compaction

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -19,6 +19,7 @@ use tracing::*;
 use utils::id::TenantTimelineId;
 
 use std::cmp::{max, min, Ordering};
+use std::collections::BinaryHeap;
 use std::collections::HashMap;
 use std::fs;
 use std::ops::{Deref, Range};
@@ -81,6 +82,26 @@ enum FlushLoopState {
     Running,
     Exited,
 }
+
+
+/// Wrapper for key range to provide reverse ordering by range length for BinaryHeap
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Hole(pub Range<Key>);
+
+impl Ord for Hole {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let other_len = other.0.end.to_i128() - other.0.start.to_i128();
+        let self_len = self.0.end.to_i128() - self.0.start.to_i128();
+        other_len.cmp(&self_len)
+    }
+}
+
+impl PartialOrd for Hole {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 
 pub struct Timeline {
     conf: &'static PageServerConf,
@@ -2947,6 +2968,31 @@ impl Timeline {
             },
         )?;
 
+		// Determine N largest holes where N is number of compacted layers
+		let max_holes = deltas_to_compact.len();
+		let min_hole_length = (target_file_size / page_cache::PAGE_SZ as u64) as i128;
+
+		// min-heap (reserve space for one more element added before eviction)
+		let mut heap: BinaryHeap<Hole> = BinaryHeap::with_capacity(max_holes + 1);
+        let mut prev: Option<Key> = None;
+		for (next_key, _next_lsn, _size) in itertools::process_results(
+            deltas_to_compact.iter().map(|l| l.key_iter(ctx)),
+            |iter_iter| iter_iter.kmerge_by(|a, b| a.0 <= b.0))?
+		{
+            if let Some(prev_key) = prev {
+                if next_key.to_i128() - prev_key.to_i128() >= min_hole_length {
+                    heap.push(Hole(prev_key..next_key));
+                    if heap.len() > max_holes {
+                        heap.pop(); // remove smallest hole
+                    }
+                }
+            }
+            prev = Some(next_key.next());
+		}
+		let mut holes = heap.into_vec();
+        holes.sort_by_key(|hole| hole.0.start);
+		let mut next_hole = 0; // index of next hole in holes vector
+
         // Merge the contents of all the input delta layers into a new set
         // of delta layers, based on the current partitioning.
         //
@@ -3045,10 +3091,16 @@ impl Timeline {
                     if is_dup_layer
                         || dup_end_lsn.is_valid()
                         || written_size + key_values_total_size > target_file_size
+						|| (next_hole < holes.len() && key >= holes[next_hole].0.end) // stop on hole
                     {
                         // ... if so, flush previous layer and prepare to write new one
                         new_layers.push(writer.take().unwrap().finish(prev_key.unwrap().next())?);
                         writer = None;
+
+						if next_hole < holes.len() && key >= holes[next_hole].0.end {
+							// skip hole
+							next_hole += 1;
+						}
                     }
                 }
                 // Remember size of key value because at next iteration we will access next item

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3005,7 +3005,7 @@ impl Timeline {
         }
         drop(layers);
         let mut holes = heap.into_vec();
-        holes.sort_by_key(|hole| hole.key_range.start);
+        holes.sort_unstable_by_key(|hole| hole.key_range.start);
         let mut next_hole = 0; // index of next hole in holes vector
 
         // Merge the contents of all the input delta layers into a new set

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -83,7 +83,6 @@ enum FlushLoopState {
     Exited,
 }
 
-
 /// Wrapper for key range to provide reverse ordering by range length for BinaryHeap
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Hole(pub Range<Key>);
@@ -101,7 +100,6 @@ impl PartialOrd for Hole {
         Some(self.cmp(other))
     }
 }
-
 
 pub struct Timeline {
     conf: &'static PageServerConf,
@@ -2968,17 +2966,17 @@ impl Timeline {
             },
         )?;
 
-		// Determine N largest holes where N is number of compacted layers
-		let max_holes = deltas_to_compact.len();
-		let min_hole_length = (target_file_size / page_cache::PAGE_SZ as u64) as i128;
+        // Determine N largest holes where N is number of compacted layers
+        let max_holes = deltas_to_compact.len();
+        let min_hole_length = (target_file_size / page_cache::PAGE_SZ as u64) as i128;
 
-		// min-heap (reserve space for one more element added before eviction)
-		let mut heap: BinaryHeap<Hole> = BinaryHeap::with_capacity(max_holes + 1);
+        // min-heap (reserve space for one more element added before eviction)
+        let mut heap: BinaryHeap<Hole> = BinaryHeap::with_capacity(max_holes + 1);
         let mut prev: Option<Key> = None;
-		for (next_key, _next_lsn, _size) in itertools::process_results(
+        for (next_key, _next_lsn, _size) in itertools::process_results(
             deltas_to_compact.iter().map(|l| l.key_iter(ctx)),
-            |iter_iter| iter_iter.kmerge_by(|a, b| a.0 <= b.0))?
-		{
+            |iter_iter| iter_iter.kmerge_by(|a, b| a.0 <= b.0),
+        )? {
             if let Some(prev_key) = prev {
                 if next_key.to_i128() - prev_key.to_i128() >= min_hole_length {
                     heap.push(Hole(prev_key..next_key));
@@ -2988,10 +2986,10 @@ impl Timeline {
                 }
             }
             prev = Some(next_key.next());
-		}
-		let mut holes = heap.into_vec();
+        }
+        let mut holes = heap.into_vec();
         holes.sort_by_key(|hole| hole.0.start);
-		let mut next_hole = 0; // index of next hole in holes vector
+        let mut next_hole = 0; // index of next hole in holes vector
 
         // Merge the contents of all the input delta layers into a new set
         // of delta layers, based on the current partitioning.
@@ -3091,16 +3089,17 @@ impl Timeline {
                     if is_dup_layer
                         || dup_end_lsn.is_valid()
                         || written_size + key_values_total_size > target_file_size
-						|| (next_hole < holes.len() && key >= holes[next_hole].0.end) // stop on hole
+                        || (next_hole < holes.len() && key >= holes[next_hole].0.end)
+                    // stop on hole
                     {
                         // ... if so, flush previous layer and prepare to write new one
                         new_layers.push(writer.take().unwrap().finish(prev_key.unwrap().next())?);
                         writer = None;
 
-						if next_hole < holes.len() && key >= holes[next_hole].0.end {
-							// skip hole
-							next_hole += 1;
-						}
+                        if next_hole < holes.len() && key >= holes[next_hole].0.end {
+                            // skip hole
+                            next_hole += 1;
+                        }
                     }
                 }
                 // Remember size of key value because at next iteration we will access next item


### PR DESCRIPTION
## Describe your changes

This is yet another attempt to address problem with storage size ballooning #2948
Previous PR #3348 tries to address this problem by maintaining list of holes for each layer.
The problem with this approach is that we have to load all layer on pageserver start.
Lazy loading of layers is not possible any more.

This PR tries to collect information of N largest holes on compaction time and exclude this holes from produced layers.
It can cause generation of larger number of layers (up to 2 times) and producing small layers.
But it requires minimal changes in code and doesn't affect storage format.

For graphical explanation please see thread: https://github.com/neondatabase/neon/pull/3597#discussion_r1112704451

## Issue ticket number and link

#2948
#3348

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

