### PR TITLE
chore: clippies introduced in rust 1.68

### DIFF
--- a/libs/pq_proto/src/lib.rs
+++ b/libs/pq_proto/src/lib.rs
@@ -313,7 +313,7 @@ impl FeMessage {
                 b'f' => Ok(Some(FeMessage::CopyFail)),
                 b'p' => Ok(Some(FeMessage::PasswordMessage(body))),
                 tag => {
-                    return Err(ConnectionError::Protocol(format!(
+                    Err(ConnectionError::Protocol(format!(
                         "unknown message tag: {tag},'{body:?}'"
                     )))
                 }

--- a/libs/pq_proto/src/lib.rs
+++ b/libs/pq_proto/src/lib.rs
@@ -312,11 +312,9 @@ impl FeMessage {
                 b'c' => Ok(Some(FeMessage::CopyDone)),
                 b'f' => Ok(Some(FeMessage::CopyFail)),
                 b'p' => Ok(Some(FeMessage::PasswordMessage(body))),
-                tag => {
-                    Err(ConnectionError::Protocol(format!(
-                        "unknown message tag: {tag},'{body:?}'"
-                    )))
-                }
+                tag => Err(ConnectionError::Protocol(format!(
+                    "unknown message tag: {tag},'{body:?}'"
+                ))),
             }
         })
     }

--- a/libs/utils/src/fs_ext.rs
+++ b/libs/utils/src/fs_ext.rs
@@ -11,7 +11,7 @@ where
     P: AsRef<Path>,
 {
     fn is_empty_dir(&self) -> io::Result<bool> {
-        Ok(fs::read_dir(self)?.into_iter().next().is_none())
+        Ok(fs::read_dir(self)?.next().is_none())
     }
 }
 

--- a/libs/utils/src/postgres_backend_async.rs
+++ b/libs/utils/src/postgres_backend_async.rs
@@ -276,7 +276,10 @@ impl PostgresBackend {
         S: Future,
     {
         let ret = self.run_message_loop(handler, shutdown_watcher).await;
-        let _ = self.stream.shutdown();
+        let ignored = self.stream.shutdown().await;
+        if let Err(e) = ignored {
+            tracing::warn!("socket shutdown failed: {e:?}");
+        }
         ret
     }
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1243,11 +1243,11 @@ impl Tenant {
             "Cannot run GC iteration on inactive tenant"
         );
 
-        let gc_result = self
-            .gc_iteration_internal(target_timeline_id, horizon, pitr, ctx)
-            .await;
+        
 
-        gc_result
+        self
+            .gc_iteration_internal(target_timeline_id, horizon, pitr, ctx)
+            .await
     }
 
     /// Perform one compaction iteration.

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1243,10 +1243,7 @@ impl Tenant {
             "Cannot run GC iteration on inactive tenant"
         );
 
-        
-
-        self
-            .gc_iteration_internal(target_timeline_id, horizon, pitr, ctx)
+        self.gc_iteration_internal(target_timeline_id, horizon, pitr, ctx)
             .await
     }
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3147,9 +3147,7 @@ impl Timeline {
             }
 
             fail_point!("delta-layer-writer-fail-before-finish", |_| {
-                Err(
-                    anyhow::anyhow!("failpoint delta-layer-writer-fail-before-finish").into(),
-                )
+                Err(anyhow::anyhow!("failpoint delta-layer-writer-fail-before-finish").into())
             });
 
             writer.as_mut().unwrap().put_value(key, lsn, value)?;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3147,9 +3147,9 @@ impl Timeline {
             }
 
             fail_point!("delta-layer-writer-fail-before-finish", |_| {
-                return Err(
+                Err(
                     anyhow::anyhow!("failpoint delta-layer-writer-fail-before-finish").into(),
-                );
+                )
             });
 
             writer.as_mut().unwrap().put_value(key, lsn, value)?;

--- a/proxy/src/scram/messages.rs
+++ b/proxy/src/scram/messages.rs
@@ -14,7 +14,7 @@ pub const SCRAM_RAW_NONCE_LEN: usize = 18;
 fn validate_sasl_extensions<'a>(parts: impl Iterator<Item = &'a str>) -> Option<()> {
     for mut chars in parts.map(|s| s.chars()) {
         let attr = chars.next()?;
-        if !('a'..='z').contains(&attr) && !('A'..='Z').contains(&attr) {
+        if !attr.is_ascii_lowercase() && !attr.is_ascii_uppercase() {
             return None;
         }
         let eq = chars.next()?;


### PR DESCRIPTION
First commit is the automatically `--fix` ones, seemed quite straightforward.

Second commit is more interesting, seems we have forgotten to flush the socket on closing. I wonder if there have been some issues related to this? Perhaps a regression test could be created.