### PR TITLE
Improve synthetic_size json output:

### DIFF
--- a/libs/tenant_size_model/src/lib.rs
+++ b/libs/tenant_size_model/src/lib.rs
@@ -37,10 +37,15 @@ pub struct Segment {
     /// LSN at this point
     pub lsn: u64,
 
+    pub parent_lsn: Option<u64>,
+
+    pub wal_from_parent: Option<u64>,
+
     /// Logical size at this node, if known.
     pub size: Option<u64>,
 
     /// If true, the segment from parent to this node is needed by `retention_period`
+    /// if wal_from_parent is needed by `retention_period`?
     pub needed: bool,
 }
 

--- a/libs/tenant_size_model/tests/tests.rs
+++ b/libs/tenant_size_model/tests/tests.rs
@@ -17,6 +17,8 @@ impl ScenarioBuilder {
         let init_segment = Segment {
             parent: None,
             lsn: 0,
+            parent_lsn: None,
+            wal_from_parent: None,
             size: Some(0),
             needed: false, // determined later
         };
@@ -36,6 +38,8 @@ impl ScenarioBuilder {
         let newseg = Segment {
             parent: Some(lastseg_id),
             lsn: lastseg.lsn + lsn_bytes,
+            parent_lsn: Some(lastseg.lsn),
+            wal_from_parent: Some(lsn_bytes),
             size: Some((lastseg.size.unwrap() as i64 + size_bytes) as u64),
             needed: false,
         };


### PR DESCRIPTION


## Describe your changes

Improve json that is used for visualization.

- add new fields 'parent_lsn' and 'wal_from_parent' to segments;
- output 'timeline_inputs' lsns as u64 to be consistent with other places

This pseudocode describes how to interpret the json to understand how final synthetic_size was calculated:

```
arr is the array of `SegmentSizeResult` records

for i in  0..arr.len() {
    tenant_synthetic_size += match arr[i].method
    {
        SnapshotHere -> segments[i].size,
        Wal -> segments[i].wal_from_parent.   //can be null, that's ok
        SnapshotLater | Skipped -> 0,
    }
}
```
@duskpoet , FYI

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

