### PR TITLE
CORS preflight OPTIONS support for /sql (http fetch) endpoint

### DIFF
--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -222,15 +222,14 @@ async fn ws_handler(
             r
         })
     } else if request.uri().path() == "/sql" && request.method() == Method::OPTIONS {
-      Response::builder()
-        .header("Allow", "OPTIONS, POST")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Access-Control-Allow-Headers", "Neon-Connection-String, Neon-Raw-Text-Output, Neon-Array-Mode, Neon-Pool-Opt-In")
-        .header("Access-Control-Max-Age", "86400" /* 24 hours */)
-        .status(StatusCode::OK)  // 204 is also valid, but see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS#status_code
-        .body(Body::empty())
-        .map_err(|e| ApiError::BadRequest(e.into()))
-
+        Response::builder()
+            .header("Allow", "OPTIONS, POST")
+            .header("Access-Control-Allow-Origin", "*")
+            .header("Access-Control-Allow-Headers", "Neon-Connection-String, Neon-Raw-Text-Output, Neon-Array-Mode, Neon-Pool-Opt-In")
+            .header("Access-Control-Max-Age", "86400" /* 24 hours */)
+            .status(StatusCode::OK)  // 204 is also valid, but see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS#status_code
+            .body(Body::empty())
+            .map_err(|e| ApiError::BadRequest(e.into()))
     } else {
         json_response(StatusCode::BAD_REQUEST, "query is not supported")
     }

--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -225,9 +225,12 @@ async fn ws_handler(
         Response::builder()
             .header("Allow", "OPTIONS, POST")
             .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Headers", "Neon-Connection-String, Neon-Raw-Text-Output, Neon-Array-Mode, Neon-Pool-Opt-In")
+            .header(
+                "Access-Control-Allow-Headers",
+                "Neon-Connection-String, Neon-Raw-Text-Output, Neon-Array-Mode, Neon-Pool-Opt-In",
+            )
             .header("Access-Control-Max-Age", "86400" /* 24 hours */)
-            .status(StatusCode::OK)  // 204 is also valid, but see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS#status_code
+            .status(StatusCode::OK) // 204 is also valid, but see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS#status_code
             .body(Body::empty())
             .map_err(|e| ApiError::BadRequest(e.into()))
     } else {

--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -221,6 +221,16 @@ async fn ws_handler(
             );
             r
         })
+    } else if request.uri().path() == "/sql" && request.method() == Method::OPTIONS {
+      Response::builder()
+        .header("Allow", "OPTIONS, POST")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("Access-Control-Allow-Headers", "Neon-Connection-String, Neon-Raw-Text-Output, Neon-Array-Mode, Neon-Pool-Opt-In")
+        .header("Access-Control-Max-Age", "86400" /* 24 hours */)
+        .status(StatusCode::OK)  // 204 is also valid, but see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS#status_code
+        .body(Body::empty())
+        .map_err(|e| ApiError::BadRequest(e.into()))
+
     } else {
         json_response(StatusCode::BAD_REQUEST, "query is not supported")
     }


### PR DESCRIPTION
## Problem

HTTP fetch can't be used from browsers because proxy doesn't support [CORS 'preflight' `OPTIONS` requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests).

## Summary of changes

Added a simple `OPTIONS` endpoint for `/sql`.

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
