### PR TITLE
GitHub Autocomment: Retry on server errors

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -409,6 +409,8 @@ jobs:
             steps.create-allure-report-release.outputs.report-url
           )
         with:
+          # Retry script for 5XX server errors: https://github.com/actions/github-script#retries
+          retries: 5
           script: |
             const reports = [{
               buildType: "debug",


### PR DESCRIPTION
Retry posting/updating a comment in case of 5XX errors from GitHub API

Ref https://github.com/neondatabase/neon/actions/runs/4619261006/jobs/8168123155?pr=3954