### PR TITLE
[WIP] refactor: use layer cache for layer download

### DIFF
--- a/pageserver/src/disk_usage_eviction_task.rs
+++ b/pageserver/src/disk_usage_eviction_task.rs
@@ -60,7 +60,7 @@ use utils::serde_percent::Percent;
 use crate::{
     config::PageServerConf,
     task_mgr::{self, TaskKind, BACKGROUND_RUNTIME},
-    tenant::{self, storage_layer::PersistentLayer, Timeline},
+    tenant::{self, storage_layer::{PersistentLayer, RemoteLayerDesc}, Timeline},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -329,7 +329,7 @@ pub async fn disk_usage_eviction_task_iteration_impl<U: Usage>(
     // If we get far enough in the list that we start to evict layers that are below
     // the tenant's min-resident-size threshold, print a warning, and memorize the disk
     // usage at that point, in 'usage_planned_min_resident_size_respecting'.
-    let mut batched: HashMap<_, Vec<Arc<dyn PersistentLayer>>> = HashMap::new();
+    let mut batched: HashMap<_, Vec<Arc<RemoteLayerDesc>>> = HashMap::new();
     let mut warned = None;
     let mut usage_planned = usage_pre;
     for (i, (partition, candidate)) in candidates.into_iter().enumerate() {
@@ -434,7 +434,7 @@ pub async fn disk_usage_eviction_task_iteration_impl<U: Usage>(
 #[derive(Clone)]
 struct EvictionCandidate {
     timeline: Arc<Timeline>,
-    layer: Arc<dyn PersistentLayer>,
+    layer: Arc<RemoteLayerDesc>,
     last_activity_ts: SystemTime,
 }
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -84,6 +84,7 @@ pub mod block_io;
 pub mod disk_btree;
 pub(crate) mod ephemeral_file;
 pub mod layer_map;
+pub mod layer_cache;
 
 pub mod metadata;
 mod par_fsync;

--- a/pageserver/src/tenant/layer_cache.rs
+++ b/pageserver/src/tenant/layer_cache.rs
@@ -1,0 +1,34 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use super::storage_layer::{LayerFileName, PersistentLayer, RemoteLayerDesc};
+
+pub struct LayerCache {
+    layers: Mutex<HashMap<LayerFileName, Arc<dyn PersistentLayer>>>,
+}
+
+impl LayerCache {
+    pub fn new() -> Self {
+        Self {
+            layers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn get(&self, layer_fname: &LayerFileName) -> Option<Arc<dyn PersistentLayer>> {
+        let guard: std::sync::MutexGuard<HashMap<LayerFileName, Arc<dyn PersistentLayer>>> =
+            self.layers.lock().unwrap();
+        guard.get(layer_fname).cloned()
+    }
+
+    pub fn contains(&self, layer_fname: &LayerFileName) -> bool {
+        let guard = self.layers.lock().unwrap();
+        guard.contains_key(layer_fname)
+    }
+
+    pub fn insert(&self, layer_fname: LayerFileName, persistent_layer: Arc<dyn PersistentLayer>) {
+        let mut guard = self.layers.lock().unwrap();
+        guard.insert(layer_fname, persistent_layer);
+    }
+}

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -37,7 +37,7 @@ pub use delta_layer::{DeltaLayer, DeltaLayerWriter};
 pub use filename::{DeltaFileName, ImageFileName, LayerFileName};
 pub use image_layer::{ImageLayer, ImageLayerWriter};
 pub use inmemory_layer::InMemoryLayer;
-pub use remote_layer::RemoteLayer;
+pub use remote_layer::RemoteLayerDesc;
 
 use super::layer_map::BatchedUpdates;
 
@@ -431,14 +431,6 @@ pub trait PersistentLayer: Layer {
     /// Permanently remove this layer from disk.
     fn delete_resident_layer_file(&self) -> Result<()>;
 
-    fn downcast_remote_layer(self: Arc<Self>) -> Option<std::sync::Arc<RemoteLayer>> {
-        None
-    }
-
-    fn is_remote_layer(&self) -> bool {
-        false
-    }
-
     /// Returns None if the layer file size is not known.
     ///
     /// Should not change over the lifetime of the layer object because
@@ -448,16 +440,6 @@ pub trait PersistentLayer: Layer {
     fn info(&self, reset: LayerAccessStatsReset) -> HistoricLayerInfo;
 
     fn access_stats(&self) -> &LayerAccessStats;
-}
-
-pub fn downcast_remote_layer(
-    layer: &Arc<dyn PersistentLayer>,
-) -> Option<std::sync::Arc<RemoteLayer>> {
-    if layer.is_remote_layer() {
-        Arc::clone(layer).downcast_remote_layer()
-    } else {
-        None
-    }
 }
 
 /// Holds metadata about a layer without any content. Used mostly for testing.

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -30,6 +30,7 @@ use crate::repository::{Key, Value, KEY_SIZE};
 use crate::tenant::blob_io::{BlobCursor, BlobWriter, WriteBlobWriter};
 use crate::tenant::block_io::{BlockBuf, BlockCursor, BlockReader, FileBlockReader};
 use crate::tenant::disk_btree::{DiskBtreeBuilder, DiskBtreeReader, VisitDirection};
+use crate::tenant::remote_timeline_client::index::LayerFileMetadata;
 use crate::tenant::storage_layer::{
     PersistentLayer, ValueReconstructResult, ValueReconstructState,
 };
@@ -57,7 +58,7 @@ use utils::{
 
 use super::{
     DeltaFileName, Layer, LayerAccessStats, LayerAccessStatsReset, LayerFileName, LayerIter,
-    LayerKeyIter, PathOrConf,
+    LayerKeyIter, PathOrConf, RemoteLayerDesc,
 };
 
 ///
@@ -661,6 +662,17 @@ impl DeltaLayer {
             self.timeline_id,
             self.tenant_id,
             &self.layer_name(),
+        )
+    }
+
+    /// Create layer descriptor for this image layer
+    pub fn layer_desc(&self) -> RemoteLayerDesc {
+        RemoteLayerDesc::new_delta(
+            self.tenant_id,
+            self.timeline_id,
+            &self.layer_name(),
+            &LayerFileMetadata::new(self.file_size()),
+            LayerAccessStats::empty_will_record_residence_event_later(),
         )
     }
 }

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -26,6 +26,7 @@ use crate::repository::{Key, KEY_SIZE};
 use crate::tenant::blob_io::{BlobCursor, BlobWriter, WriteBlobWriter};
 use crate::tenant::block_io::{BlockBuf, BlockReader, FileBlockReader};
 use crate::tenant::disk_btree::{DiskBtreeBuilder, DiskBtreeReader, VisitDirection};
+use crate::tenant::remote_timeline_client::index::LayerFileMetadata;
 use crate::tenant::storage_layer::{
     LayerAccessStats, PersistentLayer, ValueReconstructResult, ValueReconstructState,
 };
@@ -53,7 +54,7 @@ use utils::{
 };
 
 use super::filename::{ImageFileName, LayerFileName};
-use super::{Layer, LayerAccessStatsReset, LayerIter, PathOrConf};
+use super::{Layer, LayerAccessStatsReset, LayerIter, PathOrConf, RemoteLayerDesc};
 
 ///
 /// Header stored in the beginning of the file
@@ -462,6 +463,17 @@ impl ImageLayer {
             self.timeline_id,
             self.tenant_id,
             &self.layer_name(),
+        )
+    }
+
+    /// Create layer descriptor for this image layer
+    pub fn layer_desc(&self) -> RemoteLayerDesc {
+        RemoteLayerDesc::new_img(
+            self.tenant_id,
+            self.timeline_id,
+            &self.layer_name(),
+            &LayerFileMetadata::new(self.file_size()),
+            LayerAccessStats::empty_will_record_residence_event_later(),
         )
     }
 }

--- a/pageserver/src/tenant/timeline/eviction_task.rs
+++ b/pageserver/src/tenant/timeline/eviction_task.rs
@@ -29,7 +29,7 @@ use crate::{
     task_mgr::{self, TaskKind, BACKGROUND_RUNTIME},
     tenant::{
         config::{EvictionPolicy, EvictionPolicyLayerAccessThreshold},
-        storage_layer::PersistentLayer,
+        storage_layer::{PersistentLayer, RemoteLayerDesc},
         LogicalSizeCalculationCause, Tenant,
     },
 };
@@ -184,11 +184,11 @@ impl Timeline {
         // NB: all the checks can be invalidated as soon as we release the layer map lock.
         // We don't want to hold the layer map lock during eviction.
         // So, we just need to deal with this.
-        let candidates: Vec<Arc<dyn PersistentLayer>> = {
+        let candidates: Vec<Arc<RemoteLayerDesc>> = {
             let layers = self.layers.read().unwrap();
             let mut candidates = Vec::new();
             for hist_layer in layers.iter_historic_layers() {
-                if hist_layer.is_remote_layer() {
+                if !self.layer_cache.contains(&hist_layer.filename()) {
                     continue;
                 }
 


### PR DESCRIPTION
## Problem

part of https://github.com/neondatabase/neon/issues/4373

## Summary of changes

DO NOT REVIEW. THIS IS WIP. Early comments are welcomed. This is the minimum change we will need to make in order to have the layer cache. To make the logic clear, more refactor is needed and we should move more things to the layer cache.

This PR adds a new `layer_cache`, and refactors LayerMap to only store RemoteLayerDesc. If we want to retrieve the underlying layer object, we will need to get it from layer_map.

* Add `layer_cache`. Note that `layer_cache` current does not handle any download / eviction logic. It is simply a HashMap. We should move more things to that struct in this PR.
* Rename `RemoteLayer` to `RemoteLayerDesc`. Change `LayerMap` to store the mapping of `RemoteLayerDesc` instead of `dyn PersistentLayer`.
* `replace` is removed from `LayerMap`. Now we have a function called `ensure_consistent`. Every time we download a file from the remote storage, we should call this function to ensure it is consistent.

**The code just compiles and needs further testing.** The eviction logic is not yet moved to layer cache. RemoteLayerDesc could be further simplified to only record necessary info. LayerMap needs refactor so that we do not need to call replace.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
