### PR TITLE
fix(proxy): stray span enter globbers up logs

### DIFF
--- a/proxy/src/console/mgmt.rs
+++ b/proxy/src/console/mgmt.rs
@@ -48,13 +48,13 @@ pub async fn task_main(listener: TcpListener) -> anyhow::Result<()> {
 
         tokio::task::spawn(
             async move {
-                info!("started a new console management API thread");
+                info!("started a new console management API task");
                 scopeguard::defer! {
-                    info!("console management API thread is about to finish");
+                    info!("console management API task is about to finish");
                 }
 
                 if let Err(e) = handle_connection(socket).await {
-                    error!("thread failed with an error: {e}");
+                    error!("task failed with an error: {e}");
                 }
             }
             .instrument(span),


### PR DESCRIPTION
Prod logs have deep span nesting indicating memory leak as pointed out by @conradludgate:

```
2023-07-03T09:11:10.295688Z  INFO mgmt{peer=10.8.51.207:37655}:...10k bytes of mgmt spans for each ephemeral port...:mgmt{peer=10.8.51.207:57907}: spawned a task for 10.8.146.39:43695
```

These were introduced in #3759 and has been untouched since, maybe no one watches proxy logs? :) I found it by accident when looking to see if proxy logs have ansi colors with `{neon_service="proxy"}`.

The solution is to mostly stop using `Span::enter` or `Span::entered` in async code. Kept on `Span::entered` in cancel on shutdown related path.