### PR TITLE
Use inmem LSN values for determining WAL removal horizon.

### DIFF
--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -654,7 +654,10 @@ impl Timeline {
         let remover: Box<dyn Fn(u64) -> Result<(), anyhow::Error>>;
         {
             let shared_state = self.write_shared_state();
-            horizon_segno = shared_state.sk.get_horizon_segno(wal_backup_enabled);
+            horizon_segno = shared_state.sk.get_horizon_segno(
+                wal_backup_enabled,
+                self.walsenders.get_remote_consistent_lsn(),
+            );
             remover = shared_state.sk.wal_store.remove_up_to();
             if horizon_segno <= 1 || horizon_segno <= shared_state.last_removed_segno {
                 return Ok(());


### PR DESCRIPTION
Fixes out of space deadlock when WAL removal requires control file update. To avoid s3 offloading getting stuck due to missing WAL segment, check its existence in s3 if locally it doesn't exist.

A part of https://github.com/neondatabase/neon/issues/3957