### PR TITLE
`list_files` function in `remote_storage`

### DIFF
--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -98,6 +98,8 @@ pub trait RemoteStorage: Send + Sync + 'static {
     /// "foo/bar/cat567.txt", "foo/bar/dog123", "foo/bar/dog456"]
     /// whereas,
     /// list_prefixes("foo/bar/") = ["cat", "dog"]
+    ///
+    /// Also note that this does not filter out "folders"
     async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>>;
 
     /// Streams the local file contents into remote into the remote storage entry.

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -94,17 +94,17 @@ pub trait RemoteStorage: Send + Sync + 'static {
         prefix: Option<&RemotePath>,
     ) -> Result<Vec<RemotePath>, DownloadError>;
 
-    /// Lists all files in directory
-    /// Note: this is slightly different than list_prefixes,
-    /// because it is for listing files instead of for listing
-    /// names sharing common prefixes.
+    /// Lists all files in directory "recursively" 
+    /// (not really recursively, because AWS has a flat namespace)
+    /// Note: This is subtely different than list_prefixes,
+    /// because it is for listing files instead of listing
+    /// names sharing common prefixes. 
     /// For example,
     /// list_files("foo/bar") = ["foo/bar/cat123.txt",
-    /// "foo/bar/cat567.txt", "foo/bar/dog123", "foo/bar/dog456"]
+    /// "foo/bar/cat567.txt", "foo/bar/dog123.txt", "foo/bar/dog456.txt"]
     /// whereas,
     /// list_prefixes("foo/bar/") = ["cat", "dog"]
-    ///
-    /// Also note that this does not filter out "folders"
+    /// See `test_real_s3.rs` for more details.
     async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>>;
 
     /// Streams the local file contents into remote into the remote storage entry.

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -94,11 +94,11 @@ pub trait RemoteStorage: Send + Sync + 'static {
         prefix: Option<&RemotePath>,
     ) -> Result<Vec<RemotePath>, DownloadError>;
 
-    /// Lists all files in directory "recursively" 
+    /// Lists all files in directory "recursively"
     /// (not really recursively, because AWS has a flat namespace)
     /// Note: This is subtely different than list_prefixes,
     /// because it is for listing files instead of listing
-    /// names sharing common prefixes. 
+    /// names sharing common prefixes.
     /// For example,
     /// list_files("foo/bar") = ["foo/bar/cat123.txt",
     /// "foo/bar/cat567.txt", "foo/bar/dog123.txt", "foo/bar/dog456.txt"]

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -70,6 +70,9 @@ impl RemotePath {
     pub fn join(&self, segment: &Path) -> Self {
         Self(self.0.join(segment))
     }
+    pub fn extension(&self) -> Option<&str> {
+        self.0.extension()?.to_str()
+    }
 }
 
 /// Storage (potentially remote) API to manage its state.
@@ -85,6 +88,17 @@ pub trait RemoteStorage: Send + Sync + 'static {
         &self,
         prefix: Option<&RemotePath>,
     ) -> Result<Vec<RemotePath>, DownloadError>;
+
+    /// Lists all files in directory
+    /// Note: this is slightly different than list_prefixes,
+    /// because it is for listing files instead of for listing
+    /// names sharing common prefixes.
+    /// For example,
+    /// list_files("foo/bar") = ["foo/bar/cat123.txt",
+    /// "foo/bar/cat567.txt", "foo/bar/dog123", "foo/bar/dog456"]
+    /// whereas,
+    /// list_prefixes("foo/bar/") = ["cat", "dog"]
+    async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>>;
 
     /// Streams the local file contents into remote into the remote storage entry.
     async fn upload(
@@ -171,6 +185,14 @@ impl GenericRemoteStorage {
             Self::LocalFs(s) => s.list_prefixes(prefix).await,
             Self::AwsS3(s) => s.list_prefixes(prefix).await,
             Self::Unreliable(s) => s.list_prefixes(prefix).await,
+        }
+    }
+
+    pub async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>> {
+        match self {
+            Self::LocalFs(s) => s.list_files(folder).await,
+            Self::AwsS3(s) => s.list_files(folder).await,
+            Self::Unreliable(s) => s.list_files(folder).await,
         }
     }
 

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -70,6 +70,11 @@ impl RemotePath {
     pub fn join(&self, segment: &Path) -> Self {
         Self(self.0.join(segment))
     }
+
+    pub fn get_path(&self) -> &PathBuf {
+        &self.0
+    }
+
     pub fn extension(&self) -> Option<&str> {
         self.0.extension()?.to_str()
     }

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -132,6 +132,7 @@ impl RemoteStorage for LocalFs {
         Ok(prefixes)
     }
 
+    // TODO: this has slightly different behavior than the aws function because aws has flat namespace
     async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>> {
         let full_path = match folder {
             Some(folder) => folder.with_base(&self.storage_root),

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -48,6 +48,14 @@ impl LocalFs {
         Ok(Self { storage_root })
     }
 
+    // mirrors S3Bucket::s3_object_to_relative_path
+    fn local_file_to_relative_path(&self, key: PathBuf) -> RemotePath {
+        let relative_path = key
+            .strip_prefix(&self.storage_root)
+            .expect("relative path must contain storage_root as prefix");
+        RemotePath(relative_path.into())
+    }
+
     async fn read_storage_metadata(
         &self,
         file_path: &Path,
@@ -132,23 +140,30 @@ impl RemoteStorage for LocalFs {
         Ok(prefixes)
     }
 
-    // TODO: this has slightly different behavior than the aws function because aws has flat namespace
+    // recursively lists all files in a directory,
+    // mirroring the `list_files` for `s3_bucket`
     async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>> {
         let full_path = match folder {
             Some(folder) => folder.with_base(&self.storage_root),
             None => self.storage_root.clone(),
         };
-        let mut entries = fs::read_dir(full_path).await?;
         let mut files = vec![];
-        while let Some(entry) = entries.next_entry().await? {
-            let file_name: PathBuf = entry.file_name().into();
-            let file_type = entry.file_type().await?;
-            if file_type.is_file() {
-                let mut file_remote_path = RemotePath::new(&file_name)?;
-                if let Some(folder) = folder {
-                    file_remote_path = folder.join(&file_name);
+        let mut directory_queue = vec![full_path.clone()];
+
+        while !directory_queue.is_empty() {
+            let cur_folder = directory_queue
+                .pop()
+                .expect("queue cannot be empty: we just checked");
+            let mut entries = fs::read_dir(cur_folder.clone()).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                let file_name: PathBuf = entry.file_name().into();
+                let full_file_name = cur_folder.clone().join(&file_name);
+                let file_remote_path =
+                    self.local_file_to_relative_path(full_file_name.clone().into());
+                files.push(file_remote_path.clone());
+                if full_file_name.is_dir() {
+                    directory_queue.push(full_file_name);
                 }
-                files.push(file_remote_path);
             }
         }
         Ok(files)

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -133,7 +133,7 @@ impl RemoteStorage for LocalFs {
     }
 
     async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>> {
-        let full_path = match folder.clone() {
+        let full_path = match folder {
             Some(folder) => folder.with_base(&self.storage_root),
             None => self.storage_root.clone(),
         };

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -158,8 +158,7 @@ impl RemoteStorage for LocalFs {
             while let Some(entry) = entries.next_entry().await? {
                 let file_name: PathBuf = entry.file_name().into();
                 let full_file_name = cur_folder.clone().join(&file_name);
-                let file_remote_path =
-                    self.local_file_to_relative_path(full_file_name.clone().into());
+                let file_remote_path = self.local_file_to_relative_path(full_file_name.clone());
                 files.push(file_remote_path.clone());
                 if full_file_name.is_dir() {
                     directory_queue.push(full_file_name);

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -347,11 +347,13 @@ impl RemoteStorage for S3Bucket {
         Ok(document_keys)
     }
 
+    /// See the doc for `RemoteStorage::list_files`
     async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>> {
         let folder_name = folder
             .map(|p| self.relative_path_to_s3_object(p))
             .or_else(|| self.prefix_in_bucket.clone());
 
+        // AWS may need to break the response into several parts
         let mut continuation_token = None;
         let mut all_files = vec![];
         loop {

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -377,12 +377,8 @@ impl RemoteStorage for S3Bucket {
                 })
                 .context("Failed to list files in S3 bucket")?;
 
-            dbg!(self.prefix_in_bucket.clone());
-            dbg!(response.contents());
-
             for object in response.contents().unwrap_or_default() {
                 let object_path = object.key().expect("response does not contain a key");
-                dbg!(object_path);
                 let remote_path = self.s3_object_to_relative_path(object_path);
                 all_files.push(remote_path);
             }

--- a/libs/remote_storage/src/simulate_failures.rs
+++ b/libs/remote_storage/src/simulate_failures.rs
@@ -83,6 +83,11 @@ impl RemoteStorage for UnreliableWrapper {
         self.inner.list_prefixes(prefix).await
     }
 
+    async fn list_files(&self, folder: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>> {
+        self.attempt(RemoteOp::ListPrefixes(folder.cloned()))?;
+        self.inner.list_files(folder).await
+    }
+
     async fn upload(
         &self,
         data: impl tokio::io::AsyncRead + Unpin + Send + Sync + 'static,

--- a/libs/remote_storage/tests/test_real_s3.rs
+++ b/libs/remote_storage/tests/test_real_s3.rs
@@ -371,7 +371,7 @@ fn create_s3_client(
     let random_prefix_part = std::time::SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("random s3 test prefix part calculation")?
-        .as_millis();
+        .as_nanos();
     let remote_storage_config = RemoteStorageConfig {
         max_concurrent_syncs: NonZeroUsize::new(100).unwrap(),
         max_sync_errors: NonZeroU32::new(5).unwrap(),

--- a/libs/remote_storage/tests/test_real_s3.rs
+++ b/libs/remote_storage/tests/test_real_s3.rs
@@ -134,8 +134,7 @@ async fn s3_list_files_works(ctx: &mut MaybeEnabledS3WithSimpleTestBlobs) -> any
         .map(|x| RemotePath::new(Path::new(x)).expect("must be valid name"))
         .collect();
     assert_eq!(
-        nested_remote_files.clone(),
-        trim_remote_blobs,
+        nested_remote_files, trim_remote_blobs,
         "remote storage list_files on subdirrectory mismatches with the uploads."
     );
     Ok(())

--- a/libs/remote_storage/tests/test_real_s3.rs
+++ b/libs/remote_storage/tests/test_real_s3.rs
@@ -301,12 +301,15 @@ impl AsyncTestContext for MaybeEnabledS3WithTestBlobs {
     }
 }
 
+// NOTE: the setups for the list_prefixes test and the list_files test are very similar
+// However, they are not idential. The list_prefixes function is concerned with listing prefixes,
+// whereas the list_files function is concerned with listing files.
+// See `RemoteStorage::list_files` documentation for more details
 enum MaybeEnabledS3WithSimpleTestBlobs {
     Enabled(S3WithSimpleTestBlobs),
     Disabled,
     UploadsFailed(anyhow::Error, S3WithSimpleTestBlobs),
 }
-
 struct S3WithSimpleTestBlobs {
     enabled: EnabledS3,
     remote_blobs: HashSet<RemotePath>,
@@ -475,6 +478,7 @@ async fn cleanup(client: &Arc<GenericRemoteStorage>, objects_to_delete: HashSet<
     }
 }
 
+// Uploads files `folder{j}/blob{i}.txt`. See test description for more details.
 async fn upload_simple_s3_data(
     client: &Arc<GenericRemoteStorage>,
     upload_tasks_count: usize,


### PR DESCRIPTION
## Problem
Need a function to list all files in a folder in remote_storage
## Summary of changes
Created `list_files` function. Note that this is slightly
different from the already existing `list_prefixes` function.
See https://neondb.slack.com/archives/C033RQ5SPDH/p1686664086706709
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [x] Do not forget to reformat commit message to not include the above checklist
