### PR TITLE
Upload Postgres Extensions to S3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -728,7 +728,6 @@ jobs:
       # During the transition period we need to have extensions in both places (in S3 and in compute-node image),
       # so we won't build extension twice, but extract them from compute-node.
       #
-      # # XXX: We don't push this image to ECR yet, we need to create a repo first
       # - name: Kaniko build extensions only
       #   run: |
       #     # Kaniko is suposed to clean up after itself if --cleanup flag is set, but it doesn't.
@@ -770,8 +769,8 @@ jobs:
 
     env:
       # While on transition period extract extensions from compute-node image (see a comment above for compute-node-image job)
-      # EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
-      EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
+      # EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions-${{ matrix.version }}:${{ needs.tag.outputs.build-tag }}
+      EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{ needs.tag.outputs.build-tag }}
       # In compute image we have a bit different directory layout (/usr/local/pgsql put into /usr/local).
       # This variable can be inlined after
       # USR_LOCAL_PGSQL_PATH: /usr/local/pgsql
@@ -797,11 +796,14 @@ jobs:
           rm -rf ./usr-local-pgsql/share/extension/neon*
           rm -rf ./usr-local-pgsql/lib/neon*
 
+      # XXX: check upload to prod bucket
       - name: Upload postgres-extensions to S3
+        env:
+          BUCKET: ${{ github.ref_name == 'release' && 'neon-prod-extensions' || 'neon-dev-extensions' }}
         run: |
           # Directories are specified in Dockerfile.compute-node for postgres-extensions target
-          aws s3 cp --recursive ./usr-local-pgsql/share/extension s3://neon-dev-extensions/${{needs.tag.outputs.build-tag}}/${{ matrix.version }}/share/extension
-          aws s3 cp --recursive ./usr-local-pgsql/lib             s3://neon-dev-extensions/${{needs.tag.outputs.build-tag}}/${{ matrix.version }}/lib
+          aws s3 cp --recursive ./usr-local-pgsql/share/extension s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/share/extension
+          aws s3 cp --recursive ./usr-local-pgsql/lib             s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/lib
 
       - name: Cleanup
         if: ${{ always() && steps.create-container.outputs.CID }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -746,6 +746,7 @@ jobs:
       #                      --build-arg PG_VERSION=${{ matrix.version }} \
       #                      --build-arg REPOSITORY=369495373322.dkr.ecr.eu-central-1.amazonaws.com \
       #                      --dockerfile Dockerfile.compute-node \
+      #                      --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions-${{ matrix.version }}:${{needs.tag.outputs.build-tag}} \
       #                      --destination neondatabase/extensions-${{ matrix.version }}:${{needs.tag.outputs.build-tag}} \
       #                      --cleanup \
       #                      --target postgres-extensions
@@ -769,8 +770,7 @@ jobs:
 
     env:
       # While on transition period extract extensions from compute-node image (see a comment above for compute-node-image job)
-      # # XXX: Switch to ECR repo once it's created
-      # EXTENSIONS_IMAGE: neondatabase/extensions-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
+      # EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
       EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
       # In compute image we have a bit different directory layout (/usr/local/pgsql put into /usr/local).
       # This variable can be inlined after
@@ -919,6 +919,7 @@ jobs:
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:${{needs.tag.outputs.build-tag}} latest
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} latest
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:${{needs.tag.outputs.build-tag}} latest
+          crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions:${{needs.tag.outputs.build-tag}} latest
 
       - name: Push images to production ECR
         if: |
@@ -931,6 +932,7 @@ jobs:
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:latest
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:latest
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:latest
+          crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/extensions:latest
 
       - name: Configure Docker Hub login
         run: |
@@ -954,6 +956,7 @@ jobs:
           crane tag neondatabase/vm-compute-node-v14:${{needs.tag.outputs.build-tag}} latest
           crane tag neondatabase/compute-node-v15:${{needs.tag.outputs.build-tag}} latest
           crane tag neondatabase/vm-compute-node-v15:${{needs.tag.outputs.build-tag}} latest
+          crane tag neondatabase/extensions:${{needs.tag.outputs.build-tag}} latest
 
       - name: Cleanup ECR folder
         run: rm -rf ~/.ecr

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -793,6 +793,10 @@ jobs:
           rm -rf ./usr-local-pgsql # Just in case
           docker cp ${{ steps.create-container.outputs.CID }}:${USR_LOCAL_PGSQL_PATH} ./usr-local-pgsql
 
+          # Delete Neon extensitons (they always present on compute-node image)
+          rm -rf ./usr-local-pgsql/share/extension/neon*
+          rm -rf ./usr-local-pgsql/lib/neon*
+
       - name: Upload postgres-extensions to S3
         run: |
           # Directories are specified in Dockerfile.compute-node for postgres-extensions target

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -754,70 +754,6 @@ jobs:
       - name: Cleanup ECR folder
         run: rm -rf ~/.ecr
 
-  upload-postgres-extensions-to-s3:
-    # XXX: commenting this out for testing
-    # if: |
-    #   (github.ref_name == 'main' || github.ref_name == 'release') &&
-    #   github.event_name != 'workflow_dispatch'
-    runs-on: ${{ github.ref_name != 'release' && fromJSON('["self-hosted", "prod", "x64"]') || fromJSON('["self-hosted", "gen3", "small"]') }}
-    needs: [ tag, compute-node-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [ v14, v15 ]
-
-    env:
-      # While on transition period extract extensions from compute-node image (see a comment above for compute-node-image job)
-      # EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions-${{ matrix.version }}:${{ needs.tag.outputs.build-tag }}
-      EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{ needs.tag.outputs.build-tag }}
-      # In compute image we have a bit different directory layout (/usr/local/pgsql put into /usr/local).
-      # This variable can be inlined after
-      # USR_LOCAL_PGSQL_PATH: /usr/local/pgsql
-      USR_LOCAL_PGSQL_PATH: /usr/local
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_PROD }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_PROD }}
-
-    steps:
-      - name: Pull postgres-extensions image
-        run: |
-          docker pull ${EXTENSIONS_IMAGE}
-
-      - name: Create postgres-extensions container
-        id: create-container
-        run: |
-          CID=$(docker create ${EXTENSIONS_IMAGE} true)
-          echo "CID=${CID}" >> $GITHUB_OUTPUT
-
-      - name: Extract postgres-extensions from container
-        run: |
-          rm -rf ./usr-local-pgsql # Just in case
-          docker cp ${{ steps.create-container.outputs.CID }}:${USR_LOCAL_PGSQL_PATH} ./usr-local-pgsql
-
-          # Delete Neon extensitons (they always present on compute-node image)
-          rm -rf ./usr-local-pgsql/share/extension/neon*
-          rm -rf ./usr-local-pgsql/lib/neon*
-
-      - name: Upload postgres-extensions to S3 (debug)
-        run: aws sts get-caller-identity
-
-      - name: Upload postgres-extensions to S3
-        env:
-          BUCKETS: |
-            ${{ github.ref_name != 'release' &&
-              '["neon-prod-extensions-ap-southeast-1", "neon-prod-extensions-eu-central-1", "neon-prod-extensions-us-east-1", "neon-prod-extensions-us-east-2", "neon-prod-extensions-us-west-2"]' ||
-              '["neon-dev-extensions-eu-central-1", "neon-dev-extensions-eu-west-1", "neon-dev-extensions-us-east-2"]' }}
-        run: |
-          for BUCKET in $(echo $BUCKETS | jq --raw-output '.[]'); do
-            # Source directories are specified in Dockerfile.compute-node for postgres-extensions target
-            aws s3 cp --recursive --only-show-errors ./usr-local-pgsql/share/extension s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/share/extension
-            aws s3 cp --recursive --only-show-errors ./usr-local-pgsql/lib             s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/lib
-          done
-
-      - name: Cleanup
-        if: ${{ always() && steps.create-container.outputs.CID }}
-        run: |
-          docker rm ${{ steps.create-container.outputs.CID }}
-
   vm-compute-node-image:
     runs-on: [ self-hosted, gen3, large ]
     needs: [ tag, compute-node-image ]
@@ -976,6 +912,70 @@ jobs:
 
       - name: Cleanup ECR folder
         run: rm -rf ~/.ecr
+
+  upload-postgres-extensions-to-s3:
+    # XXX: commenting this out for testing
+    # if: |
+    #   (github.ref_name == 'main' || github.ref_name == 'release') &&
+    #   github.event_name != 'workflow_dispatch'
+    runs-on: ${{ github.ref_name != 'release' && fromJSON('["self-hosted", "prod", "x64"]') || fromJSON('["self-hosted", "gen3", "small"]') }}
+    needs: [ tag, promote-images ]
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ v14, v15 ]
+
+    env:
+      # While on transition period extract extensions from compute-node image (see a comment above for compute-node-image job)
+      # EXTENSIONS_IMAGE: ${{ github.ref_name != 'release' && '093970136003' || '369495373322'}}.dkr.ecr.eu-central-1.amazonaws.com/extensions-${{ matrix.version }}:latest
+      EXTENSIONS_IMAGE: ${{ github.ref_name != 'release' && '093970136003' || '369495373322'}}.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:latest
+      # In compute image we have a bit different directory layout (/usr/local/pgsql put into /usr/local).
+      # This variable can be inlined after
+      # USR_LOCAL_PGSQL_PATH: /usr/local/pgsql
+      USR_LOCAL_PGSQL_PATH: /usr/local
+      AWS_ACCESS_KEY_ID: ${{ github.ref_name != 'release' && secrets.AWS_ACCESS_KEY_PROD || secrets.AWS_ACCESS_KEY_DEV }}
+      AWS_SECRET_ACCESS_KEY: ${{ github.ref_name != 'release' && secrets.AWS_SECRET_KEY_PROD || secrets.AWS_SECRET_KEY_DEV }}
+
+    steps:
+      - name: Pull postgres-extensions image
+        run: |
+          docker pull ${EXTENSIONS_IMAGE}
+
+      - name: Create postgres-extensions container
+        id: create-container
+        run: |
+          CID=$(docker create ${EXTENSIONS_IMAGE} true)
+          echo "CID=${CID}" >> $GITHUB_OUTPUT
+
+      - name: Extract postgres-extensions from container
+        run: |
+          rm -rf ./usr-local-pgsql # Just in case
+          docker cp ${{ steps.create-container.outputs.CID }}:${USR_LOCAL_PGSQL_PATH} ./usr-local-pgsql
+
+          # Delete Neon extensitons (they always present on compute-node image)
+          rm -rf ./usr-local-pgsql/share/extension/neon*
+          rm -rf ./usr-local-pgsql/lib/neon*
+
+      - name: Upload postgres-extensions to S3 (debug)
+        run: aws sts get-caller-identity
+
+      - name: Upload postgres-extensions to S3
+        env:
+          BUCKETS: |
+            ${{ github.ref_name != 'release' &&
+              '["neon-prod-extensions-ap-southeast-1", "neon-prod-extensions-eu-central-1", "neon-prod-extensions-us-east-1", "neon-prod-extensions-us-east-2", "neon-prod-extensions-us-west-2"]' ||
+              '["neon-dev-extensions-eu-central-1", "neon-dev-extensions-eu-west-1", "neon-dev-extensions-us-east-2"]' }}
+        run: |
+          for BUCKET in $(echo $BUCKETS | jq --raw-output '.[]'); do
+            # Source directories are specified in Dockerfile.compute-node for postgres-extensions target
+            aws s3 cp --recursive --only-show-errors ./usr-local-pgsql/share/extension s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/share/extension
+            aws s3 cp --recursive --only-show-errors ./usr-local-pgsql/lib             s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/lib
+          done
+
+      - name: Cleanup
+        if: ${{ always() && steps.create-container.outputs.CID }}
+        run: |
+          docker rm ${{ steps.create-container.outputs.CID }}
 
   deploy:
     runs-on: [ self-hosted, gen3, small ]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -722,10 +722,87 @@ jobs:
                            --dockerfile Dockerfile.compute-node
                            --destination 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
                            --destination neondatabase/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
+                           --cleanup
+
+      # Due to a kaniko bug, we can't use cache for extensions image, thus it takes about the same amount of time as compute-node image to build (~10 min)
+      # During the transition period we need to have extensions in both places (in S3 and in compute-node image),
+      # so we won't build extension twice, but extract them from compute-node.
+      #
+      # # XXX: We don't push this image to ECR yet, we need to create a repo first
+      # - name: Kaniko build extensions only
+      #   run: |
+      #     # Kaniko is suposed to clean up after itself if --cleanup flag is set, but it doesn't.
+      #     # Despite some fixes were made in https://github.com/GoogleContainerTools/kaniko/pull/2504 (in kaniko v1.11.0),
+      #     # it still fails with error:
+      #     #   error building image: could not save file: copying file: symlink postgres /kaniko/1/usr/local/pgsql/bin/postmaster: file exists
+      #     #
+      #     # Ref https://github.com/GoogleContainerTools/kaniko/issues/1406
+      #     find /kaniko -maxdepth 1 -mindepth 1 -type d -regex "/kaniko/[0-9]*" -exec rm -rv {} \;
+      #
+      #     /kaniko/executor --reproducible --snapshot-mode=redo --skip-unused-stages --cache=true \
+      #                      --cache-repo 369495373322.dkr.ecr.eu-central-1.amazonaws.com/cache \
+      #                      --context . \
+      #                      --build-arg GIT_VERSION=${{ github.sha }} \
+      #                      --build-arg PG_VERSION=${{ matrix.version }} \
+      #                      --build-arg REPOSITORY=369495373322.dkr.ecr.eu-central-1.amazonaws.com \
+      #                      --dockerfile Dockerfile.compute-node \
+      #                      --destination neondatabase/extensions-${{ matrix.version }}:${{needs.tag.outputs.build-tag}} \
+      #                      --cleanup \
+      #                      --target postgres-extensions
 
       # Cleanup script fails otherwise - rm: cannot remove '/nvme/actions-runner/_work/_temp/_github_home/.ecr': Permission denied
       - name: Cleanup ECR folder
         run: rm -rf ~/.ecr
+
+  upload-postgres-extensions-to-s3:
+    # XXX: commenting this out for testing
+    # TODO: backet for release should be different from the main
+    # if: |
+    #   (github.ref_name == 'main' || github.ref_name == 'release') &&
+    #   github.event_name != 'workflow_dispatch'
+    runs-on: [ self-hosted, gen3, small ]
+    needs: [ tag, compute-node-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ v14, v15 ]
+
+    env:
+      # While on transition period extract extensions from compute-node image (see a comment above for compute-node-image job)
+      # # XXX: Switch to ECR repo once it's created
+      # EXTENSIONS_IMAGE: neondatabase/extensions-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
+      EXTENSIONS_IMAGE: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
+      # In compute image we have a bit different directory layout (/usr/local/pgsql put into /usr/local).
+      # This variable can be inlined after
+      # USR_LOCAL_PGSQL_PATH: /usr/local/pgsql
+      USR_LOCAL_PGSQL_PATH: /usr/local
+
+    steps:
+      - name: Pull postgres-extensions image
+        run: |
+          docker pull ${EXTENSIONS_IMAGE}
+
+      - name: Create postgres-extensions container
+        id: create-container
+        run: |
+          CID=$(docker create ${EXTENSIONS_IMAGE} true)
+          echo "CID=${CID}" >> $GITHUB_OUTPUT
+
+      - name: Extract postgres-extensions from container
+        run: |
+          rm -rf ./usr-local-pgsql # Just in case
+          docker cp ${{ steps.create-container.outputs.CID }}:${USR_LOCAL_PGSQL_PATH} ./usr-local-pgsql
+
+      - name: Upload postgres-extensions to S3
+        run: |
+          # Directories are specified in Dockerfile.compute-node for postgres-extensions target
+          aws s3 cp --recursive ./usr-local-pgsql/share/extension s3://neon-dev-extensions/${{needs.tag.outputs.build-tag}}/${{ matrix.version }}/share/extension
+          aws s3 cp --recursive ./usr-local-pgsql/lib             s3://neon-dev-extensions/${{needs.tag.outputs.build-tag}}/${{ matrix.version }}/lib
+
+      - name: Cleanup
+        if: ${{ always() && steps.create-container.outputs.CID }}
+        run: |
+          docker rm ${{ steps.create-container.outputs.CID }}
 
   vm-compute-node-image:
     runs-on: [ self-hosted, gen3, large ]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -774,6 +774,8 @@ jobs:
       # This variable can be inlined after
       # USR_LOCAL_PGSQL_PATH: /usr/local/pgsql
       USR_LOCAL_PGSQL_PATH: /usr/local
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_PROD }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_PROD }}
 
     steps:
       - name: Pull postgres-extensions image

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -795,6 +795,9 @@ jobs:
           rm -rf ./usr-local-pgsql/share/extension/neon*
           rm -rf ./usr-local-pgsql/lib/neon*
 
+      - name: Upload postgres-extensions to S3 (debug)
+        run: aws sts get-caller-identity
+
       - name: Upload postgres-extensions to S3
         env:
           BUCKETS: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -759,7 +759,7 @@ jobs:
     # if: |
     #   (github.ref_name == 'main' || github.ref_name == 'release') &&
     #   github.event_name != 'workflow_dispatch'
-    runs-on: ${{ github.ref_name == 'release' && fromJSON('["self-hosted", "prod", "x64"]') || fromJSON('["self-hosted", "gen3", "small"]') }}
+    runs-on: ${{ github.ref_name != 'release' && fromJSON('["self-hosted", "prod", "x64"]') || fromJSON('["self-hosted", "gen3", "small"]') }}
     needs: [ tag, compute-node-image ]
     strategy:
       fail-fast: false
@@ -798,7 +798,7 @@ jobs:
       - name: Upload postgres-extensions to S3
         env:
           BUCKETS: |
-            ${{ github.ref_name == 'release' &&
+            ${{ github.ref_name != 'release' &&
               '["neon-prod-extensions-ap-southeast-1", "neon-prod-extensions-eu-central-1", "neon-prod-extensions-us-east-1", "neon-prod-extensions-us-east-2", "neon-prod-extensions-us-west-2"]' ||
               '["neon-dev-extensions-eu-central-1", "neon-dev-extensions-eu-west-1", "neon-dev-extensions-us-east-2"]' }}
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -869,7 +869,7 @@ jobs:
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:${{needs.tag.outputs.build-tag}} latest
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} latest
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:${{needs.tag.outputs.build-tag}} latest
-          # TODO: Uncomment when we have build this image in `compute-node-image`
+          # TODO: Uncomment when we start to build this image in `compute-node-image`
           # crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions:${{needs.tag.outputs.build-tag}} latest
 
       - name: Push images to production ECR
@@ -883,7 +883,7 @@ jobs:
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:latest
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:latest
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:latest
-          # TODO: Uncomment when we have build this image in `compute-node-image`
+          # TODO: Uncomment when we start to build this image in `compute-node-image`
           # crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/extensions:latest
 
       - name: Configure Docker Hub login
@@ -914,11 +914,10 @@ jobs:
         run: rm -rf ~/.ecr
 
   upload-postgres-extensions-to-s3:
-    # XXX: commenting this out for testing
-    # if: |
-    #   (github.ref_name == 'main' || github.ref_name == 'release') &&
-    #   github.event_name != 'workflow_dispatch'
-    runs-on: ${{ github.ref_name != 'release' && fromJSON('["self-hosted", "prod", "x64"]') || fromJSON('["self-hosted", "gen3", "small"]') }}
+    if: |
+      (github.ref_name == 'main' || github.ref_name == 'release') &&
+       github.event_name != 'workflow_dispatch'
+    runs-on: ${{ github.ref_name == 'release' && fromJSON('["self-hosted", "prod", "x64"]') || fromJSON('["self-hosted", "gen3", "small"]') }}
     needs: [ tag, promote-images ]
     strategy:
       fail-fast: false
@@ -927,14 +926,18 @@ jobs:
 
     env:
       # While on transition period extract extensions from compute-node image (see a comment above for compute-node-image job)
-      # EXTENSIONS_IMAGE: ${{ github.ref_name != 'release' && '093970136003' || '369495373322'}}.dkr.ecr.eu-central-1.amazonaws.com/extensions-${{ matrix.version }}:latest
-      EXTENSIONS_IMAGE: ${{ github.ref_name != 'release' && '093970136003' || '369495373322'}}.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:latest
+      # EXTENSIONS_IMAGE: ${{ github.ref_name == 'release' && '093970136003' || '369495373322'}}.dkr.ecr.eu-central-1.amazonaws.com/extensions-${{ matrix.version }}:latest
+      EXTENSIONS_IMAGE: ${{ github.ref_name == 'release' && '093970136003' || '369495373322'}}.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:latest
       # In compute image we have a bit different directory layout (/usr/local/pgsql put into /usr/local).
       # This variable can be inlined after
       # USR_LOCAL_PGSQL_PATH: /usr/local/pgsql
       USR_LOCAL_PGSQL_PATH: /usr/local
-      AWS_ACCESS_KEY_ID: ${{ github.ref_name != 'release' && secrets.AWS_ACCESS_KEY_PROD || secrets.AWS_ACCESS_KEY_DEV }}
-      AWS_SECRET_ACCESS_KEY: ${{ github.ref_name != 'release' && secrets.AWS_SECRET_KEY_PROD || secrets.AWS_SECRET_KEY_DEV }}
+      AWS_ACCESS_KEY_ID: ${{ github.ref_name == 'release' && secrets.AWS_ACCESS_KEY_PROD || secrets.AWS_ACCESS_KEY_DEV }}
+      AWS_SECRET_ACCESS_KEY: ${{ github.ref_name == 'release' && secrets.AWS_SECRET_KEY_PROD || secrets.AWS_SECRET_KEY_DEV }}
+      S3_BUCKETS: |
+        ${{ github.ref_name == 'release' &&
+          '["neon-prod-extensions-ap-southeast-1", "neon-prod-extensions-eu-central-1", "neon-prod-extensions-us-east-1", "neon-prod-extensions-us-east-2", "neon-prod-extensions-us-west-2"]' ||
+          '["neon-dev-extensions-eu-central-1", "neon-dev-extensions-eu-west-1", "neon-dev-extensions-us-east-2"]' }}
 
     steps:
       - name: Pull postgres-extensions image
@@ -956,17 +959,9 @@ jobs:
           rm -rf ./usr-local-pgsql/share/extension/neon*
           rm -rf ./usr-local-pgsql/lib/neon*
 
-      - name: Upload postgres-extensions to S3 (debug)
-        run: aws sts get-caller-identity
-
       - name: Upload postgres-extensions to S3
-        env:
-          BUCKETS: |
-            ${{ github.ref_name != 'release' &&
-              '["neon-prod-extensions-ap-southeast-1", "neon-prod-extensions-eu-central-1", "neon-prod-extensions-us-east-1", "neon-prod-extensions-us-east-2", "neon-prod-extensions-us-west-2"]' ||
-              '["neon-dev-extensions-eu-central-1", "neon-dev-extensions-eu-west-1", "neon-dev-extensions-us-east-2"]' }}
         run: |
-          for BUCKET in $(echo $BUCKETS | jq --raw-output '.[]'); do
+          for BUCKET in $(echo ${S3_BUCKETS} | jq --raw-output '.[]'); do
             # Source directories are specified in Dockerfile.compute-node for postgres-extensions target
             aws s3 cp --recursive --only-show-errors ./usr-local-pgsql/share/extension s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/share/extension
             aws s3 cp --recursive --only-show-errors ./usr-local-pgsql/lib             s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/lib

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -756,7 +756,6 @@ jobs:
 
   upload-postgres-extensions-to-s3:
     # XXX: commenting this out for testing
-    # TODO: backet for release should be different from the main
     # if: |
     #   (github.ref_name == 'main' || github.ref_name == 'release') &&
     #   github.event_name != 'workflow_dispatch'
@@ -796,14 +795,20 @@ jobs:
           rm -rf ./usr-local-pgsql/share/extension/neon*
           rm -rf ./usr-local-pgsql/lib/neon*
 
-      # XXX: check upload to prod bucket
       - name: Upload postgres-extensions to S3
+        # TODO: Remove when prod buckets are ready
+        # if: github.ref_name == 'main' && github.event_name != 'workflow_dispatch'
         env:
-          BUCKET: ${{ github.ref_name == 'release' && 'neon-prod-extensions' || 'neon-dev-extensions' }}
+          BUCKETS: |
+            ${{ github.ref_name == 'release' &&
+              '["neon-prod-extensions-ap-southeast-1", "neon-prod-extensions-eu-central-1", "neon-prod-extensions-us-east-1", "neon-prod-extensions-us-east-2", "neon-prod-extensions-us-west-2"]' ||
+              '["neon-dev-extensions-eu-central-1", "neon-dev-extensions-eu-west-1", "neon-dev-extensions-us-east-2"]' }}
         run: |
-          # Directories are specified in Dockerfile.compute-node for postgres-extensions target
-          aws s3 cp --recursive ./usr-local-pgsql/share/extension s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/share/extension
-          aws s3 cp --recursive ./usr-local-pgsql/lib             s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/lib
+          for BUCKET in $(echo $BUCKETS | jq --raw-output '.[]'); do
+            # Source directories are specified in Dockerfile.compute-node for postgres-extensions target
+            aws s3 cp --recursive --only-show-errors ./usr-local-pgsql/share/extension s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/share/extension
+            aws s3 cp --recursive --only-show-errors ./usr-local-pgsql/lib             s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}/lib
+          done
 
       - name: Cleanup
         if: ${{ always() && steps.create-container.outputs.CID }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -759,7 +759,7 @@ jobs:
     # if: |
     #   (github.ref_name == 'main' || github.ref_name == 'release') &&
     #   github.event_name != 'workflow_dispatch'
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: ${{ github.ref_name == 'release' && fromJSON('["self-hosted", "prod", "x64"]') || fromJSON('["self-hosted", "gen3", "small"]') }}
     needs: [ tag, compute-node-image ]
     strategy:
       fail-fast: false
@@ -796,8 +796,6 @@ jobs:
           rm -rf ./usr-local-pgsql/lib/neon*
 
       - name: Upload postgres-extensions to S3
-        # TODO: Remove when prod buckets are ready
-        # if: github.ref_name == 'main' && github.event_name != 'workflow_dispatch'
         env:
           BUCKETS: |
             ${{ github.ref_name == 'release' &&

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -933,7 +933,8 @@ jobs:
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:${{needs.tag.outputs.build-tag}} latest
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} latest
           crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:${{needs.tag.outputs.build-tag}} latest
-          crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions:${{needs.tag.outputs.build-tag}} latest
+          # TODO: Uncomment when we have build this image in `compute-node-image`
+          # crane tag 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions:${{needs.tag.outputs.build-tag}} latest
 
       - name: Push images to production ECR
         if: |
@@ -946,7 +947,8 @@ jobs:
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v14:latest
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/compute-node-v15:latest
           crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:latest
-          crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/extensions:latest
+          # TODO: Uncomment when we have build this image in `compute-node-image`
+          # crane copy 369495373322.dkr.ecr.eu-central-1.amazonaws.com/extensions:${{needs.tag.outputs.build-tag}} 093970136003.dkr.ecr.eu-central-1.amazonaws.com/extensions:latest
 
       - name: Configure Docker Hub login
         run: |

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -700,6 +700,15 @@ RUN rm /usr/local/pgsql/lib/lib*.a
 
 #########################################################################################
 #
+# Extenstion only
+#
+#########################################################################################
+FROM scratch AS postgres-extensions
+COPY --from=postgres-cleanup-layer /usr/local/pgsql/share/extension /usr/local/pgsql/share/extension
+COPY --from=postgres-cleanup-layer /usr/local/pgsql/lib             /usr/local/pgsql/lib
+
+#########################################################################################
+#
 # Final layer
 # Put it all together into the final image
 #


### PR DESCRIPTION
## Problem

We want to store Postgres Extensions in S3 (resolves https://github.com/neondatabase/neon/issues/4493).

Proposed solution:
- Create a separate docker image (from scratch) that contains only extensions
- Do not include extensions into compute-node (except for neon extensions)*
- For release and main builds upload extract extension from the image and upload to S3 (`s3://<bucket>/<release version>/<postgres_version>/...`)**

An example of S3 layout: https://s3.console.aws.amazon.com/s3/buckets/neon-dev-extensions?region=eu-central-1&prefix=5314225671/&showversions=false

*) We're not doing it until the feature is not fully implemented
**) This differs from the initial proposal in https://github.com/neondatabase/neon/issues/4493 of putting extensions straight into `s3://<bucket>/<postgres_version>/...`, because we can't upload directory atomicly. A drawback of this is that we end up with unnecessary copies of files ~2.1 GB per release (i.e. +2.1 GB for each commit in main also). We don't really need to update extensions for each release if there're no relevant changes, but this requires extra work.

## Summary of changes
- Created a separate stage in Dockerfile.compute-node `postgres-extensions` that contains only extensions
- Added a separate step in a workflow that builds `postgres-extensions` image (because of a bug in kaniko this step is commented out because it takes way too long to get built)
- Extract extensions from the image and upload files to S3 for release and main builds
- Upload extenstions only for staging (for now)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
