### PR TITLE
fix the logical size term definition

### DIFF
--- a/docs/synthetic-size.md
+++ b/docs/synthetic-size.md
@@ -37,7 +37,7 @@ The synthetic size is designed to:
 
 ## Terms & assumptions
 
-- logical size is the size of a database *at a given point in
+- logical size is the size of a branch *at a given point in
   time*. It's the total size of all tables in all databases, as you
   see with "\l+" in psql for example, plus the Postgres SLRUs and some
   small amount of metadata. NOTE that currently, Neon does not include


### PR DESCRIPTION
a size of a *database* cannot be a sum of the sizes of *all databases* indicating that a logical size is calculated for a branch

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] i checked the suggested changes
- [x] this is not a core feature
- [x] this is just a docs update, does not require analytics
- [x] this PR does not require a public announcement

