### PR TITLE
replace has_in_progress_downloads with new attachment_status field

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -728,7 +728,7 @@ mod tests {
                 "slug": "Active",
             },
             "current_physical_size": 42,
-            "has_in_progress_downloads": "attached",
+            "attachment_status": "attached",
         });
 
         let original_broken = TenantInfo {

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -226,7 +226,6 @@ impl TenantConfigRequest {
 }
 
 /// See [`TenantState::attachment_status`] and the OpenAPI docs for context.
-#[serde_as]
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum TenantAttachmentStatus {

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -51,10 +51,10 @@ impl TenantState {
     pub fn attachment_status(&self) -> TenantAttachmentStatus {
         use TenantAttachmentStatus::*;
         match self {
-            // The attach procedure writes the marker file before adding the Attaching tenant to the layer map.
+            // The attach procedure writes the marker file before adding the Attaching tenant to the tenants map.
             // So, technically, we can return Attached here.
             // However, as soon as Console observes Attached, it will proceed with the Postgres-level health check.
-            // But, our attach task might still we might still be fetching the remote timelines, etc.
+            // But, our attach task might still be fetching the remote timelines, etc.
             // So, return `Maybe` while Attaching, making Console wait for the attach task to finish.
             Self::Attaching => Maybe,
             // tenant mgr startup distinguishes attaching from loading via marker file.

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -351,8 +351,8 @@ paths:
         attachment status.
 
         After the client has received a 202, it MUST poll the tenant's
-        attachment status (field `attachement_status`) to reach state `attached`.
-        If the `attachement_status` is missing, the client MUST retry the `/attach`
+        attachment status (field `attachment_status`) to reach state `attached`.
+        If the `attachment_status` is missing, the client MUST retry the `/attach`
         request (goto previous paragraph). This is a robustness measure in case the tenant
         status endpoint is buggy, but the attach operation is ongoing.
 

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -352,7 +352,7 @@ paths:
 
         After the client has received a 202, it MUST poll the tenant's
         attachment status (field `attachement_status`) to reach state `attached`.
-        If the `attachemnt_status`` is missing, the client MUST retry the `/attach`
+        If the `attachement_status` is missing, the client MUST retry the `/attach`
         request (goto previous paragraph). This is a robustness measure in case the tenant
         status endpoint is buggy, but the attach operation is ongoing.
 

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -362,7 +362,7 @@ paths:
         * MUST NOT ASSUME that the /attach request has been lost in the network,
         * MUST NOT ASSUME that the request has been lost, based on the observation
           that a subsequent tenant status request returns 404. The request may
-          still be in flight.
+          still be in flight. It must be retried.
       responses:
         "202":
           description: Tenant attaching scheduled

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -346,18 +346,17 @@ paths:
         starts writing to the tenant's S3 state unless it receives one of the
         distinguished errors below that state otherwise.
 
-        The method to identify whether a request has arrived at the pageserver, and
-        whether it has succeeded, is to poll for the tenant status to reach "Active"
-        or "Broken" state. These values are currently not explicitly documented in
-        the API spec.
-        Polling for `has_in_progress_downloads == false` is INCORRECT because that
-        value can turn `false` during shutdown while the Attach operation is still
-        unfinished.
+        If a client receives a not-distinguished response, e.g., a network timeout,
+        it MUST retry the /attach request and poll again for the tenant's
+        attachment status.
+
+        After the client has received a 202, it MUST poll the tenant's
+        attachment status (field `attachement_status`) to reach state `attached`.
+        If the `attachemnt_status`` is missing, the client MUST retry the `/attach`
+        request (goto previous paragraph). This is a robustness measure in case the tenant
+        status endpoint is buggy, but the attach operation is ongoing.
 
         There is no way to cancel an in-flight request.
-
-        If a client receives a not-distinguished response, e.g., a network timeout,
-        it MUST retry the /attach request and poll again for tenant status.
 
         In any case, it must
         * NOT ASSUME that the /attach request has been lost in the network,
@@ -888,13 +887,27 @@ components:
       type: object
       required:
         - id
+        - attachment_status
       properties:
         id:
           type: string
         current_physical_size:
           type: integer
-        has_in_progress_downloads:
-          type: boolean
+        attachment_status:
+          description: |
+            Status of this tenant's attachment to this pageserver.
+
+            - `maybe` means almost nothing, don't read anything into it
+              except for the fact that the pageserver _might_ be already
+              writing to the tenant's S3 state, so, DO NOT ATTACH the
+              tenant to any other pageserver, or we risk split-brain.
+            - `attached` means that the attach operation has completed,
+              maybe successfully, maybe not. Perform a health check at
+              the Postgres level to determine healthiness of the tenant.
+
+            See the tenant `/attach` endpoint for more information.
+          type: string
+          enum: [ "maybe", "attached" ]
     TenantCreateInfo:
       type: object
       properties:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -358,10 +358,11 @@ paths:
 
         There is no way to cancel an in-flight request.
 
-        In any case, it must
-        * NOT ASSUME that the /attach request has been lost in the network,
-        * NOT ASSUME that the request has been lost based on a subsequent
-          tenant status request returning 404. (The request may still be in flight!)
+        In any case, the client
+        * MUST NOT ASSUME that the /attach request has been lost in the network,
+        * MUST NOT ASSUME that the request has been lost, based on the observation
+          that a subsequent tenant status request returns 404. The request may
+          still be in flight.
       responses:
         "202":
           description: Tenant attaching scheduled

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -467,7 +467,7 @@ async fn tenant_list_handler(request: Request<Body>) -> Result<Response<Body>, A
             id: *id,
             state: state.clone(),
             current_physical_size: None,
-            has_in_progress_downloads: Some(state.has_in_progress_downloads()),
+            attachment_status: state.attachment_status(),
         })
         .collect::<Vec<TenantInfo>>();
 
@@ -492,7 +492,7 @@ async fn tenant_status(request: Request<Body>) -> Result<Response<Body>, ApiErro
             id: tenant_id,
             state: state.clone(),
             current_physical_size: Some(current_physical_size),
-            has_in_progress_downloads: Some(state.has_in_progress_downloads()),
+            attachment_status: state.attachment_status(),
         })
     }
     .instrument(info_span!("tenant_status_handler", tenant = %tenant_id))

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -459,6 +459,33 @@ struct RemoteStartupData {
     remote_metadata: TimelineMetadata,
 }
 
+#[derive(Debug)]
+pub(crate) enum AttachMarkerFilePresence {
+    Absent,
+    Present,
+}
+
+impl AttachMarkerFilePresence {
+    /// Returns that the claim made about marker file presence in `self`
+    /// corresponds to reality.
+    fn verify(
+        &self,
+        conf: &'static PageServerConf,
+        tenant_id: TenantId,
+    ) -> anyhow::Result<Result<(), ()>> {
+        let marker_file = conf.tenant_attaching_mark_file_path(&tenant_id);
+        let exists = marker_file
+            .try_exists()
+            .context("check existence of attach marker file")?;
+        Ok(match (self, exists) {
+            (AttachMarkerFilePresence::Absent, false) => Ok(()),
+            (AttachMarkerFilePresence::Present, true) => Ok(()),
+            (AttachMarkerFilePresence::Absent, true) => Err(()),
+            (AttachMarkerFilePresence::Present, false) => Err(()),
+        })
+    }
+}
+
 impl Tenant {
     /// Yet another helper for timeline initialization.
     /// Contains the common part of `load_local_timeline` and `load_remote_timeline`.
@@ -591,9 +618,10 @@ impl Tenant {
     /// finishes. You can use wait_until_active() to wait for the task to
     /// complete.
     ///
-    pub fn spawn_attach(
+    pub(crate) fn spawn_attach(
         conf: &'static PageServerConf,
         tenant_id: TenantId,
+        marker_file_presence: AttachMarkerFilePresence,
         remote_storage: GenericRemoteStorage,
         ctx: &RequestContext,
     ) -> Arc<Tenant> {
@@ -623,11 +651,40 @@ impl Tenant {
             "attach tenant",
             false,
             async move {
-                match tenant_clone.attach(ctx).await {
-                    Ok(_) => {}
+                let mut marker_file_presence = marker_file_presence;
+                match tenant_clone.attach(&mut marker_file_presence, ctx).await {
+                    Ok(_) => {
+                        info!(?marker_file_presence, "tenant attached");
+                        assert!(matches!(
+                            marker_file_presence,
+                            AttachMarkerFilePresence::Absent
+                        ));
+                    }
                     Err(e) => {
-                        tenant_clone.set_broken(e.to_string());
-                        error!("error attaching tenant: {:?}", e);
+                        error!(?marker_file_presence, "error attaching tenant: {:?}", e);
+                        match marker_file_presence {
+                            AttachMarkerFilePresence::Absent => {
+                                // We can reach here if we fail to create the marker file.
+                                //
+                                // The tenant may or may not be in the tenant map already,
+                                // it depends on our caller.
+                                //
+                                // There is no on-disk state for this tenant (empty tenant dir doesn't count.)
+                                //
+                                // It is crucial to not report the tenant attachment status as Attached.
+                                // So, we must not transition into Broken state.
+                                // It would be best to just delete the tenant object from the tenants
+                                // map, but, we're not in control of that here.
+                                todo!("find a solution")
+                            }
+                            AttachMarkerFilePresence::Present => {
+                                // If the marker is present, it's ok to transition into Broken.
+                                // We will report AttachmentStatus::Attached from then on.
+                                // That's accurate because we will try to attach the tenant again
+                                // on pageserver restart.
+                                tenant_clone.set_broken(e.to_string());
+                            }
+                        }
                     }
                 }
                 Ok(())
@@ -640,7 +697,11 @@ impl Tenant {
     /// Background task that downloads all data for a tenant and brings it to Active state.
     ///
     #[instrument(skip_all, fields(tenant_id=%self.tenant_id))]
-    async fn attach(self: &Arc<Tenant>, ctx: RequestContext) -> anyhow::Result<()> {
+    async fn attach(
+        self: &Arc<Tenant>,
+        marker_file_presence: &mut AttachMarkerFilePresence,
+        ctx: RequestContext,
+    ) -> anyhow::Result<()> {
         // Create directory with marker file to indicate attaching state.
         // The load_local_tenants() function in tenant::mgr relies on the marker file
         // to determine whether a tenant has finished attaching.
@@ -661,6 +722,7 @@ impl Tenant {
         }
         debug_assert!(tenant_dir.is_dir());
         debug_assert!(marker_file.is_file());
+        *marker_file_presence = AttachMarkerFilePresence::Present;
 
         // Get list of remote timelines
         // download index files for every tenant timeline
@@ -755,6 +817,7 @@ impl Tenant {
             .with_context(|| format!("unlink attach marker file {}", marker_file.display()))?;
         crashsafe::fsync(marker_file.parent().expect("marker file has parent dir"))
             .context("fsync tenant directory after unlinking attach marker file")?;
+        *marker_file_presence = AttachMarkerFilePresence::Absent;
 
         utils::failpoint_sleep_millis_async!("attach-before-activate");
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -654,7 +654,11 @@ impl Tenant {
         // 2. we'd need to think about cancel safety. Turns out dropping a tokio::fs future
         //    doesn't wait for the activity in the fs thread pool.
         crashsafe::create_dir_all(&tenant_dir).context("create tenant directory")?;
-        match fs::OpenOptions::new().create_new(true).open(&marker_file) {
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&marker_file)
+        {
             Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 // Either this is a retry of attach or there is a concurrent task also doing attach for this tenant.

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -19,7 +19,7 @@ use crate::config::PageServerConf;
 use crate::context::{DownloadBehavior, RequestContext};
 use crate::task_mgr::{self, TaskKind};
 use crate::tenant::config::TenantConfOpt;
-use crate::tenant::{Tenant, TenantState};
+use crate::tenant::{Tenant, TenantState, AttachMarkerFilePresence};
 use crate::IGNORED_TENANT_FILE_NAME;
 
 use utils::fs_ext::PathExt;
@@ -186,7 +186,13 @@ pub fn schedule_local_tenant_processing(
     let tenant = if conf.tenant_attaching_mark_file_path(&tenant_id).exists() {
         info!("tenant {tenant_id} has attaching mark file, resuming its attach operation");
         if let Some(remote_storage) = remote_storage {
-            Tenant::spawn_attach(conf, tenant_id, remote_storage, ctx)
+            Tenant::spawn_attach(
+                conf,
+                tenant_id,
+                AttachMarkerFilePresence::Present,
+                remote_storage,
+                ctx,
+            )
         } else {
             warn!("tenant {tenant_id} has attaching mark file, but pageserver has no remote storage configured");
             Tenant::create_broken_tenant(conf, tenant_id)
@@ -466,7 +472,13 @@ pub async fn attach_tenant(
             "Cannot attach tenant {tenant_id}, local tenant directory already exists"
         );
 
-        let tenant = Tenant::spawn_attach(conf, tenant_id, remote_storage, ctx);
+        let tenant = Tenant::spawn_attach(
+            conf,
+            tenant_id,
+            AttachMarkerFilePresence::Absent,
+            remote_storage,
+            ctx,
+        );
         vacant_entry.insert(tenant);
         Ok(())
     })


### PR DESCRIPTION
Control Plane currently [^1] polls for `has_in_progress_downloads == false` after /attach to determine that an attach operation succeeded.

As pointed out in the OpenAPI spec as of neon#4151, polling for `has_in_progress_downloads` is incorrect.

This patch changes the situation by
- removing `has_in_progress_downloads`
- adding a new field `attachment_status.`
- changing instructions for `/attach` to poll for `attachment_status == attached`.

This makes the instructions in `/attach` actionable for Control Plane. NB that we don't expose the TenantState in the OpenAPI docs, even though we expose it in the endpoint. That is with good reason because we don't want to commit to a fixed set of tenant states forever. Hence, the separate `attachment_status` field that exposes the bare minimum required to make /attach + subsequent polling 100% safe wrt split brain.

It would have been nice to report failures explicitly, but the problem is that we lose that state when we restart. So, we return `attached` upon attach failure. The tenant is Broken in that case, causing Control Plane's subsequent health check will fail. Control Plane can roll back the relocation operation then.
NB: the reliance on the subsequent health check is no change to what we had before this patch!
NB: we can always add additional TenantAttachmentStatus'es in the future to communicate failure.

This PR also moves the attach-marker file's creation to the API handler's synchronous part. That was done to avoid the need to distinguish
* `Attaching but marker not yet written => AttachmentStatus::Maybe` from
* `Attaching, marker written, but attach failed for other reason => AttachmentStatus::Attached`

Coincidentally, this also adds more transactionality to the /attach API because we only return 202 once we've written the marker file. But, in the end, it doesn't affect how the control plane interacts with us or how it needs to do retries. So, we don't mention any of this in the API docs.

[^1]: The one-click tenant relocation PR cloud#4740, currently WIP, is
      the first real user.
