### PR TITLE
Update vm-builder v0.11.1 -> v0.12.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -767,7 +767,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.11.1
+      VM_BUILDER_VERSION: v0.12.1
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This should only affect the version of the vm-informant used. The only PR changing the informant since v0.11.1 was:

* https://github.com/neondatabase/autoscaling/pull/389

The bug that autoscaling#389 fixed impacts all pooled VMs, so the updated images from this PR must be released before https://github.com/neondatabase/cloud/pull/5721.
