### PR TITLE
test_runner: add links to grafana for remote tests

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -17,6 +17,7 @@ import uuid
 from collections import defaultdict
 from contextlib import closing, contextmanager
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Flag, auto
 from functools import cached_property
 from itertools import chain, product
@@ -48,6 +49,7 @@ from fixtures.types import Lsn, TenantId, TimelineId
 from fixtures.utils import (
     ATTACHMENT_NAME_REGEX,
     Fn,
+    allure_add_grafana_links,
     allure_attach_from_dir,
     get_self_dir,
     subprocess_capture,
@@ -2436,9 +2438,14 @@ def remote_pg(
     connstr = os.getenv("BENCHMARK_CONNSTR")
     if connstr is None:
         raise ValueError("no connstr provided, use BENCHMARK_CONNSTR environment variable")
-
+    start_ms = int(datetime.timestamp(datetime.now(timezone.utc)) * 1000)
     with RemotePostgres(pg_bin, connstr) as remote_pg:
         yield remote_pg
+
+    end_ms = int(datetime.timestamp(datetime.now(timezone.utc)) * 1000)
+    host = parse_dsn(connstr).get("host", "")
+    if host.endswith(".neon.build"):
+        allure_add_grafana_links(host, start_ms, end_ms)
 
 
 class PSQL:

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -17,7 +17,7 @@ import uuid
 from collections import defaultdict
 from contextlib import closing, contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Flag, auto
 from functools import cached_property
 from itertools import chain, product
@@ -2438,14 +2438,15 @@ def remote_pg(
     connstr = os.getenv("BENCHMARK_CONNSTR")
     if connstr is None:
         raise ValueError("no connstr provided, use BENCHMARK_CONNSTR environment variable")
-    start_ms = int(datetime.timestamp(datetime.now(timezone.utc)) * 1000)
+    start_ms = int(datetime.utcnow().timestamp() * 1000)
     with RemotePostgres(pg_bin, connstr) as remote_pg:
         yield remote_pg
 
-    end_ms = int(datetime.timestamp(datetime.now(timezone.utc)) * 1000)
+    end_ms = int(datetime.utcnow().timestamp() * 1000)
     host = parse_dsn(connstr).get("host", "")
     if host.endswith(".neon.build"):
-        allure_add_grafana_links(host, start_ms, end_ms)
+        # Add 10s margin to the start and end times
+        allure_add_grafana_links(host, start_ms - 10_000, end_ms + 10_000)
 
 
 class PSQL:

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -186,15 +186,14 @@ def allure_attach_from_dir(dir: Path):
             allure.attach.file(source, name, attachment_type, extension)
 
 
+DATASOURCE_ID = "xHHYY0dVz"
+
+
 def allure_add_grafana_links(host: str, start_ms: int, end_ms: int):
     """Add links to server logs in Grafana to Allure report"""
     # We expect host to be in format like ep-divine-night-159320.us-east-2.aws.neon.build
-    endpoint_id, region_id, *_ = host.split(".")
-    # Add 10s margin to the start and end times
-    start_ms_str = str(start_ms - 10_000)
-    end_ms_str = str(end_ms + 10_000)
+    endpoint_id, region_id, _ = host.split(".", 2)
 
-    datasource = "xHHYY0dVz"
     expressions = {
         "compute logs": f'{{app="compute-node-{endpoint_id}", neon_region="{region_id}"}}',
         "k8s events": f'{{job="integrations/kubernetes/eventhandler"}} |~ "name=compute-node-{endpoint_id}-"',
@@ -203,19 +202,19 @@ def allure_add_grafana_links(host: str, start_ms: int, end_ms: int):
     }
 
     params: Dict[str, Any] = {
-        "datasource": datasource,
+        "datasource": DATASOURCE_ID,
         "queries": [
             {
                 "expr": "<PUT AN EXPRESSION HERE>",
                 "refId": "A",
-                "datasource": {"type": "loki", "uid": datasource},
+                "datasource": {"type": "loki", "uid": DATASOURCE_ID},
                 "editorMode": "code",
                 "queryType": "range",
             }
         ],
         "range": {
-            "from": start_ms_str,
-            "to": end_ms_str,
+            "from": str(start_ms),
+            "to": str(end_ms),
         },
     }
     for name, expr in expressions.items():


### PR DESCRIPTION
## Describe your changes
Add Grafana links to the allure report to make it easier to debug perf test failures

- [Example in logs](https://github.com/neondatabase/neon/actions/runs/4627776430/jobs/8186091457#step:9:252)
- [Example in allure report](https://neon-github-public-dev.s3.amazonaws.com/reports/branch-bayandin-add-grafana-links-to-test-results/remote/4627776430/index.html#suites/5008d72a1ba3c0d618a030a938fc035c/928f1cee4ab72524/) 

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
