### PR TITLE
Add local free space monitor

### DIFF
--- a/pgxn/neon/file_cache.c
+++ b/pgxn/neon/file_cache.c
@@ -211,7 +211,7 @@ FileCacheMonitorMain(Datum main_arg)
 {
 	/*
 	 * Choose file system state monitor interval so that space can not be exosted
-	 * during this period but not onger than  MAX_MONITOR_INTERVAL (10 sec)
+	 * during this period but not longer than  MAX_MONITOR_INTERVAL (10 sec)
 	 */
 	uint64 monitor_interval = Min(MAX_MONITOR_INTERVAL_USEC, lfc_free_space_watermark*MB/MAX_DISK_WRITE_RATE);
 

--- a/pgxn/neon/file_cache.c
+++ b/pgxn/neon/file_cache.c
@@ -94,7 +94,7 @@ static shmem_startup_hook_type prev_shmem_startup_hook;
 #if PG_VERSION_NUM>=150000
 static shmem_request_hook_type prev_shmem_request_hook;
 #endif
-static int   lfc_shrinking_factor; /* power of two by which local cache size will be srinked when lfc_free_space_watermark is reached */
+static int   lfc_shrinking_factor; /* power of two by which local cache size will be shrinked when lfc_free_space_watermark is reached */
 
 static void
 lfc_shmem_startup(void)

--- a/pgxn/neon/file_cache.c
+++ b/pgxn/neon/file_cache.c
@@ -199,7 +199,7 @@ lfc_change_limit_hook(int newval, void *extra)
  * First time low space watermark is reached cache size is divided by two,
  * second time by four,... Finally we remove all chunks from local cache.
  *
- * Please notie that we are not changing lfc_cache_size: it is used to be adjusted by autoscaler.
+ * Please notice that we are not changing lfc_cache_size: it is used to be adjusted by autoscaler.
  * We only throw away cached chunks but do not prevent from filling cache by new chunks.
  *
  * Interval of poooling cache state is calculated as minimal time needed to consume lfc_free_space_watermark


### PR DESCRIPTION
## Describe your changes

Monitor free spae in local file system and shrink local file cache size if it is under watermark.
Neon is using local storage for temp files (temp table + intermediate results), unlogged relations
and local file cache.

Ideally all space not used for temporary files should be used for local file cache.
Temporary files and even unlogged relation are intended to have small life time (because
them can be lost at  any moment in case of compute restart).

So the policy is to overcommit local cache size and shrink it if there is not enough  free space.
As far as temporary files are expected to be needed for a short time, there i no need
to permanently shrink local file cache size. Instead of it, we just throw away least recently accessed elements
from local file cache, releasing some space on the local disk.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

