### PR TITLE
Do not return Error in case of duplicate layer detetion

### DIFF
--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -55,8 +55,8 @@ use anyhow::Result;
 use std::collections::VecDeque;
 use std::ops::Range;
 use std::sync::Arc;
-use utils::lsn::Lsn;
 use tracing::*;
+use utils::lsn::Lsn;
 
 use historic_layer_coverage::BufferedHistoricLayerCoverage;
 pub use historic_layer_coverage::Replacement;
@@ -282,12 +282,12 @@ where
                 layer.short_id()
             );
         } else {
-			self.historic.insert(key, Arc::clone(&layer));
+            self.historic.insert(key, Arc::clone(&layer));
 
-			if Self::is_l0(&layer) {
-				self.l0_delta_layers.push(layer);
-			}
-		}
+            if Self::is_l0(&layer) {
+                self.l0_delta_layers.push(layer);
+            }
+        }
         Ok(())
     }
 

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -285,7 +285,7 @@ where
                 }
                 warn!("Replace duplicate layer {} in layer map", layer.short_id());
             }
-            Replacement::Unexpected(_) => bail!("Replace layer with itslef is prohibited"),
+            Replacement::Unexpected(_) => bail!("Replace layer with itself is prohibited"),
             Replacement::NotFound | Replacement::RemovalBuffered => {
                 self.historic.insert(key, Arc::clone(&layer));
 

--- a/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
+++ b/pageserver/src/tenant/layer_map/historic_layer_coverage.rs
@@ -417,14 +417,6 @@ impl<Value: Clone> BufferedHistoricLayerCoverage<Value> {
         }
     }
 
-    pub fn contains(&self, layer_key: &LayerKey) -> bool {
-        match self.buffer.get(layer_key) {
-            Some(None) => false,                         // layer remove was buffered
-            Some(_) => true,                             // layer insert was buffered
-            None => self.layers.contains_key(layer_key), // no buffered ops for this layer
-        }
-    }
-
     pub fn insert(&mut self, layer_key: LayerKey, value: Value) {
         self.buffer.insert(layer_key, Some(value));
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3300,6 +3300,10 @@ impl Timeline {
 
         drop(all_keys_iter); // So that deltas_to_compact is no longer borrowed
 
+        fail_point!("compact-level0-phase1-finish", |_| {
+            Err(anyhow::anyhow!("failpoint compact-level0-phase1-finish").into())
+        });
+
         Ok(CompactLevel0Phase1Result {
             new_layers,
             deltas_to_compact,

--- a/test_runner/regress/test_duplicate_layers.py
+++ b/test_runner/regress/test_duplicate_layers.py
@@ -16,7 +16,7 @@ def test_duplicate_layers(neon_env_builder: NeonEnvBuilder, pg_bin: PgBin):
     # These warnings are expected, when the pageserver is restarted abruptly
     env.pageserver.allowed_errors.append(".*found future image layer.*")
     env.pageserver.allowed_errors.append(".*found future delta layer.*")
-    env.pageserver.allowed_errors.append(".*Attempt to insert duplicate layer.*")
+    env.pageserver.allowed_errors.append(".*duplicate layer.*")
 
     pageserver_http = env.pageserver.http_client()
 

--- a/test_runner/regress/test_duplicate_layers.py
+++ b/test_runner/regress/test_duplicate_layers.py
@@ -1,5 +1,6 @@
-import pytest
 import time
+
+import pytest
 from fixtures.neon_fixtures import NeonEnvBuilder, PgBin
 
 

--- a/test_runner/regress/test_duplicate_layers.py
+++ b/test_runner/regress/test_duplicate_layers.py
@@ -1,0 +1,41 @@
+import pytest
+import time
+from fixtures.neon_fixtures import NeonEnvBuilder, PgBin
+
+
+# Test duplicate layer detection
+#
+# This test sets fail point at the end of first compaction phase:
+# after flushing new L1 layers but before deletion of L0 layes
+# It should cause generation of duplicate L1 layer by compaction after restart
+@pytest.mark.timeout(600)
+def test_duplicate_layers(neon_env_builder: NeonEnvBuilder, pg_bin: PgBin):
+    env = neon_env_builder.init_start()
+
+    # These warnings are expected, when the pageserver is restarted abruptly
+    env.pageserver.allowed_errors.append(".*found future image layer.*")
+    env.pageserver.allowed_errors.append(".*found future delta layer.*")
+    env.pageserver.allowed_errors.append(".*Attempt to insert duplicate layer.*")
+
+    pageserver_http = env.pageserver.http_client()
+
+    # Use aggressive compaction and checkpoint settings
+    tenant_id, _ = env.neon_cli.create_tenant(
+        conf={
+            "checkpoint_distance": f"{1024 ** 2}",
+            "compaction_target_size": f"{1024 ** 2}",
+            "compaction_period": "1 s",
+            "compaction_threshold": "3",
+        }
+    )
+    endpoint = env.endpoints.create_start("main", tenant_id=tenant_id)
+    connstr = endpoint.connstr(options="-csynchronous_commit=off")
+    pg_bin.run_capture(["pgbench", "-i", "-s10", connstr])
+
+    pageserver_http.configure_failpoints(("compact-level0-phase1-finish", "exit"))
+
+    with pytest.raises(Exception):
+        pg_bin.run_capture(["pgbench", "-P1", "-N", "-c5", "-T500", "-Mprepared", connstr])
+    env.pageserver.stop()
+    env.pageserver.start()
+    time.sleep(10)  # let compaction to be performed


### PR DESCRIPTION
## Describe your changes

compact_level0_phase1 flush created new L1 layers to the disk and only after it compact_level0 can remove old layers. So it guarantees that we do not loose some data if compaction is interrupted.
If pageserver is interrupted at this moment then after pageserver restart the following state of layers are possible:

    Some subset of new L1 layers is present at the disk + all old L0 layers
    All new L1 layers are present at the disk + some subset of old L0 layers

In any case subsequent compaction may produce duplicates of L1 layers.

## Issue ticket number and link

Fixes changes made in this PR: https://github.com/neondatabase/neon/pull/3869
Discussion: https://neondb.slack.com/archives/C033QLM5P7D/p1682519017949719

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
