### PR TITLE
test: make test_ondemand_download_timetravel less flaky

### DIFF
--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -192,11 +192,15 @@ def test_ondemand_download_timetravel(
         # wait until pageserver receives that data
         wait_for_last_record_lsn(client, tenant_id, timeline_id, current_lsn)
 
-        # run checkpoint manually to be sure that data landed in remote storage
-        client.timeline_checkpoint(tenant_id, timeline_id)
+        if checkpoint_number < 19:
+            # run checkpoint manually to be sure that data landed in remote storage
+            client.timeline_checkpoint(tenant_id, timeline_id)
 
     ##### Stop the first pageserver instance, erase all its data
     env.postgres.stop_all()
+
+    # do the last checkpoint only after stopping pg
+    client.timeline_checkpoint(tenant_id, timeline_id)
 
     # wait until pageserver has successfully uploaded all the data to remote storage
     wait_for_sk_commit_lsn_to_reach_remote_storage(

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -186,6 +186,8 @@ def test_ondemand_download_timetravel(
     for checkpoint_number in range(1, 20):
         with pg.cursor() as cur:
             cur.execute(f"UPDATE testtab SET checkpoint_number = {checkpoint_number}")
+
+        with pg.cursor() as cur:
             current_lsn = Lsn(query_scalar(cur, "SELECT pg_current_wal_flush_lsn()"))
         lsns.append((checkpoint_number, current_lsn))
 

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -247,10 +247,9 @@ def test_ondemand_download_timetravel(
     num_layers_downloaded = [0]
     resident_size = [get_resident_physical_size()]
     for (checkpoint_number, lsn) in lsns:
-        pg_old = env.postgres.create_start(
+        with env.postgres.create_start(
             branch_name="main", node_name=f"test_old_lsn_{checkpoint_number}", lsn=lsn
-        )
-        with pg_old.cursor() as cur:
+        ) as pg_old, pg_old.cursor() as cur:
             # assert query_scalar(cur, f"select count(*) from testtab where checkpoint_number={checkpoint_number}") == 100000
             assert (
                 query_scalar(


### PR DESCRIPTION
Do the last checkpoint only after stopping pg while also lowering the number of running postgres instances by the test from N to constant (1 or 2).

The test is sometimes flaky, wondering if this approach to checkpointing helps, I'll be running the regression tests multiple times, because flakyness only ever appeared with real_s3.

Hopefully fixes #3209.