### PR TITLE
Simplify github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-## Describe your changes
+## Problem
 
-## Issue ticket number and link
+## Summary of changes
 
 ## Checklist before requesting a review
 - [ ] I have performed a self-review of my code.


### PR DESCRIPTION
## Problem

Recently PR descriptions got longer but harder to actually read. Some problems come from our template:
1. The suggested order of sections in the template is unnatural. Talks about solution first, problem later. People naturally want to talk about the problem first, so they put paragraphs about the problem in the "wrong" section.
2. The sections are speaking to the writer, not the reader. Example: "Describe your changes" is not a good section

The checklist also adds quite a bit of noise but I have no good ideas for it so I'm not changing it.

In general when we notice that circumventing the process becomes the norm, we should dial back on process so we don't teach ourselves to ignore our own advice. We should somehow raise the bar for PR description quality, but there are other methods besides templates:
1. Set a good example
2. Praise good examples ("#props" slack channel maybe?)
3. When a PR is unreadable, ask the author for more. People want their PRs reviewed fast, and usually do what it takes to achieve that when given feedback

## Summary of changes

- reordered the sections
- simplified the language

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [x] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.
