### PR TITLE
GitHub Autocomment: comment commits for branches

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -409,9 +409,7 @@ jobs:
         uses: ./.github/actions/allure-report-generate
 
       - uses: actions/github-script@v6
-        if: >
-          !cancelled() &&
-          github.event_name == 'pull_request'
+        if: ${{ !cancelled() }}
         with:
           # Retry script for 5XX server errors: https://github.com/actions/github-script#retries
           retries: 5
@@ -421,7 +419,7 @@ jobs:
               reportJsonUrl: "${{ steps.create-allure-report.outputs.report-json-url }}",
             }
 
-            const script = require("./scripts/pr-comment-test-report.js")
+            const script = require("./scripts/comment-test-report.js")
             await script({
               github,
               context,


### PR DESCRIPTION
## Problem

GitHub Autocomment script posts a comment only for PRs, which makes it harder to debug failed tests on main or release branch failures.

Example of such comment for a commit: https://github.com/neondatabase/neon/commit/9d7318b97d4df54519ba4c5576a956022d395ac2#commitcomment-114797780

## Summary of changes
- Change the GitHub Autocomment script to be able to post a comment to either a PR or a commit of a branch

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
