### PR TITLE
build_and_test.yml: ensure tests & ./run_clippy.sh pass for build in the Dockerfile

### DIFF
--- a/.github/actions/set-build-env-vars/action.yml
+++ b/.github/actions/set-build-env-vars/action.yml
@@ -9,6 +9,8 @@ runs:
   steps:
     - name: Determine build vars
       shell: bash -euxo pipefail {0}
+      env:
+        VARIANT: ${{ inputs.variant }}
       run: |
         case "$VARIANT" in
           debug)

--- a/.github/actions/set-build-env-vars/action.yml
+++ b/.github/actions/set-build-env-vars/action.yml
@@ -1,0 +1,50 @@
+name: "Set build env vars"
+description: "Set various env vars for building neon.git, depending on the build variant"
+inputs:
+  variant:
+    description: "One of debug, release, or image"
+    required: true
+runs:
+  using: "composite"
+  env:
+    VARIANT: ${{ inputs.variant }}
+  steps:
+  - name: Determine build vars
+    id: determine-build-vars
+    run: |
+      case "$VARIANT" in
+        debug)
+          cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
+          CARGO_FEATURES="--features testing"
+          CARGO_FLAGS="--locked"
+          TARGET_DIR_NAME="debug"
+          BUILD_TYPE="debug"
+          ;;
+        release)
+          cov_prefix=""
+          CARGO_FEATURES="--features testing"
+          CARGO_FLAGS="--locked --release"
+          TARGET_DIR_NAME="release"
+          BUILD_TYPE="release"
+          ;;
+        image)
+          # Like we do in the Dockerfile built by the neon-image stage.
+          # The Dockerfile doesn't do cargo test & clippy, though.
+          # That's why we have it here.
+          cov_prefix=""
+          CARGO_FEATURES=""
+          CARGO_FLAGS="--locked --release"
+          TARGET_DIR_NAME="release"
+          BUILD_TYPE="release"
+          ;;
+        *)
+          echo "Unknown VARIANT: $VARIANT"
+          exit 1
+          ;;
+      esac
+      echo "cov_prefix=${cov_prefix}" >> $GITHUB_ENV
+      echo "CARGO_FEATURES=${CARGO_FEATURES}" >> $GITHUB_ENV
+      echo "CARGO_FLAGS=${CARGO_FLAGS}" >> $GITHUB_ENV
+      echo "CARGO_HOME=${GITHUB_WORKSPACE}/.cargo" >> $GITHUB_ENV
+      echo "TARGET_DIR_NAME=${TARGET_DIR_NAME}" >> $GITHUB_ENV
+      echo "BUILD_TYPE=${BUILD_TYPE}" >> $GITHUB_ENV

--- a/.github/actions/set-build-env-vars/action.yml
+++ b/.github/actions/set-build-env-vars/action.yml
@@ -48,3 +48,4 @@ runs:
         echo "CARGO_HOME=${GITHUB_WORKSPACE}/.cargo" >> $GITHUB_ENV
         echo "TARGET_DIR_NAME=${TARGET_DIR_NAME}" >> $GITHUB_ENV
         echo "BUILD_TYPE=${BUILD_TYPE}" >> $GITHUB_ENV
+        echo "VARIANT=${VARIANT}" >> $GITHUB_ENV

--- a/.github/actions/set-build-env-vars/action.yml
+++ b/.github/actions/set-build-env-vars/action.yml
@@ -6,45 +6,43 @@ inputs:
     required: true
 runs:
   using: "composite"
-  env:
-    VARIANT: ${{ inputs.variant }}
   steps:
-  - name: Determine build vars
-    id: determine-build-vars
-    run: |
-      case "$VARIANT" in
-        debug)
-          cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
-          CARGO_FEATURES="--features testing"
-          CARGO_FLAGS="--locked"
-          TARGET_DIR_NAME="debug"
-          BUILD_TYPE="debug"
-          ;;
-        release)
-          cov_prefix=""
-          CARGO_FEATURES="--features testing"
-          CARGO_FLAGS="--locked --release"
-          TARGET_DIR_NAME="release"
-          BUILD_TYPE="release"
-          ;;
-        image)
-          # Like we do in the Dockerfile built by the neon-image stage.
-          # The Dockerfile doesn't do cargo test & clippy, though.
-          # That's why we have it here.
-          cov_prefix=""
-          CARGO_FEATURES=""
-          CARGO_FLAGS="--locked --release"
-          TARGET_DIR_NAME="release"
-          BUILD_TYPE="release"
-          ;;
-        *)
-          echo "Unknown VARIANT: $VARIANT"
-          exit 1
-          ;;
-      esac
-      echo "cov_prefix=${cov_prefix}" >> $GITHUB_ENV
-      echo "CARGO_FEATURES=${CARGO_FEATURES}" >> $GITHUB_ENV
-      echo "CARGO_FLAGS=${CARGO_FLAGS}" >> $GITHUB_ENV
-      echo "CARGO_HOME=${GITHUB_WORKSPACE}/.cargo" >> $GITHUB_ENV
-      echo "TARGET_DIR_NAME=${TARGET_DIR_NAME}" >> $GITHUB_ENV
-      echo "BUILD_TYPE=${BUILD_TYPE}" >> $GITHUB_ENV
+    - name: Determine build vars
+      shell: bash -euxo pipefail {0}
+      run: |
+        case "$VARIANT" in
+          debug)
+            cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
+            CARGO_FEATURES="--features testing"
+            CARGO_FLAGS="--locked"
+            TARGET_DIR_NAME="debug"
+            BUILD_TYPE="debug"
+            ;;
+          release)
+            cov_prefix=""
+            CARGO_FEATURES="--features testing"
+            CARGO_FLAGS="--locked --release"
+            TARGET_DIR_NAME="release"
+            BUILD_TYPE="release"
+            ;;
+          image)
+            # Like we do in the Dockerfile built by the neon-image stage.
+            # The Dockerfile doesn't do cargo test & clippy, though.
+            # That's why we have it here.
+            cov_prefix=""
+            CARGO_FEATURES=""
+            CARGO_FLAGS="--locked --release"
+            TARGET_DIR_NAME="release"
+            BUILD_TYPE="release"
+            ;;
+          *)
+            echo "Unknown VARIANT: $VARIANT"
+            exit 1
+            ;;
+        esac
+        echo "cov_prefix=${cov_prefix}" >> $GITHUB_ENV
+        echo "CARGO_FEATURES=${CARGO_FEATURES}" >> $GITHUB_ENV
+        echo "CARGO_FLAGS=${CARGO_FLAGS}" >> $GITHUB_ENV
+        echo "CARGO_HOME=${GITHUB_WORKSPACE}/.cargo" >> $GITHUB_ENV
+        echo "TARGET_DIR_NAME=${TARGET_DIR_NAME}" >> $GITHUB_ENV
+        echo "BUILD_TYPE=${BUILD_TYPE}" >> $GITHUB_ENV

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ debug, release ]
+        build_type: [ debug, release, image ]
     env:
       BUILD_TYPE: ${{ matrix.build_type }}
       GIT_VERSION: ${{ github.sha }}
@@ -181,18 +181,38 @@ jobs:
       # corresponding Cargo.toml files for their descriptions.
       - name: Set env variables
         run: |
-          CARGO_FEATURES="--features testing"
-          if [[ $BUILD_TYPE == "debug" ]]; then
-            cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
-            CARGO_FLAGS="--locked"
-          elif [[ $BUILD_TYPE == "release" ]]; then
-            cov_prefix=""
-            CARGO_FLAGS="--locked --release"
-          fi
+          case "$BUILD_TYPE" in
+            debug)
+              cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
+              CARGO_FEATURES="--features testing"
+              CARGO_FLAGS="--locked"
+              TARGET_DIR_NAME="debug"
+              ;;
+            release)
+              cov_prefix=""
+              CARGO_FEATURES="--features testing"
+              CARGO_FLAGS="--locked --release"
+              TARGET_DIR_NAME="release"
+              ;;
+            image)
+              # Like we do in the Dockerfile built by the neon-image stage.
+              # The Dockerfile doesn't do cargo test & clippy, though.
+              # That's why we have it here.
+              cov_prefix=""
+              CARGO_FEATURES=""
+              CARGO_FLAGS="--locked --release"
+              TARGET_DIR_NAME="release"
+              ;;
+            *)
+              echo "Unknown BUILD_TYPE: $BUILD_TYPE"
+              exit 1
+              ;;
+          esac
           echo "cov_prefix=${cov_prefix}" >> $GITHUB_ENV
           echo "CARGO_FEATURES=${CARGO_FEATURES}" >> $GITHUB_ENV
           echo "CARGO_FLAGS=${CARGO_FLAGS}" >> $GITHUB_ENV
           echo "CARGO_HOME=${GITHUB_WORKSPACE}/.cargo" >> $GITHUB_ENV
+          echo "TARGET_DIR_NAME=${TARGET_DIR_NAME}" >> $GITHUB_ENV
 
       # Disabled for now
       # Don't include the ~/.cargo/registry/src directory. It contains just
@@ -262,7 +282,7 @@ jobs:
             jq -r '.packages[].targets[] | select(.kind | index("bin")) | .name'
           )
           for bin in $binaries; do
-            SRC=target/$BUILD_TYPE/$bin
+            SRC=target/$TARGET_DIR_NAME/$bin
             DST=/tmp/neon/bin/$bin
             cp "$SRC" "$DST"
           done
@@ -291,6 +311,11 @@ jobs:
             for bin in $binaries; do
               echo "/tmp/neon/bin/$bin" >> /tmp/coverage/binaries.list
             done
+          else
+            if [ "$cov_prefix" != "" ]; then
+              echo "expecting coverage prefix to be empty for all build types except debug, got BUILD_TYPE=$BUILD_TYPE"
+              exit 1
+            fi
           fi
 
       - name: Install postgres binaries

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -111,9 +111,6 @@ jobs:
       - name: Get postgres headers
         run: make postgres-headers -j$(nproc)
 
-      - name: Run cargo clippy
-        run: ./run_clippy.sh
-
       # Use `${{ !cancelled() }}` to run quck tests after the longer clippy run
       - name: Check formatting
         if: ${{ !cancelled() }}
@@ -131,6 +128,36 @@ jobs:
         if: ${{ !cancelled() }}
         run: cargo deny check
 
+  clippy:
+    runs-on: [ self-hosted, gen3, large ]
+    container:
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
+      options: --init
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - debug
+          - release
+          - image
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 1
+
+      - uses: ./.github/actions/set-build-env-vars
+        with:
+          variant: ${{ matrix.variant }}
+
+      - name: Get postgres headers
+        run: make postgres-headers -j$(nproc)
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets $CARGO_FLAGS $CARGO_FEATURES -- -A unknown_lints -D warnings
+
   build-neon:
     runs-on: [ self-hosted, gen3, large ]
     container:
@@ -139,13 +166,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type:
+        variant:
           - debug
           - release
           - image
     env:
-      # NB: BUILD_TYPE != MATRIX_BUILD_TYPE; the former is a Makefile variable
-      MATRIX_BUILD_TYPE: ${{ matrix.build_type }}
       GIT_VERSION: ${{ github.sha }}
 
     steps:
@@ -165,6 +190,10 @@ jobs:
           submodules: true
           fetch-depth: 1
 
+      - uses: ./.github/actions/set-build-env-vars
+        with:
+          variant: ${{ matrix.variant }}
+
       - name: Set pg 14 revision for caching
         id: pg_v14_rev
         run: echo pg_rev=$(git rev-parse HEAD:vendor/postgres-v14) >> $GITHUB_OUTPUT
@@ -172,56 +201,6 @@ jobs:
       - name: Set pg 15 revision for caching
         id: pg_v15_rev
         run: echo pg_rev=$(git rev-parse HEAD:vendor/postgres-v15) >> $GITHUB_OUTPUT
-
-      # Set some environment variables used by all the steps.
-      #
-      # CARGO_FLAGS is extra options to pass to "cargo build", "cargo test" etc.
-      #   It also includes --features, if any
-      #
-      # CARGO_FEATURES is passed to "cargo metadata". It is separate from CARGO_FLAGS,
-      #   because "cargo metadata" doesn't accept --release or --debug options
-      #
-      # We run tests with addtional features, that are turned off by default (e.g. in release builds), see
-      # corresponding Cargo.toml files for their descriptions.
-      - name: Set env variables
-        run: |
-          case "$MATRIX_BUILD_TYPE" in
-            debug)
-              cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
-              CARGO_FEATURES="--features testing"
-              CARGO_FLAGS="--locked"
-              TARGET_DIR_NAME="debug"
-              BUILD_TYPE="debug"
-              ;;
-            release)
-              cov_prefix=""
-              CARGO_FEATURES="--features testing"
-              CARGO_FLAGS="--locked --release"
-              TARGET_DIR_NAME="release"
-              BUILD_TYPE="release"
-              ;;
-            image)
-              # Like we do in the Dockerfile built by the neon-image stage.
-              # The Dockerfile doesn't do cargo test & clippy, though.
-              # That's why we have it here.
-              cov_prefix=""
-              CARGO_FEATURES=""
-              CARGO_FLAGS="--locked --release"
-              TARGET_DIR_NAME="release"
-              BUILD_TYPE="release"
-              ;;
-            *)
-              echo "Unknown MATRIX_BUILD_TYPE: $MATRIX_BUILD_TYPE"
-              exit 1
-              ;;
-          esac
-          echo "cov_prefix=${cov_prefix}" >> $GITHUB_ENV
-          echo "CARGO_FEATURES=${CARGO_FEATURES}" >> $GITHUB_ENV
-          echo "CARGO_FLAGS=${CARGO_FLAGS}" >> $GITHUB_ENV
-          echo "CARGO_HOME=${GITHUB_WORKSPACE}/.cargo" >> $GITHUB_ENV
-          echo "TARGET_DIR_NAME=${TARGET_DIR_NAME}" >> $GITHUB_ENV
-          echo "MATRIX_BUILD_TYPE=${MATRIX_BUILD_TYPE}" >> $GITHUB_ENV
-          echo "BUILD_TYPE=${BUILD_TYPE}" >> $GITHUB_ENV
 
       # Disabled for now
       # Don't include the ~/.cargo/registry/src directory. It contains just

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -139,9 +139,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ debug, release, image ]
+        build_type:
+          - debug
+          - release
+          - image
     env:
-      BUILD_TYPE: ${{ matrix.build_type }}
+      # NB: BUILD_TYPE != MATRIX_BUILD_TYPE; the former is a Makefile variable
+      MATRIX_BUILD_TYPE: ${{ matrix.build_type }}
       GIT_VERSION: ${{ github.sha }}
 
     steps:
@@ -181,18 +185,20 @@ jobs:
       # corresponding Cargo.toml files for their descriptions.
       - name: Set env variables
         run: |
-          case "$BUILD_TYPE" in
+          case "$MATRIX_BUILD_TYPE" in
             debug)
               cov_prefix="scripts/coverage --profraw-prefix=$GITHUB_JOB --dir=/tmp/coverage run"
               CARGO_FEATURES="--features testing"
               CARGO_FLAGS="--locked"
               TARGET_DIR_NAME="debug"
+              BUILD_TYPE="debug"
               ;;
             release)
               cov_prefix=""
               CARGO_FEATURES="--features testing"
               CARGO_FLAGS="--locked --release"
               TARGET_DIR_NAME="release"
+              BUILD_TYPE="release"
               ;;
             image)
               # Like we do in the Dockerfile built by the neon-image stage.
@@ -202,9 +208,10 @@ jobs:
               CARGO_FEATURES=""
               CARGO_FLAGS="--locked --release"
               TARGET_DIR_NAME="release"
+              BUILD_TYPE="release"
               ;;
             *)
-              echo "Unknown BUILD_TYPE: $BUILD_TYPE"
+              echo "Unknown MATRIX_BUILD_TYPE: $MATRIX_BUILD_TYPE"
               exit 1
               ;;
           esac
@@ -213,6 +220,8 @@ jobs:
           echo "CARGO_FLAGS=${CARGO_FLAGS}" >> $GITHUB_ENV
           echo "CARGO_HOME=${GITHUB_WORKSPACE}/.cargo" >> $GITHUB_ENV
           echo "TARGET_DIR_NAME=${TARGET_DIR_NAME}" >> $GITHUB_ENV
+          echo "MATRIX_BUILD_TYPE=${MATRIX_BUILD_TYPE}" >> $GITHUB_ENV
+          echo "BUILD_TYPE=${BUILD_TYPE}" >> $GITHUB_ENV
 
       # Disabled for now
       # Don't include the ~/.cargo/registry/src directory. It contains just
@@ -288,7 +297,7 @@ jobs:
           done
 
           # Install test executables and write list of all binaries (for code coverage)
-          if [[ $BUILD_TYPE == "debug" ]]; then
+          if [[ $MATRIX_BUILD_TYPE == "debug" ]]; then
             # Keep bloated coverage data files away from the rest of the artifact
             mkdir -p /tmp/coverage/
 
@@ -313,7 +322,7 @@ jobs:
             done
           else
             if [ "$cov_prefix" != "" ]; then
-              echo "expecting coverage prefix to be empty for all build types except debug, got BUILD_TYPE=$BUILD_TYPE"
+              echo "expecting coverage prefix to be empty for all gh matrix build types except 'debug', got MATRIX_BUILD_TYPE=$MATRIX_BUILD_TYPE"
               exit 1
             fi
           fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -276,7 +276,7 @@ jobs:
           done
 
           # Install test executables and write list of all binaries (for code coverage)
-          if [[ $MATRIX_BUILD_TYPE == "debug" ]]; then
+          if [[ $VARIANT == "debug" ]]; then
             # Keep bloated coverage data files away from the rest of the artifact
             mkdir -p /tmp/coverage/
 
@@ -301,7 +301,7 @@ jobs:
             done
           else
             if [ "$cov_prefix" != "" ]; then
-              echo "expecting coverage prefix to be empty for all gh matrix build types except 'debug', got MATRIX_BUILD_TYPE=$MATRIX_BUILD_TYPE"
+              echo "expecting coverage prefix to be empty for all variants except 'debug', got VARIANT=$VARIANT"
               exit 1
             fi
           fi


### PR DESCRIPTION
This patch adds a third build type to the build-neon build matrix. This build type corresponds to what we do in Dockerfile, i.e., a `--release` build without `--features testing`.

The advantage of doing it this way is that we can re-use the steps from the fine-grained & richer build-neon workflow job.

The disadvantage is that we duplicate the build arguments from the Dockerfile.

The alternative is to do it the other way around, i.e., from the Dockerfile, invoke `cargo test` and `./run_clippy.sh`.

However, that would duplicate all the CARGO_FLAGS and CARGO_FEATURES logic that we have in the build-neon workflow job. Which seems worse to me.
