### PR TITLE
Pageserver reconnect v2

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -349,7 +349,6 @@ pageserver_flush(void)
 	if (!connected)
 	{
 		neon_log(WARNING, "Tried to flush while disconnected");
-		return false;
 	}
 	else
 	{

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -325,7 +325,7 @@ pageserver_receive(void)
 		}
 		else if (rc == -1)
 		{
-			neon_log(ERROR, "pageserver_receive disconnect because call_PQgetCopyData returns -1: %s", pchomp(PQerrorMessage(pageserver_conn)));
+			neon_log(LOG, "pageserver_receive disconnect because call_PQgetCopyData returns -1: %s", pchomp(PQerrorMessage(pageserver_conn)));
 			pageserver_disconnect();
 			resp = NULL;
 		}

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -55,7 +55,7 @@ char	   *page_server_connstring;
 char	   *neon_auth_token;
 
 int			readahead_buffer_size = 128;
-int			max_reconnect_attempts = 100;
+int			max_reconnect_attempts = 60;
 int			n_unflushed_requests = 0;
 int			flush_every_n_requests = 8;
 int			max_flush_delay = 1;
@@ -465,6 +465,14 @@ pg_init_libpagestore(void)
 							1, 0, INT_MAX,
 							PGC_USERSET,
 							GUC_UNIT_S,
+							NULL, NULL, NULL);
+	DefineCustomIntVariable("neon.max_reconnect_attempts",
+							"Maximal attempts to reconnect to pages server (with 1 second timeout)",
+							NULL,
+							&max_reconnect_attempts,
+							60, 0, INT_MAX,
+							PGC_USERSET,
+							0,
 							NULL, NULL, NULL);
 	DefineCustomIntVariable("neon.readahead_buffer_size",
 							"number of prefetches to buffer",

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -223,6 +223,8 @@ pageserver_disconnect(void)
 		PQfinish(pageserver_conn);
 		pageserver_conn = NULL;
 		connected = false;
+
+		prefetch_on_ps_disconnect();
 	}
 	if (pageserver_conn_wes != NULL)
 	{
@@ -241,7 +243,6 @@ pageserver_send(NeonRequest * request)
 	{
 		neon_log(LOG, "pageserver_send disconnect bad connection");
 		pageserver_disconnect();
-		prefetch_on_ps_disconnect();
 	}
 
 	req_buff = nm_pack_request(request);
@@ -345,7 +346,6 @@ pageserver_receive(void)
 	{
 		neon_log(LOG, "pageserver_receive disconnect due to caught exception");
 		pageserver_disconnect();
-		prefetch_on_ps_disconnect();
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
@@ -442,7 +442,7 @@ pg_init_libpagestore(void)
 							"Maximal attempts to reconnect to pages server (with 1 second timeout)",
 							NULL,
 							&max_reconnect_attempts,
-							60, 0, INT_MAX,
+							10, 0, INT_MAX,
 							PGC_USERSET,
 							0,
 							NULL, NULL, NULL);

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -145,9 +145,9 @@ extern char *nm_to_string(NeonMessage * msg);
 
 typedef struct
 {
-	void		(*send) (NeonRequest * request);
+	bool		(*send) (NeonRequest * request);
 	NeonResponse *(*receive) (void);
-	void		(*flush) (void);
+	bool		(*flush) (void);
 }			page_server_api;
 
 extern void prefetch_on_ps_disconnect(void);

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -498,6 +498,7 @@ resend_requests:
 			.forknum = slot->buftag.forkNum,
 			.blkno = slot->buftag.blockNum,
 		};
+		Assert(slot->status == PRFS_REQUESTED);
 		if (!page_server->send((NeonRequest *) &request))
 			goto resend_requests;
 	}
@@ -718,11 +719,12 @@ prefetch_do_request(PrefetchRequest *slot, bool *force_latest, XLogRecPtr *force
 	MyPState->n_unused -= 1;
 	MyPState->ring_unused += 1;
 
-	if (!page_server->send((NeonRequest *) &request))
-		resend_prefetch_requests();
-
 	/* update slot state */
 	slot->status = PRFS_REQUESTED;
+
+
+	if (!page_server->send((NeonRequest *) &request))
+		resend_prefetch_requests();
 
 	prfh_insert(MyPState->prf_hash, slot, &found);
 	Assert(!found);

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -481,7 +481,7 @@ prefetch_cleanup_trailing_unused(void)
  * In case of pageserver reconnection we need to resend all in-flight prefetch requests
  */
 static void
-resend_refetch_requests(void)
+resend_prefetch_requests(void)
 {
 resend_requests:
 	for (int n_requests_inflight = MyPState->n_requests_inflight; n_requests_inflight != 0; n_requests_inflight--)


### PR DESCRIPTION
## Problem

Compute is not always able to reconnect to pages server.
First of all it caused by long time of restart of pageserver.
So number of attempts is increased from 5 (hardcoded) to 60 (GUC).
Also we do not perform flush after each command to increase performance (it is especially critical for prefetch).
Unfortunately such pending flush makes it not possible to transparently reconnect to restarted pageserver.
What we can do is to try to minimzie such probabilty.
Most likely broken connection will be detected in first sens command after some idle period.
This is why max_flush_delay parameter is added which force flush to be performed after first request after some idle period.

See #4497

## Summary of changes

Add neon.max_reconnect_attempts and neon.max_glush_delay GUCs which contol when flush has to be done 
and when it is possible to try to reconnect to page server


## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
