### PR TITLE
Rename neon_local sk logs s/safekeeper 1.log/safekeeper-1.log.

### DIFF
--- a/control_plane/src/safekeeper.rs
+++ b/control_plane/src/safekeeper.rs
@@ -163,7 +163,7 @@ impl SafekeeperNode {
         }
 
         background_process::start_process(
-            &format!("safekeeper {id}"),
+            &format!("safekeeper-{id}"),
             &datadir,
             &self.env.safekeeper_bin(),
             &args,


### PR DESCRIPTION
I don't like spaces in file names.