### PR TITLE
tenant loops: refactor wait-for-active and cancellation

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1588,7 +1588,7 @@ impl Tenant {
     }
 
     /// Changes tenant status to active, unless shutdown was already requested.
-    fn activate(&self, ctx: &RequestContext) -> anyhow::Result<()> {
+    fn activate(self: &Arc<Self>, ctx: &RequestContext) -> anyhow::Result<()> {
         debug_assert_current_span_has_tenant_id();
 
         let mut result = Ok(());
@@ -1621,7 +1621,7 @@ impl Tenant {
 
                     // Spawn gc and compaction loops. The loops will shut themselves
                     // down when they notice that the tenant is inactive.
-                    tasks::start_background_loops(self.tenant_id);
+                    tasks::start_background_loops(self);
 
                     let mut activated_timelines = 0;
                     let mut timelines_broken_during_activation = 0;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1750,7 +1750,7 @@ impl Tenant {
         });
     }
 
-    pub async fn wait_to_become_active(&self) -> Result<(), WaitToBecomeActiveError> {
+    pub async fn wait_to_become_active(&self) -> anyhow::Result<()> {
         let mut receiver = self.state.subscribe();
         loop {
             let current_state = receiver.borrow_and_update().clone();


### PR DESCRIPTION
`wait_for_active_tenant` is mis-named: its purpose is not to wait for the tenant to become active, but, to prevent new loop iterations while the tenant is not active.

However, we never allow a tenant to transition from `!Active` to `Active` state again. So, the "while not active" aspect is moot.

Futher, we know that we spawnt he background loops `Tenant::activate` when we just made the tenant `Active`. So, we will never actually wait for the tenant to become active.

The only condition where the tenant can be observed `!Active` is when we're shutting down, i.e., transitioning the tenant to `Stopping`. The loops should exit when that happens.

But `wait_for_active_tenant` doesn't handle that case. The individual loops use `task_mgr::shutdown_token()` for that.

This patch simplifies the code by

1. removing `wait_for_active_tenant` which we have shown above to be quite useless, and
2. by making cancellation of the loops a concern of the `Tenant::set_stopping` / `Tenant::set_broken`

This in turn allows us to remove `Tenant::subscribe_for_state_updates`, which is great because now `Tenant::state` is only watched through well-defined APIs like `Tenant::wait_to_become_active`.

The context for this PR is me trying to find an alternative to https://github.com/neondatabase/neon/pull/4291
which is s part of the https://github.com/orgs/neondatabase/projects/38 (async get_value_reconstruct_data).

I don't know if this leads to a true alternative for 4291, but, it's a useful cleanup by itself.

Stacked on top of https://github.com/neondatabase/neon/pull/4298