### PR TITLE
[ABANDONED] make `Timeline::get`'s disk IO async through `spawn_blocking` (parking_lot sync primitves)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pageserver_api",
+ "parking_lot",
  "pin-project-lite",
  "postgres",
  "postgres-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,6 +5425,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "parking_lot",
  "prost",
  "rand",
  "regex",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -75,7 +75,8 @@ enum-map.workspace = true
 enumset.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
-parking_lot.workspace = true
+# feature "send_guard" markes it so that lock guards are Send
+parking_lot = { workspace = true, default-features = false, features = [ "send_guard" ] }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -75,6 +75,7 @@ enum-map.workspace = true
 enumset.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
+parking_lot.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -560,7 +560,6 @@ impl Tenant {
                 || timeline
                     .layers
                     .read()
-                    .unwrap()
                     .iter_historic_layers()
                     .next()
                     .is_some(),
@@ -2502,8 +2501,7 @@ impl Tenant {
         ) {
             Ok(new_timeline) => {
                 if init_layers {
-                    new_timeline.layers.write().unwrap().next_open_layer_at =
-                        Some(new_timeline.initdb_lsn);
+                    new_timeline.layers.write().next_open_layer_at = Some(new_timeline.initdb_lsn);
                 }
                 debug!(
                     "Successfully created initial files for timeline {tenant_id}/{new_timeline_id}"

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -22,6 +22,7 @@ use pageserver_api::models::{
 };
 use std::ops::Range;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::warn;
@@ -335,6 +336,13 @@ impl LayerAccessStats {
     }
 }
 
+pub(crate) type GetValueReconstructFuture = Pin<
+    Box<
+        dyn Send
+            + std::future::Future<Output = Result<(ValueReconstructState, ValueReconstructResult)>>,
+    >,
+>;
+
 /// Supertrait of the [`Layer`] trait that captures the bare minimum interface
 /// required by [`LayerMap`].
 ///
@@ -372,12 +380,12 @@ pub trait Layer: std::fmt::Debug + Send + Sync {
     /// the predecessor layer and call again with the same 'reconstruct_data' to
     /// collect more data.
     fn get_value_reconstruct_data(
-        &self,
+        self: Arc<Self>,
         key: Key,
         lsn_range: Range<Lsn>,
-        reconstruct_data: &mut ValueReconstructState,
-        ctx: &RequestContext,
-    ) -> Result<ValueReconstructResult>;
+        reconstruct_data: ValueReconstructState,
+        ctx: RequestContext,
+    ) -> GetValueReconstructFuture;
 
     /// A short ID string that uniquely identifies the given layer within a [`LayerMap`].
     fn short_id(&self) -> String;
@@ -486,12 +494,12 @@ impl Layer for LayerDescriptor {
     }
 
     fn get_value_reconstruct_data(
-        &self,
+        self: Arc<Self>,
         _key: Key,
         _lsn_range: Range<Lsn>,
-        _reconstruct_data: &mut ValueReconstructState,
-        _ctx: &RequestContext,
-    ) -> Result<ValueReconstructResult> {
+        _reconstruct_data: ValueReconstructState,
+        _ctx: RequestContext,
+    ) -> GetValueReconstructFuture {
         todo!("This method shouldn't be part of the Layer trait")
     }
 

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -46,7 +46,7 @@ use std::io::{Seek, SeekFrom};
 use std::ops::Range;
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::*;
 
 use utils::{
@@ -56,8 +56,8 @@ use utils::{
 };
 
 use super::{
-    DeltaFileName, Layer, LayerAccessStats, LayerAccessStatsReset, LayerFileName, LayerIter,
-    LayerKeyIter, PathOrConf,
+    DeltaFileName, GetValueReconstructFuture, Layer, LayerAccessStats, LayerAccessStatsReset,
+    LayerFileName, LayerIter, LayerKeyIter, PathOrConf,
 };
 
 ///
@@ -318,89 +318,91 @@ impl Layer for DeltaLayer {
     }
 
     fn get_value_reconstruct_data(
-        &self,
+        self: Arc<Self>,
         key: Key,
         lsn_range: Range<Lsn>,
-        reconstruct_state: &mut ValueReconstructState,
-        ctx: &RequestContext,
-    ) -> anyhow::Result<ValueReconstructResult> {
-        ensure!(lsn_range.start >= self.lsn_range.start);
-        let mut need_image = true;
+        mut reconstruct_state: ValueReconstructState,
+        ctx: RequestContext,
+    ) -> GetValueReconstructFuture {
+        Box::pin(async move {
+            ensure!(lsn_range.start >= self.lsn_range.start);
+            let mut need_image = true;
 
-        ensure!(self.key_range.contains(&key));
+            ensure!(self.key_range.contains(&key));
 
-        {
-            // Open the file and lock the metadata in memory
-            let inner = self.load(LayerAccessKind::GetValueReconstructData, ctx)?;
+            {
+                // Open the file and lock the metadata in memory
+                let inner = self.load(LayerAccessKind::GetValueReconstructData, &ctx)?;
 
-            // Scan the page versions backwards, starting from `lsn`.
-            let file = inner.file.as_ref().unwrap();
-            let tree_reader = DiskBtreeReader::<_, DELTA_KEY_SIZE>::new(
-                inner.index_start_blk,
-                inner.index_root_blk,
-                file,
-            );
-            let search_key = DeltaKey::from_key_lsn(&key, Lsn(lsn_range.end.0 - 1));
+                // Scan the page versions backwards, starting from `lsn`.
+                let file = inner.file.as_ref().unwrap();
+                let tree_reader = DiskBtreeReader::<_, DELTA_KEY_SIZE>::new(
+                    inner.index_start_blk,
+                    inner.index_root_blk,
+                    file,
+                );
+                let search_key = DeltaKey::from_key_lsn(&key, Lsn(lsn_range.end.0 - 1));
 
-            let mut offsets: Vec<(Lsn, u64)> = Vec::new();
+                let mut offsets: Vec<(Lsn, u64)> = Vec::new();
 
-            tree_reader.visit(&search_key.0, VisitDirection::Backwards, |key, value| {
-                let blob_ref = BlobRef(value);
-                if key[..KEY_SIZE] != search_key.0[..KEY_SIZE] {
-                    return false;
-                }
-                let entry_lsn = DeltaKey::extract_lsn_from_buf(key);
-                if entry_lsn < lsn_range.start {
-                    return false;
-                }
-                offsets.push((entry_lsn, blob_ref.pos()));
-
-                !blob_ref.will_init()
-            })?;
-
-            // Ok, 'offsets' now contains the offsets of all the entries we need to read
-            let mut cursor = file.block_cursor();
-            let mut buf = Vec::new();
-            for (entry_lsn, pos) in offsets {
-                cursor.read_blob_into_buf(pos, &mut buf).with_context(|| {
-                    format!(
-                        "Failed to read blob from virtual file {}",
-                        file.file.path.display()
-                    )
-                })?;
-                let val = Value::des(&buf).with_context(|| {
-                    format!(
-                        "Failed to deserialize file blob from virtual file {}",
-                        file.file.path.display()
-                    )
-                })?;
-                match val {
-                    Value::Image(img) => {
-                        reconstruct_state.img = Some((entry_lsn, img));
-                        need_image = false;
-                        break;
+                tree_reader.visit(&search_key.0, VisitDirection::Backwards, |key, value| {
+                    let blob_ref = BlobRef(value);
+                    if key[..KEY_SIZE] != search_key.0[..KEY_SIZE] {
+                        return false;
                     }
-                    Value::WalRecord(rec) => {
-                        let will_init = rec.will_init();
-                        reconstruct_state.records.push((entry_lsn, rec));
-                        if will_init {
-                            // This WAL record initializes the page, so no need to go further back
+                    let entry_lsn = DeltaKey::extract_lsn_from_buf(key);
+                    if entry_lsn < lsn_range.start {
+                        return false;
+                    }
+                    offsets.push((entry_lsn, blob_ref.pos()));
+
+                    !blob_ref.will_init()
+                })?;
+
+                // Ok, 'offsets' now contains the offsets of all the entries we need to read
+                let mut cursor = file.block_cursor();
+                let mut buf = Vec::new();
+                for (entry_lsn, pos) in offsets {
+                    cursor.read_blob_into_buf(pos, &mut buf).with_context(|| {
+                        format!(
+                            "Failed to read blob from virtual file {}",
+                            file.file.path.display()
+                        )
+                    })?;
+                    let val = Value::des(&buf).with_context(|| {
+                        format!(
+                            "Failed to deserialize file blob from virtual file {}",
+                            file.file.path.display()
+                        )
+                    })?;
+                    match val {
+                        Value::Image(img) => {
+                            reconstruct_state.img = Some((entry_lsn, img));
                             need_image = false;
                             break;
                         }
+                        Value::WalRecord(rec) => {
+                            let will_init = rec.will_init();
+                            reconstruct_state.records.push((entry_lsn, rec));
+                            if will_init {
+                                // This WAL record initializes the page, so no need to go further back
+                                need_image = false;
+                                break;
+                            }
+                        }
                     }
                 }
+                // release metadata lock and close the file
             }
-            // release metadata lock and close the file
-        }
 
-        // If an older page image is needed to reconstruct the page, let the
-        // caller know.
-        if need_image {
-            Ok(ValueReconstructResult::Continue)
-        } else {
-            Ok(ValueReconstructResult::Complete)
-        }
+            // If an older page image is needed to reconstruct the page, let the
+            // caller know.
+            if need_image {
+                Ok((reconstruct_state, ValueReconstructResult::Continue))
+            } else {
+                Ok((reconstruct_state, ValueReconstructResult::Complete))
+            }
+        })
     }
 }
 

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -43,7 +43,7 @@ use std::io::{Seek, SeekFrom};
 use std::ops::Range;
 use std::os::unix::prelude::FileExt;
 use std::path::{Path, PathBuf};
-use std::sync::{RwLock, RwLockReadGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 use tracing::*;
 
 use utils::{
@@ -53,7 +53,7 @@ use utils::{
 };
 
 use super::filename::{ImageFileName, LayerFileName};
-use super::{Layer, LayerAccessStatsReset, LayerIter, PathOrConf};
+use super::{GetValueReconstructFuture, Layer, LayerAccessStatsReset, LayerIter, PathOrConf};
 
 ///
 /// Header stored in the beginning of the file
@@ -197,38 +197,41 @@ impl Layer for ImageLayer {
 
     /// Look up given page in the file
     fn get_value_reconstruct_data(
-        &self,
+        self: Arc<Self>,
         key: Key,
         lsn_range: Range<Lsn>,
-        reconstruct_state: &mut ValueReconstructState,
-        ctx: &RequestContext,
-    ) -> anyhow::Result<ValueReconstructResult> {
-        assert!(self.key_range.contains(&key));
-        assert!(lsn_range.start >= self.lsn);
-        assert!(lsn_range.end >= self.lsn);
+        mut reconstruct_state: ValueReconstructState,
+        ctx: RequestContext,
+    ) -> GetValueReconstructFuture {
+        Box::pin(async move {
+            assert!(self.key_range.contains(&key));
+            assert!(lsn_range.start >= self.lsn);
+            assert!(lsn_range.end >= self.lsn);
 
-        let inner = self.load(LayerAccessKind::GetValueReconstructData, ctx)?;
+            let inner = self.load(LayerAccessKind::GetValueReconstructData, &ctx)?;
 
-        let file = inner.file.as_ref().unwrap();
-        let tree_reader = DiskBtreeReader::new(inner.index_start_blk, inner.index_root_blk, file);
+            let file = inner.file.as_ref().unwrap();
+            let tree_reader =
+                DiskBtreeReader::new(inner.index_start_blk, inner.index_root_blk, file);
 
-        let mut keybuf: [u8; KEY_SIZE] = [0u8; KEY_SIZE];
-        key.write_to_byte_slice(&mut keybuf);
-        if let Some(offset) = tree_reader.get(&keybuf)? {
-            let blob = file.block_cursor().read_blob(offset).with_context(|| {
-                format!(
-                    "failed to read value from data file {} at offset {}",
-                    self.path().display(),
-                    offset
-                )
-            })?;
-            let value = Bytes::from(blob);
+            let mut keybuf: [u8; KEY_SIZE] = [0u8; KEY_SIZE];
+            key.write_to_byte_slice(&mut keybuf);
+            if let Some(offset) = tree_reader.get(&keybuf)? {
+                let blob = file.block_cursor().read_blob(offset).with_context(|| {
+                    format!(
+                        "failed to read value from data file {} at offset {}",
+                        self.path().display(),
+                        offset
+                    )
+                })?;
+                let value = Bytes::from(blob);
 
-            reconstruct_state.img = Some((self.lsn, value));
-            Ok(ValueReconstructResult::Complete)
-        } else {
-            Ok(ValueReconstructResult::Missing)
-        }
+                reconstruct_state.img = Some((self.lsn, value));
+                Ok((reconstruct_state, ValueReconstructResult::Complete))
+            } else {
+                Ok((reconstruct_state, ValueReconstructResult::Missing))
+            }
+        })
     }
 }
 

--- a/pageserver/src/tenant/storage_layer/remote_layer.rs
+++ b/pageserver/src/tenant/storage_layer/remote_layer.rs
@@ -6,7 +6,7 @@ use crate::context::RequestContext;
 use crate::repository::Key;
 use crate::tenant::layer_map::BatchedUpdates;
 use crate::tenant::remote_timeline_client::index::LayerFileMetadata;
-use crate::tenant::storage_layer::{Layer, ValueReconstructResult, ValueReconstructState};
+use crate::tenant::storage_layer::{Layer, ValueReconstructState};
 use anyhow::{bail, Result};
 use pageserver_api::models::HistoricLayerInfo;
 use std::ops::Range;
@@ -21,8 +21,8 @@ use utils::{
 use super::filename::{DeltaFileName, ImageFileName, LayerFileName};
 use super::image_layer::ImageLayer;
 use super::{
-    DeltaLayer, LayerAccessStats, LayerAccessStatsReset, LayerIter, LayerKeyIter,
-    LayerResidenceStatus, PersistentLayer,
+    DeltaLayer, GetValueReconstructFuture, LayerAccessStats, LayerAccessStatsReset, LayerIter,
+    LayerKeyIter, LayerResidenceStatus, PersistentLayer,
 };
 
 /// RemoteLayer is a not yet downloaded [`ImageLayer`] or
@@ -83,16 +83,18 @@ impl Layer for RemoteLayer {
     }
 
     fn get_value_reconstruct_data(
-        &self,
+        self: Arc<Self>,
         _key: Key,
         _lsn_range: Range<Lsn>,
-        _reconstruct_state: &mut ValueReconstructState,
-        _ctx: &RequestContext,
-    ) -> Result<ValueReconstructResult> {
-        bail!(
-            "layer {} needs to be downloaded",
-            self.filename().file_name()
-        );
+        _reconstruct_state: ValueReconstructState,
+        _ctx: RequestContext,
+    ) -> GetValueReconstructFuture {
+        Box::pin(async move {
+            bail!(
+                "layer {} needs to be downloaded",
+                self.filename().file_name()
+            );
+        })
     }
 
     fn is_incremental(&self) -> bool {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -504,12 +504,13 @@ impl Timeline {
             None => None,
         };
 
-        let mut reconstruct_state = ValueReconstructState {
+        let reconstruct_state = ValueReconstructState {
             records: Vec::new(),
             img: cached_page_img,
         };
 
-        self.get_reconstruct_data(key, lsn, &mut reconstruct_state, ctx)
+        let reconstruct_state = self
+            .get_reconstruct_data(key, lsn, reconstruct_state, ctx)
             .await?;
 
         self.metrics
@@ -2146,9 +2147,9 @@ impl Timeline {
         &self,
         key: Key,
         request_lsn: Lsn,
-        reconstruct_state: &mut ValueReconstructState,
+        mut reconstruct_state: ValueReconstructState,
         ctx: &RequestContext,
-    ) -> Result<(), PageReconstructError> {
+    ) -> Result<ValueReconstructState, PageReconstructError> {
         // Start from the current timeline.
         let mut timeline_owned;
         let mut timeline = self;
@@ -2175,12 +2176,12 @@ impl Timeline {
             // The function should have updated 'state'
             //info!("CALLED for {} at {}: {:?} with {} records, cached {}", key, cont_lsn, result, reconstruct_state.records.len(), cached_lsn);
             match result {
-                ValueReconstructResult::Complete => return Ok(()),
+                ValueReconstructResult::Complete => return Ok(reconstruct_state),
                 ValueReconstructResult::Continue => {
                     // If we reached an earlier cached page image, we're done.
                     if cont_lsn == cached_lsn + 1 {
                         self.metrics.materialized_page_cache_hit_counter.inc_by(1);
-                        return Ok(());
+                        return Ok(reconstruct_state);
                     }
                     if prev_lsn <= cont_lsn {
                         // Didn't make any progress in last iteration. Error out to avoid
@@ -2237,13 +2238,19 @@ impl Timeline {
                             // Get all the data needed to reconstruct the page version from this layer.
                             // But if we have an older cached page image, no need to go past that.
                             let lsn_floor = max(cached_lsn + 1, start_lsn);
-                            result = match open_layer.get_value_reconstruct_data(
-                                key,
-                                lsn_floor..cont_lsn,
-                                reconstruct_state,
-                                ctx,
-                            ) {
-                                Ok(result) => result,
+                            result = match Arc::clone(open_layer)
+                                .get_value_reconstruct_data(
+                                    key,
+                                    lsn_floor..cont_lsn,
+                                    reconstruct_state,
+                                    ctx.attached_child(),
+                                )
+                                .await
+                            {
+                                Ok((new_reconstruct_state, result)) => {
+                                    reconstruct_state = new_reconstruct_state;
+                                    result
+                                }
                                 Err(e) => return Err(PageReconstructError::from(e)),
                             };
                             cont_lsn = lsn_floor;
@@ -2263,13 +2270,19 @@ impl Timeline {
                         if cont_lsn > start_lsn {
                             //info!("CHECKING for {} at {} on frozen layer {}", key, cont_lsn, frozen_layer.filename().display());
                             let lsn_floor = max(cached_lsn + 1, start_lsn);
-                            result = match frozen_layer.get_value_reconstruct_data(
-                                key,
-                                lsn_floor..cont_lsn,
-                                reconstruct_state,
-                                ctx,
-                            ) {
-                                Ok(result) => result,
+                            result = match Arc::clone(frozen_layer)
+                                .get_value_reconstruct_data(
+                                    key,
+                                    lsn_floor..cont_lsn,
+                                    reconstruct_state,
+                                    ctx.attached_child(),
+                                )
+                                .await
+                            {
+                                Ok((new_reconstruct_state, result)) => {
+                                    reconstruct_state = new_reconstruct_state;
+                                    result
+                                }
                                 Err(e) => return Err(PageReconstructError::from(e)),
                             };
                             cont_lsn = lsn_floor;
@@ -2297,13 +2310,19 @@ impl Timeline {
                             // Get all the data needed to reconstruct the page version from this layer.
                             // But if we have an older cached page image, no need to go past that.
                             let lsn_floor = max(cached_lsn + 1, lsn_floor);
-                            result = match layer.get_value_reconstruct_data(
-                                key,
-                                lsn_floor..cont_lsn,
-                                reconstruct_state,
-                                ctx,
-                            ) {
-                                Ok(result) => result,
+                            result = match Arc::clone(&layer)
+                                .get_value_reconstruct_data(
+                                    key,
+                                    lsn_floor..cont_lsn,
+                                    reconstruct_state,
+                                    ctx.attached_child(),
+                                )
+                                .await
+                            {
+                                Ok((new_reconstruct_state, result)) => {
+                                    reconstruct_state = new_reconstruct_state;
+                                    result
+                                }
                                 Err(e) => return Err(PageReconstructError::from(e)),
                             };
                             cont_lsn = lsn_floor;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2143,6 +2143,24 @@ impl Timeline {
     ///
     /// This function takes the current timeline's locked LayerMap as an argument,
     /// so callers can avoid potential race conditions.
+    ///
+    // TODO: find a way to not hold the Timeline::layers lock during get_value_reconstruct_data calls.
+    //
+    // Since these calls do local disk IO, they'll be reasonably fast, until come disk IOPS bound.
+    // We have lots of headroom on current pageservers, so, it's going to be fine for now.
+    //
+    // We can't use tokio::sync::RwLock that easily because its guard is not Send, but,
+    // many tasks that access Timeline::layers run inside task_mgr tasks, which are required
+    // to be Send. It has been tried in origin/problame/asyncify-get-reconstruct-data--tokio-sync.
+    //
+    // The solution will probably be to have an immutable + multi-versioned layer map, allowing
+    // us to grab a snapshot of the layer map once and execute this function on the snapshot.
+    //
+    // Or, we could invest time to figure out whether we can drop the layer map lock after
+    // we grabbed the layer, do the IO, re-aquire, and continue the traversal.
+    //
+    // (Why is this allow() not inside the function? Because clippy doesn't respect it then).
+    #[allow(clippy::await_holding_lock)]
     async fn get_reconstruct_data(
         &self,
         key: Key,

--- a/pageserver/src/tenant/timeline/eviction_task.rs
+++ b/pageserver/src/tenant/timeline/eviction_task.rs
@@ -178,7 +178,7 @@ impl Timeline {
         // We don't want to hold the layer map lock during eviction.
         // So, we just need to deal with this.
         let candidates: Vec<Arc<dyn PersistentLayer>> = {
-            let layers = self.layers.read().unwrap();
+            let layers = self.layers.read();
             let mut candidates = Vec::new();
             for hist_layer in layers.iter_historic_layers() {
                 if hist_layer.is_remote_layer() {

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -36,6 +36,7 @@ nom = { version = "7" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128"] }
+parking_lot = { version = "0.12", features = ["send_guard"] }
 prost = { version = "0.11" }
 rand = { version = "0.8", features = ["small_rng"] }
 regex = { version = "1" }


### PR DESCRIPTION
Summary
==========

Before this PR, we'd execute the synchronous IOs inside `Layer::get_value_reconstruct_data` on the tokio main executor threads.

This has a bunch of problems:
* We limit IO parallelism among all the timelines to the number of tokio main executor threads (default: ncpus (?))
* While we do IO, no other async code can run on that executor thread.
  So, we starve other `async` tasks that are runnable.

I found this while analyzing https://github.com/neondatabase/neon/issues/4154 .
I have no concrete hypothesis for why 4154 would be caused by above problems.
But, I know that 4154 happens only on the CI runners.
The CI runners are notorious for high CPU usage, which, with regards to task starvation,
has the same effect as blocking the executor threads through blocking IO.
So, even if this change makes 4154 go away, this is not a fix for it.
But anyways, the problems above are severe enough to be worth a fix, regardless of 4154.

Implementation
==============

This PR conversts Tenant::timelines and Timeline::layers from std::sync to parking_lot primitives.
We use parking lot with the `send_guard` feature enabled.
That makes the `Mutex` and `RwLock` guard objects `Send`.
Having them `Send` allows us to hold them across `.await` points.

With these preliminaries out of the way, we can turn
`Layer::get_value_reconstruct_data` into an async trait method.
Rust doesn't have async trait methods yet, so, the method is still sync,
but we make it return a boxed future.

The boxed future can outlive the `get_value_reconstruct_data` invocation.
So, we have to `move` all the arguments into the boxed future.
This primarily affects how the `ValueReconstructState` is handled.
Before this PR, it was passed in as a `&mut`.
With this PR, we pass it in by value and the future returns it back.
So, it will be moved through a bunch of `get_value_reconstruct_data` futures over the course of a `Timeline::get` call.

Inside the boxed future, we use `spawn_blocking` to execute the same synchronous code that we had before this patch.
We could switch to `tokio::fs` in the future, but, that would require getting rid of the `std::sync` primitives used inside the various `Layer` types.

Performance
===========

Anticipiated performance impact:

* Each `get_value_reconstruct_data` call now allocates the returned boxed future.
 * These are short-lived allocations, and, for a given Timeline::get call, there's only
   one of them at a time.
   Maybe we could pre-allocate these at the beginning of `Timeline::get`,
   or have a slab cache of sorts.
   But I think given that we will do system call, the direct overhead of the allocation is miniscule.
   Fragmentation may become an issue, which could be solved through a slab cache.
* The `spawn_blocking` has overhead, because, it's basically a thread pool underneath.
* In total, I'd still expect that no longer blocking the executors has a positive impact on
  currently un-monitored metrics like the p9X of the `time an async task waits to be polled`.


Maintainability
===============

The use of the `Send` parking_lot mutex & rwlock guards is my biggest concern.
For example, with them, it's no longer a compile-time error to `download_remote_layer` while holding the layer map lock.
If we believe that we can't catch such issues in code review, perhaps it's better to reduce hold times of `Tenant::timelines` and `Timelines::layers` first.
Then, we can drop the parking_lot patches from this PR.