### PR TITLE
test: stricly find WARN, ERROR lines

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2155,7 +2155,7 @@ class NeonPageserver(PgProtocol):
 
     def assert_no_errors(self):
         logfile = open(os.path.join(self.env.repo_dir, "pageserver.log"), "r")
-        error_or_warn = re.compile("ERROR|WARN")
+        error_or_warn = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+(ERROR|WARN)")
         errors = []
         while True:
             line = logfile.readline()


### PR DESCRIPTION
this prevents flakyness when `WARN|ERROR` appears in some other part of the line, for example in a random filename, example: https://neon-github-public-dev.s3.amazonaws.com/reports/pr-3781/release/4403017929/index.html#suites/b97efae3a617afb71cb8142f5afa5224/307366134339ef79/:

```
AssertionError: assert not ['2023-03-13T08:59:41.054061Z  INFO request{method=PUT path=/v1/tenant/668abf460277c01ed6d9dd9bac485dc5/timeline/b90c1...b2a7e6/000000067F000032AC000040010000000200-000000067F000032AC000040010000000280__0000000003E6D958.q7WARNts.___temp\n']
```