### PR TITLE
Fix flaky tests

### DIFF
--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, DefaultDict, Dict
 
 import pytest
+import time
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import (
     NeonEnvBuilder,
@@ -215,7 +216,6 @@ def test_ondemand_download_timetravel(
     filled_size = get_resident_physical_size()
     log.info(filled_size)
     assert filled_current_physical == filled_size, "we don't yet do layer eviction"
-
 
     # Wait until generated image layers are uploaded to S3
     time.sleep(3)

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, DefaultDict, Dict
 
 import pytest
-import time
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import (
     NeonEnvBuilder,

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -216,6 +216,10 @@ def test_ondemand_download_timetravel(
     log.info(filled_size)
     assert filled_current_physical == filled_size, "we don't yet do layer eviction"
 
+
+    # Wait until generated image layers are uploaded to S3
+    time.sleep(3)
+
     env.pageserver.stop()
 
     # remove all the layer files

--- a/test_runner/regress/test_tenants_with_remote_storage.py
+++ b/test_runner/regress/test_tenants_with_remote_storage.py
@@ -280,6 +280,7 @@ def test_tenant_upgrades_index_json_from_v0(
 
         timeline_file.seek(0)
         json.dump(v0_index_part, timeline_file)
+        timeline_file.truncate(timeline_file.tell())
 
     env.pageserver.start()
     pageserver_http = env.pageserver.http_client()


### PR DESCRIPTION
## Describe your changes

test_on_demand_download is flaky because not waiting until created image layer is transferred to S3.
test_tenants_with_remote_storage just leaves garbage at the end of overwritten file.

Right solution for test_on_demand_download is to add some API call to wait completion of synchronization with S3 (not just based on last record LSN). But right now it is solved using sleep.

## Issue ticket number and link

#3209 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

