### PR TITLE
compute_ctl: add flag to avoid config step

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -442,7 +442,7 @@ impl ComputeNode {
 
         let pg = self.start_postgres(spec.storage_auth_token.clone())?;
 
-        if spec.spec.mode == ComputeMode::Primary {
+        if spec.spec.mode == ComputeMode::Primary && !spec.spec.already_configured {
             self.apply_config(&compute_state)?;
         }
 

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -450,6 +450,7 @@ impl Endpoint {
 
         // Create spec file
         let spec = ComputeSpec {
+            already_configured: false,
             format_version: 1.0,
             operation_uuid: None,
             cluster: Cluster {

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -27,6 +27,12 @@ pub struct ComputeSpec {
     pub cluster: Cluster,
     pub delta_operations: Option<Vec<DeltaOp>>,
 
+    /// An optinal hint that can be passed to speed up startup time if we know
+    /// that no mutations (like role creation, database creation) need to be
+    /// done on the actual database to start.
+    #[serde(default)] // Default false
+    pub already_configured: bool,
+
     // Information needed to connect to the storage layer.
     //
     // `tenant_id`, `timeline_id` and `pageserver_connstring` are always needed.


### PR DESCRIPTION
## Problem
See https://github.com/neondatabase/neon/pull/4450 and https://github.com/neondatabase/cloud/issues/5315

## Summary of changes
1. Add a new optional flag and use it. There are no new tests but the existing test for parsing a config already passes without changes, so this shouldn't break anything and can be deployed without changes on the cloud side