### PR TITLE
build: run clippy for powerset of features

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -111,8 +111,18 @@ jobs:
       - name: Get postgres headers
         run: make postgres-headers -j$(nproc)
 
-      - name: Run cargo clippy
-        run: ./run_clippy.sh
+      - uses: taiki-e/install-action@cargo-hack
+
+      # cargo hack runs the given cargo subcommand (clippy in this case) for all feature combinations.
+      # This will catch compiler & clippy warnings in all feature combinations.
+      # TODO: use cargo hack for build and test as well, but, that's quite expensive.
+      # NB: keep clippy args in sync with ./run_clippy.sh
+      - run: |
+          echo "CLIPPY_COMMON_ARGS=--locked --workspace --all-targets -- -A unknown_lints -D warning" >> $GITHUB_ENV
+      - name: Run cargo clippy (debug)
+        run: cargo hack --feature-powerset clippy $CLIPPY_COMMON_ARGS
+      - name: Run cargo clippy (release)
+        run: cargo hack --feature-powerset clippy $CLIPPY_COMMON_ARGS --release
 
       # Use `${{ !cancelled() }}` to run quck tests after the longer clippy run
       - name: Check formatting

--- a/run_clippy.sh
+++ b/run_clippy.sh
@@ -11,4 +11,9 @@
 # * `-A unknown_lints` – do not warn about unknown lint suppressions
 #                        that people with newer toolchains might use
 # * `-D warnings`      - fail on any warnings (`cargo` returns non-zero exit status)
+
+# NB: the CI runs the full feature powerset, so, it catches slightly more errors
+# at the expense of longer runtime. This script is used by developers, so, don't
+# do that here.
+# NB: keep the args after the `--` in sync with the CI YAMLs.
 cargo clippy --locked --all --all-targets --all-features -- -A unknown_lints -D warnings


### PR DESCRIPTION
This will catch compiler & clippy warnings in all feature combinations.

We should probably use cargo hack for build and test as well, but, that's quite expensive and would add to overall CI wait times.

obsoletes https://github.com/neondatabase/neon/pull/4073 refs https://github.com/neondatabase/neon/pull/4070