### PR TITLE
fix: coalesce deleting a timeline

### DIFF
--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -60,6 +60,10 @@ pub mod tracing_span_assert;
 
 pub mod rate_limit;
 
+/// Primitive for coalescing operations into a single task which will not be cancelled by for
+/// example external http client closing the connection.
+pub mod shared_retryable;
+
 mod failpoint_macro_helpers {
 
     /// use with fail::cfg("$name", "return(2000)")
@@ -96,6 +100,7 @@ mod failpoint_macro_helpers {
         tracing::info!("failpoint {:?}: sleep done", name);
     }
 }
+
 pub use failpoint_macro_helpers::failpoint_sleep_helper;
 
 /// This is a shortcut to embed git sha into binaries and avoid copying the same build script to all packages

--- a/libs/utils/src/shared_retryable.rs
+++ b/libs/utils/src/shared_retryable.rs
@@ -219,6 +219,8 @@ where
         }
     }
 
+    /// Returns a Ok if the previous attempt had resulted in a terminal result. Err is returned
+    /// when an attempt can be joined and possibly needs to be spawned.
     async fn decide_to_retry_or_join<F, Fut, E2>(
         &self,
         retry_with: F,

--- a/libs/utils/src/shared_retryable.rs
+++ b/libs/utils/src/shared_retryable.rs
@@ -503,7 +503,7 @@ impl<V: std::fmt::Debug> MaybeDone<V> {
                 let same = weak
                     .upgrade()
                     // we don't yet have Receiver::same_channel
-                    .map(|rx| Arc::ptr_eq(&_expected_rx, &rx))
+                    .map(|rx| Arc::ptr_eq(_expected_rx, &rx))
                     .unwrap_or(false);
                 assert!(same, "different channel had been replaced or dropped");
             }

--- a/libs/utils/src/shared_retryable.rs
+++ b/libs/utils/src/shared_retryable.rs
@@ -124,14 +124,15 @@ where
     /// Many futures can call this function and get the terminal result from an earlier attempt or
     /// start a new attempt, or join an existing one.
     ///
-    /// If a task calling this method is cancelled, at worst, a new attempt which is immediatedly
-    /// deemed as having panicked will happen, but without a panic ever happening.
+    /// If a task calling this method is cancelled before spawning the returned future, this
+    /// attempt is immediatedly deemed as having panicked will happen, but without a panic ever
+    /// happening.
     ///
     /// Returns one future for waiting for the result and possibly another which needs to be
     /// spawned when `Some`. Spawning has to happen before waiting is started, otherwise the first
     /// future will never make progress.
     ///
-    /// This complication exists because on pageserver we cannot use `tokio::spawn` directly
+    /// This complication exists because on `pageserver` we cannot use `tokio::spawn` directly
     /// at this time.
     pub async fn try_restart<E2>(
         &self,

--- a/libs/utils/src/shared_retryable.rs
+++ b/libs/utils/src/shared_retryable.rs
@@ -159,7 +159,7 @@ where
 {
     /// Restart a previously failed operation unless it already completed with a terminal result.
     ///
-    /// Many tasks can call this function and and get the terminal result from an earlier attempt
+    /// Many futures can call this function and and get the terminal result from an earlier attempt
     /// or start a new attempt, or join an existing one.
     ///
     /// Compared to `Self::try_restart`, this method also spawns the future to run, which would
@@ -182,7 +182,7 @@ where
 
     /// Restart a previously failed operation unless it already completed with a terminal result.
     ///
-    /// Many tasks can call this function and get the terminal result from an earlier attempt or
+    /// Many futures can call this function and get the terminal result from an earlier attempt or
     /// start a new attempt, or join an existing one.
     ///
     /// If a task calling this method is cancelled, at worst, a new attempt which is immediatedly

--- a/libs/utils/src/shared_retryable.rs
+++ b/libs/utils/src/shared_retryable.rs
@@ -1,0 +1,645 @@
+use std::sync::Arc;
+
+/// Container using which many request handlers can come together and join a single task to
+/// completion instead of racing each other and their own cancellation.
+///
+/// In a picture:
+///
+/// ```text
+/// SharedRetryable::try_restart         Spawned task completes with only one concurrent attempt
+///                             \       /
+///      request handler 1 ---->|--X
+///      request handler 2 ---->|-------|
+///      request handler 3 ---->|-------|
+///                             \------>/
+/// (X = cancelled during await)
+/// ```
+///
+/// Implementation is cancel safe. Implementation and internal structure are hurt by the inability
+/// to just spawn the task, but this is needed for pageserver usage.
+///
+/// Implementation exposes a fully decomposed [`SharedRetryable::try_restart`] which requires the
+/// caller to do the spawning before awaiting for the result. If the caller is dropped while this
+/// happens, a new attempt will be required, and all concurrent awaiters will see a
+/// [`RetriedTaskPanicked`] error.
+///
+/// There is another "family of APIs" [`SharedRetryable::attempt_spawn`] for infallible futures. It is
+/// just provided for completeness, and it does not have a fully decomposed version like
+/// `try_restart`.
+///
+/// For `try_restart_*` family of APIs, there is a concept of two leveled results. The inner level
+/// is returned by the executed future. It needs to be `Clone`. Most errors are not `Clone`, so
+/// implementation advice is to log the happened error, and not propagate more than a label as the
+/// "inner error" which will be used to build an outer error. The outer error will also have to be
+/// convertable from [`RetriedTaskPanicked`] to absorb that case as well.
+///
+/// ## Example
+///
+/// A shared service value completes the infallible work once, even if called concurrently by
+/// multiple cancellable tasks.
+///
+/// ```
+/// use utils::shared_retryable::{SharedRetryable, Retryable, RetriedTaskPanicked};
+/// use std::sync::Arc;
+///
+/// #[derive(Debug, Clone, Copy)]
+/// enum OneLevelError {
+///   TaskPanicked
+/// }
+///
+/// impl Retryable for OneLevelError {
+///   fn is_permanent(&self) -> bool {
+///     // for a single level errors, this wording is weird
+///     !matches!(self, OneLevelError::TaskPanicked)
+///   }
+/// }
+///
+/// impl From<RetriedTaskPanicked> for OneLevelError {
+///   fn from(_: RetriedTaskPanicked) -> Self {
+///     OneLevelError::TaskPanicked
+///   }
+/// }
+///
+/// #[derive(Clone, Default)]
+/// struct Service(SharedRetryable<Result<u8, OneLevelError>>);
+///
+/// impl Service {
+///   async fn work(&self, completions: Arc<std::sync::atomic::AtomicUsize>) -> Result<u8, OneLevelError> {
+///     self.0.try_restart_spawn(
+///       || async move {
+///         // give time to cancel some of the tasks
+///         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+///         completions.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+///         Self::work_once().await
+///       }
+///     )
+///       .await
+///   }
+///
+///   async fn work_once() -> Result<u8, OneLevelError> {
+///     Ok(42)
+///   }
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///   let svc = Service::default();
+///
+///   let mut js = tokio::task::JoinSet::new();
+///
+///   let barrier = Arc::new(tokio::sync::Barrier::new(10 + 1));
+///   let completions = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+///
+///   let handles = (0..10).map(|_| js.spawn({
+///     let svc = svc.clone();
+///     let barrier = barrier.clone();
+///     let completions = completions.clone();
+///     async move {
+///       // make sure all tasks are ready to start at the same time
+///       barrier.wait().await;
+///       // after successfully starting the work, any of the futures could get cancelled
+///       svc.work(completions).await
+///     }
+///   })).collect::<Vec<_>>();
+///
+///   barrier.wait().await;
+///
+///   tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+///
+///   handles[5].abort();
+///
+///   let mut cancellations = 0;
+///
+///   while let Some(res) = js.join_next().await {
+///     // all complete with the same result
+///     match res {
+///       Ok(res) => assert_eq!(res.unwrap(), 42),
+///       Err(je) => {
+///         // except for the one task we cancelled; it's cancelling
+///         // does not interfere with the result
+///         assert!(je.is_cancelled());
+///         cancellations += 1;
+///         assert_eq!(cancellations, 1, "only 6th task was aborted");
+///       }
+///     }
+///   }
+///
+///   // there will be at most one terminal completion
+///   assert_eq!(completions.load(std::sync::atomic::Ordering::Relaxed), 1);
+/// }
+/// ```
+#[derive(Clone)]
+pub struct SharedRetryable<V> {
+    inner: Arc<tokio::sync::Mutex<Option<MaybeDone<V>>>>,
+}
+
+impl<V> Default for SharedRetryable<V> {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(None)),
+        }
+    }
+}
+
+/// Determine if an error is transient or permanent.
+pub trait Retryable {
+    fn is_permanent(&self) -> bool {
+        true
+    }
+}
+
+/// Retried task panicked, was cancelled, or never spawned (see [`SharedRetryable::try_restart`]).
+#[derive(Debug, PartialEq, Eq)]
+pub struct RetriedTaskPanicked;
+
+impl<T, E1> SharedRetryable<Result<T, E1>>
+where
+    T: Clone + std::fmt::Debug + Send + 'static,
+    E1: Clone + Retryable + std::fmt::Debug + Send + 'static,
+{
+    /// Restart a previously failed operation unless it already completed with a terminal result.
+    ///
+    /// Many tasks can call this function and and get the terminal result from an earlier attempt
+    /// or start a new attempt, or join an existing one.
+    ///
+    /// Compared to `Self::try_restart`, this method also spawns the future to run, which would
+    /// otherwise have to be done manually.
+    pub async fn try_restart_spawn<F, Fut, E2>(&self, retry_with: F) -> Result<T, E2>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, E1>> + Send + 'static,
+        E2: From<E1> + From<RetriedTaskPanicked> + Send + 'static,
+    {
+        let (recv, maybe_fut) = self.try_restart(retry_with).await;
+
+        if let Some(fut) = maybe_fut {
+            // top level function, we must spawn, pageserver cannot use this
+            tokio::spawn(fut);
+        }
+
+        recv.await
+    }
+
+    /// Restart a previously failed operation unless it already completed with a terminal result.
+    ///
+    /// Many tasks can call this function and get the terminal result from an earlier attempt or
+    /// start a new attempt, or join an existing one.
+    ///
+    /// If a task calling this method is cancelled, at worst, a new attempt which is immediatedly
+    /// deemed as having panicked will happen, but without a panic ever happening.
+    ///
+    /// Returns one future for waiting for the result and possibly another which needs to be
+    /// spawned when `Some`. Spawning has to happen before waiting is started, otherwise the first
+    /// future will never make progress.
+    ///
+    /// This complication exists because on pageserver we cannot use `tokio::spawn` directly
+    /// at this time.
+    pub async fn try_restart<F, Fut, E2>(
+        &self,
+        retry_with: F,
+    ) -> (
+        impl std::future::Future<Output = Result<T, E2>> + Send + 'static,
+        Option<impl std::future::Future<Output = ()> + Send + 'static>,
+    )
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, E1>> + Send + 'static,
+        E2: From<E1> + Send + 'static,
+        E2: From<RetriedTaskPanicked>,
+    {
+        use futures::future::Either;
+
+        match self.decide_to_retry_or_join(retry_with).await {
+            Ok(terminal) => (Either::Left(async move { terminal }), None),
+            Err((rx, maybe_fut)) => {
+                let recv = Self::make_oneshot_alike_receiver(rx);
+
+                (Either::Right(recv), maybe_fut)
+            }
+        }
+    }
+
+    async fn decide_to_retry_or_join<F, Fut, E2>(
+        &self,
+        retry_with: F,
+    ) -> Result<
+        Result<T, E2>,
+        (
+            tokio::sync::broadcast::Receiver<Result<T, E1>>,
+            Option<impl std::future::Future<Output = ()> + Send + 'static>,
+        ),
+    >
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, E1>> + Send + 'static,
+        E2: From<E1>,
+        E2: From<RetriedTaskPanicked>,
+    {
+        let mut g = self.inner.lock().await;
+
+        let maybe_rx = match g.as_ref() {
+            Some(MaybeDone::Done(Ok(t))) => return Ok(Ok(t.to_owned())),
+            Some(MaybeDone::Done(Err(e))) if e.is_permanent() => {
+                return Ok(Err(E2::from(e.to_owned())))
+            }
+            Some(MaybeDone::Pending(weak)) => {
+                // failure to upgrade can mean only one thing: there was an unexpected
+                // panic which we consider as a transient retryable error.
+                weak.upgrade()
+            }
+            Some(MaybeDone::Done(Err(_retryable))) => None,
+            None => None,
+        };
+
+        let (strong, maybe_fut) = match maybe_rx {
+            Some(strong) => (strong, None),
+            None => {
+                // new attempt
+                // panic safety: invoke the factory before configuring the pending value
+                let fut = retry_with();
+
+                let (strong, fut) = self.make_run_and_complete(fut, &mut g);
+                (strong, Some(fut))
+            }
+        };
+
+        // important: the Arc<Receiver> is not held after unlocking
+        // important: we resubscribe before lock is released to be sure to get a message which
+        // is sent once receiver is dropped
+        let rx = strong.resubscribe();
+        drop(strong);
+        Err((rx, maybe_fut))
+    }
+
+    /// Spawn and configure a new attempt.
+    ///
+    /// Returns an `Arc<Receiver<V>>` which is valid until the attempt completes, and the future
+    /// which will run to completion outside the lifecycle of the caller.
+    fn make_run_and_complete<Fut>(
+        &self,
+        fut: Fut,
+        g: &mut tokio::sync::MutexGuard<'_, Option<MaybeDone<Result<T, E1>>>>,
+    ) -> (
+        Arc<tokio::sync::broadcast::Receiver<Result<T, E1>>>,
+        impl std::future::Future<Output = ()> + Send + 'static,
+    )
+    where
+        Fut: std::future::Future<Output = Result<T, E1>> + Send + 'static,
+    {
+        #[cfg(debug_assertions)]
+        match &**g {
+            Some(MaybeDone::Pending(weak)) => {
+                assert!(
+                    weak.upgrade().is_none(),
+                    "when starting a restart, should no longer have an upgradeable channel"
+                );
+            }
+            Some(MaybeDone::Done(Err(err))) => {
+                assert!(
+                    !err.is_permanent(),
+                    "when restarting, the err must be transient"
+                );
+            }
+            Some(MaybeDone::Done(Ok(_))) => {
+                panic!("unexpected restart after a completion on MaybeDone");
+            }
+            None => {}
+        }
+
+        self.make_run_and_complete_any(fut, g)
+    }
+
+    /// Oneshot alike as in it's a future which will be consumed by an `await`.
+    ///
+    /// Otherwise the caller might think it's beneficial or reasonable to poll the channel multiple
+    /// times.
+    fn make_oneshot_alike_receiver<E2>(
+        mut rx: tokio::sync::broadcast::Receiver<Result<T, E1>>,
+    ) -> impl std::future::Future<Output = Result<T, E2>> + Send + 'static
+    where
+        E2: From<E1>,
+        E2: From<RetriedTaskPanicked>,
+    {
+        use tokio::sync::broadcast::error::RecvError;
+
+        async move {
+            match rx.recv().await {
+                Ok(Ok(t)) => Ok(t),
+                Ok(Err(e)) => Err(E2::from(e)),
+                Err(RecvError::Closed | RecvError::Lagged(_)) => {
+                    // lagged doesn't mean anything with 1 send, but whatever, handle it the same
+                    // this case should only ever happen if a panick happened in the `fut`.
+                    Err(E2::from(RetriedTaskPanicked))
+                }
+            }
+        }
+    }
+}
+
+impl<V> SharedRetryable<V>
+where
+    V: std::fmt::Debug + Clone + Send + 'static,
+{
+    /// Attempt to run once a spawned future to completion.
+    ///
+    /// Any previous attempt which panicked will be retried, but the `RetriedTaskPanicked` will be
+    /// returned when the most recent attempt panicked.
+    pub async fn attempt_spawn<F, Fut>(&self, attempt_with: F) -> Result<V, RetriedTaskPanicked>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = V> + Send + 'static,
+    {
+        let (rx, maybe_fut) = {
+            let mut g = self.inner.lock().await;
+
+            let maybe_rx = match g.as_ref() {
+                Some(MaybeDone::Done(v)) => return Ok(v.to_owned()),
+                Some(MaybeDone::Pending(weak)) => {
+                    // see comment in try_restart
+                    weak.upgrade()
+                }
+                None => None,
+            };
+
+            let (strong, maybe_fut) = match maybe_rx {
+                Some(strong) => (strong, None),
+                None => {
+                    let fut = attempt_with();
+
+                    let (strong, fut) = self.make_run_and_complete_any(fut, &mut g);
+                    (strong, Some(fut))
+                }
+            };
+
+            // see try_restart for important notes
+            let rx = strong.resubscribe();
+            drop(strong);
+            (rx, maybe_fut)
+        };
+
+        if let Some(fut) = maybe_fut {
+            // this is a top level function, need to spawn directly
+            // from pageserver one wouldn't use this but more piecewise functions
+            tokio::spawn(fut);
+        }
+
+        let recv = Self::make_oneshot_alike_receiver_any(rx);
+
+        recv.await
+    }
+
+    /// Configure a new attempt, but leave spawning it to the caller.
+    ///
+    /// Forgetting the returned future is outside of scope of any correctness guarantees; all of
+    /// the waiters will then be deadlocked, and the MaybeDone will forever be pending. Dropping
+    /// and not running the future will lead to busy looping behaviour.
+    ///
+    /// Also returns an `Arc<Receiver<V>>` which is valid until the attempt completes.
+    fn make_run_and_complete_any<Fut>(
+        &self,
+        fut: Fut,
+        g: &mut tokio::sync::MutexGuard<'_, Option<MaybeDone<V>>>,
+    ) -> (
+        Arc<tokio::sync::broadcast::Receiver<V>>,
+        impl std::future::Future<Output = ()> + Send + 'static,
+    )
+    where
+        Fut: std::future::Future<Output = V> + Send + 'static,
+    {
+        let (tx, rx) = tokio::sync::broadcast::channel(1);
+        let strong = Arc::new(rx);
+
+        **g = Some(MaybeDone::Pending(Arc::downgrade(&strong)));
+
+        let retry = {
+            let strong = strong.clone();
+            let this = self.clone();
+            async move { this.run_and_complete(fut, tx, strong).await }
+        };
+
+        #[cfg(debug_assertions)]
+        match &**g {
+            Some(MaybeDone::Pending(weak)) => {
+                let rx = weak.upgrade().expect("holding the weak and strong locally");
+                assert!(Arc::ptr_eq(&strong, &rx));
+            }
+            _ => unreachable!("MaybeDone::pending must be set after spawn_and_run_complete_any"),
+        }
+
+        (strong, retry)
+    }
+
+    /// Run the actual attempt, and communicate the response via both:
+    /// - setting the `MaybeDone::Done`
+    /// - the broadcast channel
+    async fn run_and_complete<Fut>(
+        &self,
+        fut: Fut,
+        tx: tokio::sync::broadcast::Sender<V>,
+        strong: Arc<tokio::sync::broadcast::Receiver<V>>,
+    ) where
+        Fut: std::future::Future<Output = V>,
+    {
+        let res = fut.await;
+
+        {
+            let mut g = self.inner.lock().await;
+            MaybeDone::complete(&mut *g, &strong, res.clone());
+
+            // make the weak un-upgradeable by dropping the final alive
+            // reference to it. it is final Arc because the Arc never escapes
+            // the critical section.
+            Arc::try_unwrap(strong).expect("expected this to be the only Arc<Receiver<V>>");
+        }
+
+        // now no one can get the Pending(weak) value to upgrade and they only see
+        // the Done(res).
+        //
+        // send the result value to listeners, if any
+        drop(tx.send(res));
+    }
+
+    fn make_oneshot_alike_receiver_any(
+        mut rx: tokio::sync::broadcast::Receiver<V>,
+    ) -> impl std::future::Future<Output = Result<V, RetriedTaskPanicked>> + Send + 'static {
+        use tokio::sync::broadcast::error::RecvError;
+
+        async move {
+            match rx.recv().await {
+                Ok(t) => Ok(t),
+                Err(RecvError::Closed | RecvError::Lagged(_)) => {
+                    // lagged doesn't mean anything with 1 send, but whatever, handle it the same
+                    // this case should only ever happen if a panick happened in the `fut`.
+                    Err(RetriedTaskPanicked)
+                }
+            }
+        }
+    }
+}
+
+/// MaybeDone handles synchronization for multiple requests and the single actual task.
+///
+/// If request handlers witness `Pending` which they are able to upgrade, they are guaranteed a
+/// useful `recv().await`, where useful means "value" or "disconnect" arrives. If upgrade fails,
+/// this means that "disconnect" has happened in the past.
+///
+/// On successful execution the one executing task will set this to `Done` variant, with the actual
+/// resulting value.
+#[derive(Debug)]
+pub enum MaybeDone<V> {
+    Pending(std::sync::Weak<tokio::sync::broadcast::Receiver<V>>),
+    Done(V),
+}
+
+impl<V: std::fmt::Debug> MaybeDone<V> {
+    fn complete(
+        this: &mut Option<MaybeDone<V>>,
+        _expected_rx: &Arc<tokio::sync::broadcast::Receiver<V>>,
+        outcome: V,
+    ) {
+        #[cfg(debug_assertions)]
+        match this {
+            Some(MaybeDone::Pending(weak)) => {
+                let same = weak
+                    .upgrade()
+                    // we don't yet have Receiver::same_channel
+                    .map(|rx| Arc::ptr_eq(&_expected_rx, &rx))
+                    .unwrap_or(false);
+                assert!(same, "different channel had been replaced or dropped");
+            }
+            other => panic!("unexpected MaybeDone: {other:?}"),
+        }
+
+        *this = Some(MaybeDone::Done(outcome));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{RetriedTaskPanicked, Retryable, SharedRetryable};
+
+    #[derive(Debug)]
+    enum OuterError {
+        AttemptPanicked,
+        Unlucky,
+    }
+
+    #[derive(Clone, Debug)]
+    enum InnerError {
+        Unlucky,
+    }
+
+    impl Retryable for InnerError {
+        fn is_permanent(&self) -> bool {
+            false
+        }
+    }
+
+    impl From<InnerError> for OuterError {
+        fn from(_: InnerError) -> Self {
+            OuterError::Unlucky
+        }
+    }
+
+    impl From<RetriedTaskPanicked> for OuterError {
+        fn from(_: RetriedTaskPanicked) -> Self {
+            OuterError::AttemptPanicked
+        }
+    }
+
+    #[tokio::test]
+    async fn restartable_until_permanent() {
+        let shr = SharedRetryable::<Result<u8, InnerError>>::default();
+
+        let res = shr
+            .try_restart_spawn(|| async move { todo!("really unlucky") })
+            .await;
+
+        assert!(matches!(res, Err(OuterError::AttemptPanicked)));
+
+        let res = shr
+            .try_restart_spawn(|| async move { Err(InnerError::Unlucky) })
+            .await;
+
+        assert!(matches!(res, Err(OuterError::Unlucky)));
+
+        let res = shr.try_restart_spawn(|| async move { Ok(42) }).await;
+
+        assert!(matches!(res, Ok::<u8, OuterError>(42)));
+
+        let res = shr
+            .try_restart_spawn(|| async move { panic!("rerun should clone Ok(42)") })
+            .await;
+
+        assert!(matches!(res, Ok::<u8, OuterError>(42)));
+    }
+
+    /// Demonstration of the SharedRetryable::attempt
+    #[tokio::test]
+    async fn attemptable_until_no_panic() {
+        let shr = SharedRetryable::<u8>::default();
+
+        let res = shr
+            .attempt_spawn(|| async move { panic!("should not interfere") })
+            .await;
+
+        assert!(matches!(res, Err(RetriedTaskPanicked)), "{res:?}");
+
+        let res = shr.attempt_spawn(|| async move { 42 }).await;
+
+        assert_eq!(res, Ok(42));
+
+        let res = shr
+            .attempt_spawn(|| async move { panic!("should not be called") })
+            .await;
+
+        assert_eq!(res, Ok(42));
+    }
+
+    #[tokio::test]
+    async fn cancelling_spawner_is_fine() {
+        let shr = SharedRetryable::<Result<u8, InnerError>>::default();
+
+        let (recv1, maybe_fut) = shr
+            .try_restart(|| async move { panic!("should not have been called") })
+            .await;
+        let should_be_spawned = maybe_fut.unwrap();
+
+        let (recv2, maybe_fut) = shr
+            .try_restart(|| async move {
+                panic!("should never be called because waiting on should_be_spawned")
+            })
+            .await;
+        assert!(
+            matches!(maybe_fut, None),
+            "only the first one should had created the future"
+        );
+
+        let mut recv1 = std::pin::pin!(recv1);
+        let mut recv2 = std::pin::pin!(recv2);
+
+        tokio::select! {
+            _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {},
+            _ = &mut recv1 => unreachable!("should not have completed because should_be_spawned not spawned"),
+            _ = &mut recv2 => unreachable!("should not have completed because should_be_spawned not spawned"),
+        }
+
+        drop(should_be_spawned);
+
+        let res = recv1.await;
+        assert!(matches!(res, Err(OuterError::AttemptPanicked)), "{res:?}");
+
+        let res = recv2.await;
+        assert!(matches!(res, Err(OuterError::AttemptPanicked)), "{res:?}");
+
+        // but we can still reach a terminal state if the api is not misused or the
+        // should_be_spawned winner is not cancelled
+
+        let recv1 = shr.try_restart_spawn::<_, _, OuterError>(|| async move { Ok(42) });
+        let recv2 = shr.try_restart_spawn::<_, _, OuterError>(|| async move { Ok(43) });
+
+        assert_eq!(recv1.await.unwrap(), 42);
+        assert_eq!(recv2.await.unwrap(), 42, "43 should never be returned");
+    }
+}

--- a/libs/utils/src/shared_retryable.rs
+++ b/libs/utils/src/shared_retryable.rs
@@ -20,7 +20,8 @@ use std::sync::Arc;
 /// ```
 ///
 /// Implementation is cancel safe. Implementation and internal structure are hurt by the inability
-/// to just spawn the task, but this is needed for pageserver usage.
+/// to just spawn the task, but this is needed for `pageserver` usage. Within `pageserver`, the
+/// `task_mgr` must be used to spawn the future because it will cause awaiting during shutdown.
 ///
 /// Implementation exposes a fully decomposed [`SharedRetryable::try_restart`] which requires the
 /// caller to do the spawning before awaiting for the result. If the caller is dropped while this

--- a/libs/utils/src/shared_retryable.rs
+++ b/libs/utils/src/shared_retryable.rs
@@ -472,7 +472,7 @@ mod tests {
         let shr = SharedRetryable::<Result<u8, InnerError>>::default();
 
         let res = shr
-            .try_restart_spawn(|| async move { todo!("really unlucky") })
+            .try_restart_spawn(|| async move { panic!("really unlucky") })
             .await;
 
         assert!(matches!(res, Err(OuterError::AttemptPanicked)));

--- a/libs/utils/src/shared_retryable.rs
+++ b/libs/utils/src/shared_retryable.rs
@@ -11,7 +11,10 @@ use std::sync::Arc;
 ///      request handler 1 ---->|--X
 ///      request handler 2 ---->|-------|
 ///      request handler 3 ---->|-------|
-///                             \------>/
+///                             |       |
+///                             v       |
+///       one spawned task      \------>/
+///
 /// (X = cancelled during await)
 /// ```
 ///

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -272,6 +272,9 @@ pub enum TaskKind {
 
     #[cfg(test)]
     UnitTest,
+
+    /// Task which is the only task to delete this particular timeline
+    DeleteTimeline,
 }
 
 #[derive(Default)]

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1657,26 +1657,11 @@ impl Tenant {
                     }));
 
                 match removed_timeline {
-                    Ok(None) => {
-                        // This can legitimately happen if there's a concurrent call to this function.
-                        //   T1                                             T2
-                        //   lock
-                        //   unlock
-                        //                                                  lock
-                        //                                                  unlock
-                        //                                                  remove files
-                        //                                                  lock
-                        //                                                  remove from map
-                        //                                                  unlock
-                        //                                                  return
-                        //   remove files
-                        //   lock
-                        //   remove from map observes empty map
-                        //   unlock
-                        //   return
-                        debug!("concurrent call to this function won the race");
-                    }
                     Ok(Some(_)) => {}
+                    Ok(None) => {
+                        // with SharedRetryable this should no longer happen
+                        warn!("no other task should had dropped the Timeline");
+                    }
                     Err(_panic) => return Err(InnerDeleteTimelineError::DeletedGrewChildren),
                 }
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1503,8 +1503,6 @@ impl Tenant {
             timeline
         };
 
-        let span = tracing::Span::current();
-
         // if we have concurrent requests, we will only execute one version of following future;
         // initially it did not have any means to be cancelled.
         //
@@ -1672,7 +1670,7 @@ impl Tenant {
                 Ok(())
             }
             // execute in the *winner's* span so we will capture the request id etc.
-            .instrument(span)
+            .in_current_span()
         };
 
         let (recv, maybe_fut) = timeline.delete_self.try_restart(factory).await;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1540,6 +1540,7 @@ impl Tenant {
                                 // load and attach code bails out if _any_ of the timeline fails to fetch its IndexPart.
                                 // That is, before we declare the Tenant as Active.
                                 // But we only allow calls to delete_timeline on Active tenants.
+                                warn!("failed to stop RemoteTimelineClient due to uninitialized queue");
                                 return Err(InnerDeleteTimelineError::QueueUninitialized);
                             }
                         },

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1505,7 +1505,6 @@ impl Tenant {
 
         let span = tracing::Span::current();
 
-        // FIXME: simplify uploading
         // if we have concurrent requests, we will only execute one version of following future;
         // initially it did not have any means to be cancelled.
         //

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1671,7 +1671,7 @@ impl Tenant {
 
                 Ok(())
             }
-            // execute in the *winners* span so we will capture the request id etc.
+            // execute in the *winner's* span so we will capture the request id etc.
             .instrument(span)
         };
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1626,7 +1626,7 @@ impl Tenant {
                         }
                         Err(e) => {
                             warn!(
-                                "failed to remove local timeline directory {}: {e}",
+                                "failed to remove local timeline directory {}: {e:#}",
                                 local_timeline_directory.display()
                             );
                             return Err(

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -227,6 +227,9 @@ pub struct Timeline {
     state: watch::Sender<TimelineState>,
 
     eviction_task_timeline_state: tokio::sync::Mutex<EvictionTaskTimelineState>,
+
+    pub(super) delete_self:
+        utils::shared_retryable::SharedRetryable<Result<(), super::InnerDeleteTimelineError>>,
 }
 
 /// Internal structure to hold all data needed for logical size calculation.
@@ -1421,6 +1424,8 @@ impl Timeline {
                 eviction_task_timeline_state: tokio::sync::Mutex::new(
                     EvictionTaskTimelineState::default(),
                 ),
+
+                delete_self: utils::shared_retryable::SharedRetryable::default(),
             };
             result.repartition_threshold = result.get_checkpoint_distance() / 10;
             result

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -391,13 +391,14 @@ def test_concurrent_timeline_delete_if_first_stuck_at_index_upload(
         # release the pause
         ps_http.configure_failpoints((failpoint_name, "off"))
 
-        # both should had succeeded
+        # both should had succeeded: the second call will coalesce with the already-ongoing first call
         result = delete_results.get()
         assert result == "success"
         result = delete_results.get()
         assert result == "success"
 
         # the second call will try to transition the timeline into Stopping state, but it's already in that state
+        # (the transition to Stopping state is not part of the request coalescing, because Tenant and Timeline states are a mess already)
         env.pageserver.allowed_errors.append(
             f".*{child_timeline_id}.*Ignoring new state, equal to the existing one: Stopping"
         )

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -401,6 +401,13 @@ def test_concurrent_timeline_delete_if_first_stuck_at_index_upload(
         env.pageserver.allowed_errors.append(
             f".*{child_timeline_id}.*Ignoring new state, equal to the existing one: Stopping"
         )
+
+        def second_call_attempt():
+            assert env.pageserver.log_contains(
+                f".*{child_timeline_id}.*Ignoring new state, equal to the existing one: Stopping"
+            )
+
+        wait_until(50, 0.1, second_call_attempt)
     finally:
         log.info("joining 1st thread")
         # in any case, make sure the lifetime of the thread is bounded to this test

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -473,3 +473,6 @@ def test_delete_timeline_client_hangup(neon_env_builder: NeonEnvBuilder):
                 pass
 
     wait_until(50, 0.5, timeline_goes_away)
+    env.pageserver.allowed_errors.append(
+        f".*NotFound: Timeline {env.initial_tenant}/{child_timeline_id} was not found"
+    )

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -324,11 +324,7 @@ def test_concurrent_timeline_delete_if_first_stuck_at_index_upload(
     If we're stuck uploading the index file with the is_delete flag,
     eventually console will hand up and retry.
     If we're still stuck at the retry time, ensure that the retry
-    fails with status 500, signalling to console that it should retry
-    later.
-    Ideally, timeline_delete should return 202 Accepted and require
-    console to poll for completion, but, that would require changing
-    the API contract.
+    eventually completes with the same status.
     """
 
     neon_env_builder.enable_remote_storage(
@@ -342,7 +338,6 @@ def test_concurrent_timeline_delete_if_first_stuck_at_index_upload(
 
     ps_http = env.pageserver.http_client()
 
-    # make the first call sleep practically forever
     failpoint_name = "persist_index_part_with_deleted_flag_after_set_before_upload_pause"
     ps_http.configure_failpoints((failpoint_name, "pause"))
 


### PR DESCRIPTION
Supercedes an earlier #4159. In an effort to let us write easier code, this particular function was giving us a lot of trouble and so I created `utils::shared_retried::SharedRetried`. It's implementation grew much nastier than I initially wanted, mainly for ability to use `task_mgr::spawn`.

SharedRetried has some tests. It has a bit contrived features because of how we can produce non-terminal or retried results from the future factory that is passed to `try_restart`:
- `Ok(())` is always terminal
- `Err(InnerDeleteTimelineError::DeletedGrewChildren)` is terminal because normally panics from this one future would be non-terminal, but this intentional panicking-to-poison-tenant is caught as a separate case

"Terminal" results mean, that there will not be any more attempts. With the `Ok(())` case, the request handler would most likely be the only one keeping a timeline alive, so no need to retry. After `DeletedGrewChildren` we have no way to retry.

The hope is that in future we can write easier management api request handlers, which are not cancelled.

Reviewing:
- start by looking at the tests of `SharedRetried` to understand how it's meant to be used
- then look at the doc comment
- then remember to turn on "hide whitespace" before looking at the delete_timeline changes

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
