### PR TITLE
Basebackup forward compatibility

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -904,7 +904,7 @@ where
 
             self.check_permission(Some(tenant_id))?;
 
-            let lsn = if params.len() == 3 {
+            let lsn = if params.len() >= 3 {
                 Some(
                     Lsn::from_str(params[2])
                         .with_context(|| format!("Failed to parse Lsn from {}", params[2]))?,


### PR DESCRIPTION
## Problem
Currently it's hard to implement https://github.com/neondatabase/neon/pull/4482 because old pageserver would be incompatible with new compute.

## Summary of changes
Make sure that extra parameters in `basebackup` are ignored so that we can make forward-compatible changes.

NOTE: reverting a pageserver to a state before this PR was merged will break things. So we should wait a week or two after merging this and before introducing protocol changes