### PR TITLE
Store timeline logical size in key-value storage to make it persistent

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -282,7 +282,6 @@ pub struct TimelineInfo {
     /// Sum of the size of all layer files.
     /// If a layer is present in both local FS and S3, it counts only once.
     pub current_physical_size: Option<u64>, // is None when timeline is Unloaded
-    pub current_logical_size_non_incremental: Option<u64>,
 
     pub timeline_dir_layer_file_size_sum: Option<u64>,
 

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -237,11 +237,6 @@ pub enum TaskKind {
     /// See [`crate::disk_usage_eviction_task`].
     DiskUsageEviction,
 
-    // Initial logical size calculation
-    InitialLogicalSizeCalculation,
-
-    OndemandLogicalSizeCalculation,
-
     // Task that flushes frozen in-memory layers to disk
     LayerFlushTask,
 

--- a/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
@@ -346,9 +346,7 @@ pub(super) async fn handle_walreceiver_connection(
 
             // Send the replication feedback message.
             // Regular standby_status_update fields are put into this message.
-            let (timeline_logical_size, _) = timeline
-                .get_current_logical_size(&ctx)
-                .context("Status update creation failed to get current logical size")?;
+            let timeline_logical_size = timeline.get_current_logical_size();
             let status_update = PageserverFeedback {
                 current_timeline_size: timeline_logical_size,
                 last_received_lsn,


### PR DESCRIPTION
## Problem

Right now logical storage size is not persistent and has to be recalculated on each pageserver restart.
It can increase both start and stop server time, although it is done now by background thread.
In any case - there is quite complex code responsible for logical size calculation.
It can e eliminated if we persist logical size in our key value storage.

pros:
- no need to calculate logial size o each pageserver restar

cons:
- we have to write additional information in KV storage. But as far as it has to e done only at layer delta file generation, overhead is not expected to be large.

## Summary of changes

Persist logical size in KV storage and remove all code performing calculation of logical size in background.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
