### PR TITLE
audit & fix test_timeline_delete.py's usage of ps_http.timeline_delete()

### DIFF
--- a/test_runner/fixtures/pageserver/utils.py
+++ b/test_runner/fixtures/pageserver/utils.py
@@ -213,7 +213,10 @@ def wait_timeline_detail_404(
 
 
 def timeline_delete_wait_completed(
-    pageserver_http: PageserverHttpClient, tenant_id: TenantId, timeline_id: TimelineId
+    pageserver_http: PageserverHttpClient,
+    tenant_id: TenantId,
+    timeline_id: TimelineId,
+    **delete_args,
 ):
-    pageserver_http.timeline_delete(tenant_id=tenant_id, timeline_id=timeline_id)
+    pageserver_http.timeline_delete(tenant_id=tenant_id, timeline_id=timeline_id, **delete_args)
     wait_timeline_detail_404(pageserver_http, tenant_id, timeline_id)

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -95,8 +95,13 @@ def test_timeline_delete(neon_simple_env: NeonEnv):
         match=f"Timeline {env.initial_tenant}/{leaf_timeline_id} was not found",
     ) as exc:
         ps_http.timeline_detail(env.initial_tenant, leaf_timeline_id)
-
     assert exc.value.status_code == 404
+
+    wait_until(
+        number_of_iterations=3,
+        interval=0.2,
+        func=lambda: ps_http.timeline_delete(env.initial_tenant, parent_timeline_id),
+    )
 
     # Check that we didn't pick up the timeline again after restart.
     # See https://github.com/neondatabase/neon/issues/3560

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -100,7 +100,9 @@ def test_timeline_delete(neon_simple_env: NeonEnv):
     wait_until(
         number_of_iterations=3,
         interval=0.2,
-        func=lambda: ps_http.timeline_delete(env.initial_tenant, parent_timeline_id),
+        func=lambda: timeline_delete_wait_completed(
+            ps_http, env.initial_tenant, parent_timeline_id
+        ),
     )
 
     # Check that we didn't pick up the timeline again after restart.


### PR DESCRIPTION
(For https://github.com/neondatabase/neon/pull/4495)

Most of the `test_delete_timeline.py` tests make negative tests, i.e., "does `ps_http.timeline_delete()` fail in this and that scenario".
These can be left alone.

But when we actually do the deletions, we need to use the helper that polls for completion.


