### PR TITLE
Revert "Add `neondatabase/release` team as a default reviewers for storage"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,3 @@ jobs:
         head: releases/${{ steps.date.outputs.date }}
         base: release
         title: Release ${{ steps.date.outputs.date }}
-        team_reviewers: release


### PR DESCRIPTION

This reverts commit daeaa767c405532f0c8bdb8a5765f0c13fd83aee.

## Describe your changes
Two times in a row release PRs weren't created after introducing these changes.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

