### PR TITLE
Fix allowed error again

### DIFF
--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -619,7 +619,7 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     log.info("sending delete request")
     checkpoint_allowed_to_fail.set()
     env.pageserver.allowed_errors.append(
-        ".+ERROR Error processing HTTP request: InternalServerError\\(timeline is Stopping"
+        ".+: Error processing HTTP request: InternalServerError\\(timeline is Stopping"
     )
     client.timeline_delete(tenant_id, timeline_id)
 

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -619,7 +619,7 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     log.info("sending delete request")
     checkpoint_allowed_to_fail.set()
     env.pageserver.allowed_errors.append(
-        ".+: Error processing HTTP request: InternalServerError\\(timeline is Stopping"
+        ".* ERROR .*Error processing HTTP request: InternalServerError\\(timeline is Stopping"
     )
     client.timeline_delete(tenant_id, timeline_id)
 


### PR DESCRIPTION
Fixes #3360 again, this time checking all other "Error processing HTTP request" messages and aligning the regex with the two others.

After this:

```
$ rg 'Error processing' test_runner/
test_runner/regress/test_remote_storage.py
622:        ".* ERROR .*Error processing HTTP request: InternalServerError\\(timeline is Stopping"

test_runner/regress/test_ondemand_download.py
693:        ".* ERROR .*Error processing HTTP request: InternalServerError\\(get local timeline info"

test_runner/fixtures/neon_fixtures.py
2081:            ".*Error processing HTTP request: Forbidden",
```