### PR TITLE
Add layer stats cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,6 +2530,7 @@ dependencies = [
  "bytes",
  "clap 4.3.0",
  "git-version",
+ "itertools",
  "pageserver",
  "postgres_ffi",
  "svg_fmt",

--- a/pageserver/ctl/Cargo.toml
+++ b/pageserver/ctl/Cargo.toml
@@ -16,3 +16,4 @@ postgres_ffi.workspace = true
 utils.workspace = true
 svg_fmt.workspace = true
 workspace_hack.workspace = true
+itertools.workspace = true


### PR DESCRIPTION
## Problem

We need fast, realistic, reproducible, black-box tests for read/write amplification.

That can't be achieved with end-to-end python tests, because we have to choose if we want a fast test or a realistic (large database) test. We could speed up the test by tweaking flags, but then the test is no longer black-box (our write amplification tests, like `test_random_writes` are already outdated). Also this method limits us to synthetic tests only.

One way to achieve this is to download the L0 layers from an actual database, feed them to the compaction algorithm of the pageserver and analyze what comes out. But that's also slow because we have millions of keys per layer, and it would also take up a lot of space. However, by statistically summarizing the keys in these L0 layers and then running compaction simulation over the summary, we can achieve fast tests.

## Summary of changes
In this PR I add a CLI for outputting a statistical summary of a delta layer. Initially I considered summarizing the layer using quantiles, but that would make some of our optimizations "like layer holes" untestable. So instead I summarize the layer distribution using a histogram with fixed 8MB key partitions. See comments in the code for more justification.

On local tests (running this tool over layers generated by pgbench) I see that the summary is orders of magnitude smaller than the full layer dump, which is promising. The next step is to test this script on more layers (including real ones) to see how effective the approach would be, before committing to implement compaction and gc over statistical layer summaries. Meanwhile I'd appreciate feedback on the general approach, and alternative ideas for writing fast tests for layer ops.