### PR TITLE
fix synthetic size for (last_record_lsn - gc_horizon) < initdb_lsn

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -586,7 +586,6 @@ pub struct TimelineMetrics {
     pub flush_time_histo: StorageTimeMetrics,
     pub compact_time_histo: StorageTimeMetrics,
     pub create_images_time_histo: StorageTimeMetrics,
-    pub init_logical_size_histo: StorageTimeMetrics,
     pub logical_size_histo: StorageTimeMetrics,
     pub load_layer_map_histo: StorageTimeMetrics,
     pub garbage_collect_histo: StorageTimeMetrics,
@@ -619,8 +618,6 @@ impl TimelineMetrics {
         let compact_time_histo = StorageTimeMetrics::new("compact", &tenant_id, &timeline_id);
         let create_images_time_histo =
             StorageTimeMetrics::new("create images", &tenant_id, &timeline_id);
-        let init_logical_size_histo =
-            StorageTimeMetrics::new("init logical size", &tenant_id, &timeline_id);
         let logical_size_histo = StorageTimeMetrics::new("logical size", &tenant_id, &timeline_id);
         let load_layer_map_histo =
             StorageTimeMetrics::new("load layer map", &tenant_id, &timeline_id);
@@ -657,7 +654,6 @@ impl TimelineMetrics {
             flush_time_histo,
             compact_time_histo,
             create_images_time_histo,
-            init_logical_size_histo,
             logical_size_histo,
             garbage_collect_histo,
             load_layer_map_histo,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -331,8 +331,8 @@ impl LogicalSize {
     /// Returns the initialized (already calculated) value, if any.
     fn initialized_size(&self, lsn: Lsn) -> Option<u64> {
         match self.initial_part_end {
-            Some(v) if v == lsn => return self.initial_logical_size.get().copied(),
-            _ => return None,
+            Some(v) if v == lsn => self.initial_logical_size.get().copied(),
+            _ => None,
         }
     }
 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -328,7 +328,8 @@ impl LogicalSize {
             .fetch_add(delta, AtomicOrdering::SeqCst);
     }
 
-    /// Returns the initialized (already calculated) value, if any.
+    /// Make the value computed by initial logical size computation
+    /// available for re-use. This doesn't contain the incremental part.
     fn initialized_size(&self, lsn: Lsn) -> Option<u64> {
         match self.initial_part_end {
             Some(v) if v == lsn => self.initial_logical_size.get().copied(),

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1911,7 +1911,7 @@ impl Timeline {
         });
         // See if we've already done the work for initial size calculation.
         // This is a short-cut for timelines that are mostly unused.
-        let timer = if let Some(size) = self.current_logical_size.initialized_size(up_to_lsn) {
+        if let Some(size) = self.current_logical_size.initialized_size(up_to_lsn) {
             if size != 0 {
                 // non-zero size means that the size has already been calculated by this method
                 // after startup. if the logical size is for a new timeline without layers the
@@ -1919,10 +1919,8 @@ impl Timeline {
                 // pageserver restart.
                 return Ok(size);
             }
-            self.metrics.init_logical_size_histo.start_timer()
-        } else {
-            self.metrics.logical_size_histo.start_timer()
-        };
+        }
+        let timer = self.metrics.logical_size_histo.start_timer();
         let logical_size = self
             .get_current_logical_size_non_incremental(up_to_lsn, cancel, ctx)
             .await?;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1913,13 +1913,7 @@ impl Timeline {
         // See if we've already done the work for initial size calculation.
         // This is a short-cut for timelines that are mostly unused.
         if let Some(size) = self.current_logical_size.initialized_size(up_to_lsn) {
-            if size != 0 {
-                // non-zero size means that the size has already been calculated by this method
-                // after startup. if the logical size is for a new timeline without layers the
-                // size will be zero, and we cannot use that, or this caching strategy until
-                // pageserver restart.
-                return Ok(size);
-            }
+            return Ok(size);
         }
         let timer = self.metrics.logical_size_histo.start_timer();
         let logical_size = self


### PR DESCRIPTION
fix synthetic size for (last_record_lsn - gc_horizon) < initdb_lsn

Assume a single-timeline project.
If the gc_horizon covers all WAL (last_record_lsn < gc_horizon)
but we have written more data than just initdb, the synthetic
size calculation worker needs to calculate the logical size
at LSN initdb_lsn (Segment BranchStart).

Before this patch, that calculation would incorrectly return
the initial logical size calculation result that we cache in
the Timeline::initial_logical_size. Presumably, because there
was confusion around initdb_lsn vs. initial size calculation.

The fix is to only hand out the initialized_size() only if
the LSN matches.

The distinction in the metrics between  "init logical size" and "logical size" was also incorrect because of the above. So, remove it.

There was a special case for `size != 0`. This was to cover the case of LogicalSize::empty_initial(), but `initial_part_end` is `None` in that case, so the new `LogicalSize::initialized_size()` will return None
in that case as well.

Lastly, to prevent confusion like this in the future, rename all occurrences of `init_lsn` to either just `lsn` or a more specific name.

Co-authored-by: Joonas Koivunen <joonas@neon.tech>
Co-authored-by: Heikki Linnakangas <heikki@neon.tech>