### PR TITLE
for #3919: make timeline deletion retryable if it fails uploading index_part or deleting the files

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1362,6 +1362,8 @@ impl Tenant {
         timeline_id: TimelineId,
         _ctx: &RequestContext,
     ) -> Result<(), DeleteTimelineError> {
+        timeline::debug_assert_current_span_has_tenant_and_timeline_id();
+
         // Transition the timeline into TimelineState::Stopping.
         // This should prevent new operations from starting.
         let timeline = {
@@ -1461,12 +1463,34 @@ impl Tenant {
             // For configurations without remote storage, we tolerate that we're not crash-safe here.
             // The timeline may come up Active but with missing layer files, in such setups.
             // See https://github.com/neondatabase/neon/pull/3919#issuecomment-1531726720
-            std::fs::remove_dir_all(&local_timeline_directory).with_context(|| {
-                format!(
-                    "Failed to remove local timeline directory '{}'",
-                    local_timeline_directory.display()
-                )
-            })?;
+            match std::fs::remove_dir_all(&local_timeline_directory) {
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    // This can happen if we're called a second time, e.g.,
+                    // because of a previous failure/cancellation at/after
+                    // failpoint timeline-delete-after-rm.
+                    //
+                    // It can also happen if we race with tenant detach, because,
+                    // it doesn't grab the layer_removal_cs lock.
+                    //
+                    // For now, log and continue.
+                    // warn! level is technically not appropriate for the
+                    // first case because we should expect retries to happen.
+                    // But the error is so rare, it seems better to get attention if it happens.
+                    let tenant_state = self.current_state();
+                    warn!(
+                        timeline_dir=?local_timeline_directory,
+                        ?tenant_state,
+                        "timeline directory not found, proceeding anyway"
+                    );
+                    // continue with the rest of the deletion
+                }
+                res => res.with_context(|| {
+                    format!(
+                        "Failed to remove local timeline directory '{}'",
+                        local_timeline_directory.display()
+                    )
+                })?,
+            }
 
             info!("finished deleting layer files, releasing layer_removal_cs.lock()");
             drop(layer_removal_guard);

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -59,6 +59,7 @@ use crate::tenant::config::TenantConfOpt;
 use crate::tenant::metadata::load_metadata;
 use crate::tenant::remote_timeline_client::index::IndexPart;
 use crate::tenant::remote_timeline_client::MaybeDeletedIndexPart;
+use crate::tenant::remote_timeline_client::PersistIndexPartWithDeletedFlagError;
 use crate::tenant::storage_layer::DeltaLayer;
 use crate::tenant::storage_layer::ImageLayer;
 use crate::tenant::storage_layer::Layer;
@@ -1426,7 +1427,15 @@ impl Tenant {
         // during attach or pageserver restart.
         // See comment in persist_index_part_with_deleted_flag.
         if let Some(remote_client) = timeline.remote_client.as_ref() {
-            remote_client.persist_index_part_with_deleted_flag().await?;
+            match remote_client.persist_index_part_with_deleted_flag().await {
+                // If we (now, or already) marked it successfully as deleted, we can proceed
+                Ok(()) | Err(PersistIndexPartWithDeletedFlagError::AlreadyDeleted(_)) => (),
+                // Bail out otherwise
+                Err(e @ PersistIndexPartWithDeletedFlagError::AlreadyInProgress(_))
+                | Err(e @ PersistIndexPartWithDeletedFlagError::Other(_)) => {
+                    return Err(DeleteTimelineError::Other(anyhow::anyhow!(e)));
+                }
+            }
         }
 
         {

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1472,6 +1472,10 @@ impl Tenant {
             drop(layer_removal_guard);
         }
 
+        fail::fail_point!("timeline-delete-after-rm", |_| {
+            Err(anyhow::anyhow!("failpoint: timeline-delete-after-rm"))?
+        });
+
         // Remove the timeline from the map.
         let mut timelines = self.timelines.lock().unwrap();
         let children_exist = timelines

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -273,9 +273,9 @@ pub enum StopError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PersistIndexPartWithDeletedFlagError {
-    #[error("timeline is already deleting, started at {0:?}")]
+    #[error("another task is already setting the deleted_flag, started at {0:?}")]
     AlreadyInProgress(NaiveDateTime),
-    #[error("timeline is deleting, deleted_at: {0:?}")]
+    #[error("the deleted_flag was already set, value is {0:?}")]
     AlreadyDeleted(NaiveDateTime),
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -205,7 +205,7 @@ pub mod index;
 mod upload;
 
 use anyhow::Context;
-use chrono::Utc;
+use chrono::{NaiveDateTime, Utc};
 // re-export these
 pub use download::{is_temp_download_file, list_remote_timelines};
 use scopeguard::ScopeGuard;
@@ -243,6 +243,7 @@ use utils::id::{TenantId, TimelineId};
 use self::index::IndexPart;
 
 use super::storage_layer::LayerFileName;
+use super::upload_queue::SetDeletedFlagProgress;
 
 // Occasional network issues and such can cause remote operations to fail, and
 // that's expected. If a download fails, we log it at info-level, and retry.
@@ -268,6 +269,16 @@ pub enum StopError {
     /// See [`RemoteTimelineClient::init_upload_queue`] and [`RemoteTimelineClient::init_upload_queue_for_empty_remote`].
     #[error("queue is not initialized")]
     QueueUninitialized,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PersistIndexPartWithDeletedFlagError {
+    #[error("timeline is already deleting, started at {0:?}")]
+    AlreadyInProgress(NaiveDateTime),
+    #[error("timeline is deleting, deleted_at: {0:?}")]
+    AlreadyDeleted(NaiveDateTime),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 /// A client for accessing a timeline's data in remote storage.
@@ -656,7 +667,7 @@ impl RemoteTimelineClient {
     /// Check method [`RemoteTimelineClient::stop`] for details.
     pub(crate) async fn persist_index_part_with_deleted_flag(
         self: &Arc<Self>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), PersistIndexPartWithDeletedFlagError> {
         let index_part_with_deleted_at = {
             let mut locked = self.upload_queue.lock().unwrap();
 
@@ -664,16 +675,26 @@ impl RemoteTimelineClient {
             // we can have inprogress index part upload that can overwrite the file
             // with missing is_deleted flag that we going to set below
             let stopped = match &mut *locked {
-                UploadQueue::Uninitialized => anyhow::bail!("is not Stopped but Uninitialized"),
-                UploadQueue::Initialized(_) => anyhow::bail!("is not Stopped but Initialized"),
+                UploadQueue::Uninitialized => {
+                    return Err(anyhow::anyhow!("is not Stopped but Uninitialized").into())
+                }
+                UploadQueue::Initialized(_) => {
+                    return Err(anyhow::anyhow!("is not Stopped but Initialized").into())
+                }
                 UploadQueue::Stopped(stopped) => stopped,
             };
 
-            if let Some(deleted_at) = stopped.deleted_at.as_ref() {
-                anyhow::bail!("timeline is deleting, deleted_at: {:?}", deleted_at);
-            }
+            match stopped.deleted_at {
+                SetDeletedFlagProgress::NotRunning => (), // proceed
+                SetDeletedFlagProgress::InProgress(at) => {
+                    return Err(PersistIndexPartWithDeletedFlagError::AlreadyInProgress(at));
+                }
+                SetDeletedFlagProgress::Successful(at) => {
+                    return Err(PersistIndexPartWithDeletedFlagError::AlreadyDeleted(at));
+                }
+            };
             let deleted_at = Utc::now().naive_utc();
-            stopped.deleted_at = Some(deleted_at);
+            stopped.deleted_at = SetDeletedFlagProgress::InProgress(deleted_at);
 
             let mut index_part = IndexPart::new(
                 stopped.latest_files.clone(),
@@ -696,7 +717,7 @@ impl RemoteTimelineClient {
                 ),
                 UploadQueue::Stopped(stopped) => stopped,
             };
-            stopped.deleted_at = None;
+            stopped.deleted_at = SetDeletedFlagProgress::NotRunning;
         });
 
         #[cfg(feature = "testing")]
@@ -724,8 +745,23 @@ impl RemoteTimelineClient {
         )
         .await?;
 
-        // all good, keep the deleted_at flag
+        // all good, disarm the guard and mark as success
         ScopeGuard::into_inner(undo_deleted_at);
+        {
+            let mut locked = self.upload_queue.lock().unwrap();
+            let stopped = match &mut *locked {
+                UploadQueue::Uninitialized | UploadQueue::Initialized(_) => unreachable!(
+                    "there's no way out of Stopping, and we checked it's Stopping above: {:?}",
+                    locked.as_str(),
+                ),
+                UploadQueue::Stopped(stopped) => stopped,
+            };
+            stopped.deleted_at = SetDeletedFlagProgress::Successful(
+                index_part_with_deleted_at
+                    .deleted_at
+                    .expect("we set it above"),
+            );
+        }
 
         Ok(())
     }
@@ -1119,7 +1155,7 @@ impl RemoteTimelineClient {
                         latest_files,
                         last_uploaded_consistent_lsn,
                         latest_metadata,
-                        deleted_at: None,
+                        deleted_at: SetDeletedFlagProgress::NotRunning,
                     })
                 }
             }

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -76,7 +76,7 @@ pub(crate) struct UploadQueueInitialized {
     pub(crate) queued_operations: VecDeque<UploadOp>,
 }
 
-#[derive(Clone,Copy)]
+#[derive(Clone, Copy)]
 pub(super) enum SetDeletedFlagProgress {
     NotRunning,
     InProgress(NaiveDateTime),

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -76,12 +76,18 @@ pub(crate) struct UploadQueueInitialized {
     pub(crate) queued_operations: VecDeque<UploadOp>,
 }
 
+#[derive(Clone,Copy)]
+pub(super) enum SetDeletedFlagProgress {
+    NotRunning,
+    InProgress(NaiveDateTime),
+    Successful(NaiveDateTime),
+}
+
 pub(super) struct UploadQueueStopped {
     pub(super) latest_files: HashMap<LayerFileName, LayerFileMetadata>,
     pub(super) last_uploaded_consistent_lsn: Lsn,
     pub(super) latest_metadata: TimelineMetadata,
-    /// If Some(), a call to `persist_index_part_with_deleted_flag` is ongoing or finished.
-    pub(super) deleted_at: Option<NaiveDateTime>,
+    pub(super) deleted_at: SetDeletedFlagProgress,
 }
 
 impl UploadQueue {

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -962,14 +962,11 @@ def test_concurrent_timeline_delete_if_first_stuck_at_index_upload(
 
         # make the second call and assert behavior
         log.info("second call start")
-        with pytest.raises(
-            PageserverApiException, match="timeline is deleting, deleted_at"
-        ) as second_call_err:
+        error_msg_re = "another task is already setting the deleted_flag, started at"
+        with pytest.raises(PageserverApiException, match=error_msg_re) as second_call_err:
             ps_http.timeline_delete(env.initial_tenant, child_timeline_id)
         assert second_call_err.value.status_code == 500
-        env.pageserver.allowed_errors.append(
-            f".*{child_timeline_id}.*timeline is deleting, deleted_at: .*"
-        )
+        env.pageserver.allowed_errors.append(f".*{child_timeline_id}.*{error_msg_re}.*")
         # the second call will try to transition the timeline into Stopping state as well
         env.pageserver.allowed_errors.append(
             f".*{child_timeline_id}.*Ignoring new state, equal to the existing one: Stopping"

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -113,7 +113,9 @@ def test_delete_timeline_post_rm_failure(neon_env_builder: NeonEnvBuilder):
 
     at_failpoint_log_message = f".*{env.initial_timeline}.*at failpoint {failpoint_name}.*"
     env.pageserver.allowed_errors.append(at_failpoint_log_message)
-    env.pageserver.allowed_errors.append(f".*DELETE.*{env.initial_timeline}.*InternalServerError.*{failpoint_name}")
+    env.pageserver.allowed_errors.append(
+        f".*DELETE.*{env.initial_timeline}.*InternalServerError.*{failpoint_name}"
+    )
 
     # retry without failpoint, it should succeed
     ps_http.configure_failpoints((failpoint_name, "off"))
@@ -124,7 +126,9 @@ def test_delete_timeline_post_rm_failure(neon_env_builder: NeonEnvBuilder):
     env.pageserver.allowed_errors.append(
         f".*{env.initial_timeline}.*Ignoring new state, equal to the existing one: Stopping"
     )
-    env.pageserver.allowed_errors.append(f".*{env.initial_timeline}.*timeline directory not found, proceeding anyway.*")
+    env.pageserver.allowed_errors.append(
+        f".*{env.initial_timeline}.*timeline directory not found, proceeding anyway.*"
+    )
 
 
 # TODO Test that we correctly handle GC of files that are stuck in upload queue.

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -1,5 +1,5 @@
 import pytest
-from fixtures.neon_fixtures import NeonEnv
+from fixtures.neon_fixtures import NeonEnv, NeonEnvBuilder
 from fixtures.pageserver.http import PageserverApiException
 from fixtures.types import TenantId, TimelineId
 from fixtures.utils import wait_until
@@ -92,3 +92,37 @@ def test_timeline_delete(neon_simple_env: NeonEnv):
         match=f"Timeline {env.initial_tenant}/{leaf_timeline_id} was not found",
     ) as exc:
         ps_http.timeline_detail(env.initial_tenant, leaf_timeline_id)
+
+
+def test_delete_timeline_post_rm_failure(neon_env_builder: NeonEnvBuilder):
+    """
+    If there is a failure after removing the timeline directory, the delete operation
+    should be retryable.
+    """
+
+    env = neon_env_builder.init_start()
+    assert env.initial_timeline
+
+    ps_http = env.pageserver.http_client()
+
+    failpoint_name = "timeline-delete-after-rm"
+    ps_http.configure_failpoints((failpoint_name, "return"))
+
+    with pytest.raises(PageserverApiException, match=f"failpoint: {failpoint_name}"):
+        ps_http.timeline_delete(env.initial_tenant, env.initial_timeline)
+
+    at_failpoint_log_message = f".*{env.initial_timeline}.*at failpoint {failpoint_name}.*"
+    env.pageserver.allowed_errors.append(at_failpoint_log_message)
+
+    # retry without failpoint, it should succeed
+    ps_http.configure_failpoints((failpoint_name, "off"))
+
+    # this should succeed
+    ps_http.timeline_delete(env.initial_tenant, env.initial_timeline, timeout=2)
+    # the second call will try to transition the timeline into Stopping state, but it's already in that state
+    env.pageserver.allowed_errors.append(
+        f".*{env.initial_timeline}.*Ignoring new state, equal to the existing one: Stopping"
+    )
+
+
+# TODO Test that we correctly handle GC of files that are stuck in upload queue.

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -113,6 +113,7 @@ def test_delete_timeline_post_rm_failure(neon_env_builder: NeonEnvBuilder):
 
     at_failpoint_log_message = f".*{env.initial_timeline}.*at failpoint {failpoint_name}.*"
     env.pageserver.allowed_errors.append(at_failpoint_log_message)
+    env.pageserver.allowed_errors.append(f".*DELETE.*{env.initial_timeline}.*InternalServerError.*{failpoint_name}")
 
     # retry without failpoint, it should succeed
     ps_http.configure_failpoints((failpoint_name, "off"))
@@ -123,6 +124,7 @@ def test_delete_timeline_post_rm_failure(neon_env_builder: NeonEnvBuilder):
     env.pageserver.allowed_errors.append(
         f".*{env.initial_timeline}.*Ignoring new state, equal to the existing one: Stopping"
     )
+    env.pageserver.allowed_errors.append(f".*{env.initial_timeline}.*timeline directory not found, proceeding anyway.*")
 
 
 # TODO Test that we correctly handle GC of files that are stuck in upload queue.


### PR DESCRIPTION
Before this PR, timeline delete was not retryable if it failed with an error earlier. Previously,

- if we had failed after uploading the index part but before remove_dir_all, the retry would have failed because `IndexPart::deleted_at` is already `Some()`.
- if we had failed after remove_dir_all, the retry would have failed because the directory doesn't exist.

This PR adds a test case and fixes these two issues.
