### PR TITLE
Add tracing spans with request_id into pageserver management API handlers

### DIFF
--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -83,6 +83,8 @@ where
             } else {
                 info!("Handling request");
             }
+
+            // note that we have an `err_handler` set below, that would log any `?`
             let response = (self.0)(request).await?;
 
             let response_status = response.status();

--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -85,6 +85,8 @@ where
             // Note that we reuse `error::handler` here and not returning and error at all,
             // yet cannot use `!` directly in the method signature due to `routerify::RouterBuilder` limitation.
             // Usage of the error handler also means that we expect only the `ApiError` errors to be raised in this call.
+            //
+            // Panics are not handled separately, there's a `tracing_panic_hook` from another module to do that globally.
             match (self.0)(request).await {
                 Ok(response) => {
                     let response_status = response.status();


### PR DESCRIPTION
Adds a newtype that creates a span with request_id from https://github.com/neondatabase/neon/pull/3708 for every HTTP request served.

Before:
```
2023-03-06T16:43:43.324783Z DEBUG parsed 3 headers
2023-03-06T16:43:43.324802Z DEBUG incoming body is empty
2023-03-06T16:43:43.324855Z DEBUG GET /v1/status 34428955-0145-4f0d-9358-e1987fdda1d2
2023-03-06T16:43:43.324864Z  INFO Status check called
2023-03-06T16:43:43.324867Z DEBUG Status check debug message
2023-03-06T16:43:43.324883Z DEBUG GET /v1/status 34428955-0145-4f0d-9358-e1987fdda1d2 200 OK
2023-03-06T16:43:43.324916Z DEBUG flushed 228 bytes
2023-03-06T16:43:43.325068Z DEBUG read eof
```

After:
```
2023-03-06T16:38:20.355714Z DEBUG parsed 3 headers
2023-03-06T16:38:20.355736Z DEBUG incoming body is empty
2023-03-06T16:38:20.355946Z DEBUG GET /v1/status ad25e104-f0a2-4124-a991-2893df678554
2023-03-06T16:38:20.356028Z  INFO request{method=GET path=/v1/status request_id=ad25e104-f0a2-4124-a991-2893df678554}: Status check called
2023-03-06T16:38:20.356059Z DEBUG request{method=GET path=/v1/status request_id=ad25e104-f0a2-4124-a991-2893df678554}: Status check debug message
2023-03-06T16:38:20.356210Z DEBUG GET /v1/status ad25e104-f0a2-4124-a991-2893df678554 200 OK
2023-03-06T16:38:20.356351Z DEBUG flushed 228 bytes
2023-03-06T16:38:20.356529Z DEBUG read eof
```

As an alternative implementation, one could use a 
* procmacro to place an annotation on every request handler method

Would hurt the complilation, require to create a separate procmacro crate with some code to parse things, etc.
Seems too heavy for such kind of task.

* `TraitExt` trait implemented on routerify's Router.

Makes us coupled to routerify even more compared to this PR, which is not a good thing if we would want to switch from routerify to something else.