### PR TITLE
fix: pageserver_ondisk_layers metric

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -81,6 +81,7 @@ pub mod block_io;
 pub mod disk_btree;
 pub(crate) mod ephemeral_file;
 pub mod layer_map;
+mod measured_layer_map;
 
 pub mod metadata;
 mod par_fsync;

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -269,6 +269,8 @@ where
 
     /// Start a batch of updates, applied on drop
     pub fn batch_update(&mut self) -> BatchedUpdates<'_, L> {
+        // Note: MeasuredLayerMap::batch_update wraps this, when extending or changing batched
+        // updates, make changes there as well
         BatchedUpdates { layer_map: self }
     }
 

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -48,7 +48,6 @@ mod layer_coverage;
 
 use crate::context::RequestContext;
 use crate::keyspace::KeyPartitioning;
-use crate::metrics::NUM_ONDISK_LAYERS;
 use crate::repository::Key;
 use crate::tenant::storage_layer::InMemoryLayer;
 use crate::tenant::storage_layer::Layer;
@@ -287,8 +286,6 @@ where
         if Self::is_l0(&layer) {
             self.l0_delta_layers.push(layer);
         }
-
-        NUM_ONDISK_LAYERS.inc();
     }
 
     ///
@@ -313,8 +310,6 @@ where
                 "failed to locate removed historic layer from l0_delta_layers"
             );
         }
-
-        NUM_ONDISK_LAYERS.dec();
     }
 
     pub(self) fn replace_historic_noflush(

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -153,11 +153,7 @@ where
         expected: &Arc<L>,
         new: Arc<L>,
     ) -> anyhow::Result<Replacement<Arc<L>>> {
-        fail::fail_point!("layermap-replace-notfound", |_| Ok(
-            // this is not what happens if an L0 layer was not found a anyhow error but perhaps
-            // that should be changed. this is good enough to show a replacement failure.
-            Replacement::NotFound
-        ));
+        fail::fail_point!("layermap-replace-notfound", |_| Ok(Replacement::NotFound));
 
         self.layer_map.replace_historic_noflush(expected, new)
     }
@@ -337,12 +333,15 @@ where
 
         let l0_index = if expected_l0 {
             // find the index in case replace worked, we need to replace that as well
-            Some(
-                self.l0_delta_layers
-                    .iter()
-                    .position(|slot| Self::compare_arced_layers(slot, expected))
-                    .ok_or_else(|| anyhow::anyhow!("existing l0 delta layer was not found"))?,
-            )
+            let pos = self
+                .l0_delta_layers
+                .iter()
+                .position(|slot| Self::compare_arced_layers(slot, expected));
+
+            if pos.is_none() {
+                return Ok(Replacement::NotFound);
+            }
+            pos
         } else {
             None
         };

--- a/pageserver/src/tenant/measured_layer_map.rs
+++ b/pageserver/src/tenant/measured_layer_map.rs
@@ -50,15 +50,23 @@ pub struct BatchedUpdates<'a> {
 impl BatchedUpdates<'_> {
     /// See [layer_map::BatchedUpdates::insert_historic].
     pub fn insert_historic(&mut self, layer: Arc<dyn PersistentLayer>) {
+        let is_remote = layer.is_remote_layer();
+
         self.inner.insert_historic(layer);
 
-        NUM_ONDISK_LAYERS.inc();
+        if !is_remote {
+            NUM_ONDISK_LAYERS.inc();
+        }
     }
     /// See [layer_map::BatchedUpdates::remove_historic].
     pub fn remove_historic(&mut self, layer: Arc<dyn PersistentLayer>) {
+        let is_remote = layer.is_remote_layer();
+
         self.inner.remove_historic(layer);
 
-        NUM_ONDISK_LAYERS.dec();
+        if !is_remote {
+            NUM_ONDISK_LAYERS.dec();
+        }
     }
     /// See [layer_map::BatchedUpdates::replace_historic].
     pub fn replace_historic(

--- a/pageserver/src/tenant/measured_layer_map.rs
+++ b/pageserver/src/tenant/measured_layer_map.rs
@@ -58,6 +58,7 @@ impl BatchedUpdates<'_> {
             NUM_ONDISK_LAYERS.inc();
         }
     }
+
     /// See [layer_map::BatchedUpdates::remove_historic].
     pub fn remove_historic(&mut self, layer: Arc<dyn PersistentLayer>) {
         let is_remote = layer.is_remote_layer();
@@ -68,6 +69,7 @@ impl BatchedUpdates<'_> {
             NUM_ONDISK_LAYERS.dec();
         }
     }
+
     /// See [layer_map::BatchedUpdates::replace_historic].
     pub fn replace_historic(
         &mut self,
@@ -95,6 +97,7 @@ impl BatchedUpdates<'_> {
 
         Ok(res)
     }
+
     /// See [layer_map::BatchedUpdates::flush].
     pub fn flush(self) {
         self.inner.flush()

--- a/pageserver/src/tenant/measured_layer_map.rs
+++ b/pageserver/src/tenant/measured_layer_map.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::metrics::NUM_ONDISK_LAYERS;
 use crate::tenant::layer_map::{self, Replacement};
 use crate::tenant::storage_layer::PersistentLayer;
 
@@ -49,11 +50,15 @@ pub struct BatchedUpdates<'a> {
 impl BatchedUpdates<'_> {
     /// See [layer_map::BatchedUpdates::insert_historic].
     pub fn insert_historic(&mut self, layer: Arc<dyn PersistentLayer>) {
-        self.inner.insert_historic(layer)
+        self.inner.insert_historic(layer);
+
+        NUM_ONDISK_LAYERS.inc();
     }
     /// See [layer_map::BatchedUpdates::remove_historic].
     pub fn remove_historic(&mut self, layer: Arc<dyn PersistentLayer>) {
-        self.inner.remove_historic(layer)
+        self.inner.remove_historic(layer);
+
+        NUM_ONDISK_LAYERS.dec();
     }
     /// See [layer_map::BatchedUpdates::replace_historic].
     pub fn replace_historic(

--- a/pageserver/src/tenant/measured_layer_map.rs
+++ b/pageserver/src/tenant/measured_layer_map.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use crate::tenant::layer_map::{self, Replacement};
+use crate::tenant::storage_layer::PersistentLayer;
+
+/// Metrics updating wrapper around the real layermap.
+///
+/// The real layermap is needed to be generic over all layers to allow benchmarking and testing,
+/// but for real pageserver use we need only `dyn PersistentLayer`.
+///
+/// `Deref` and `DerefMut` delegate to original layer map, this type only implements the needed
+/// methods for metrics.
+///
+/// See [layer_map::LayerMap].
+#[derive(Default)]
+pub struct MeasuredLayerMap(layer_map::LayerMap<dyn PersistentLayer>);
+
+impl std::ops::Deref for MeasuredLayerMap {
+    type Target = layer_map::LayerMap<dyn PersistentLayer>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for MeasuredLayerMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl MeasuredLayerMap {
+    /// See [layer_map::LayerMap::batch_update].
+    pub fn batch_update(&mut self) -> BatchedUpdates<'_> {
+        BatchedUpdates {
+            inner: self.0.batch_update(),
+        }
+    }
+}
+
+/// See [layer_map::BatchedUpdates].
+///
+/// Wrapper for handling metric updates.
+#[must_use]
+pub struct BatchedUpdates<'a> {
+    inner: layer_map::BatchedUpdates<'a, dyn PersistentLayer>,
+}
+
+impl BatchedUpdates<'_> {
+    /// See [layer_map::BatchedUpdates::insert_historic].
+    pub fn insert_historic(&mut self, layer: Arc<dyn PersistentLayer>) {
+        self.inner.insert_historic(layer)
+    }
+    /// See [layer_map::BatchedUpdates::remove_historic].
+    pub fn remove_historic(&mut self, layer: Arc<dyn PersistentLayer>) {
+        self.inner.remove_historic(layer)
+    }
+    /// See [layer_map::BatchedUpdates::replace_historic].
+    pub fn replace_historic(
+        &mut self,
+        expected: &Arc<dyn PersistentLayer>,
+        new: Arc<dyn PersistentLayer>,
+    ) -> anyhow::Result<Replacement<Arc<dyn PersistentLayer>>> {
+        self.inner.replace_historic(expected, new)
+    }
+    /// See [layer_map::BatchedUpdates::flush].
+    pub fn flush(self) {
+        self.inner.flush()
+    }
+}

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -544,7 +544,7 @@ def test_compaction_downloads_on_demand_with_image_creation(
     """
     neon_env_builder.enable_remote_storage(
         remote_storage_kind=remote_storage_kind,
-        test_name="test_compaction_downloads_on_demand",
+        test_name="test_compaction_downloads_on_demand_with_image_creation",
     )
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -55,10 +55,10 @@ def test_tenant_creation_fails(neon_simple_env: NeonEnv):
 
 
 def test_tenants_normal_work(neon_env_builder: NeonEnvBuilder):
+    """Tests tenants with and without wal acceptors"""
     neon_env_builder.num_safekeepers = 3
 
     env = neon_env_builder.init_start()
-    """Tests tenants with and without wal acceptors"""
     tenant_1, _ = env.neon_cli.create_tenant()
     tenant_2, _ = env.neon_cli.create_tenant()
 


### PR DESCRIPTION
Current pageserver_ondisk_layers is wrong, see issue. To fix that, we need `trait PersistentLayer` in LayerMap. Solve this need by introducing a wrapper `MeasuredLayerMap` where the metrics are updated. Additionally an existing test which does evictions is modified to check this fixed metric (couldn't find an existing test case and nothing broke).

Additionally has three unrelated fixes.

Cc: #3705 (separate from adding a metric for remote layers)

