### PR TITLE
create_delta_layer: avoid needless `stat`

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3033,6 +3033,8 @@ impl Timeline {
         par_fsync::par_fsync(&[self.conf.timeline_path(&self.timeline_id, &self.tenant_id)])
             .context("fsync of timeline dir")?;
 
+        let sz = new_delta.desc.file_size;
+
         // Add it to the layer map
         let l = Arc::new(new_delta);
         let mut layers = self.layers.write().unwrap();
@@ -3044,9 +3046,6 @@ impl Timeline {
         );
         batch_updates.insert_historic(l.layer_desc().clone(), l);
         batch_updates.flush();
-
-        // update the timeline's physical size
-        let sz = new_delta_path.metadata()?.len();
 
         self.metrics.resident_physical_size_gauge.add(sz);
         // update metrics

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3029,7 +3029,7 @@ impl Timeline {
         // 2. fsync them
         // 3. rename to the final name
         // 4. fsync the parent directory
-        par_fsync::par_fsync(&[new_delta_path.clone()]).context("fsync of delta layer")?;
+        par_fsync::par_fsync(&[new_delta_path]).context("fsync of delta layer")?;
         par_fsync::par_fsync(&[self.conf.timeline_path(&self.timeline_id, &self.tenant_id)])
             .context("fsync of timeline dir")?;
 


### PR DESCRIPTION
We already do it inside `frozen_layer.write_to_disk()`.

Context: https://github.com/neondatabase/neon/pull/4441#discussion_r1228083959