### PR TITLE
[pageserver] Do several adjustements to the `find_lsn_for_timestamp`

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -330,7 +330,7 @@ async fn get_lsn_by_timestamp_handler(request: Request<Body>) -> Result<Response
 
     let result = match result {
         LsnForTimestamp::Present(lsn) => format!("{lsn}"),
-        LsnForTimestamp::Future(_lsn) => "future".into(),
+        LsnForTimestamp::Future(lsn) => format!("{lsn}"),
         LsnForTimestamp::Past(_lsn) => "past".into(),
         LsnForTimestamp::NoData(_lsn) => "nodata".into(),
     };


### PR DESCRIPTION
## Describe your changes

1. Use `max(find_lsn_for_timestamp, ancestor_lsn)` as a lower boundary for search. We use this method to figure out the branching LSN for new branch, but GC cutoff could be before branching point and we cannot create new branch with LSN < `ancestor_lsn`.

2. Search for the first commit **before** specified timestamp. This resolves two drawbacks: i) newly created branch won't contain physical changes from later commits that will be marked as aborted, and will need to be vacuumed away; and ii) we can still figure out a reasonable branching LSN if there were no new commits since the specified timestamp.

3. Change `get_lsn_by_timestamp` API method to return LSN even if we only found commit **before** the specified timestamp.

Resolves #3414

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

