### PR TITLE
init_empty_layer_map: use `try_write`

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1598,7 +1598,9 @@ impl Timeline {
     /// Initialize with an empty layer map. Used when creating a new timeline.
     ///
     pub(super) fn init_empty_layer_map(&self, start_lsn: Lsn) {
-        let mut layers = self.layers.write().unwrap();
+        let mut layers = self.layers.try_write().expect(
+            "in the context where we call this function, no other task has access to the object",
+        );
         layers.next_open_layer_at = Some(Lsn(start_lsn.0));
     }
 


### PR DESCRIPTION
This is preliminary work for/from #4220 (async `Layer::get_value_reconstruct_data`).
Or more specifically, #4441, where we turn Timeline::layers into a tokio::sync::RwLock.

By using try_write() here, we can avoid turning init_empty_layer_map async,
which is nice because much of its transitive call(er) graph isn't async.
