### PR TITLE
layer deletion: Improve a comment and fix TOCTOU

### DIFF
--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -344,20 +344,18 @@ impl RemoteStorage for LocalFs {
 
     async fn delete(&self, path: &RemotePath) -> anyhow::Result<()> {
         let file_path = path.with_base(&self.storage_root);
-        let res: std::io::Result<()> = || {
-            let metadata = file_path.metadata()?;
-            if !metadata.is_file() {
-                anyhow::bail!("{file_path:?} is not a file");
-            }
-            fs::remove_file(file_path)
-        } ();
-        match res {
+        match fs::remove_file(&file_path).await {
             Ok(()) => Ok(()),
             // The file doesn't exist. This shouldn't yield an error to mirror S3's behaviour.
             // See https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
             // > If there isn't a null version, Amazon S3 does not remove any objects but will still respond that the command was successful.
             Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(anyhow::anyhow!(e)),
+            Err(e) => {
+                if !file_path.is_file() {
+                    anyhow::bail!("{file_path:?} is not a file");
+                }
+                Err(anyhow::anyhow!(e))
+            }
         }
     }
 

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -350,12 +350,7 @@ impl RemoteStorage for LocalFs {
             // See https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
             // > If there isn't a null version, Amazon S3 does not remove any objects but will still respond that the command was successful.
             Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
-            Err(e) => {
-                if !file_path.is_file() {
-                    anyhow::bail!("{file_path:?} is not a file");
-                }
-                Err(anyhow::anyhow!(e))
-            }
+            Err(e) => Err(anyhow::anyhow!(e)),
         }
     }
 

--- a/pageserver/src/tenant/remote_timeline_client/delete.rs
+++ b/pageserver/src/tenant/remote_timeline_client/delete.rs
@@ -19,9 +19,10 @@ pub(super) async fn delete_layer<'a>(
 
     let path_to_delete = conf.remote_path(local_layer_path)?;
 
-    // XXX: If the deletion fails because the object already didn't exist,
-    // it would be good to just issue a warning but consider it success.
-    // https://github.com/neondatabase/neon/issues/2934
+    // We don't want to print an error if the delete failed if the file has
+    // already been deleted. Thankfully, in this situation S3 already
+    // does not yield an error. While OS-provided local file system APIs do yield
+    // errors, we avoid them in the `LocalFs` wrapper.
     storage.delete(&path_to_delete).await.with_context(|| {
         format!("Failed to delete remote layer from storage at {path_to_delete:?}")
     })


### PR DESCRIPTION
The comment referenced an issue that was already closed. Remove that reference and replace it with an explanation why we already don't print an error.

See discussion in https://github.com/neondatabase/neon/issues/2934#issuecomment-1626505916

For the TOCTOU fixes, the two calls after the `.exists()` both didn't handle the situation well where the file was deleted after the initial `.exists()`: one would assume that the path wasn't a file, giving a bad error, the second would give an accurate error but that's not wanted either.

The new code still has a minor race condition in that we might print that some file is not a file if it's actually been deleted if the deletion happens at the wrong moment, but in that instance there would have been an error anyways, so it's just a degradation of an error message, which is acceptable.