### PR TITLE
fix: allow ERROR log to appear per allowed failure

### DIFF
--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -618,6 +618,9 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     # checkpoint operations. Hence, checkpoint is allowed to fail now.
     log.info("sending delete request")
     checkpoint_allowed_to_fail.set()
+    env.pageserver.allowed_errors.append(
+        ".+ERROR Error processing HTTP request: InternalServerError\\(timeline is Stopping.+"
+    )
     client.timeline_delete(tenant_id, timeline_id)
 
     assert not timeline_path.exists()

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -619,7 +619,7 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     log.info("sending delete request")
     checkpoint_allowed_to_fail.set()
     env.pageserver.allowed_errors.append(
-        ".+ERROR Error processing HTTP request: InternalServerError\\(timeline is Stopping.+"
+        ".+ERROR Error processing HTTP request: InternalServerError\\(timeline is Stopping"
     )
     client.timeline_delete(tenant_id, timeline_id)
 


### PR DESCRIPTION
Trying to fix #3360.

The test already allows the background thread trying to checkpoint to fail, however the resulting log message is currently not allowed thus causing flakyness ~~(or hiding some other problem)~~ -- no other problems were discovered.