### PR TITLE
fix: less logging at shutdown

### DIFF
--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -485,7 +485,10 @@ pub async fn shutdown_tasks(
         };
         if let Some(mut join_handle) = join_handle {
             // let's see if test failures could be caused by allocating the timeout in most cases
-            if let Some(_) = futures::future::poll_immediate(&mut join_handle).await {
+            if futures::future::poll_immediate(&mut join_handle)
+                .await
+                .is_some()
+            {
                 return;
             }
 

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -485,13 +485,8 @@ pub async fn shutdown_tasks(
         };
         if let Some(mut join_handle) = join_handle {
             // let's see if test failures could be caused by allocating the timeout in most cases
-            match futures::future::poll_immediate(&mut join_handle).await {
-                Some(_) => {
-                    return;
-                }
-                None => {
-                    // lets allocate a timeout and then wait for it
-                }
+            if let Some(_) = futures::future::poll_immediate(&mut join_handle).await {
+                return;
             }
 
             let mut passed = false;

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -483,8 +483,7 @@ pub async fn shutdown_tasks(
             let mut task_mut = task.mutable.lock().unwrap();
             task_mut.join_handle.take()
         };
-        if let Some(join_handle) = join_handle {
-            tokio::pin!(join_handle);
+        if let Some(mut join_handle) = join_handle {
             let mut passed = false;
             loop {
                 tokio::select! {

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -484,6 +484,16 @@ pub async fn shutdown_tasks(
             task_mut.join_handle.take()
         };
         if let Some(mut join_handle) = join_handle {
+            // let's see if test failures could be caused by allocating the timeout in most cases
+            match futures::future::poll_immediate(&mut join_handle).await {
+                Some(_) => {
+                    return;
+                }
+                None => {
+                    // lets allocate a timeout and then wait for it
+                }
+            }
+
             let mut passed = false;
             loop {
                 tokio::select! {

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -489,13 +489,13 @@ pub async fn shutdown_tasks(
                 .await
                 .is_some()
             {
-                return;
+                continue;
             }
 
             let mut passed = false;
             loop {
                 tokio::select! {
-                    _ = &mut join_handle => { return; },
+                    _ = &mut join_handle => { continue; },
                     _ = tokio::time::sleep(std::time::Duration::from_secs(1)), if !passed => {
                         passed = true;
                         info!("waiting for {} to shut down", task.name);

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -495,7 +495,7 @@ pub async fn shutdown_tasks(
             let mut passed = false;
             loop {
                 tokio::select! {
-                    _ = &mut join_handle => { continue; },
+                    _ = &mut join_handle => { break; },
                     _ = tokio::time::sleep(std::time::Duration::from_secs(1)), if !passed => {
                         passed = true;
                         info!("waiting for {} to shut down", task.name);


### PR DESCRIPTION
Log less during shutdown; don't log anything for quickly (less than 1s) exiting tasks.