### PR TITLE
Add pageserver parameter forced_image_creation_limit which can be used…

### DIFF
--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -369,6 +369,10 @@ impl PageServerNode {
             evictions_low_residence_duration_metric_threshold: settings
                 .remove("evictions_low_residence_duration_metric_threshold")
                 .map(|x| x.to_string()),
+            forced_image_creation_limit: settings
+                .remove("forced_image_creation_limit")
+                .map(|x| x.parse::<u64>())
+                .transpose()?,
         };
 
         // If tenant ID was not specified, generate one
@@ -463,6 +467,11 @@ impl PageServerNode {
                 evictions_low_residence_duration_metric_threshold: settings
                     .remove("evictions_low_residence_duration_metric_threshold")
                     .map(|x| x.to_string()),
+                forced_image_creation_limit: settings
+                    .remove("forced_image_creation_limit")
+                    .map(|x| x.parse::<u64>())
+                    .transpose()
+                    .context("Failed to parse 'forced_image_creation_limit' as an integer")?,
             }
         };
 

--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -369,10 +369,11 @@ impl PageServerNode {
             evictions_low_residence_duration_metric_threshold: settings
                 .remove("evictions_low_residence_duration_metric_threshold")
                 .map(|x| x.to_string()),
-            forced_image_creation_limit: settings
-                .remove("forced_image_creation_limit")
-                .map(|x| x.parse::<u64>())
-                .transpose()?,
+            gc_feedback: settings
+                .remove("gc_feedback")
+                .map(|x| x.parse::<bool>())
+                .transpose()
+                .context("Failed to parse 'gc_feedback' as bool")?,
         };
 
         // If tenant ID was not specified, generate one
@@ -467,11 +468,11 @@ impl PageServerNode {
                 evictions_low_residence_duration_metric_threshold: settings
                     .remove("evictions_low_residence_duration_metric_threshold")
                     .map(|x| x.to_string()),
-                forced_image_creation_limit: settings
-                    .remove("forced_image_creation_limit")
-                    .map(|x| x.parse::<u64>())
+                gc_feedback: settings
+                    .remove("gc_feedback")
+                    .map(|x| x.parse::<bool>())
                     .transpose()
-                    .context("Failed to parse 'forced_image_creation_limit' as an integer")?,
+                    .context("Failed to parse 'gc_feedback' as bool")?,
             }
         };
 

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -223,8 +223,7 @@ pub struct TenantConfig {
     pub eviction_policy: Option<serde_json::Value>,
     pub min_resident_size_override: Option<u64>,
     pub evictions_low_residence_duration_metric_threshold: Option<String>,
-    /// Maximal number of image layer which creation is requested by GC
-    pub forced_image_creation_limit: Option<u64>,
+    pub gc_feedback: Option<bool>,
 }
 
 #[serde_as]
@@ -283,7 +282,7 @@ impl TenantConfigRequest {
             eviction_policy: None,
             min_resident_size_override: None,
             evictions_low_residence_duration_metric_threshold: None,
-            forced_image_creation_limit: None,
+            gc_feedback: None,
         };
         TenantConfigRequest { tenant_id, config }
     }

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -223,6 +223,8 @@ pub struct TenantConfig {
     pub eviction_policy: Option<serde_json::Value>,
     pub min_resident_size_override: Option<u64>,
     pub evictions_low_residence_duration_metric_threshold: Option<String>,
+    /// Maximal number of image layer which creation is requested by GC
+    pub forced_image_creation_limit: Option<u64>,
 }
 
 #[serde_as]
@@ -281,6 +283,7 @@ impl TenantConfigRequest {
             eviction_policy: None,
             min_resident_size_override: None,
             evictions_low_residence_duration_metric_threshold: None,
+            forced_image_creation_limit: None,
         };
         TenantConfigRequest { tenant_id, config }
     }

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -108,7 +108,7 @@ pub mod defaults {
 
 #min_resident_size_override = .. # in bytes
 #evictions_low_residence_duration_metric_threshold = '{DEFAULT_EVICTIONS_LOW_RESIDENCE_DURATION_METRIC_THRESHOLD}'
-#forced_image_creation_limit = {DEFAULT_FORCED_IMAGE_CREATION_LIMIT}
+#gc_feedback = false
 # [remote_storage]
 
 "###
@@ -828,11 +828,12 @@ impl PageServerConf {
             )?);
         }
 
-        if let Some(forced_image_creation_limit) = item.get("forced_image_creation_limit") {
-            t_conf.forced_image_creation_limit = Some(parse_toml_u64(
-                "forced_image_creation_limit",
-                forced_image_creation_limit,
-            )?);
+        if let Some(gc_feedback) = item.get("gc_feedback") {
+            t_conf.gc_feedback = Some(
+                gc_feedback
+                    .as_bool()
+                    .with_context(|| "configure option gc_feedback is not a bool".to_string())?,
+            );
         }
 
         Ok(t_conf)

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -108,7 +108,7 @@ pub mod defaults {
 
 #min_resident_size_override = .. # in bytes
 #evictions_low_residence_duration_metric_threshold = '{DEFAULT_EVICTIONS_LOW_RESIDENCE_DURATION_METRIC_THRESHOLD}'
-
+#forced_image_creation_limit = {DEFAULT_FORCED_IMAGE_CREATION_LIMIT}
 # [remote_storage]
 
 "###
@@ -825,6 +825,13 @@ impl PageServerConf {
             t_conf.evictions_low_residence_duration_metric_threshold = Some(parse_toml_duration(
                 "evictions_low_residence_duration_metric_threshold",
                 item,
+            )?);
+        }
+
+        if let Some(forced_image_creation_limit) = item.get("forced_image_creation_limit") {
+            t_conf.forced_image_creation_limit = Some(parse_toml_u64(
+                "forced_image_creation_limit",
+                forced_image_creation_limit,
             )?);
         }
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3209,6 +3209,7 @@ pub mod harness {
                 evictions_low_residence_duration_metric_threshold: Some(
                     tenant_conf.evictions_low_residence_duration_metric_threshold,
                 ),
+                forced_image_creation_limit: Some(tenant_conf.forced_image_creation_limit),
             }
         }
     }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3209,7 +3209,7 @@ pub mod harness {
                 evictions_low_residence_duration_metric_threshold: Some(
                     tenant_conf.evictions_low_residence_duration_metric_threshold,
                 ),
-                forced_image_creation_limit: Some(tenant_conf.forced_image_creation_limit),
+                gc_feedback: Some(tenant_conf.gc_feedback),
             }
         }
     }

--- a/pageserver/src/tenant/config.rs
+++ b/pageserver/src/tenant/config.rs
@@ -42,6 +42,7 @@ pub mod defaults {
     pub const DEFAULT_WALRECEIVER_LAGGING_WAL_TIMEOUT: &str = "3 seconds";
     pub const DEFAULT_MAX_WALRECEIVER_LSN_WAL_LAG: u64 = 10 * 1024 * 1024;
     pub const DEFAULT_EVICTIONS_LOW_RESIDENCE_DURATION_METRIC_THRESHOLD: &str = "24 hour";
+    pub const DEFAULT_FORCED_IMAGE_CREATION_LIMIT: u64 = 1024;
 }
 
 /// Per-tenant configuration options
@@ -99,6 +100,7 @@ pub struct TenantConf {
     // See the corresponding metric's help string.
     #[serde(with = "humantime_serde")]
     pub evictions_low_residence_duration_metric_threshold: Duration,
+    pub forced_image_creation_limit: u64,
 }
 
 /// Same as TenantConf, but this struct preserves the information about
@@ -175,6 +177,10 @@ pub struct TenantConfOpt {
     #[serde(with = "humantime_serde")]
     #[serde(default)]
     pub evictions_low_residence_duration_metric_threshold: Option<Duration>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub forced_image_creation_limit: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -242,6 +248,9 @@ impl TenantConfOpt {
             evictions_low_residence_duration_metric_threshold: self
                 .evictions_low_residence_duration_metric_threshold
                 .unwrap_or(global_conf.evictions_low_residence_duration_metric_threshold),
+            forced_image_creation_limit: self
+                .forced_image_creation_limit
+                .unwrap_or(global_conf.forced_image_creation_limit),
         }
     }
 }
@@ -278,6 +287,7 @@ impl Default for TenantConf {
                 DEFAULT_EVICTIONS_LOW_RESIDENCE_DURATION_METRIC_THRESHOLD,
             )
             .expect("cannot parse default evictions_low_residence_duration_metric_threshold"),
+            forced_image_creation_limit: DEFAULT_FORCED_IMAGE_CREATION_LIMIT,
         }
     }
 }
@@ -372,6 +382,7 @@ impl TryFrom<&'_ models::TenantConfig> for TenantConfOpt {
                     ))?,
             );
         }
+        tenant_conf.forced_image_creation_limit = request_data.forced_image_creation_limit;
 
         Ok(tenant_conf)
     }

--- a/pageserver/src/tenant/config.rs
+++ b/pageserver/src/tenant/config.rs
@@ -42,7 +42,12 @@ pub mod defaults {
     pub const DEFAULT_WALRECEIVER_LAGGING_WAL_TIMEOUT: &str = "3 seconds";
     pub const DEFAULT_MAX_WALRECEIVER_LSN_WAL_LAG: u64 = 10 * 1024 * 1024;
     pub const DEFAULT_EVICTIONS_LOW_RESIDENCE_DURATION_METRIC_THRESHOLD: &str = "24 hour";
-    pub const DEFAULT_FORCED_IMAGE_CREATION_LIMIT: u64 = 1024;
+    // This parameter limits amount of image layer generated due to GC request.
+    // It should avoid storage space explosion caused by taken in account GC feedback for existed projects.
+    // Total amount of forced image layers is limited by forced_image_creation_limit*compaction_target_size
+    // per GC iteration. As far as GC will be able to remove old layers only after PiTR interval expiration,
+    // maximal storage extension is pitr_interval/gc_period*forced_image_creation_limit*compaction_target_size
+    pub const DEFAULT_FORCED_IMAGE_CREATION_LIMIT: u64 = 10;
 }
 
 /// Per-tenant configuration options

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2973,15 +2973,14 @@ impl Timeline {
                     // create a new image layer, check if the range is already covered at more recent LSNs.
                     if !layers
                         .image_layer_exists(&img_range, &(Lsn::min(lsn, *cutoff_lsn)..lsn + 1))?
+                        && *forced_image_layers_count < self.get_forced_image_creation_limit()
                     {
-                        if *forced_image_layers_count < self.get_forced_image_creation_limit() {
-                            debug!(
-                                "Force generation of layer {}-{} wanted by GC, cutoff={}, lsn={})",
-                                img_range.start, img_range.end, cutoff_lsn, lsn
-                            );
-                            *forced_image_layers_count += 1;
-                            return Ok(true);
-                        }
+                        debug!(
+                            "Force generation of layer {}-{} wanted by GC, cutoff={}, lsn={})",
+                            img_range.start, img_range.end, cutoff_lsn, lsn
+                        );
+                        *forced_image_layers_count += 1;
+                        return Ok(true);
                     }
                 }
             }

--- a/test_runner/regress/test_attach_tenant_config.py
+++ b/test_runner/regress/test_attach_tenant_config.py
@@ -158,6 +158,7 @@ def test_fully_custom_config(positive_env: NeonEnv):
             "threshold": "23h",
         },
         "evictions_low_residence_duration_metric_threshold": "2days",
+        "forced_image_creation_limit": 1000,
         "gc_horizon": 23 * (1024 * 1024),
         "gc_period": "2h 13m",
         "image_creation_threshold": 7,

--- a/test_runner/regress/test_attach_tenant_config.py
+++ b/test_runner/regress/test_attach_tenant_config.py
@@ -158,7 +158,7 @@ def test_fully_custom_config(positive_env: NeonEnv):
             "threshold": "23h",
         },
         "evictions_low_residence_duration_metric_threshold": "2days",
-        "forced_image_creation_limit": 1000,
+        "gc_feedback": True,
         "gc_horizon": 23 * (1024 * 1024),
         "gc_period": "2h 13m",
         "image_creation_threshold": 7,


### PR DESCRIPTION
This parameter can be use  to restrict number of image layers generated because of GC request (wanted image layers).
Been set to zero it completely eliminates creation of such image layers.
So it allows to avoid extra storage consumption after merging #3673

## Problem
PR #3673 forces generation of missed image layers. So i short term is cause cause increase (in worst case up to two times) size of storage.
It was intended (by me) that GC period is comparable with PiTR interval.
But looks like it is not the case now - GC is performed much more frequently. It may cause the problem with space exhaustion: GC forces new image creation while large PiTR still prevent GC from collecting old layers.

## Summary of changes

Add new pageserver parameter` forced_image_creation_limit` which restrict number of created image layers which are requested by  GC.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
