### PR TITLE
revert: static global init logical size limiter

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1911,22 +1911,6 @@ impl Timeline {
                 // to spawn_ondemand_logical_size_calculation.
                 let cancel = CancellationToken::new();
 
-                /// Ugly, but necessary until `spawn_blocking` is used for blocking I/O, otherwise
-                /// we could lock up all worker threads.
-                static GLOBAL_INITIAL_LOGICAL_SIZES_AT_ONCE: once_cell::sync::Lazy<Arc<tokio::sync::Semaphore>> = once_cell::sync::Lazy::new(|| {
-                    let cores = std::thread::available_parallelism();
-                    // half rationale: we have other blocking work which will start later:
-                    // consumption metrics and per timeline eviction task. we however need to
-                    // be fast to accept page reads, so perhaps this is a suitable middle ground?
-                    let max_blocked_threads = cores.map(|count| count.get() / 2);
-                    let max_blocked_threads = max_blocked_threads.unwrap_or(1);
-                    let max_blocked_threads = std::cmp::max(1, max_blocked_threads);
-                    tracing::info!("using max {max_blocked_threads} threads for initial logical size");
-                    Arc::new(tokio::sync::Semaphore::new(max_blocked_threads))
-                });
-
-                let _permit = GLOBAL_INITIAL_LOGICAL_SIZES_AT_ONCE.clone().acquire_owned().await.expect("global semaphore is never closed");
-
                 let calculated_size = match self_clone
                     .logical_size_calculation_task(lsn, LogicalSizeCalculationCause::Initial, &background_ctx, cancel)
                     .await


### PR DESCRIPTION
added in #4366. revert for testing without it; it may have unintenteded side-effects, and it's very difficult to understand the results from the 10k load testing environments. earlier results: https://github.com/neondatabase/neon/pull/4366#issuecomment-1567491064