### PR TITLE
delete_timeline: request coalescing

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -139,12 +139,9 @@ impl From<crate::tenant::DeleteTimelineError> for ApiError {
     fn from(value: crate::tenant::DeleteTimelineError) -> Self {
         use crate::tenant::DeleteTimelineError::*;
         match value {
-            NotFound => ApiError::NotFound(anyhow::anyhow!("timeline not found")),
-            HasChildren => ApiError::BadRequest(anyhow::anyhow!(
-                "Cannot delete timeline which has child timelines"
-            )),
-            StopUploadQueue(e) => ApiError::InternalServerError(e.into()),
-            Other(e) => ApiError::InternalServerError(e),
+            NotFound => ApiError::NotFound(value.into()),
+            HasChildren => ApiError::BadRequest(value.into()),
+            _ => ApiError::InternalServerError(value.into()),
         }
     }
 }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1458,6 +1458,11 @@ impl Tenant {
                     Some(Ok(())) => return Ok(()),
                     Some(Err(e)) if e.is_permanent() => return Err(DeleteTimelineError::from(e)),
                     Some(Err(_retryable)) => true,
+                    // FIXME: if the task panics without getting to the send_replace, we will be
+                    // stuck here, so perhaps this should be a futures::future::Shared, only
+                    // communicate with the joinhandle return value?
+                    //
+                    // there is no test for this yet
                     None => false,
                 };
 

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -262,7 +262,7 @@ pub enum MaybeDeletedIndexPart {
 }
 
 /// Errors that can arise when calling [`RemoteTimelineClient::stop`].
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub enum StopError {
     /// Returned if the upload queue was never initialized.
     /// See [`RemoteTimelineClient::init_upload_queue`] and [`RemoteTimelineClient::init_upload_queue_for_empty_remote`].
@@ -681,7 +681,7 @@ impl RemoteTimelineClient {
                 stopped
                     .latest_metadata
                     .to_bytes()
-                    .context("serialize metadata")?,
+                    .expect("timeline metadata serialization expected to pass"),
             );
             index_part.deleted_at = Some(deleted_at);
             index_part
@@ -699,6 +699,7 @@ impl RemoteTimelineClient {
             stopped.deleted_at = None;
         });
 
+        // this is for pausing
         #[cfg(feature = "testing")]
         tokio::task::spawn_blocking({
             let current = tracing::Span::current();

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -204,7 +204,6 @@ mod download;
 pub mod index;
 mod upload;
 
-use anyhow::Context;
 use chrono::Utc;
 // re-export these
 pub use download::{is_temp_download_file, list_remote_timelines};


### PR DESCRIPTION
Uses request coalescing and spawned task instead of the previous hopefully idempotent `delete_timeline`, which I don't think is possible, see: <https://github.com/neondatabase/neon/pull/3919/files#r1185357135>. Buiilds upon #4156.

This fails the `test_concurrent_timeline_delete_if_first_stuck_at_index_upload` from #3919, but passes others in the same file. It has at least one huge problem with the `watch` channel, noted as a fixme.