### PR TITLE
Don't propagate but log file not found error in layer uploading

### DIFF
--- a/pageserver/src/tenant/remote_timeline_client/upload.rs
+++ b/pageserver/src/tenant/remote_timeline_client/upload.rs
@@ -68,7 +68,7 @@ pub(super) async fn upload_timeline_layer<'a>(
             // file might not have been written in the first place, which also indicates
             // a bug. Still log the situation so that we can keep an eye on it.
             // See https://github.com/neondatabase/neon/issues/4526
-            info!("Couldn't find a file at the layer's path {source_path:?} for upload. Likely the file was deleted before and an upload is not required any more.");
+            info!(path = %source_path.display(), "File to upload doesn't exist. Likely the file has been deleted and an upload is not required any more.");
             return Ok(());
         }
         Err(e) => Err(e)

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2918,20 +2918,7 @@ impl Timeline {
                 HashMap::from([(delta_path, metadata)])
             };
 
-        // Have a failpoint that can use the `pause` failpoint action.
-        // We don't want to block the executor thread, hence, spawn_blocking + await.
-        if cfg!(feature = "testing") {
-            tokio::task::spawn_blocking({
-                let current = tracing::Span::current();
-                move || {
-                    let _entered = current.entered();
-                    tracing::info!("at failpoint flush-frozen-before-sync");
-                    fail::fail_point!("flush-frozen-before-sync");
-                }
-            })
-            .await
-            .expect("spawn_blocking");
-        }
+        pausable_failpoint!("flush-frozen-before-sync");
 
         // The new on-disk layers are now in the layer map. We can remove the
         // in-memory layer from the map now. We do not modify `LayerFileManager` because

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2918,7 +2918,20 @@ impl Timeline {
                 HashMap::from([(delta_path, metadata)])
             };
 
-        fail_point!("flush-frozen-before-sync");
+        // Have a failpoint that can use the `pause` failpoint action.
+        // We don't want to block the executor thread, hence, spawn_blocking + await.
+        if cfg!(feature = "testing") {
+            tokio::task::spawn_blocking({
+                let current = tracing::Span::current();
+                move || {
+                    let _entered = current.entered();
+                    tracing::info!("at failpoint flush-frozen-before-sync");
+                    fail::fail_point!("flush-frozen-before-sync");
+                }
+            })
+            .await
+            .expect("spawn_blocking");
+        }
 
         // The new on-disk layers are now in the layer map. We can remove the
         // in-memory layer from the map now. We do not modify `LayerFileManager` because

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -793,14 +793,14 @@ def test_compaction_delete_before_upload(
     env = neon_env_builder.init_start()
 
     # create tenant with config that will determinstically allow
-    # compaction and gc
+    # compaction and disables gc
     tenant_id, timeline_id = env.neon_cli.create_tenant(
         conf={
             # Set a small compaction threshold
             "compaction_threshold": "3",
             # Disable GC
             "gc_period": "0s",
-            # disable PITR so that GC considers just gc_horizon
+            # disable PITR
             "pitr_interval": "0s",
         }
     )
@@ -868,6 +868,9 @@ def test_compaction_delete_before_upload(
     # Ensure that this actually terminates
     wait_upload_queue_empty(client, tenant_id, timeline_id)
 
+    # For now we are hitting this message.
+    # Maybe in the future the underlying race condition will be fixed,
+    # but until then, ensure that this message is hit instead.
     assert env.pageserver.log_contains("for upload, assuming an upload is not required any more.")
 
 

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -868,6 +868,8 @@ def test_compaction_delete_before_upload(
     # Ensure that this actually terminates
     wait_upload_queue_empty(client, tenant_id, timeline_id)
 
+    assert env.pageserver.log_contains("for upload, assuming an upload is not required any more.")
+
 
 def wait_upload_queue_empty(
     client: PageserverHttpClient, tenant_id: TenantId, timeline_id: TimelineId


### PR DESCRIPTION
## Problem

This addresses the issue in #4526 by adding a test that reproduces the race condition that gave rise to the bug (or at least *a* race condition that gave rise to the same error message), and then implementing a fix that just prints a message to the log if a file could not been found for uploading. Even though the underlying race condition is not fixed yet, this will un-block the upload queue in that situation, greatly reducing the impact of such a (rare) race.

Fixes #4526.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
