### PR TITLE
test_runner: workaround rerunfailures and timeout incompatibility

### DIFF
--- a/test_runner/fixtures/flaky.py
+++ b/test_runner/fixtures/flaky.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, MutableMapping, cast
 
 import pytest
 from _pytest.config import Config
@@ -64,9 +64,7 @@ def pytest_collection_modifyitems(config: Config, items: List[pytest.Item]):
             #
             # - [1] https://github.com/pytest-dev/pytest-rerunfailures/issues/99
             # - [2] https://github.com/pytest-dev/pytest-timeout/issues/142
-
-            # Slap Any to avoid mypy error: Unsupported target for indexed assignment ("Mapping[str, Any]"),
-            #   which is, strictly speaking correct, but we need to modify marker kwargs in place
-            timeout_marker: Any = item.get_closest_marker("timeout")
+            timeout_marker = item.get_closest_marker("timeout")
             if timeout_marker is not None:
-                timeout_marker.kwargs["func_only"] = True
+                kwargs = cast(MutableMapping[str, Any], timeout_marker.kwargs)
+                kwargs["func_only"] = True


### PR DESCRIPTION
## Problem

`pytest-timeout` and `pytest-rerunfailures` are incompatible (or rather not fully compatible). Timeouts aren't set for reruns.

Ref https://github.com/pytest-dev/pytest-rerunfailures/issues/99

## Summary of changes
- Dynamically make timeouts `func_only` for tests that we're going to retry. It applies timeouts for reruns as well.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
