### PR TITLE
cancellation in continued anti redownload hacks

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1729,8 +1729,6 @@ impl Timeline {
             TaskKind::InitialLogicalSizeCalculation,
             DownloadBehavior::Download,
         );
-        let cancel = CancellationToken::new();
-        let _dg = cancel.clone().drop_guard();
         task_mgr::spawn(
             task_mgr::BACKGROUND_RUNTIME.handle(),
             task_mgr::TaskKind::InitialLogicalSizeCalculation,
@@ -1740,6 +1738,9 @@ impl Timeline {
             false,
             // NB: don't log errors here, task_mgr will do that.
             async move {
+                // no cancellation here, because nothing really waits for this to complete compared
+                // to spawn_ondemand_logical_size_calculation.
+                let cancel = CancellationToken::new();
                 let calculated_size = match self_clone
                     .logical_size_calculation_task(lsn, &background_ctx, cancel)
                     .await

--- a/pageserver/src/tenant/timeline/eviction_task.rs
+++ b/pageserver/src/tenant/timeline/eviction_task.rs
@@ -396,22 +396,24 @@ impl Timeline {
             .eviction_task_immitated_concurrent_logical_size_queries
             .inner();
 
-        // TODO(christian): `cancel` should be propagated through `ctx` so that all the
-        // ondemand size calculation tasks spawned by this get cancelled when
-        // `cancel.is_cancelled()`.
-        let _cancel = cancel;
         let mut throwaway_cache = HashMap::new();
-        let gather_result =
-            crate::tenant::size::gather_inputs(tenant, limit, None, &mut throwaway_cache, ctx)
-                .await;
-        match gather_result {
-            Ok(_) => {}
-            Err(e) => {
-                // We don't care about the result, but, if it failed, we should log it,
-                // since consumption metric might be hitting the cached value and
-                // thus not encountering this error.
-                warn!("failed to imitate synthetic size calculation accesses: {e:#}")
-            }
+        let gather =
+            crate::tenant::size::gather_inputs(tenant, limit, None, &mut throwaway_cache, ctx);
+        tokio::pin!(gather);
+
+        tokio::select! {
+            _ = cancel.cancelled() => {}
+            gather_result = gather => {
+                match gather_result {
+                    Ok(_) => {},
+                    Err(e) => {
+                        // We don't care about the result, but, if it failed, we should log it,
+                        // since consumption metric might be hitting the cached value and
+                        // thus not encountering this error.
+                        warn!("failed to imitate synthetic size calculation accesses: {e:#}")
+                    }
+                }
+           }
         }
     }
 }


### PR DESCRIPTION
One less ephemeral cancellation token, instead create one before spawning instead after spawning.

Re: https://github.com/neondatabase/neon/pull/3871#discussion_r1149396092