### PR TITLE
refactor: abstraction for the below-threshold counter

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -197,7 +197,7 @@ static PERSISTENT_BYTES_WRITTEN: Lazy<IntCounterVec> = Lazy::new(|| {
 
 static EVICTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "pageserver_evictions_count",
+        "pageserver_evictions",
         "Number of layers evicted from the pageserver",
         &["tenant_id", "timeline_id"]
     )
@@ -206,7 +206,7 @@ static EVICTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
 
 static EVICTIONS_WITH_LOW_RESIDENCE_DURATION: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "pageserver_evictions_with_low_residence_duration_count",
+        "pageserver_evictions_with_low_residence_duration",
         "If a layer is evicted that was resident for less than `low_threshold`, it is counted to this counter. \
          Residence duration is determined using the `residence_duration_data_source`.",
         &["tenant_id", "timeline_id", "residence_duration_data_source", "low_threshold_secs"]

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -697,7 +697,7 @@ impl Drop for TimelineMetrics {
         let _ = PERSISTENT_BYTES_WRITTEN.remove_label_values(&[tenant_id, timeline_id]);
         let _ = EVICTIONS.remove_label_values(&[tenant_id, timeline_id]);
         self.evictions_with_low_residence_duration
-            .remove(&tenant_id, &timeline_id);
+            .remove(tenant_id, timeline_id);
         for op in STORAGE_TIME_OPERATIONS {
             let _ =
                 STORAGE_TIME_SUM_PER_TIMELINE.remove_label_values(&[op, tenant_id, timeline_id]);

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1112,9 +1112,9 @@ impl Timeline {
                 self.metrics.evictions.inc();
 
                 if let Some(delta) = local_layer_residence_duration {
-                    if delta < self.conf.evictions_low_residence_duration_metric_threshold {
-                        self.metrics.evictions_with_low_residence_duration.inc();
-                    }
+                    self.metrics
+                        .evictions_with_low_residence_duration
+                        .observe(delta);
                 }
 
                 true
@@ -1235,8 +1235,10 @@ impl Timeline {
                 metrics: TimelineMetrics::new(
                     &tenant_id,
                     &timeline_id,
-                    "mtime",
-                    conf.evictions_low_residence_duration_metric_threshold,
+                    crate::metrics::EvictionsWithLowResidenceDurationBuilder::new(
+                        "mtime",
+                        conf.evictions_low_residence_duration_metric_threshold,
+                    ),
                 ),
 
                 flush_loop_state: Mutex::new(FlushLoopState::NotStarted),

--- a/test_runner/fixtures/metrics.py
+++ b/test_runner/fixtures/metrics.py
@@ -78,7 +78,7 @@ PAGESERVER_PER_TENANT_METRICS: Tuple[str, ...] = (
     "pageserver_created_persistent_files_total",
     "pageserver_written_persistent_bytes_total",
     "pageserver_tenant_states_count",
-    "pageserver_evictions_count",
-    "pageserver_evictions_with_low_residence_duration_count",
+    "pageserver_evictions_total",
+    "pageserver_evictions_with_low_residence_duration_total",
     *PAGESERVER_PER_TENANT_REMOTE_TIMELINE_CLIENT_METRICS,
 )


### PR DESCRIPTION
This targets #3837 .
I didn't want to push there directly because I'm not sure this refactor is a net win.

---

This wraps the following aspects of the
evictions_with_low_residence_duration counter into an abstraction:

* observations are only counted if below threshold
  * Previously, this was done at the call site
* Adding the data source and threshold label values
* Removal of the metric values

It's a shame that the underlying `prometheus` library doesn't allow currying of the labels. We could turn this into a more generic abstraction otherwise.

Is this refactor a net win?
Pro: yes because it encapsulates above aspects.
No: not in line with how other metrics are done, they don't have their
    own wrapper type
