### PR TITLE
Support aarch64 in walredo seccomp code

### DIFF
--- a/pgxn/neon_walredo/seccomp.c
+++ b/pgxn/neon_walredo/seccomp.c
@@ -12,9 +12,10 @@
  * This code is intended to support both x86_64 and aarch64. The latter
  * doesn't implement some syscalls like open and select. We allow both
  * select (absent on aarch64) and pselect6 (present on both architectures)
- * Since we don't call select syscall directly we may expect that libc will
- * call pselect6 on aarch64. One may check syscalls presense on a certain
- * architecture using `scmp_sys_resolver` tool from seccomp package.
+ * We call select(2) through libc, and the libc wrapper calls select or pselect6
+ * depending on the architecture. You can check which syscalls are present on
+ * different architectures with the `scmp_sys_resolver` tool from the
+ * seccomp package.
  *
  * We use this mode to disable all syscalls not in the allowlist. This
  * approach has its pros & cons:


### PR DESCRIPTION
Aarch64 doesn't implement some old syscalls like open and select. Use openat instead of open to check if seccomp is supported. Leave both select and pselect6 in the allowlist since we don't call select syscall directly and may hope that libc will call pselect6 on aarch64.

To check whether some syscall is supported it is possible to use `scmp_sys_resolver` from seccopm package:

```
> apt install seccopm
> scmp_sys_resolver -a x86_64 select
23
> scmp_sys_resolver -a aarch64 select
-10101
> scmp_sys_resolver -a aarch64 pselect6
72
```

Negative value means that syscall is not supported.

Another cross-check is to look up for the actuall syscall table in `unistd.h`. To resolve all the macroses one can use `gcc -E` as it is done in `dump_sys_aarch64()` function in libseccomp/src/arch-syscall-validate.
