### PR TITLE
eviction: add global histogram for iteration durations

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -186,6 +186,16 @@ static PERSISTENT_BYTES_WRITTEN: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("failed to define a metric")
 });
 
+pub(crate) static EVICTION_ITERATION_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "pageserver_eviction_iteration_duration_seconds_global",
+        "Time spent on a single eviction iteration",
+        &["period_secs", "threshold_secs"],
+        STORAGE_OP_BUCKETS.into(), // TODO: could use better buckets?
+    )
+    .expect("failed to define a metric")
+});
+
 static EVICTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "pageserver_evictions",

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -191,7 +191,7 @@ pub(crate) static EVICTION_ITERATION_DURATION: Lazy<HistogramVec> = Lazy::new(||
         "pageserver_eviction_iteration_duration_seconds_global",
         "Time spent on a single eviction iteration",
         &["period_secs", "threshold_secs"],
-        STORAGE_OP_BUCKETS.into(), // TODO: could use better buckets?
+        STORAGE_OP_BUCKETS.into(),
     )
     .expect("failed to define a metric")
 });

--- a/pageserver/src/tenant/timeline/eviction_task.rs
+++ b/pageserver/src/tenant/timeline/eviction_task.rs
@@ -120,6 +120,13 @@ impl Timeline {
                 }
                 let elapsed = start.elapsed();
                 crate::tenant::tasks::warn_when_period_overrun(elapsed, p.period, "eviction");
+                crate::metrics::EVICTION_ITERATION_DURATION
+                    .get_metric_with_label_values(&[
+                        &format!("{}", p.period.as_secs()),
+                        &format!("{}", p.threshold.as_secs()),
+                    ])
+                    .unwrap()
+                    .observe(elapsed.as_secs_f64());
                 ControlFlow::Continue(start + p.period)
             }
         }


### PR DESCRIPTION
I would like to know whether and by how much the eviction iterations spike in the $period-sized window that happens every $threshold , when all the timelines do the imitate accesses.

refs https://github.com/neondatabase/neon/issues/4154