### PR TITLE
Avoid holes between generated image layers

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2728,9 +2728,9 @@ impl Timeline {
         let mut start_lsn = Key::MIN;
 
         for partition in partitioning.parts.iter() {
+            let img_range = start_lsn..partition.ranges.last().unwrap().end;
+            start_lsn = img_range.end;
             if force || self.time_for_new_image_layer(partition, lsn)? {
-                let img_range = start_lsn..partition.ranges.last().unwrap().end;
-                start_lsn = img_range.end;
                 let mut image_layer_writer = ImageLayerWriter::new(
                     self.conf,
                     self.timeline_id,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2725,11 +2725,11 @@ impl Timeline {
         // KeySpace::partition may contain partitions <100000000..100000099> and <200000000..200000199>.
         // If there is delta layer <100000000..300000000> then it never be garbage collected because
         // image layers  <100000000..100000099> and <200000000..200000199> are not completely covering it.
-        let mut start_lsn = Key::MIN;
+        let mut start = Key::MIN;
 
         for partition in partitioning.parts.iter() {
-            let img_range = start_lsn..partition.ranges.last().unwrap().end;
-            start_lsn = img_range.end;
+            let img_range = start..partition.ranges.last().unwrap().end;
+            start = img_range.end;
             if force || self.time_for_new_image_layer(partition, lsn)? {
                 let mut image_layer_writer = ImageLayerWriter::new(
                     self.conf,


### PR DESCRIPTION
## Describe your changes

When we perform partitioning of the whole key space, we take in account actual ranges of relation present in the database. So if we have relation with relid=1 and size 100 and relation with relid=2 with size 200 then result of KeySpace::partition may contain partitions <100000000..100000099> and <200000000..200000199>. Generated image layers will contain the same boundaries.
But when GC is checking image coverage to find out of old layer is fully covered by newer image layer and so can be deleted, it takes in account only full key range. I.e. if there is delta layer <100000000..300000000> then it never be garbage collected because image layers  <100000000..100000099> and <200000000..200000199> are not completely covering it.This is how it looks in practice:

000000067F000032AC00000A300000000000-000000067F000032AC00000A330000000000__000000000F761828
000000067F000032AC00000A31000000001F-000000067F000032AC00000A620000000005__0000000001696070-000000000442A551
000000067F000032AC00000A3300FFFFFFFF-000000067F000032AC00000A650100000000__000000000F761828

So there are two image layers covering delta layer but ... there is a hole:  A330000000000...A3300FFFFFFFF and as a result delta layer is not collected.

## Issue ticket number and link

This PR is deeply related with #3673 because it is addressing the same problem: old layers are not utilized by GC.
The test test_gc_old_layers.py in #3673 can be used to see effect of this patch.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

