### PR TITLE
Refactor 'spec' in ComputeState.

### DIFF
--- a/compute_tools/src/http/api.rs
+++ b/compute_tools/src/http/api.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::thread;
 
-use crate::compute::{ComputeNode, ComputeState};
+use crate::compute::{ComputeNode, ComputeState, ParsedSpec};
 use compute_api::requests::ConfigurationRequest;
 use compute_api::responses::{ComputeStatus, ComputeStatusResponse, GenericAPIError};
 
@@ -18,8 +18,8 @@ use tracing_utils::http::OtelName;
 
 fn status_response_from_state(state: &ComputeState) -> ComputeStatusResponse {
     ComputeStatusResponse {
-        tenant: state.tenant.clone(),
-        timeline: state.timeline.clone(),
+        tenant: state.pspec.as_ref().map(|pspec| pspec.tenant.clone()),
+        timeline: state.pspec.as_ref().map(|pspec| pspec.timeline.clone()),
         status: state.status,
         last_active: state.last_active,
         error: state.error.clone(),
@@ -135,6 +135,12 @@ async fn handle_configure_request(
     let spec_raw = String::from_utf8(body_bytes.to_vec()).unwrap();
     if let Ok(request) = serde_json::from_str::<ConfigurationRequest>(&spec_raw) {
         let spec = request.spec;
+
+        let parsed_spec = match ParsedSpec::try_from(spec) {
+            Ok(ps) => ps,
+            Err(msg) => return Err((msg, StatusCode::PRECONDITION_FAILED)),
+        };
+
         // XXX: wrap state update under lock in code blocks. Otherwise,
         // we will try to `Send` `mut state` into the spawned thread
         // bellow, which will cause error:
@@ -150,7 +156,7 @@ async fn handle_configure_request(
                 );
                 return Err((msg, StatusCode::PRECONDITION_FAILED));
             }
-            state.spec = spec;
+            state.pspec = Some(parsed_spec);
             state.status = ComputeStatus::ConfigurationPending;
             compute.state_changed.notify_all();
             drop(state);

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -12,8 +12,8 @@ pub struct GenericAPIError {
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct ComputeStatusResponse {
-    pub tenant: String,
-    pub timeline: String,
+    pub tenant: Option<String>,
+    pub timeline: Option<String>,
     pub status: ComputeStatus,
     #[serde(serialize_with = "rfc3339_serialize")]
     pub last_active: DateTime<Utc>,


### PR DESCRIPTION
Sometimes, it contained real values, sometimes just defaults if the spec was not received yet. Make the state more clear by making it an Option instead.

One consequence is that if some of the required settings like neon.tenant_id are missing from the spec file sent to the /configure endpoint, it is spotted earlier and you get an immediate HTTP error response. Not that it matters very much, but it's nicer nevertheless.
