### PR TITLE
test: allow gc to get unlucky

### DIFF
--- a/test_runner/regress/test_pageserver_restarts_under_workload.py
+++ b/test_runner/regress/test_pageserver_restarts_under_workload.py
@@ -20,7 +20,7 @@ def test_pageserver_restarts_under_worload(neon_simple_env: NeonEnv, pg_bin: PgB
     # the background task may complete the init task delay after finding an
     # active tenant, but shutdown starts right before Tenant::gc_iteration
     env.pageserver.allowed_errors.append(
-        r"Gc failed, retrying in \S+: Cannot run GC iteration on inactive tenant"
+        r".*Gc failed, retrying in \S+: Cannot run GC iteration on inactive tenant"
     )
 
     def run_pgbench(pg: Postgres):

--- a/test_runner/regress/test_pageserver_restarts_under_workload.py
+++ b/test_runner/regress/test_pageserver_restarts_under_workload.py
@@ -17,6 +17,12 @@ def test_pageserver_restarts_under_worload(neon_simple_env: NeonEnv, pg_bin: PgB
     n_restarts = 10
     scale = 10
 
+    # the background task may complete the init task delay after finding an
+    # active tenant, but shutdown starts right before Tenant::gc_iteration
+    env.pageserver.allowed_errors.append(
+        r"Gc failed, retrying in \S+: Cannot run GC iteration on inactive tenant"
+    )
+
     def run_pgbench(pg: Postgres):
         connstr = pg.connstr()
         log.info(f"Start a pgbench workload on pg {connstr}")


### PR DESCRIPTION
this failure case was probably introduced by b220ba6, because earlier the gc would always have run fast enough for restart every 1s. however, test got added later, so we have just been lucky.

fixes #3824 by allowing this error to happen.