### PR TITLE
fix: metric used for alerting threshold on staging

### DIFF
--- a/.github/ansible/staging.eu-west-1.hosts.yaml
+++ b/.github/ansible/staging.eu-west-1.hosts.yaml
@@ -8,6 +8,7 @@ storage:
       pg_distrib_dir: /usr/local
       metric_collection_endpoint: http://neon-internal-api.aws.neon.build/billing/api/v1/usage_events
       metric_collection_interval: 10min
+      evictions_low_residence_duration_metric_threshold: "20m"
       disk_usage_based_eviction:
         max_usage_pct: 80
         # TODO: learn typical resident-size growth rate [GiB/minute] and configure

--- a/.github/ansible/staging.us-east-2.hosts.yaml
+++ b/.github/ansible/staging.us-east-2.hosts.yaml
@@ -8,6 +8,7 @@ storage:
       pg_distrib_dir: /usr/local
       metric_collection_endpoint: http://neon-internal-api.aws.neon.build/billing/api/v1/usage_events
       metric_collection_interval: 10min
+      evictions_low_residence_duration_metric_threshold: "20m"
       disk_usage_based_eviction:
         max_usage_pct: 80
         # TODO: learn typical resident-size growth rate [GiB/minute] and configure


### PR DESCRIPTION
This should remove the too eager alerts from staging.

Difficulty with this setting is that it needs to be kept in sync with the eviction task config.. Unsure where that should be documented, because even we forgot it.
