### PR TITLE
Allow installation of `pg_stat_statements`

### DIFF
--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -38,6 +38,7 @@ RUN cd postgres && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/insert_username.control && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/intagg.control && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/moddatetime.control && \
+    echo 'trusted = true' >> /usr/local/pgsql/share/extension/pg_stat_statements.control && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/pgrowlocks.control && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/pgstattuple.control && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/refint.control && \


### PR DESCRIPTION
## Describe your changes
There are a lot of requests for this extension. Previously, we agreed to add well-known extensions by default into `shared_preload_libraries`. So, I went ahead and removed the logic that installed this extension when the feature flag was set.

## Issue ticket number and link
After releasing this PR to prod, we need to change the logic in the control plane where this library will be added in the `shared_preload_libraries` setting by default. ~~It requires a two-phase release.~~ I was wrong because we have this extension on production. It is mostly valid for public announce. That we can share this info only after having both PRs on production

neondatabase/cloud#4579

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
