### PR TITLE
GitHub Actions: change S3 prefix for latest artifacts

### DIFF
--- a/.github/actions/download/action.yml
+++ b/.github/actions/download/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: false
     required: false
   prefix:
-    description: "S3 prefix. Default is '${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}'"
+    description: "S3 prefix. Default is 'artifacts/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}'"
     required: false
 
 runs:
@@ -26,7 +26,7 @@ runs:
         TARGET: ${{ inputs.path }}
         ARCHIVE: /tmp/downloads/${{ inputs.name }}.tar.zst
         SKIP_IF_DOES_NOT_EXIST: ${{ inputs.skip-if-does-not-exist }}
-        PREFIX: artifacts/${{ inputs.prefix || format('{0}/{1}', github.run_id, github.run_attempt) }}
+        PREFIX: ${{ inputs.prefix || format('artifacts/{0}/{1}', github.run_id, github.run_attempt) }}
       run: |
         BUCKET=neon-github-public-dev
         FILENAME=$(basename $ARCHIVE)

--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -61,7 +61,7 @@ runs:
       with:
         name: neon-${{ runner.os }}-${{ inputs.build_type }}-artifact
         path: /tmp/neon-previous
-        prefix: latest
+        prefix: latest-artifacts
 
     - name: Download compatibility snapshot for Postgres 14
       if: inputs.build_type != 'remote'
@@ -69,7 +69,7 @@ runs:
       with:
         name: compatibility-snapshot-${{ inputs.build_type }}-pg14
         path: /tmp/compatibility_snapshot_pg14
-        prefix: latest
+        prefix: latest-artifacts
 
     - name: Checkout
       if: inputs.needs_postgres_source == 'true'
@@ -187,7 +187,7 @@ runs:
         name: compatibility-snapshot-${{ inputs.build_type }}-pg14-${{ github.run_id }}
         # The path includes a test name (test_create_snapshot) and directory that the test creates (compatibility_snapshot_pg14), keep the path in sync with the test
         path: /tmp/test_output/test_create_snapshot/compatibility_snapshot_pg14/
-        prefix: latest
+        prefix: latest-artifacts
 
     - name: Create Allure report
       if: success() || failure()

--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: "A directory or file to upload"
     required: true
   prefix:
-    description: "S3 prefix. Default is '${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}'"
+    description: "S3 prefix. Default is 'artifacts/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}'"
     required: false
 
 runs:
@@ -45,7 +45,7 @@ runs:
       env:
         SOURCE: ${{ inputs.path }}
         ARCHIVE: /tmp/uploads/${{ inputs.name }}.tar.zst
-        PREFIX: artifacts/${{ inputs.prefix || format('{0}/{1}', github.run_id, github.run_attempt) }}
+        PREFIX: ${{ inputs.prefix || format('artifacts/{0}/{1}', github.run_id, github.run_attempt) }}
       run: |
         BUCKET=neon-github-public-dev
         FILENAME=$(basename $ARCHIVE)

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         name: neon-${{ runner.os }}-release-artifact
         path: /tmp/neon/
-        prefix: latest
+        prefix: latest-artifacts
 
     - name: Create Neon Project
       id: create-neon-project
@@ -152,7 +152,7 @@ jobs:
       with:
         name: neon-${{ runner.os }}-release-artifact
         path: /tmp/neon/
-        prefix: latest
+        prefix: latest-artifacts
 
     - name: Add Postgres binaries to PATH
       run: |
@@ -309,7 +309,7 @@ jobs:
       with:
         name: neon-${{ runner.os }}-release-artifact
         path: /tmp/neon/
-        prefix: latest
+        prefix: latest-artifacts
 
     - name: Add Postgres binaries to PATH
       run: |
@@ -420,7 +420,7 @@ jobs:
       with:
         name: neon-${{ runner.os }}-release-artifact
         path: /tmp/neon/
-        prefix: latest
+        prefix: latest-artifacts
 
     - name: Add Postgres binaries to PATH
       run: |
@@ -525,7 +525,7 @@ jobs:
       with:
         name: neon-${{ runner.os }}-release-artifact
         path: /tmp/neon/
-        prefix: latest
+        prefix: latest-artifacts
 
     - name: Add Postgres binaries to PATH
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -921,7 +921,7 @@ jobs:
       - name: Promote compatibility snapshot for the release
         env:
           BUCKET: neon-github-public-dev
-          PREFIX: artifacts/latest
+          PREFIX: latest-artifacts
         run: |
           # Update compatibility snapshot for the release
           for build_type in debug release; do


### PR DESCRIPTION
## Describe your changes

We store the latest version of artifacts (latest release) on s3 in `artifacts/latest`. Apart from this, we keep all build artifacts in `artifacts/${GITHUB_RUN_ID}`.
Having such structure makes it complicated to have a terraform s3 lifecycle rule for deleting old artifacts.
I suggest moving `artifacts/latest` to `latest-artifacts` prefix (I've copied the current version of the latest artifacts to make old and new code work)

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

