### PR TITLE
allow repeated IO errors from compute node

### DIFF
--- a/proxy/src/http/conn_pool.rs
+++ b/proxy/src/http/conn_pool.rs
@@ -228,6 +228,7 @@ async fn connect_to_compute(
         match connect_to_compute_once(node_info, conn_info).await {
             Err(e) if num_retries == NUM_RETRIES_WAKE_COMPUTE => {
                 if let Some(wait_duration) = retry_connect_in(&e, num_retries) {
+                    error!(error = ?e, "could not connect to compute node");
                     if should_wake {
                         match try_wake(node_info, &extra, &creds).await {
                             Ok(Some(x)) => should_wake = x,
@@ -238,6 +239,8 @@ async fn connect_to_compute(
                     if !wait_duration.is_zero() {
                         time::sleep(wait_duration).await;
                     }
+                } else {
+                    return Err(e.into());
                 }
             }
             other => return Ok(other?),

--- a/proxy/src/http/conn_pool.rs
+++ b/proxy/src/http/conn_pool.rs
@@ -10,7 +10,7 @@ use crate::{auth, console};
 use super::sql_over_http::MAX_RESPONSE_SIZE;
 
 use crate::proxy::try_wake;
-use crate::proxy::{NUM_RETRIES_WAKE_COMPUTE, RETRY_WAIT_DURATION};
+use crate::proxy::{BASE_RETRY_WAIT_DURATION, NUM_RETRIES_WAKE_COMPUTE};
 
 use tracing::error;
 use tracing::info;
@@ -222,11 +222,11 @@ async fn connect_to_compute(
 
     // This code is a copy of `connect_to_compute` from `src/proxy.rs` with
     // the difference that it uses `tokio_postgres` for the connection.
-    let mut num_retries: usize = NUM_RETRIES_WAKE_COMPUTE;
+    let mut num_retries = 0;
     let mut should_wake = true;
     loop {
         match connect_to_compute_once(node_info, conn_info).await {
-            Err(e) if num_retries > 0 => {
+            Err(e) if num_retries == NUM_RETRIES_WAKE_COMPUTE => {
                 if let Some(wait_duration) = retry_connect_in(&e, num_retries) {
                     if should_wake {
                         match try_wake(node_info, &extra, &creds).await {
@@ -243,23 +243,26 @@ async fn connect_to_compute(
             other => return Ok(other?),
         }
 
-        num_retries -= 1;
+        num_retries += 1;
         info!(retries_left = num_retries, "retrying connect");
     }
 }
 
-fn retry_connect_in(err: &tokio_postgres::Error, num_retries: usize) -> Option<time::Duration> {
+fn retry_connect_in(err: &tokio_postgres::Error, num_retries: u32) -> Option<time::Duration> {
     use tokio_postgres::error::SqlState;
     match err.code() {
         // retry all errors at least once immediately
-        _ if num_retries == NUM_RETRIES_WAKE_COMPUTE => Some(time::Duration::ZERO),
+        _ if num_retries == 0 => Some(time::Duration::ZERO),
         // keep retrying connection errors every 100ms
         Some(
             &SqlState::CONNECTION_FAILURE
             | &SqlState::CONNECTION_EXCEPTION
             | &SqlState::CONNECTION_DOES_NOT_EXIST
             | &SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-        ) => Some(RETRY_WAIT_DURATION),
+        ) => {
+            // 3/2 = 1.5 which seems to be an ok growth factor heuristic
+            Some(BASE_RETRY_WAIT_DURATION * 3_u32.pow(num_retries) / 2_u32.pow(num_retries))
+        }
         // otherwise, don't retry
         _ => None,
     }

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -322,7 +322,6 @@ async fn connect_to_compute_once(
     node_info
         .config
         .connect(allow_self_signed_compute, timeout)
-        // .inspect_err(|_: &compute::ConnectionError| invalidate_cache(node_info))
         .await
 }
 

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -362,6 +362,7 @@ async fn connect_to_compute(
         match connect_to_compute_once(node_info, timeout).await {
             Err(e) if num_retries < NUM_RETRIES_WAKE_COMPUTE => {
                 if let Some(wait_duration) = retry_connect_in(&e, num_retries) {
+                    error!(error = ?e, "could not connect to compute node");
                     if should_wake {
                         match try_wake(node_info, extra, creds).await {
                             Ok(Some(x)) => {
@@ -374,6 +375,8 @@ async fn connect_to_compute(
                     if !wait_duration.is_zero() {
                         time::sleep(wait_duration).await;
                     }
+                } else {
+                    return Err(e);
                 }
             }
             other => return other,

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -6,12 +6,17 @@ use crate::{
     cancellation::{self, CancelMap},
     compute::{self, PostgresConnection},
     config::{ProxyConfig, TlsConfig},
-    console::{self, messages::MetricsAuxInfo},
+    console::{
+        self,
+        errors::{ApiError, WakeComputeError},
+        messages::MetricsAuxInfo,
+    },
     error::io_error,
     stream::{PqStream, Stream},
 };
 use anyhow::{bail, Context};
 use futures::TryFutureExt;
+use hyper::StatusCode;
 use metrics::{register_int_counter, register_int_counter_vec, IntCounter, IntCounterVec};
 use once_cell::sync::Lazy;
 use pq_proto::{BeMessage as Be, FeStartupPacket, StartupMessageParams};
@@ -25,7 +30,9 @@ use tracing::{error, info, warn};
 use utils::measured_stream::MeasuredStream;
 
 /// Number of times we should retry the `/proxy_wake_compute` http request.
-pub const NUM_RETRIES_WAKE_COMPUTE: usize = 1;
+/// 50 * 100ms = 5s
+pub const NUM_RETRIES_WAKE_COMPUTE: usize = 50;
+pub const RETRY_WAIT_DURATION: time::Duration = time::Duration::from_millis(100);
 
 const ERR_INSECURE_CONNECTION: &str = "connection is insecure (try using `sslmode=require`)";
 const ERR_PROTO_VIOLATION: &str = "protocol violation";
@@ -315,7 +322,7 @@ async fn connect_to_compute_once(
     node_info
         .config
         .connect(allow_self_signed_compute, timeout)
-        .inspect_err(|_: &compute::ConnectionError| invalidate_cache(node_info))
+        // .inspect_err(|_: &compute::ConnectionError| invalidate_cache(node_info))
         .await
 }
 
@@ -329,6 +336,7 @@ async fn connect_to_compute(
     creds: &auth::BackendType<'_, auth::ClientCredentials<'_>>,
 ) -> Result<PostgresConnection, compute::ConnectionError> {
     let mut num_retries: usize = NUM_RETRIES_WAKE_COMPUTE;
+    let mut should_wake = true;
     loop {
         // Apply startup params to the (possibly, cached) compute node info.
         node_info.config.set_startup_params(params);
@@ -354,22 +362,69 @@ async fn connect_to_compute(
 
         match connect_to_compute_once(node_info, timeout).await {
             Err(e) if num_retries > 0 => {
-                info!("compute node's state has changed; requesting a wake-up");
-                match creds.wake_compute(extra).map_err(io_error).await? {
-                    // Update `node_info` and try one more time.
-                    Some(mut new) => {
-                        new.config.reuse_password(&node_info.config);
-                        *node_info = new;
+                if let Some(wait_duration) = retry_connect_in(&e, num_retries) {
+                    if should_wake {
+                        match try_wake(node_info, extra, creds).await {
+                            Ok(Some(x)) => {
+                                should_wake = x;
+                            }
+                            Ok(None) => return Err(e),
+                            Err(e) => return Err(io_error(e).into()),
+                        }
                     }
-                    // Link auth doesn't work that way, so we just exit.
-                    None => return Err(e),
+                    if !wait_duration.is_zero() {
+                        time::sleep(wait_duration).await;
+                    }
                 }
             }
             other => return other,
         }
 
         num_retries -= 1;
-        info!("retrying after wake-up ({num_retries} attempts left)");
+        info!(retries_left = num_retries, "retrying connect");
+    }
+}
+
+/// Attempts to wake up the compute node.
+/// * Returns Ok(Some(true)) if there was an error waking but retries are acceptable
+/// * Returns Ok(Some(false)) if the wakeup succeeded
+/// * Returns Ok(None) or Err(e) if there was an error
+pub async fn try_wake(
+    node_info: &mut console::CachedNodeInfo,
+    extra: &console::ConsoleReqExtra<'_>,
+    creds: &auth::BackendType<'_, auth::ClientCredentials<'_>>,
+) -> Result<Option<bool>, WakeComputeError> {
+    info!("compute node's state has likely changed; requesting a wake-up");
+    invalidate_cache(node_info);
+    match creds.wake_compute(extra).await {
+        // retry wake if the compute was in an invalid state
+        Err(WakeComputeError::ApiError(ApiError::Console {
+            status: StatusCode::BAD_REQUEST,
+            ..
+        })) => Ok(Some(true)),
+        // Update `node_info` and try again.
+        Ok(Some(mut new)) => {
+            new.config.reuse_password(&node_info.config);
+            *node_info = new;
+            Ok(Some(false))
+        }
+        Err(e) => Err(e),
+        Ok(None) => Ok(None),
+    }
+}
+
+fn retry_connect_in(err: &compute::ConnectionError, num_retries: usize) -> Option<time::Duration> {
+    use std::io::ErrorKind;
+    match err {
+        // retry all errors at least once immediately
+        _ if num_retries == NUM_RETRIES_WAKE_COMPUTE => Some(time::Duration::ZERO),
+        // keep retrying connection errors every 100ms
+        compute::ConnectionError::CouldNotConnect(io_err) => match io_err.kind() {
+            ErrorKind::ConnectionRefused | ErrorKind::AddrNotAvailable => Some(RETRY_WAIT_DURATION),
+            _ => None,
+        },
+        // otherwise, don't retry
+        _ => None,
     }
 }
 

--- a/proxy/src/proxy/tests.rs
+++ b/proxy/src/proxy/tests.rs
@@ -1,4 +1,6 @@
 //! A group of high-level tests for connection establishing logic and auth.
+use std::io;
+
 use super::*;
 use crate::{auth, sasl, scram};
 use async_trait::async_trait;
@@ -293,4 +295,19 @@ async fn scram_auth_mock() -> anyhow::Result<()> {
         .context("server shouldn't accept client")?;
 
     Ok(())
+}
+
+#[test]
+fn connect_compute_total_wait() {
+    let err = compute::ConnectionError::CouldNotConnect(io::Error::new(
+        io::ErrorKind::ConnectionRefused,
+        "conn refused",
+    ));
+
+    let mut total_wait = tokio::time::Duration::ZERO;
+    for num_retries in 0..10 {
+        total_wait += retry_connect_in(&err, num_retries).unwrap();
+    }
+    assert!(total_wait < tokio::time::Duration::from_secs(12));
+    assert!(total_wait > tokio::time::Duration::from_secs(10));
 }


### PR DESCRIPTION
## Problem

#4598 compute nodes are not accessible some time after wake up due to kubernetes DNS not being fully propagated.

## Summary of changes

Update connect retry mechanism to support handling IO errors and sleeping for 100ms

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
