### PR TITLE
gc: only decrement resident size if GC'd layer is resident 

### DIFF
--- a/pageserver/src/tenant/config.rs
+++ b/pageserver/src/tenant/config.rs
@@ -103,6 +103,7 @@ pub struct TenantConfOpt {
     pub checkpoint_distance: Option<u64>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "humantime_serde")]
     #[serde(default)]
     pub checkpoint_timeout: Option<Duration>,
 

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -364,7 +364,7 @@ pub trait PersistentLayer: Layer {
     }
 
     /// Permanently remove this layer from disk.
-    fn delete(&self) -> Result<()>;
+    fn delete_resident_layer_file(&self) -> Result<()>;
 
     fn downcast_remote_layer(self: Arc<Self>) -> Option<std::sync::Arc<RemoteLayer>> {
         None

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -438,7 +438,7 @@ impl PersistentLayer for DeltaLayer {
         ))
     }
 
-    fn delete(&self) -> Result<()> {
+    fn delete_resident_layer_file(&self) -> Result<()> {
         // delete underlying file
         fs::remove_file(self.path())?;
         Ok(())

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -252,7 +252,7 @@ impl PersistentLayer for ImageLayer {
         unimplemented!();
     }
 
-    fn delete(&self) -> Result<()> {
+    fn delete_resident_layer_file(&self) -> Result<()> {
         // delete underlying file
         fs::remove_file(self.path())?;
         Ok(())

--- a/pageserver/src/tenant/storage_layer/remote_layer.rs
+++ b/pageserver/src/tenant/storage_layer/remote_layer.rs
@@ -155,8 +155,8 @@ impl PersistentLayer for RemoteLayer {
         bail!("cannot iterate a remote layer");
     }
 
-    fn delete(&self) -> Result<()> {
-        Ok(())
+    fn delete_resident_layer_file(&self) -> Result<()> {
+        bail!("remote layer has no layer file");
     }
 
     fn downcast_remote_layer<'a>(self: Arc<Self>) -> Option<std::sync::Arc<RemoteLayer>> {


### PR DESCRIPTION
4 commits, intended to remain separate:

commit 906d5c7b9018e88ad884c34027e56c23e9fa15e8
Author: Christian Schwarz <christian@neon.tech>
Date:   Wed Mar 1 18:42:14 2023 +0100

    fix checkpoint_timeout serialization in TenantConf

    Without this change, when actually setting this conf opt, the tenant
    would become Broken next time we load it.
    Why?
    The serde_toml representation that persist_tenant_conf would write out
    would be a TOML inline table of `secs` and `nsecs`.
    But our hand-rolled TenantConf parser expects a TOML string.

    I checked that all other `Duration` values in TenantConfOpt
    use the humantime serialization.

    Issues like this would likely be systematically prevent by
    https://github.com/neondatabase/neon/issues/3682

commit db92fec78c668e84eb6ebef3481d016ffa80663d
Author: Christian Schwarz <christian@neon.tech>
Date:   Wed Mar 1 12:09:02 2023 +0100

    eviction: remove needless if-let around resident size decrement

    The branch was always taken at runtime, so, this should not
    constitute a behavioral change.

    refs https://github.com/neondatabase/neon/issues/3722

commit 464ef0ff80f3d3a3b5050ca1f2a830b415c5f196
Author: Christian Schwarz <christian@neon.tech>
Date:   Wed Mar 1 13:06:43 2023 +0100

    eviction: add comment explaining resident size decrement on error

    https://github.com/neondatabase/neon/issues/3722

commit 2ce9515dc7c654a4b79a392fe82999f6dd336ac1
Author: Christian Schwarz <christian@neon.tech>
Date:   Wed Mar 1 17:54:59 2023 +0100

    gc: only decrement resident size if GC'd layer is resident

    Before this patch, GC would call PersistentLayer::delete()
    on every GC'ed layer.
    RemoteLayer::delete() returned Ok(()) unconditionally.
    GC would then proceed by decrementing the resident size metric,
    even though the layer is a RemoteLayer.

    This patch makes the following changes:
    - Rename PersistentLayer::delete() to delete_resident_layer_file().
      That name is unambiguous.
    - Make RemoteLayer::delete_resident_layer_file return an Err().
      We would have uncovered this bug if we had done that from the start.
    - Change GC / Timeline::delete_historic_layer check whether
      the layer is remote or not, and only call delete_resident_layer_file()
      if it's not remote. This brings us in line with how eviction does it.
    - Add a regression test.

    fixes https://github.com/neondatabase/neon/issues/3722
