### PR TITLE
feat(page_service): read timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,7 @@ dependencies = [
  "tenant_size_model",
  "thiserror",
  "tokio",
+ "tokio-io-timeout",
  "tokio-postgres",
  "tokio-tar",
  "tokio-util",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -52,6 +52,7 @@ sync_wrapper.workspace = true
 tokio-tar.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["process", "sync", "fs", "rt", "io-util", "time"] }
+tokio-io-timeout.workspace = true
 tokio-postgres.workspace = true
 tokio-util.workspace = true
 toml_edit = { workspace = true, features = [ "serde" ] }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -250,6 +250,11 @@ async fn page_service_conn_main(
 
     let peer_addr = socket.peer_addr().context("get peer address")?;
 
+    let mut socket = tokio_io_timeout::TimeoutReader::new(socket);
+    socket.set_timeout(Some(std::time::Duration::from_secs(60 * 10)));
+
+    let socket = std::pin::pin!(socket);
+
     // XXX: pgbackend.run() should take the connection_ctx,
     // and create a child per-query context when it invokes process_query.
     // But it's in a shared crate, so, we store connection_ctx inside PageServerHandler

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -250,9 +250,13 @@ async fn page_service_conn_main(
 
     let peer_addr = socket.peer_addr().context("get peer address")?;
 
+    // setup read timeout of 10 minutes. the timeout is rather arbitrary for requirements:
+    // - long enough for most valid compute connections
+    // - less than infinite to stop us from "leaking" connections to long-gone computes
+    //
+    // no write timeout is used, because the kernel is assumed to error writes after some time.
     let mut socket = tokio_io_timeout::TimeoutReader::new(socket);
     socket.set_timeout(Some(std::time::Duration::from_secs(60 * 10)));
-
     let socket = std::pin::pin!(socket);
 
     // XXX: pgbackend.run() should take the connection_ctx,


### PR DESCRIPTION
Introduce read timeouts to our `page_service` connections. Without read timeouts, we essentially leak connections.

This is a port of #3995. Split the refactorings to the other PR: #4097.

Fixes #4028.