### PR TITLE
Add an option to set "latest gc cutoff lsn" in pageserver binutils

### DIFF
--- a/pageserver/src/bin/pageserver_binutils.rs
+++ b/pageserver/src/bin/pageserver_binutils.rs
@@ -4,8 +4,6 @@
 //!
 //! Separate, `metadata` subcommand allows to print and update pageserver's metadata file.
 use std::{
-    fs,
-    io::Write,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -127,8 +125,7 @@ fn handle_metadata(path: &Path, arg_matches: &clap::ArgMatches) -> Result<(), an
 
     if update_meta {
         let metadata_bytes = meta.to_bytes()?;
-        let mut file = fs::OpenOptions::new().write(true).open(path)?;
-        file.write_all(&metadata_bytes)?;
+        std::fs::write(path, metadata_bytes)?;
     }
 
     Ok(())

--- a/pageserver/src/bin/pageserver_binutils.rs
+++ b/pageserver/src/bin/pageserver_binutils.rs
@@ -87,7 +87,7 @@ fn handle_metadata(path: &Path, arg_matches: &clap::ArgMatches) -> Result<(), an
     let metadata_bytes = std::fs::read(path)?;
     let mut meta = TimelineMetadata::from_bytes(&metadata_bytes)?;
     println!("Current metadata:\n{meta:?}");
-
+    let mut update_meta = false;
     if let Some(disk_consistent_lsn) = arg_matches.get_one::<String>("disk_consistent_lsn") {
         meta = TimelineMetadata::new(
             Lsn::from_str(disk_consistent_lsn)?,
@@ -98,6 +98,7 @@ fn handle_metadata(path: &Path, arg_matches: &clap::ArgMatches) -> Result<(), an
             meta.initdb_lsn(),
             meta.pg_version(),
         );
+        update_meta = true;
     }
     if let Some(prev_record_lsn) = arg_matches.get_one::<String>("prev_record_lsn") {
         meta = TimelineMetadata::new(
@@ -109,6 +110,7 @@ fn handle_metadata(path: &Path, arg_matches: &clap::ArgMatches) -> Result<(), an
             meta.initdb_lsn(),
             meta.pg_version(),
         );
+        update_meta = true;
     }
     if let Some(latest_gc_cuttoff) = arg_matches.get_one::<String>("latest_gc_cuttoff") {
         meta = TimelineMetadata::new(
@@ -120,11 +122,14 @@ fn handle_metadata(path: &Path, arg_matches: &clap::ArgMatches) -> Result<(), an
             meta.initdb_lsn(),
             meta.pg_version(),
         );
+        update_meta = true;
     }
 
-    let metadata_bytes = meta.to_bytes()?;
-    let mut file = fs::OpenOptions::new().write(true).open(path)?;
-    file.write_all(&metadata_bytes)?;
+    if update_meta {
+        let metadata_bytes = meta.to_bytes()?;
+        let mut file = fs::OpenOptions::new().write(true).open(path)?;
+        file.write_all(&metadata_bytes)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Problem
[#2539](https://github.com/neondatabase/neon/issues/2539)
## Summary of changes
Add support  for latest_gc_cutoff_lsn update in pageserver_binutils