### PR TITLE
Add cold start test

### DIFF
--- a/test_runner/performance/test_startup.py
+++ b/test_runner/performance/test_startup.py
@@ -1,8 +1,48 @@
 from contextlib import closing
 
 import pytest
-from fixtures.benchmark_fixture import NeonBenchmarker
+import requests
+from fixtures.benchmark_fixture import MetricReport, NeonBenchmarker
 from fixtures.neon_fixtures import NeonEnvBuilder
+
+
+# Just start and measure duration.
+#
+# This test runs pretty quickly and can be informative when used in combination
+# with emulated network delay. Some useful delay commands:
+#
+# 1. Add 2msec delay to all localhost traffic
+# `sudo tc qdisc add dev lo root handle 1:0 netem delay 2msec`
+#
+# 2. Test that it works (you should see 4ms ping)
+# `ping localhost`
+#
+# 3. Revert back to normal
+# `sudo tc qdisc del dev lo root netem`
+#
+# NOTE this test might not represent the real startup time because the basebackup
+#      for a large database might be larger, or safekeepers might need more syncing,
+#      or there might be more operations to apply during config step.
+def test_startup_simple(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenchmarker):
+    neon_env_builder.num_safekeepers = 3
+    env = neon_env_builder.init_start()
+
+    env.neon_cli.create_branch("test_startup")
+    with zenbenchmark.record_duration("start_and_select"):
+        endpoint = env.endpoints.create_start("test_startup")
+        endpoint.safe_psql("select 1;")
+
+    metrics = requests.get(f"http://localhost:{endpoint.http_port}/metrics.json").json()
+    durations = {
+        "wait_for_spec_ms": "wait_for_spec",
+        "sync_safekeepers_ms": "sync_safekeepers",
+        "basebackup_ms": "basebackup",
+        "config_ms": "config",
+        "total_startup_ms": "total_startup",
+    }
+    for key, name in durations.items():
+        value = metrics[key]
+        zenbenchmark.record(name, value, "ms", report=MetricReport.LOWER_IS_BETTER)
 
 
 # This test sometimes runs for longer than the global 5 minute timeout.


### PR DESCRIPTION
## Problem
We only have one cold start test, with some problems:
1. It doesn't report a breakdown
2. It runs too long
3. It doesn't reproduce slow behavior

Better testing can help us solve part of the problem here https://github.com/neondatabase/cloud/issues/5315

## Summary of changes
Here I add a startup test that solves (1) and (2), and also add instructions for emulating latency (will do it properly later https://github.com/neondatabase/neon/issues/3491)

To solve (3), we need to add some actual config to apply, because it doesn't look like we currently do https://github.com/neondatabase/neon/blob/df3bae2ce362f285f83b88fff96cf98094b40a9a/control_plane/src/endpoint.rs#L464
