### PR TITLE
Support read-only computes in 'compute_ctl'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "utils",
  "workspace_hack",
 ]
 

--- a/libs/compute_api/Cargo.toml
+++ b/libs/compute_api/Cargo.toml
@@ -11,4 +11,5 @@ serde.workspace = true
 serde_with.workspace = true
 serde_json.workspace = true
 
+utils = { path = "../utils" }
 workspace_hack.workspace = true


### PR DESCRIPTION
Extracted from PR #3886 for more visibility.

There are no tests included in this PR, but after PR #3886, this will be exercised by all the current python tests that we have for read-only nodes.
