### PR TITLE
Delete Unnecessary files in Extension Bucket

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -966,6 +966,8 @@ jobs:
           # Delete Neon extensitons (they always present on compute-node image)
           rm -rf ./extensions-to-upload/share/extension/neon*
           rm -rf ./extensions-to-upload/lib/neon*
+          rm -rf ./extensions-to-upload/lib/pgxs
+          rm -rf ./extensions-to-upload/lib/pkgconfig
 
           docker cp ${{ steps.create-container.outputs.EID }}:/extensions ./custom-extensions
           for EXT_NAME in $(ls ./custom-extensions); do

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -966,6 +966,8 @@ jobs:
           # Delete Neon extensitons (they always present on compute-node image)
           rm -rf ./extensions-to-upload/share/extension/neon*
           rm -rf ./extensions-to-upload/lib/neon*
+
+          # Delete leftovers from the extension build step
           rm -rf ./extensions-to-upload/lib/pgxs
           rm -rf ./extensions-to-upload/lib/pkgconfig
 


### PR DESCRIPTION
## Problem
We should not upload uneeded files to S3. Deleting these files
also simplifies the logic necessary for downloading appropriate files.
## Summary of changes
`rm -rf pgxs, pkgconfig`
