### PR TITLE
DatadirModification::flush: pre-lock layer map

### DIFF
--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -1132,11 +1132,13 @@ impl<'a> DatadirModification<'a> {
 
         let writer = self.tline.writer();
 
+        let mut layer_map = self.tline.layers.write().unwrap();
+
         // Flush relation and  SLRU data blocks, keep metadata.
         let mut result: anyhow::Result<()> = Ok(());
         self.pending_updates.retain(|&key, value| {
             if result.is_ok() && (is_rel_block_key(key) || is_slru_block_key(key)) {
-                result = writer.put(key, self.lsn, value);
+                result = writer.put_locked(key, self.lsn, value, &mut layer_map);
                 false
             } else {
                 true


### PR DESCRIPTION
This is preliminary work for/from #4220 (async `Layer::get_value_reconstruct_data`).

There, we want to switch `Timeline::layers` to be a `tokio::sync::RwLock`.

The problem with `DatadirModification::flush` is that it uses `TimelineWriter::put`, and that method needs to lock `Timeline::layers` down the call tree.

So, `TimelineWriter::put` will needs to become async.

But `DatadirModification::flush` calls `put()` from inside the `retain` closure. That won't work once `put()` becomes async, because there are no async closures in Rust.

I'm not aware of an `async`-compatible alternative for `retain`.

Hence, this patch pre-locks `Timeline::layers`, then passes the guard to the closure.

Deadlocks
=========

`TimelineWriter::put` needs to lock `Timeline::layers` when it needs to create a new `open` layer.

While we hold the `Timeline::layers` locked, the flush loop timeline task can't make progress.

But the flush loop isn't running yet in these cases.

So, I'm wondering, what actually happens at runtime if the bootstrap / basebackup import fills up the first `open` layer. What turns it `frozen`? Is anything flushing?
