### PR TITLE
add gauge for in-flight layer uploads

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -853,7 +853,7 @@ impl RemoteTimelineClientMetrics {
 
 #[cfg(test)]
 impl RemoteTimelineClientMetrics {
-    pub fn test_get_bytes_unfinished_gauge_value(
+    pub fn get_bytes_unfinished_gauge_value(
         &self,
         file_kind: &RemoteOpFileKind,
         op_kind: &RemoteOpKind,

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -850,23 +850,23 @@ impl RemoteTimelineClientMetrics {
         file_kind: &RemoteOpFileKind,
         op_kind: &RemoteOpKind,
     ) -> RemoteTimelineClientCallMetricGuard {
-        let unfinished_metric = self.calls_unfinished_gauge(file_kind, op_kind);
+        let calls_unfinished_metric = self.calls_unfinished_gauge(file_kind, op_kind);
         self.calls_started_hist(file_kind, op_kind)
-            .observe(unfinished_metric.get() as f64);
-        unfinished_metric.inc();
-        RemoteTimelineClientCallMetricGuard(Some(unfinished_metric))
+            .observe(calls_unfinished_metric.get() as f64);
+        calls_unfinished_metric.inc();
+        RemoteTimelineClientCallMetricGuard(Some(calls_unfinished_metric))
     }
 
     /// Manually decrement the metric instead of using the guard object.
     /// Using the guard object is generally preferable.
     /// See [`call_begin`] for more context.
     pub(crate) fn call_end(&self, file_kind: &RemoteOpFileKind, op_kind: &RemoteOpKind) {
-        let unfinished_metric = self.calls_unfinished_gauge(file_kind, op_kind);
+        let calls_unfinished_metric = self.calls_unfinished_gauge(file_kind, op_kind);
         debug_assert!(
-            unfinished_metric.get() > 0,
+            calls_unfinished_metric.get() > 0,
             "begin and end should cancel out"
         );
-        unfinished_metric.dec();
+        calls_unfinished_metric.dec();
     }
 }
 

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -913,7 +913,7 @@ impl RemoteTimelineClientMetrics {
 pub(crate) struct RemoteTimelineClientCallMetricGuard {
     /// Decremented on drop.
     calls_unfinished_metric: Option<IntGauge>,
-    /// If Some(), this references the bytes_finished metric, and we increment it by the given `i64` on drop.
+    /// If Some(), this references the bytes_finished metric, and we increment it by the given `u64` on drop.
     bytes_finished: Option<(IntCounter, u64)>,
 }
 

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -851,6 +851,19 @@ impl RemoteTimelineClientMetrics {
     }
 }
 
+#[cfg(test)]
+impl RemoteTimelineClientMetrics {
+    pub fn test_get_bytes_unfinished_gauge_value(
+        &self,
+        file_kind: &RemoteOpFileKind,
+        op_kind: &RemoteOpKind,
+    ) -> Option<i64> {
+        let guard = self.bytes_unfinished_gauge.lock().unwrap();
+        let key = (file_kind.as_str(), op_kind.as_str());
+        guard.get(&key).map(|gauge| gauge.get())
+    }
+}
+
 /// See [`RemoteTimelineClientMetrics::call_begin`].
 #[must_use]
 pub(crate) struct RemoteTimelineClientCallMetricGuard {

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -918,10 +918,9 @@ pub(crate) struct RemoteTimelineClientCallMetricGuard {
 }
 
 impl RemoteTimelineClientCallMetricGuard {
-    /// Consume this guard object without decrementing the metric.
-    /// The caller vouches to do this manually, so that the prior increment of the gauge will cancel out.
+    /// Consume this guard object without performing the metric updates it would do on `drop()`.
+    /// The caller vouches to do the metric updates manually.
     pub fn will_decrement_manually(mut self) {
-        // prevent drop() from decrementing
         let RemoteTimelineClientCallMetricGuard {
             calls_unfinished_metric,
             bytes_finished,
@@ -958,9 +957,9 @@ pub(crate) enum RemoteTimelineClientMetricsCallTrackSize {
 }
 
 impl RemoteTimelineClientMetrics {
-    /// Increment the metrics that track ongoing calls to the remote timeline client instance.
+    /// Update the metrics that change when a call to the remote timeline client instance starts.
     ///
-    /// Drop the returned guard object once the operation is finished to decrement the values.
+    /// Drop the returned guard object once the operation is finished to updates corresponding metrics that track completions.
     /// Or, use [`RemoteTimelineClientCallMetricGuard::will_decrement_manually`] and [`call_end`] if that
     /// is more suitable.
     /// Never do both.
@@ -992,7 +991,7 @@ impl RemoteTimelineClientMetrics {
         }
     }
 
-    /// Manually decrement the metric instead of using the guard object.
+    /// Manually udpate the metrics that track completions, instead of using the guard object.
     /// Using the guard object is generally preferable.
     /// See [`call_begin`] for more context.
     pub(crate) fn call_end(

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -219,7 +219,7 @@ use utils::lsn::Lsn;
 
 use crate::metrics::{
     MeasureRemoteOp, RemoteOpFileKind, RemoteOpKind, RemoteTimelineClientMetrics,
-    RemoteTimelineMetricCallTrackSize, REMOTE_ONDEMAND_DOWNLOADED_BYTES,
+    RemoteTimelineClientMetricsCallTrackSize, REMOTE_ONDEMAND_DOWNLOADED_BYTES,
     REMOTE_ONDEMAND_DOWNLOADED_LAYERS,
 };
 use crate::tenant::remote_timeline_client::index::LayerFileMetadata;
@@ -371,7 +371,7 @@ impl RemoteTimelineClient {
         let _unfinished_gauge_guard = self.metrics.call_begin(
             &RemoteOpFileKind::Index,
             &RemoteOpKind::Download,
-            crate::metrics::RemoteTimelineMetricCallTrackSize::DontCreateMetric {
+            crate::metrics::RemoteTimelineClientMetricsCallTrackSize::DontTrackSize {
                 reason: "no need for a downloads gauge",
             },
         );
@@ -406,7 +406,7 @@ impl RemoteTimelineClient {
             let _unfinished_gauge_guard = self.metrics.call_begin(
                 &RemoteOpFileKind::Layer,
                 &RemoteOpKind::Download,
-                crate::metrics::RemoteTimelineMetricCallTrackSize::DontCreateMetric {
+                crate::metrics::RemoteTimelineClientMetricsCallTrackSize::DontTrackSize {
                     reason: "no need for a downloads gauge",
                 },
             );
@@ -898,26 +898,26 @@ impl RemoteTimelineClient {
     ) -> Option<(
         RemoteOpFileKind,
         RemoteOpKind,
-        RemoteTimelineMetricCallTrackSize,
+        RemoteTimelineClientMetricsCallTrackSize,
     )> {
-        use RemoteTimelineMetricCallTrackSize::DontCreateMetric;
+        use RemoteTimelineClientMetricsCallTrackSize::DontTrackSize;
         let res = match op {
             UploadOp::UploadLayer(_, m) => (
                 RemoteOpFileKind::Layer,
                 RemoteOpKind::Upload,
-                RemoteTimelineMetricCallTrackSize::Bytes(m.file_size().try_into().unwrap()),
+                RemoteTimelineClientMetricsCallTrackSize::Bytes(m.file_size().try_into().unwrap()),
             ),
             UploadOp::UploadMetadata(_, _) => (
                 RemoteOpFileKind::Index,
                 RemoteOpKind::Upload,
-                DontCreateMetric {
+                DontTrackSize {
                     reason: "metadata uploads are tiny",
                 },
             ),
             UploadOp::Delete(file_kind, _) => (
                 *file_kind,
                 RemoteOpKind::Delete,
-                DontCreateMetric {
+                DontTrackSize {
                     reason: "should we track deletes? positive or negative sign?",
                 },
             ),

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -905,7 +905,7 @@ impl RemoteTimelineClient {
             UploadOp::UploadLayer(_, m) => (
                 RemoteOpFileKind::Layer,
                 RemoteOpKind::Upload,
-                RemoteTimelineClientMetricsCallTrackSize::Bytes(m.file_size().try_into().unwrap()),
+                RemoteTimelineClientMetricsCallTrackSize::Bytes(m.file_size()),
             ),
             UploadOp::UploadMetadata(_, _) => (
                 RemoteOpFileKind::Index,

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1322,7 +1322,7 @@ mod tests {
 
         let queued = client
             .metrics
-            .test_get_bytes_unfinished_gauge_value(&RemoteOpFileKind::Layer, &RemoteOpKind::Upload)
+            .get_bytes_unfinished_gauge_value(&RemoteOpFileKind::Layer, &RemoteOpKind::Upload)
             .expect("scheduling the layer file upload should have added to the gauge");
         assert_eq!(queued, content_1.len() as i64);
 
@@ -1330,7 +1330,7 @@ mod tests {
 
         let after_completion = client
             .metrics
-            .test_get_bytes_unfinished_gauge_value(&RemoteOpFileKind::Layer, &RemoteOpKind::Upload)
+            .get_bytes_unfinished_gauge_value(&RemoteOpFileKind::Layer, &RemoteOpKind::Upload)
             .unwrap();
         assert_eq!(after_completion, 0);
 

--- a/test_runner/fixtures/metrics.py
+++ b/test_runner/fixtures/metrics.py
@@ -45,6 +45,7 @@ PAGESERVER_PER_TENANT_REMOTE_TIMELINE_CLIENT_METRICS: Tuple[str, ...] = (
     *[f"pageserver_remote_timeline_client_calls_started_{x}" for x in ["bucket", "count", "sum"]],
     *[f"pageserver_remote_operation_seconds_{x}" for x in ["bucket", "count", "sum"]],
     "pageserver_remote_physical_size",
+    "pageserver_remote_timeline_client_bytes_unfinished",
 )
 
 PAGESERVER_GLOBAL_METRICS: Tuple[str, ...] = (

--- a/test_runner/fixtures/metrics.py
+++ b/test_runner/fixtures/metrics.py
@@ -45,7 +45,8 @@ PAGESERVER_PER_TENANT_REMOTE_TIMELINE_CLIENT_METRICS: Tuple[str, ...] = (
     *[f"pageserver_remote_timeline_client_calls_started_{x}" for x in ["bucket", "count", "sum"]],
     *[f"pageserver_remote_operation_seconds_{x}" for x in ["bucket", "count", "sum"]],
     "pageserver_remote_physical_size",
-    "pageserver_remote_timeline_client_bytes_unfinished",
+    "pageserver_remote_timeline_client_bytes_started_total",
+    "pageserver_remote_timeline_client_bytes_finished_total",
 )
 
 PAGESERVER_GLOBAL_METRICS: Tuple[str, ...] = (


### PR DESCRIPTION
For the "worst-case /storage usage panel", we need to compute
```
remote size + local-only size
```

We currently don't have a metric for local-only layers.

The number of in-flight layers in the upload queue is just that, so, let Prometheus scrape it.

The metric is two counters (started and finished).
The delta is the amount of in-flight uploads in the queue.

The metrics are incremented in the respective `call_unfinished_metric_*` functions.
These track ongoing operations by file_kind and op_kind.
We only need this metric for layer uploads, so, there's the new RemoteTimelineClientMetricsCallTrackSize type that forces all call sites to decide whether they want the size tracked or not.
If we find that other file_kinds or op_kinds are interesting (metadata uploads, layer downloads, layer deletes) are interesting, we can just enable them, and they'll be just another label combination within the metrics that this PR adds.

fixes https://github.com/neondatabase/neon/issues/3922
