### PR TITLE
don't push latest tags on release branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -872,7 +872,7 @@ jobs:
 
       - name: Add latest tag to images
         if: |
-          (github.ref_name == 'main' || github.ref_name == 'release') &&
+          github.ref_name == 'main' &&
            github.event_name != 'workflow_dispatch'
         run: |
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:${{needs.tag.outputs.build-tag}} latest
@@ -884,7 +884,7 @@ jobs:
 
       - name: Push images to production ECR
         if: |
-          (github.ref_name == 'main' || github.ref_name == 'release') &&
+          github.ref_name == 'main' &&
            github.event_name != 'workflow_dispatch'
         run: |
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/neon:latest
@@ -907,7 +907,7 @@ jobs:
 
       - name: Push latest tags to Docker Hub
         if: |
-          (github.ref_name == 'main' || github.ref_name == 'release') &&
+          github.ref_name == 'main' &&
           github.event_name != 'workflow_dispatch'
         run: |
           crane tag neondatabase/neon:${{needs.tag.outputs.build-tag}} latest


### PR DESCRIPTION
before this change we pushed latest tag both on main and on release. This could lead to akward situations when you start using some freshly merged to main feature and then the release happens and you start getting older image. It's possible to bump into this both locally and in cloud CI.
The proposal is to only push latest on main. This is unlikely to cause issues because now if someone merges after the release latest is agin at main. However, the tag is more consistent and not depend on timing of merges

## Problem

## Summary of changes

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
