### PR TITLE
use const instead of magic number for repartition threshold

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1492,7 +1492,8 @@ impl Timeline {
                 initial_logical_size_can_start,
                 initial_logical_size_attempt: Mutex::new(initial_logical_size_attempt),
             };
-            result.repartition_threshold = result.get_checkpoint_distance() / 10;
+            result.repartition_threshold =
+                result.get_checkpoint_distance() / result.get_compaction_threshold() as u64;
             result
                 .metrics
                 .last_record_gauge

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1298,6 +1298,10 @@ impl Timeline {
     }
 }
 
+/// Number of times we will compute partition within a checkpoint distance. Currently, this is set to 10, which
+/// indicates that we will recompute partition 10 times within a checkpoint distance.
+pub const REPARTITION_FREQ_IN_CHECKPOINT_DISTANCE: u64 = 10;
+
 // Private functions
 impl Timeline {
     fn get_checkpoint_distance(&self) -> u64 {
@@ -1493,7 +1497,7 @@ impl Timeline {
                 initial_logical_size_attempt: Mutex::new(initial_logical_size_attempt),
             };
             result.repartition_threshold =
-                result.get_checkpoint_distance() / result.get_compaction_threshold() as u64;
+                result.get_checkpoint_distance() / REPARTITION_FREQ_IN_CHECKPOINT_DISTANCE;
             result
                 .metrics
                 .last_record_gauge

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1298,9 +1298,8 @@ impl Timeline {
     }
 }
 
-/// Number of times we will compute partition within a checkpoint distance. Currently, this is set to 10, which
-/// indicates that we will recompute partition 10 times within a checkpoint distance.
-pub const REPARTITION_FREQ_IN_CHECKPOINT_DISTANCE: u64 = 10;
+/// Number of times we will compute partition within a checkpoint distance.
+const REPARTITION_FREQ_IN_CHECKPOINT_DISTANCE: u64 = 10;
 
 // Private functions
 impl Timeline {


### PR DESCRIPTION
## Problem

## Summary of changes

There is a magic number about how often we repartition and therefore affecting how often we compact. This PR makes this number `10` a global constant and add docs.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
