### PR TITLE
bump VM_BUILDER_VERSION to 0.11.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -738,7 +738,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.8.0
+      VM_BUILDER_VERSION: v0.11.0
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

## Summary of changes
Routine bump of autoscaling version `0.8.0` -> `0.11.0`. Release notes are available [here](https://github.com/neondatabase/autoscaling/releases/tag/v0.11.0).

*Note*: waiting on https://github.com/neondatabase/cloud/pull/5556

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
