### PR TITLE
feat: log how long tenant activation takes

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -118,9 +118,9 @@ pub struct Tenant {
     // Global pageserver config parameters
     pub conf: &'static PageServerConf,
 
-    /// The creation timestamp, used to measure activation delay, see:
+    /// The value creation timestamp, used to measure activation delay, see:
     /// <https://github.com/neondatabase/neon/issues/4025>
-    created_at: Instant,
+    loading_started_at: Instant,
 
     state: watch::Sender<TenantState>,
 
@@ -1518,7 +1518,7 @@ impl Tenant {
                         }
                     }
 
-                    let elapsed = self.created_at.elapsed();
+                    let elapsed = self.loading_started_at.elapsed();
                     let total_timelines = timelines_accessor.len();
 
                     // log a lot of stuff, because some tenants sometimes suffer from user-visible
@@ -1838,7 +1838,9 @@ impl Tenant {
         Tenant {
             tenant_id,
             conf,
-            created_at: Instant::now(),
+            // using now here is good enough approximation to catch tenants with really long
+            // activation times.
+            loading_started_at: Instant::now(),
             tenant_conf: Arc::new(RwLock::new(tenant_conf)),
             timelines: Mutex::new(HashMap::new()),
             gc_cs: tokio::sync::Mutex::new(()),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -118,6 +118,10 @@ pub struct Tenant {
     // Global pageserver config parameters
     pub conf: &'static PageServerConf,
 
+    /// The creation timestamp, used to measure activation delay, see:
+    /// <https://github.com/neondatabase/neon/issues/4025>
+    created_at: Instant,
+
     state: watch::Sender<TenantState>,
 
     // Overridden tenant-specific config parameters.
@@ -1476,7 +1480,7 @@ impl Tenant {
                 TenantState::Loading | TenantState::Attaching => {
                     *current_state = TenantState::Active;
 
-                    info!("Activating tenant {}", self.tenant_id);
+                    debug!(tenant_id = %self.tenant_id, "Activating tenant");
 
                     let timelines_accessor = self.timelines.lock().unwrap();
                     let not_broken_timelines = timelines_accessor
@@ -1487,12 +1491,15 @@ impl Tenant {
                     // down when they notice that the tenant is inactive.
                     tasks::start_background_loops(self.tenant_id);
 
+                    let mut activated_timelines = 0;
+                    let mut timelines_broken_during_activation = 0;
+
                     for timeline in not_broken_timelines {
                         match timeline
                             .activate(ctx)
                             .context("timeline activation for activating tenant")
                         {
-                            Ok(()) => {}
+                            Ok(()) => { activated_timelines += 1; }
                             Err(e) => {
                                 error!(
                                     "Failed to activate timeline {}: {:#}",
@@ -1503,9 +1510,18 @@ impl Tenant {
                                     "failed to activate timeline {}: {}",
                                     timeline.timeline_id, e
                                 ));
+
+                                timelines_broken_during_activation += 1;
                             }
                         }
                     }
+
+                    let elapsed = self.created_at.elapsed();
+                    let total_timelines = timelines_accessor.len();
+
+                    // log a lot of stuff, because some tenants sometimes suffer from user-visible
+                    // times to activate. see https://github.com/neondatabase/neon/issues/4025
+                    info!(since_creation_millis = elapsed.as_millis(), tenant_id = %self.tenant_id, activated_timelines, timelines_broken_during_activation, total_timelines, "Tenant activated");
                 }
             }
         });
@@ -1812,6 +1828,7 @@ impl Tenant {
         Tenant {
             tenant_id,
             conf,
+            created_at: Instant::now(),
             tenant_conf: Arc::new(RwLock::new(tenant_conf)),
             timelines: Mutex::new(HashMap::new()),
             gc_cs: tokio::sync::Mutex::new(()),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1521,7 +1521,7 @@ impl Tenant {
 
                     // log a lot of stuff, because some tenants sometimes suffer from user-visible
                     // times to activate. see https://github.com/neondatabase/neon/issues/4025
-                    info!(since_creation_millis = elapsed.as_millis(), tenant_id = %self.tenant_id, activated_timelines, timelines_broken_during_activation, total_timelines, "Tenant activated");
+                    info!(since_creation_millis = elapsed.as_millis(), tenant_id = %self.tenant_id, activated_timelines, timelines_broken_during_activation, total_timelines, post_state = <&'static str>::from(&*current_state), "activation attempt finished");
                 }
             }
         });

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1499,7 +1499,9 @@ impl Tenant {
                             .activate(ctx)
                             .context("timeline activation for activating tenant")
                         {
-                            Ok(()) => { activated_timelines += 1; }
+                            Ok(()) => {
+                                activated_timelines += 1;
+                            }
                             Err(e) => {
                                 error!(
                                     "Failed to activate timeline {}: {:#}",
@@ -1521,7 +1523,15 @@ impl Tenant {
 
                     // log a lot of stuff, because some tenants sometimes suffer from user-visible
                     // times to activate. see https://github.com/neondatabase/neon/issues/4025
-                    info!(since_creation_millis = elapsed.as_millis(), tenant_id = %self.tenant_id, activated_timelines, timelines_broken_during_activation, total_timelines, post_state = <&'static str>::from(&*current_state), "activation attempt finished");
+                    info!(
+                        since_creation_millis = elapsed.as_millis(),
+                        tenant_id = %self.tenant_id,
+                        activated_timelines,
+                        timelines_broken_during_activation,
+                        total_timelines,
+                        post_state = <&'static str>::from(&*current_state),
+                        "activation attempt finished"
+                    );
                 }
             }
         });


### PR DESCRIPTION
Adds just a counter counting up from the creation to the tenant, logged after activation. Might help guide us with the investigation of #4025.