### PR TITLE
test suite: refactor: make initial_tenant optional

### DIFF
--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -618,7 +618,9 @@ fn handle_pg(pg_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<()> {
                 .copied()
                 .context("Failed to parse postgres version from the argument string")?;
 
-            cplane.new_node(tenant_id, &node_name, timeline_id, lsn, port, pg_version)?;
+            let node =
+                cplane.new_node(tenant_id, &node_name, timeline_id, lsn, port, pg_version)?;
+            println!("{}", node.pgdata().display());
         }
         "start" => {
             let port: Option<u16> = sub_args.get_one::<u16>("port").copied();

--- a/test_runner/regress/test_neon_local_cli.py
+++ b/test_runner/regress/test_neon_local_cli.py
@@ -5,10 +5,9 @@ from fixtures.neon_fixtures import NeonEnvBuilder, PortDistributor
 # Repeats the example from README.md as close as it can
 def test_neon_cli_basics(neon_env_builder: NeonEnvBuilder, port_distributor: PortDistributor):
     env = neon_env_builder.init_configs()
-    # Skipping the init step that creates a local tenant in Pytest tests
     try:
         env.neon_cli.start()
-        env.neon_cli.create_tenant(tenant_id=env.initial_tenant, set_default=True)
+        env.neon_cli.create_tenant(set_default=True)
         env.neon_cli.pg_start(node_name="main", port=port_distributor.get_port())
 
         env.neon_cli.create_branch(new_branch_name="migration_check")


### PR DESCRIPTION
This patch makes the creation of the initial tenant & timeline optional. The motivation was https://github.com/neondatabase/neon/pull/3905#discussion_r1153627388

However, most existing tests require the env.initial_tenant. We don't want to change all of these here.

So, the apporach taken here is to make NeonEnv a subclass of NeonEnvWithoutInitialTenant. It's not a proper subclass, but more of wrapper type. Hence the __new__ hackery.
I guess this is a bad substitute for a Rust newtype + Deref impl.

The initial tenant & timeline are created in NeonEnv, and the tenant is set as default (`--set-default`).

We rely more on that default than before. Specifically, all neon_local invocation that previously used
  "--tenant-id", (tenant_id if tenant_id is not None else env.initial_tenant)
now do
  *(["--tenant-id", tenant_id] if tenant_id is not None else [])

The only real trouble with that was `Postgres` class's `pgdata_dir` member. I solved this by making `neon_local pg create` return the PGDATA dir path, instead of pre-computing it in Python. A net win, I think.
