### PR TITLE
support non-interactive transactions in sql-over-http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
 dependencies = [
  "native-tls",
  "tokio",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
 dependencies = [
  "base64 0.20.0",
  "byteorder",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=1aaedab101b23f7612042850d8f2036810fa7c7f#1aaedab101b23f7612042850d8f2036810fa7c7f"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=1aaedab101b23f7612042850d8f2036810fa7c7f#1aaedab101b23f7612042850d8f2036810fa7c7f"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
 dependencies = [
  "native-tls",
  "tokio",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=1aaedab101b23f7612042850d8f2036810fa7c7f#1aaedab101b23f7612042850d8f2036810fa7c7f"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
 dependencies = [
  "base64 0.20.0",
  "byteorder",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=1aaedab101b23f7612042850d8f2036810fa7c7f#1aaedab101b23f7612042850d8f2036810fa7c7f"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=1aaedab101b23f7612042850d8f2036810fa7c7f#1aaedab101b23f7612042850d8f2036810fa7c7f"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a7e5269d655f8dfef46cf334d9710343d671e802#a7e5269d655f8dfef46cf334d9710343d671e802"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,11 +144,11 @@ env_logger = "0.10"
 log = "0.4"
 
 ## Libraries from neondatabase/ git forks, ideally with changes to be upstreamed
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
-postgres-native-tls = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
-postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
-postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
+postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
+postgres-native-tls = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
+postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
+postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
 
 ## Other git libraries
 heapless = { default-features=false, features=[], git = "https://github.com/japaric/heapless.git", rev = "644653bf3b831c6bb4963be2de24804acf5e5001" } # upstream release pending
@@ -183,7 +183,7 @@ tonic-build = "0.9"
 
 # This is only needed for proxy's tests.
 # TODO: we should probably fork `tokio-postgres-rustls` instead.
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
 
 ################# Binary contents sections
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,11 +144,11 @@ env_logger = "0.10"
 log = "0.4"
 
 ## Libraries from neondatabase/ git forks, ideally with changes to be upstreamed
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="1aaedab101b23f7612042850d8f2036810fa7c7f" }
-postgres-native-tls = { git = "https://github.com/neondatabase/rust-postgres.git", rev="1aaedab101b23f7612042850d8f2036810fa7c7f" }
-postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="1aaedab101b23f7612042850d8f2036810fa7c7f" }
-postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="1aaedab101b23f7612042850d8f2036810fa7c7f" }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="1aaedab101b23f7612042850d8f2036810fa7c7f" }
+postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
+postgres-native-tls = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
+postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
+postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
 
 ## Other git libraries
 heapless = { default-features=false, features=[], git = "https://github.com/japaric/heapless.git", rev = "644653bf3b831c6bb4963be2de24804acf5e5001" } # upstream release pending
@@ -183,7 +183,7 @@ tonic-build = "0.9"
 
 # This is only needed for proxy's tests.
 # TODO: we should probably fork `tokio-postgres-rustls` instead.
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="1aaedab101b23f7612042850d8f2036810fa7c7f" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a7e5269d655f8dfef46cf334d9710343d671e802" }
 
 ################# Binary contents sections
 

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -216,7 +216,7 @@ pub async fn handle(
                 let result = query_to_json(&transaction, query, raw_output, array_mode).await;
                 if let Err(e) = result {
                     transaction.rollback().await?;
-                    return Err(e.into());
+                    return Err(e);
                 }
                 results.push(result?);
             }

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -242,7 +242,9 @@ async fn query_to_json<T: GenericClient>(
     array_mode: bool,
 ) -> anyhow::Result<Value> {
     let query_params = json_to_pg_text(data.params)?;
-    let row_stream = client.query_raw(&data.query, query_params).await?;
+    let row_stream = client
+        .query_raw_txt::<String, _>(data.query, query_params)
+        .await?;
 
     // Manually drain the stream into a vector to leave row_stream hanging
     // around to get a command tag. Also check that the response is not too

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -11,6 +11,7 @@ use serde_json::Map;
 use serde_json::Value;
 use tokio_postgres::types::Kind;
 use tokio_postgres::types::Type;
+use tokio_postgres::GenericClient;
 use tokio_postgres::Row;
 use url::Url;
 
@@ -21,6 +22,13 @@ use super::conn_pool::GlobalConnPool;
 struct QueryData {
     query: String,
     params: Vec<serde_json::Value>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum Payload {
+    Single(QueryData),
+    Batch(Vec<QueryData>),
 }
 
 pub const MAX_RESPONSE_SIZE: usize = 1024 * 1024; // 1 MB
@@ -192,15 +200,49 @@ pub async fn handle(
     // Read the query and query params from the request body
     //
     let body = hyper::body::to_bytes(request.into_body()).await?;
-    let QueryData { query, params } = serde_json::from_slice(&body)?;
-    let query_params = json_to_pg_text(params)?;
+    let payload: Payload = serde_json::from_slice(&body)?;
+
+    let mut client = conn_pool.get(&conn_info, !allow_pool).await?;
 
     //
     // Now execute the query and return the result
     //
-    let client = conn_pool.get(&conn_info, !allow_pool).await?;
+    let result = match payload {
+        Payload::Single(query) => query_to_json(&client, query, raw_output, array_mode).await,
+        Payload::Batch(queries) => {
+            let mut results = Vec::new();
+            let transaction = client.transaction().await?;
+            for query in queries {
+                let result = query_to_json(&transaction, query, raw_output, array_mode).await;
+                if let Err(e) = result {
+                    transaction.rollback().await?;
+                    return Err(e.into());
+                }
+                results.push(result?);
+            }
+            transaction.commit().await?;
+            Ok(Value::Array(results))
+        }
+    };
 
-    let row_stream = client.query_raw_txt(query, query_params).await?;
+    if allow_pool {
+        // return connection to the pool
+        tokio::task::spawn(async move {
+            let _ = conn_pool.put(&conn_info, client).await;
+        });
+    }
+
+    result
+}
+
+async fn query_to_json<T: GenericClient>(
+    client: &T,
+    data: QueryData,
+    raw_output: bool,
+    array_mode: bool,
+) -> anyhow::Result<Value> {
+    let query_params = json_to_pg_text(data.params)?;
+    let row_stream = client.query_raw(&data.query, query_params).await?;
 
     // Manually drain the stream into a vector to leave row_stream hanging
     // around to get a command tag. Also check that the response is not too
@@ -255,13 +297,6 @@ pub async fn handle(
         .iter()
         .map(|row| pg_text_row_to_json(row, raw_output, array_mode))
         .collect::<Result<Vec<_>, _>>()?;
-
-    if allow_pool {
-        // return connection to the pool
-        tokio::task::spawn(async move {
-            let _ = conn_pool.put(&conn_info, client).await;
-        });
-    }
 
     // resulting JSON format is based on the format of node-postgres result
     Ok(json!({

--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -201,7 +201,12 @@ async fn ws_handler(
             .await;
         let status_code = match result {
             Ok(_) => StatusCode::OK,
-            Err(_) => StatusCode::BAD_REQUEST,
+            Err(ref e) => {
+                if cfg!(debug_assertions) {
+                    error!("error in sql-over-http: {}, backtrace: {}", e, e.backtrace());
+                }
+                StatusCode::BAD_REQUEST
+            }
         };
         let json = match result {
             Ok(r) => r,

--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -203,7 +203,11 @@ async fn ws_handler(
             Ok(_) => StatusCode::OK,
             Err(ref e) => {
                 if cfg!(debug_assertions) {
-                    error!("error in sql-over-http: {}, backtrace: {}", e, e.backtrace());
+                    error!(
+                        "error in sql-over-http: {}, backtrace: {}",
+                        e,
+                        e.backtrace()
+                    );
                 }
                 StatusCode::BAD_REQUEST
             }

--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -201,16 +201,7 @@ async fn ws_handler(
             .await;
         let status_code = match result {
             Ok(_) => StatusCode::OK,
-            Err(ref e) => {
-                if cfg!(debug_assertions) {
-                    error!(
-                        "error in sql-over-http: {}, backtrace: {}",
-                        e,
-                        e.backtrace()
-                    );
-                }
-                StatusCode::BAD_REQUEST
-            }
+            Err(_) => StatusCode::BAD_REQUEST,
         };
         let json = match result {
             Ok(r) => r,


### PR DESCRIPTION
## Background
My company (Brevity) deploys hundreds (soon thousands) of cloudflare workers for our clients. We also supply each client with a neon database to handle data persistence and querying. Latency is important to our clients so the traditional sql-over-websockets approach has not worked for us because it adds too much latency to each request (no connection pooling!). To mitigate this, we currently deploy a small server for each neon database that manages a connection pool to the database and as a single api for querying data over http. 

Needless to say, we are very excited about the sql-over-http feature that is currently in development at neon because it will allow us to completely remove these extra servers from our stack (and all the orchestration that is involved). We see this as a unique value-add for Neon and it is a large reason why we choose Neon in the first place. 

## Problem
That said, the sql-over-http feature as it is currently implemented does not support our use case because it does not support basic transactions or multi-statement queries. We allow our users to create row level security policies for the data in their database and before we execute a db query on their behalf, we set some db local variables (ex `SET LOCAL jwt.claims.sub = '{user_id}'`) to establish who the current user is, which in turn allows the row level security policies to make decisions about what data the current user has access to. These local variables only live as long as the current transaction which is perfect for our use-case but means that we can not realistically use Neon's sql-over-http feature as it is currently implemented because it does not support transactions (I know it's still a work in progress). 

## Summary of changes
While I don't really expect this PR to be merged, I wanted to show a proof of concept on how basic transactions *could* be supported by the http endpoint. With this change, users can choose to send a single query to the http endpoint (which is consistent with the current functionality) *or* they can send an array of queries which would automatically be wrapped in a transaction and executed serially. Sending an array of queries would return an array of results. This would support our use case.

> NOTE: I did not have access to the custom fork of `tokio-postgres` so for the time being, I changed `query_raw_txt` back to `query_raw`. In order to support this fully, we would have to add `query_raw_txt` support to `tokio_postgres::Transaction` and the `GenericClient` trait -- which should be fairly simple. 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
