### PR TITLE
Fix Allure reports for different benchmark jobs

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -206,4 +206,4 @@ runs:
       uses: ./.github/actions/allure-report-store
       with:
         report-dir: /tmp/test_output/allure/results
-        unique-key: ${{ inputs.test_selection }}-${{ inputs.build_type }}
+        unique-key: ${{ inputs.build_type }}

--- a/scripts/pr-comment-test-report.js
+++ b/scripts/pr-comment-test-report.js
@@ -79,7 +79,17 @@ module.exports = async ({ github, context, fetch, report }) => {
     for (const parentSuite of suites.children) {
         for (const suite of parentSuite.children) {
             for (const test of suite.children) {
-                const {groups: {buildType, pgVersion}} = test.name.match(/[\[-](?<buildType>debug|release)-pg(?<pgVersion>\d+)[-\]]/)
+                let buildType, pgVersion
+                const match = test.name.match(/[\[-](?<buildType>debug|release)-pg(?<pgVersion>\d+)[-\]]/)?.groups
+                if (match) {
+                    ({buildType, pgVersion} = match)
+                } else {
+                    // It's ok, we embed BUILD_TYPE and Postgres Version into the test name only for regress suite and do not for other suites (like performance).
+                    console.info(`Cannot get BUILD_TYPE and Postgres Version from test name: "${test.name}", defaulting to "release" and "14"`)
+
+                    buildType = "release"
+                    pgVersion = "14"
+                }
 
                 pgVersions.add(pgVersion)
                 buildTypes.add(buildType)


### PR DESCRIPTION
- Fix Allure report generation failure for Nightly Benchmarks like https://github.com/neondatabase/neon/actions/runs/4964779099/jobs/8886629078#step:7:2563
- Fix GitHub Autocomment for `run-benchmarks` label (`build_and_test.yml::benchmarks` job) like https://github.com/neondatabase/neon/actions/runs/4977901684/jobs/8908595622?pr=4204