### PR TITLE
for #3919: undo take_mut usage introduced in 11c18b0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,6 @@ dependencies = [
  "strum_macros",
  "svg_fmt",
  "sync_wrapper",
- "take_mut",
  "tempfile",
  "tenant_size_model",
  "thiserror",
@@ -4197,12 +4196,6 @@ dependencies = [
  "syn 1.0.109",
  "unicode-xid",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tar"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -75,7 +75,6 @@ enum-map.workspace = true
 enumset.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
-take_mut = "0.2.2"
 
 [dev-dependencies]
 criterion.workspace = true


### PR DESCRIPTION
Commit `11c18b0` introduced `take_mut`, but, it's actually not necessary here.
`take_mut` is dangerous because it aborts if the closure handed to it panics.
We have asserts in there, let's not risk an abort.

Alternative to #4153.