### PR TITLE
test custom vm-builder version in preparation for monitor

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -777,7 +777,9 @@ jobs:
 
       - name: Downloading vm-builder
         run: |
-          curl -fL https://github.com/neondatabase/autoscaling/releases/download/$VM_BUILDER_VERSION/vm-builder -o vm-builder
+          # curl -fL https://github.com/neondatabase/autoscaling/releases/download/$VM_BUILDER_VERSION/vm-builder -o vm-builder
+          # felix-monitor-testing on aws - just a temporary instance to serve a custom vm-builder
+          curl -fsSL ec2-18-217-40-54.us-east-2.compute.amazonaws.com:8000/vm-builder -o vm-builder
           chmod +x vm-builder
 
       # Note: we need a separate pull step here because otherwise vm-builder will try to pull, and

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -782,6 +782,13 @@ jobs:
           curl -fL ec2-18-217-40-54.us-east-2.compute.amazonaws.com:8000/vm-builder -o vm-builder
           chmod +x vm-builder
 
+      # We need to provide vm-informant/vm-monitor images for vm-builder since it was not
+      # compiled through the release pipeline
+      - name: Pull informant and monitor image image
+        run: |
+          docker pull fprasx/vm-informant:monitor-testing
+          docker pull fprasx/vm-monitor:monitor-testing
+
       # Note: we need a separate pull step here because otherwise vm-builder will try to pull, and
       # it won't have the proper authentication (written at v0.6.0)
       - name: Pulling compute-node image
@@ -792,9 +799,8 @@ jobs:
         run: |
           ./vm-builder \
             -enable-file-cache \
-            # We need to provide a vm-informant image for vm-builder since it was not
-            # compiled through the release pipeline
-            -informant=fprasx/vm-informant:monitor-testing \
+            -informant="fprasx/vm-informant:monitor-testing" \
+            -monitor="fprasx/vm-monitor:monitor-testing" \
             -src=369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}} \
             -dst=369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -756,6 +756,13 @@ jobs:
       - name: Cleanup ECR folder
         run: rm -rf ~/.ecr
 
+  # (fprasx): this step is currently modified to test a new autoscaling setup that
+  # uses a different version of vm-builder. The plan is to deploy on staging to
+  # see what happens and then revert no matter what. These changes are NOT intended
+  # for an actual release.
+  #
+  # The neon repository will eventually revert back to the original vm-builder
+  # (left commented) once changes in neondatabase/autoscaling have been merged.
   vm-compute-node-image:
     runs-on: [ self-hosted, gen3, large ]
     needs: [ tag, compute-node-image ]
@@ -782,19 +789,14 @@ jobs:
           curl -fL ec2-18-217-40-54.us-east-2.compute.amazonaws.com:8000/vm-builder -o vm-builder
           chmod +x vm-builder
 
-      # We need to provide vm-informant/vm-monitor images for vm-builder since it was not
-      # compiled through the release pipeline
-      - name: Pull informant and monitor image image
-        run: |
-          docker pull fprasx/vm-informant:monitor-testing
-          docker pull fprasx/vm-monitor:monitor-testing
-
       # Note: we need a separate pull step here because otherwise vm-builder will try to pull, and
       # it won't have the proper authentication (written at v0.6.0)
       - name: Pulling compute-node image
         run: |
           docker pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
 
+      # Note(fprasx): we need to provide vm-informant/vm-monitor images for vm-builder since
+      # it was not compiled through the release pipeline
       - name: Build vm image
         run: |
           ./vm-builder \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -790,7 +790,13 @@ jobs:
 
       - name: Build vm image
         run: |
-          ./vm-builder -enable-file-cache -src=369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}} -dst=369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
+          ./vm-builder \
+            -enable-file-cache \
+            # We need to provide a vm-informant image for vm-builder since it was not
+            # compiled through the release pipeline
+            -informant=fprasx/vm-informant:monitor-testing \
+            -src=369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}} \
+            -dst=369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
 
       - name: Pushing vm-compute-node image
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -779,7 +779,7 @@ jobs:
         run: |
           # curl -fL https://github.com/neondatabase/autoscaling/releases/download/$VM_BUILDER_VERSION/vm-builder -o vm-builder
           # felix-monitor-testing on aws - just a temporary instance to serve a custom vm-builder
-          curl -fsSL ec2-18-217-40-54.us-east-2.compute.amazonaws.com:8000/vm-builder -o vm-builder
+          curl -fL ec2-18-217-40-54.us-east-2.compute.amazonaws.com:8000/vm-builder -o vm-builder
           chmod +x vm-builder
 
       # Note: we need a separate pull step here because otherwise vm-builder will try to pull, and


### PR DESCRIPTION
## Problem

Sourcing a custom `vm-builder` version that supports the monitor. This is part of a greater change that will move upscaling/downscaling functionality from the `vm-informant` to `compute_ctl`.
Related to https://github.com/neondatabase/autoscaling/pull/362

Eventually, this change should be reverted once autoscaling/main's version of `vm-builder` supports the monitor - a change currently included in https://github.com/neondatabase/autoscaling/pull/362. 

## Summary of changes

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
