### PR TITLE
Remove timeout on test_close_on_connections_exit

### DIFF
--- a/test_runner/regress/test_proxy.py
+++ b/test_runner/regress/test_proxy.py
@@ -163,7 +163,6 @@ def test_forward_params_to_client(static_proxy: NeonProxy):
                 assert conn.get_parameter_status(name) == value
 
 
-@pytest.mark.timeout(5)
 def test_close_on_connections_exit(static_proxy: NeonProxy):
     # Open two connections, send SIGTERM, then ensure that proxy doesn't exit
     # until after connections close.


### PR DESCRIPTION
We have 300s timeout on all tests, and doubling logic in popen.wait sometimes exceeds 5s, making the test flaky.

ref https://github.com/neondatabase/neon/issues/4211