### PR TITLE
Allow 'tenant_create' with a tenant token.

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -717,7 +717,7 @@ pub fn html_response(status: StatusCode, data: String) -> Result<Response<Body>,
 async fn tenant_create_handler(mut request: Request<Body>) -> Result<Response<Body>, ApiError> {
     let request_data: TenantCreateRequest = json_request(&mut request).await?;
     let target_tenant_id = request_data.new_tenant_id;
-    check_permission(&request, None)?;
+    check_permission(&request, Some(target_tenant_id))?;
 
     let _timer = STORAGE_TIME_GLOBAL
         .get_metric_with_label_values(&[StorageTimeOperation::CreateTenant.into()])

--- a/test_runner/regress/test_auth.py
+++ b/test_runner/regress/test_auth.py
@@ -55,12 +55,17 @@ def test_pageserver_auth(neon_env_builder: NeonEnvBuilder):
     # create tenant using management token
     pageserver_http_client.tenant_create(TenantId.generate())
 
-    # fail to create tenant using tenant token
+    # fail to create tenant with another tenant's token
+    new_tenant_id = TenantId.generate()
     with pytest.raises(
-        PageserverApiException,
-        match="Forbidden: Attempt to access management api with tenant scope. Permission denied",
+        PageserverApiException, match="Forbidden: Tenant id mismatch. Permission denied"
     ):
-        tenant_http_client.tenant_create(TenantId.generate())
+        tenant_http_client.tenant_create(new_tenant_id)
+
+    # succeed with the tenant's token
+    new_tenant_token = env.auth_keys.generate_tenant_token(new_tenant_id)
+    new_tenant_http_client = env.pageserver.http_client(new_tenant_token)
+    new_tenant_http_client.tenant_create(new_tenant_id)
 
 
 def test_compute_auth_to_pageserver(neon_env_builder: NeonEnvBuilder):


### PR DESCRIPTION
Perform permission check with the given tenant_id, when creating a new tenant. Seems more consistent with all the other operations, tenant_create was the only operation you couldn't perform on a tenant with a tenant token.
