### PR TITLE
test_runner: add --pg-version pytest argument

### DIFF
--- a/test_runner/README.md
+++ b/test_runner/README.md
@@ -71,7 +71,8 @@ a subdirectory for each version with naming convention `v{PG_VERSION}/`.
 Inside that dir, a `bin/postgres` binary should be present.
 `DEFAULT_PG_VERSION`: The version of Postgres to use,
 This is used to construct full path to the postgres binaries.
-Format is 2-digit major version nubmer, i.e. `DEFAULT_PG_VERSION="14"`
+Format is 2-digit major version nubmer, i.e. `DEFAULT_PG_VERSION="14"`. Alternatively,
+you can use `--pg-version` argument.
 `TEST_OUTPUT`: Set the directory where test state and test output files
 should go.
 `TEST_SHARED_FIXTURES`: Try to re-use a single pageserver for all the tests.

--- a/test_runner/conftest.py
+++ b/test_runner/conftest.py
@@ -1,4 +1,5 @@
 pytest_plugins = (
+    "fixtures.pg_version",
     "fixtures.neon_fixtures",
     "fixtures.benchmark_fixture",
     "fixtures.pg_stats",

--- a/test_runner/fixtures/pg_version.py
+++ b/test_runner/fixtures/pg_version.py
@@ -48,8 +48,8 @@ def pytest_addoption(parser: Parser):
 def pg_version(request: FixtureRequest) -> Iterator[PgVersion]:
     if v := request.config.getoption("--pg-version"):
         version, source = v, "from --pg-version commad-line argument"
-    elif v := os.environ.get("PG_VERSION"):
-        version, source = PgVersion(v), "from PG_VERSION environment variable"
+    elif v := os.environ.get("DEFAULT_PG_VERSION"):
+        version, source = PgVersion(v), "from DEFAULT_PG_VERSION environment variable"
     else:
         version, source = DEFAULT_VERSION, "default verson"
 

--- a/test_runner/fixtures/pg_version.py
+++ b/test_runner/fixtures/pg_version.py
@@ -1,0 +1,57 @@
+import enum
+import os
+from typing import Iterator
+
+import pytest
+from _pytest.config.argparsing import Parser
+from pytest import FixtureRequest
+
+from fixtures.log_helper import log
+
+"""
+This fixture is used to determine which version of Postgres to use for tests.
+"""
+
+
+# Inherit PgVersion from str rather than int to make it easier to pass as a command-line argument
+# TODO: use enum.StrEnum for Python >= 3.11
+@enum.unique
+class PgVersion(str, enum.Enum):
+    V14 = "14"
+    V15 = "15"
+    # Instead of making version an optional parameter in methods, we can use this fake entry
+    # to explicitly rely on the default server version (could be different from pg_version fixture value)
+    NOT_SET = "<-POSTRGRES VERSION IS NOT SET->"
+
+    @staticmethod
+    def from_int(int_version: int) -> "PgVersion":
+        return PgVersion(str(int_version)[:2])
+
+    # Make it less confusing in logs
+    def __repr__(self) -> str:
+        return f"'{self.value}'"
+
+
+DEFAULT_VERSION: PgVersion = PgVersion.V14
+
+
+def pytest_addoption(parser: Parser):
+    parser.addoption(
+        "--pg-version",
+        action="store",
+        type=PgVersion,
+        help="Postgres version to use for tests",
+    )
+
+
+@pytest.fixture(scope="session")
+def pg_version(request: FixtureRequest) -> Iterator[PgVersion]:
+    if v := request.config.getoption("--pg-version"):
+        version, source = v, "from --pg-version commad-line argument"
+    elif v := os.environ.get("PG_VERSION"):
+        version, source = PgVersion(v), "from PG_VERSION environment variable"
+    else:
+        version, source = DEFAULT_VERSION, "default verson"
+
+    log.info(f"pg_version is {version} ({source})")
+    yield version

--- a/test_runner/regress/test_auth.py
+++ b/test_runner/regress/test_auth.py
@@ -31,11 +31,15 @@ def test_pageserver_auth(neon_env_builder: NeonEnvBuilder):
 
     # tenant can create branches
     tenant_http_client.timeline_create(
-        tenant_id=env.initial_tenant, ancestor_timeline_id=new_timeline_id
+        pg_version=env.pg_version,
+        tenant_id=env.initial_tenant,
+        ancestor_timeline_id=new_timeline_id,
     )
     # console can create branches for tenant
     pageserver_http_client.timeline_create(
-        tenant_id=env.initial_tenant, ancestor_timeline_id=new_timeline_id
+        pg_version=env.pg_version,
+        tenant_id=env.initial_tenant,
+        ancestor_timeline_id=new_timeline_id,
     )
 
     # fail to create branch using token with different tenant_id
@@ -43,7 +47,9 @@ def test_pageserver_auth(neon_env_builder: NeonEnvBuilder):
         PageserverApiException, match="Forbidden: Tenant id mismatch. Permission denied"
     ):
         invalid_tenant_http_client.timeline_create(
-            tenant_id=env.initial_tenant, ancestor_timeline_id=new_timeline_id
+            pg_version=env.pg_version,
+            tenant_id=env.initial_tenant,
+            ancestor_timeline_id=new_timeline_id,
         )
 
     # create tenant using management token

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -16,6 +16,7 @@ from fixtures.neon_fixtures import (
 )
 from fixtures.pageserver.http import PageserverHttpClient
 from fixtures.pageserver.utils import wait_for_last_record_lsn, wait_for_upload
+from fixtures.pg_version import PgVersion
 from fixtures.types import Lsn
 from pytest import FixtureRequest
 
@@ -50,7 +51,7 @@ def test_create_snapshot(neon_env_builder: NeonEnvBuilder, pg_bin: PgBin, test_o
     # it creates a new snapshot for releases after we tested the current version against the previous snapshot in `test_backward_compatibility`.
     #
     # There's no cleanup here, it allows to adjust the data in `test_backward_compatibility` itself without re-collecting it.
-    neon_env_builder.pg_version = "14"
+    neon_env_builder.pg_version = PgVersion.V14
     neon_env_builder.num_safekeepers = 3
     neon_env_builder.enable_local_fs_remote_storage()
     neon_env_builder.preserve_database_files = True
@@ -98,7 +99,7 @@ def test_backward_compatibility(
     test_output_dir: Path,
     neon_binpath: Path,
     pg_distrib_dir: Path,
-    pg_version: str,
+    pg_version: PgVersion,
     request: FixtureRequest,
 ):
     """
@@ -153,7 +154,7 @@ def test_backward_compatibility(
 def test_forward_compatibility(
     test_output_dir: Path,
     port_distributor: PortDistributor,
-    pg_version: str,
+    pg_version: PgVersion,
     request: FixtureRequest,
     neon_binpath: Path,
 ):
@@ -345,7 +346,7 @@ def check_neon_works(
     neon_target_binpath: Path,
     neon_current_binpath: Path,
     pg_distrib_dir: Path,
-    pg_version: str,
+    pg_version: PgVersion,
     port_distributor: PortDistributor,
     test_output_dir: Path,
     pg_bin: PgBin,
@@ -404,7 +405,7 @@ def check_neon_works(
 
     shutil.rmtree(repo_dir / "local_fs_remote_storage")
     pageserver_http.timeline_delete(tenant_id, timeline_id)
-    pageserver_http.timeline_create(tenant_id, timeline_id)
+    pageserver_http.timeline_create(pg_version, tenant_id, timeline_id)
     pg_bin.run(
         ["pg_dumpall", f"--dbname={connstr}", f"--file={test_output_dir / 'dump-from-wal.sql'}"]
     )

--- a/test_runner/regress/test_timeline_size.py
+++ b/test_runner/regress/test_timeline_size.py
@@ -27,6 +27,7 @@ from fixtures.pageserver.utils import (
     wait_for_upload_queue_empty,
     wait_until_tenant_active,
 )
+from fixtures.pg_version import PgVersion
 from fixtures.types import TenantId, TimelineId
 from fixtures.utils import get_timeline_dir_size, wait_until
 
@@ -489,7 +490,7 @@ def test_timeline_size_metrics(
     test_output_dir: Path,
     port_distributor: PortDistributor,
     pg_distrib_dir: Path,
-    pg_version: str,
+    pg_version: PgVersion,
 ):
     env = neon_simple_env
     pageserver_http = env.pageserver.http_client()

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -32,6 +32,7 @@ from fixtures.neon_fixtures import (
     available_remote_storages,
 )
 from fixtures.pageserver.utils import wait_for_last_record_lsn, wait_for_upload
+from fixtures.pg_version import PgVersion
 from fixtures.types import Lsn, TenantId, TimelineId
 from fixtures.utils import get_dir_size, query_scalar, start_in_background
 
@@ -582,7 +583,11 @@ def test_s3_wal_replay(neon_env_builder: NeonEnvBuilder, remote_storage_kind: Re
         shutil.copy(f_partial_saved, f_partial_path)
 
     # recreate timeline on pageserver from scratch
-    ps_cli.timeline_create(tenant_id, timeline_id)
+    ps_cli.timeline_create(
+        pg_version=PgVersion.from_int(pg_version),
+        tenant_id=tenant_id,
+        new_timeline_id=timeline_id,
+    )
 
     wait_lsn_timeout = 60 * 3
     started_at = time.time()

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -584,7 +584,7 @@ def test_s3_wal_replay(neon_env_builder: NeonEnvBuilder, remote_storage_kind: Re
 
     # recreate timeline on pageserver from scratch
     ps_cli.timeline_create(
-        pg_version=PgVersion.from_int(pg_version),
+        pg_version=PgVersion(pg_version),
         tenant_id=tenant_id,
         new_timeline_id=timeline_id,
     )


### PR DESCRIPTION
This PR allows to set Postgres version for testing using `--pg-version` + fixes tests for the non-default Postgres version.

Example:
```sh
./scripts/pytest -s -k test_partial_evict_tenant --pg-version 15
```

Also, it'll be easier to catch and reproduce cases like https://github.com/neondatabase/neon/issues/4032.

Test failures we have for Postgres 15 (the same we have for https://github.com/neondatabase/neon/pull/2809) + failed compatibility tests which will be in a separate PR.


#### debug build: 214 tests run: 199 passed, 2 failed, 13 ([full report](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4037/debug/4709535149/index.html))
Failed tests:
- [`test_runner/regress/test_pg_regress.py::test_isolation`](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4037/debug/4709535149/index.html#suites/158be07438eb5188d40b466b6acfaeb3/ec929442ac687e76) (ran [2 times](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4037/debug/4709535149/index.html#suites/158be07438eb5188d40b466b6acfaeb3/ec929442ac687e76/retries))
- [`test_runner/regress/test_tenant_size.py::test_get_tenant_size_with_multiple_branches`](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4037/debug/4709535149/index.html#suites/d70040d097c5c7c438e421e0416d69ce/91c9b87af94826f) (ran [2 times](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4037/debug/4709535149/index.html#suites/d70040d097c5c7c438e421e0416d69ce/91c9b87af94826f/retries))

___
#### release build: 214 tests run: 200 passed, 1 failed, 13 ([full report](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4037/release/4709535149/index.html))
Failed tests:
- [`test_runner/regress/test_pg_regress.py::test_isolation`](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4037/release/4709535149/index.html#suites/158be07438eb5188d40b466b6acfaeb3/df0c62b0fae3ea2e) (ran [2 times](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4037/release/4709535149/index.html#suites/158be07438eb5188d40b466b6acfaeb3/df0c62b0fae3ea2e/retries))

___


