### PR TITLE
cold starts: Skip sync safekeepers if possible

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -338,9 +338,13 @@ impl ComputeNode {
         let lsn = match spec.mode {
             ComputeMode::Primary => {
                 info!("starting safekeepers syncing");
-                let lsn = self
-                    .sync_safekeepers(pspec.storage_auth_token.clone())
-                    .with_context(|| "failed to sync safekeepers")?;
+                let lsn = if let Some(synced_lsn) = spec.skip_sync_safekeepers {
+                    info!("no need to sync");
+                    synced_lsn
+                } else {
+                    self.sync_safekeepers(pspec.storage_auth_token.clone())
+                        .with_context(|| "failed to sync safekeepers")?
+                };
                 info!("safekeepers synced at LSN {}", lsn);
                 lsn
             }

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -68,6 +68,7 @@ pub struct EndpointConf {
     http_port: u16,
     pg_version: u32,
     skip_pg_catalog_updates: bool,
+    skip_sync_safekeepers: Option<utils::lsn::Lsn>,
 }
 
 //
@@ -137,6 +138,7 @@ impl ComputeControlPlane {
             tenant_id,
             pg_version,
             skip_pg_catalog_updates: false,
+            skip_sync_safekeepers: None,
         });
 
         ep.create_endpoint_dir()?;
@@ -151,6 +153,7 @@ impl ComputeControlPlane {
                 pg_port,
                 pg_version,
                 skip_pg_catalog_updates: false,
+                skip_sync_safekeepers: None,
             })?,
         )?;
         std::fs::write(
@@ -189,6 +192,7 @@ pub struct Endpoint {
 
     // Optimizations
     skip_pg_catalog_updates: bool,
+    skip_sync_safekeepers: Option<utils::lsn::Lsn>,
 }
 
 impl Endpoint {
@@ -223,6 +227,7 @@ impl Endpoint {
             tenant_id: conf.tenant_id,
             pg_version: conf.pg_version,
             skip_pg_catalog_updates: conf.skip_pg_catalog_updates,
+            skip_sync_safekeepers: conf.skip_sync_safekeepers,
         })
     }
 
@@ -457,6 +462,7 @@ impl Endpoint {
 
         // Create spec file
         let spec = ComputeSpec {
+            skip_sync_safekeepers: self.skip_sync_safekeepers,
             skip_pg_catalog_updates: self.skip_pg_catalog_updates,
             format_version: 1.0,
             operation_uuid: None,

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -33,6 +33,15 @@ pub struct ComputeSpec {
     #[serde(default)] // Default false
     pub skip_pg_catalog_updates: bool,
 
+    /// An optinal hint that can be passed to speed up startup time if we know
+    /// that safekeepers have already been synced at the given LSN.
+    ///
+    /// NOTE: If there's any possibility that the safekeepers could have advanced
+    ///       (e.g. if we started compute, and it crashed) we should stay on the
+    ///       safe side and provide None.
+    #[serde(default)]
+    pub skip_sync_safekeepers: Option<Lsn>,
+
     // Information needed to connect to the storage layer.
     //
     // `tenant_id`, `timeline_id` and `pageserver_connstring` are always needed.


### PR DESCRIPTION
## Problem
Part of https://github.com/neondatabase/cloud/issues/5315

We always run sync safekeepers on startup, and it consistently takes 60ms, p90 on prod.

There's already a fast path in the c code to return early if already synced, but even with that, it's still [slow](https://neondb.slack.com/archives/C04KGFVUWUQ/p1686957799076179?thread_ts=1686941861.696059&cid=C04KGFVUWUQ). We can try to debug it, but it's complicated c code and best case we still need to wait for TCP connections to safekeepers, and do some roundtrips.

## Summary of changes
- Add option to not sync if already synced
- Test

The next step would be to use this flag from the console:
1. Try to call sync_safekeepers after shutdown, and save the LSN
2. Invalidate the saved LSN before any startup attempt (successful or not)