### PR TITLE
Fix git tag name for release

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -914,7 +914,7 @@ jobs:
             exit 1
           fi
 
-      - name: Create tag "release-${{ needs.tag.outputs.build-tag }}"
+      - name: Create git tag
         if: github.ref_name == 'release'
         uses: actions/github-script@v6
         with:
@@ -924,7 +924,7 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: "refs/tags/release-${{ needs.tag.outputs.build-tag }}",
+              ref: "refs/tags/${{ needs.tag.outputs.build-tag }}",
               sha: context.sha,
             })
 


### PR DESCRIPTION
## Problem

A git tag for a release has an extra `release-` prefix (it looks like `release-release-3439`). One prefix from
https://github.com/neondatabase/neon/blob/870740c9490adec5d58f2d1ea4c8b18a286ab0a7/.github/workflows/build_and_test.yml#L46
and another one from 
https://github.com/neondatabase/neon/blob/870740c9490adec5d58f2d1ea4c8b18a286ab0a7/.github/workflows/build_and_test.yml#L927
 
## Summary of changes
- Do not add `release-` prefix when create git tag

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
