### PR TITLE
Mark `C` language as trusted to enable `pgx` extensions

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -283,6 +283,7 @@ impl ComputeNode {
         handle_databases(&self.spec, &mut client)?;
         handle_role_deletions(self, &mut client)?;
         handle_grants(self, &mut client)?;
+        ensure_c_language_is_trusted(&mut client)?;
         create_writability_check_data(&mut client)?;
 
         // 'Close' connection

--- a/compute_tools/src/spec.rs
+++ b/compute_tools/src/spec.rs
@@ -515,3 +515,16 @@ pub fn handle_grants(node: &ComputeNode, client: &mut Client) -> Result<()> {
 
     Ok(())
 }
+
+/// Mark `C` language as trusted. `pgx` extensions pretend `Rust` as `C`.
+/// To be able to install such extensions, it's needed to mark `C` language as trusted or grant a superuser role to the user.
+/// Unfortunately, currently, we don't provide such privileges. Therefore need to opt for such a workaround.
+///
+/// This is the error example:
+/// `ERROR: permission denied for language c (SQLSTATE 42501)`
+#[instrument(skip_all)]
+pub fn ensure_c_language_is_trusted(client: &mut Client) -> Result<()> {
+    let _ =
+        client.simple_query("UPDATE pg_language SET lanpltrusted = true WHERE lanname = 'c';")?;
+    Ok(())
+}


### PR DESCRIPTION
## Describe your changes
On staging:

```sql
create extension pg_graphql;

ERROR: permission denied for language c (SQLSTATE 42501)
```

## Issue ticket number and link
#3535

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

