### PR TITLE
page_service: add peer_addr span field, and set tenant_id / timeline_id fields earlier

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -479,7 +479,7 @@ impl PageServerHandler {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(base_lsn=%base_lsn, end_lsn=%_end_lsn, pg_version=%pg_version))]
+    #[instrument(skip_all, fields(%base_lsn, end_lsn=%_end_lsn, %pg_version))]
     async fn handle_import_basebackup<IO>(
         &self,
         pgb: &mut PostgresBackend<IO>,
@@ -539,7 +539,7 @@ impl PageServerHandler {
         Ok(())
     }
 
-    #[instrument(skip_all, fields(start_lsn=%start_lsn, end_lsn=%end_lsn))]
+    #[instrument(skip_all, fields(%start_lsn, %end_lsn))]
     async fn handle_import_wal<IO>(
         &self,
         pgb: &mut PostgresBackend<IO>,
@@ -747,7 +747,7 @@ impl PageServerHandler {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(lsn=?lsn, prev_lsn=?prev_lsn, full_backup=%full_backup))]
+    #[instrument(skip_all, fields(?lsn, ?prev_lsn, %full_backup))]
     async fn handle_basebackup_request<IO>(
         &mut self,
         pgb: &mut PostgresBackend<IO>,

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::io::StreamReader;
+use tracing::field;
 use tracing::*;
 use utils::id::ConnectionId;
 use utils::{
@@ -262,7 +263,7 @@ async fn page_service_conn_main(
         .context("could not set TCP_NODELAY")?;
 
     let peer_addr = socket.peer_addr().context("get peer address")?;
-    tracing::Span::current().record("peer_addr", &peer_addr.to_string());
+    tracing::Span::current().record("peer_addr", field::display(peer_addr));
 
     // setup read timeout of 10 minutes. the timeout is rather arbitrary for requirements:
     // - long enough for most valid compute connections
@@ -895,8 +896,8 @@ where
                 .with_context(|| format!("Failed to parse timeline id from {}", params[1]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id.to_string())
-                .record("timeline_id", &timeline_id.to_string());
+                .record("tenant_id", field::display(tenant_id))
+                .record("timeline_id", field::display(timeline_id));
 
             self.check_permission(Some(tenant_id))?;
 
@@ -918,8 +919,8 @@ where
                 .with_context(|| format!("Failed to parse timeline id from {}", params[1]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id.to_string())
-                .record("timeline_id", &timeline_id.to_string());
+                .record("tenant_id", field::display(tenant_id))
+                .record("timeline_id", field::display(timeline_id));
 
             self.check_permission(Some(tenant_id))?;
 
@@ -968,8 +969,8 @@ where
                 .with_context(|| format!("Failed to parse timeline id from {}", params[1]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id.to_string())
-                .record("timeline_id", &timeline_id.to_string());
+                .record("tenant_id", field::display(tenant_id))
+                .record("timeline_id", field::display(timeline_id));
 
             self.check_permission(Some(tenant_id))?;
             let timeline = get_active_tenant_timeline(tenant_id, timeline_id, &ctx).await?;
@@ -1003,8 +1004,8 @@ where
                 .with_context(|| format!("Failed to parse timeline id from {}", params[1]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id.to_string())
-                .record("timeline_id", &timeline_id.to_string());
+                .record("tenant_id", field::display(tenant_id))
+                .record("timeline_id", field::display(timeline_id));
 
             // The caller is responsible for providing correct lsn and prev_lsn.
             let lsn = if params.len() > 2 {
@@ -1061,8 +1062,8 @@ where
                 .with_context(|| format!("Failed to parse pg_version from {}", params[4]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id.to_string())
-                .record("timeline_id", &timeline_id.to_string());
+                .record("tenant_id", field::display(tenant_id))
+                .record("timeline_id", field::display(timeline_id));
 
             self.check_permission(Some(tenant_id))?;
 
@@ -1109,8 +1110,8 @@ where
                 .with_context(|| format!("Failed to parse Lsn from {}", params[3]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id.to_string())
-                .record("timeline_id", &timeline_id.to_string());
+                .record("tenant_id", field::display(tenant_id))
+                .record("timeline_id", field::display(timeline_id));
 
             self.check_permission(Some(tenant_id))?;
 
@@ -1143,7 +1144,7 @@ where
             let tenant_id = TenantId::from_str(params[0])
                 .with_context(|| format!("Failed to parse tenant id from {}", params[0]))?;
 
-            tracing::Span::current().record("tenant_id", &tenant_id.to_string());
+            tracing::Span::current().record("tenant_id", field::display(tenant_id));
 
             self.check_permission(Some(tenant_id))?;
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -746,7 +746,7 @@ impl PageServerHandler {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip_all, fields(lsn=%lsn, prev_lsn=%prev_lsn, full_backup=%full_backup))]
+    #[instrument(skip_all, fields(lsn=?lsn, prev_lsn=?prev_lsn, full_backup=%full_backup))]
     async fn handle_basebackup_request<IO>(
         &mut self,
         pgb: &mut PostgresBackend<IO>,
@@ -895,8 +895,8 @@ where
                 .with_context(|| format!("Failed to parse timeline id from {}", params[1]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id)
-                .record("timeline_id", &timeline_id);
+                .record("tenant_id", &tenant_id.to_string())
+                .record("timeline_id", &timeline_id.to_string());
 
             self.check_permission(Some(tenant_id))?;
 
@@ -918,8 +918,8 @@ where
                 .with_context(|| format!("Failed to parse timeline id from {}", params[1]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id)
-                .record("timeline_id", &timeline_id);
+                .record("tenant_id", &tenant_id.to_string())
+                .record("timeline_id", &timeline_id.to_string());
 
             self.check_permission(Some(tenant_id))?;
 
@@ -968,8 +968,8 @@ where
                 .with_context(|| format!("Failed to parse timeline id from {}", params[1]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id)
-                .record("timeline_id", &timeline_id);
+                .record("tenant_id", &tenant_id.to_string())
+                .record("timeline_id", &timeline_id.to_string());
 
             self.check_permission(Some(tenant_id))?;
             let timeline = get_active_tenant_timeline(tenant_id, timeline_id, &ctx).await?;
@@ -1003,8 +1003,8 @@ where
                 .with_context(|| format!("Failed to parse timeline id from {}", params[1]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id)
-                .record("timeline_id", &timeline_id);
+                .record("tenant_id", &tenant_id.to_string())
+                .record("timeline_id", &timeline_id.to_string());
 
             // The caller is responsible for providing correct lsn and prev_lsn.
             let lsn = if params.len() > 2 {
@@ -1061,8 +1061,8 @@ where
                 .with_context(|| format!("Failed to parse pg_version from {}", params[4]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id)
-                .record("timeline_id", &timeline_id);
+                .record("tenant_id", &tenant_id.to_string())
+                .record("timeline_id", &timeline_id.to_string());
 
             self.check_permission(Some(tenant_id))?;
 
@@ -1109,8 +1109,8 @@ where
                 .with_context(|| format!("Failed to parse Lsn from {}", params[3]))?;
 
             tracing::Span::current()
-                .record("tenant_id", &tenant_id)
-                .record("timeline_id", &timeline_id);
+                .record("tenant_id", &tenant_id.to_string())
+                .record("timeline_id", &timeline_id.to_string());
 
             self.check_permission(Some(tenant_id))?;
 
@@ -1143,7 +1143,7 @@ where
             let tenant_id = TenantId::from_str(params[0])
                 .with_context(|| format!("Failed to parse tenant id from {}", params[0]))?;
 
-            tracing::Span::current().record("tenant_id", &tenant_id);
+            tracing::Span::current().record("tenant_id", &tenant_id.to_string());
 
             self.check_permission(Some(tenant_id))?;
 


### PR DESCRIPTION
Before this PR, during shutdown, we'd find naked logs like this one for every active page service connection:

```
2023-07-05T14:13:50.791992Z  INFO shutdown request received in run_message_loop
```

This PR
1. adds a peer_addr span field to distinguish the connections in logs
2. sets the tenant_id / timeline_id fields earlier

It would be nice to have `tenant_id` and `timeline_id` directly on the `page_service_conn_main` span (empty, initially), then set them at the top of `process_query`.

But, the problem is that the debug asserts for tenant_id and timeline_id presence in the tracing span doesn't support detecting empty values (https://github.com/neondatabase/neon/issues/4676)
So, I'm a bit hesitant about over-using `Span::record`.