### PR TITLE
Issue #3748: changed pageserver_tenant_synthetic_size to pageserver_tenant_synthetic_cached_size_bytes

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -167,11 +167,11 @@ pub static TENANT_STATE_METRIC: Lazy<UIntGaugeVec> = Lazy::new(|| {
 
 pub static TENANT_SYNTHETIC_SIZE_METRIC: Lazy<UIntGaugeVec> = Lazy::new(|| {
     register_uint_gauge_vec!(
-        "pageserver_tenant_synthetic_size",
+        "pageserver_tenant_synthetic_cached_size_bytes",
         "Synthetic size of each tenant",
         &["tenant_id"]
     )
-    .expect("Failed to register pageserver_tenant_synthetic_size metric")
+    .expect("Failed to register pageserver_tenant_synthetic_cached_size_bytes metric")
 });
 
 // Metrics for cloud upload. These metrics reflect data uploaded to cloud storage,


### PR DESCRIPTION

## Describe your changes
Changed ```pageserver_tenant_synthetic_size``` to ```pageserver_tenant_synthetic_cached_size_bytes``` in ```pageserver/src/metrics.rs``` to better elaborate the unit and non-incremental nature (i.e., cached size) of the variable being measured.

## Issue ticket number and link
#3748 
https://github.com/neondatabase/neon/issues/3748