### PR TITLE
compute_ctl: enable tracing panic hook

### DIFF
--- a/compute_tools/src/logger.rs
+++ b/compute_tools/src/logger.rs
@@ -33,5 +33,7 @@ pub fn init_tracing_and_logging(default_log_level: &str) -> anyhow::Result<()> {
         .init();
     tracing::info!("logging and tracing started");
 
+    utils::logging::replace_panic_hook_with_tracing_panic_hook().forget();
+
     Ok(())
 }


### PR DESCRIPTION
## Problem

compute_ctl can panic, but `tracing` is used for logging. panic stderr output can interleave with messages from normal logging. Example: https://neondb.slack.com/archives/C033QLM5P7D/p1685454283199429?thread_ts=1685453578.548449&cid=C033QLM5P7D

## Summary of changes

Use established way (pageserver, safekeeper, storage_broker) of using `tracing` to report panics.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [x] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [x] Do not forget to reformat commit message to not include the above checklist
