### PR TITLE
Remove references to `Arc` states in compute_ctl

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -188,7 +188,7 @@ fn main() -> Result<()> {
     // Launch http service first, so we were able to serve control-plane
     // requests, while configuration is still in progress.
     let _http_handle =
-        launch_http_server(http_port, &compute).expect("cannot launch http endpoint thread");
+        launch_http_server(http_port, compute.clone()).expect("cannot launch http endpoint thread");
 
     if !spec_set {
         // No spec provided, hang waiting for it.
@@ -223,8 +223,8 @@ fn main() -> Result<()> {
     drop(state);
 
     // Launch remaining service threads
-    let _monitor_handle = launch_monitor(&compute);
-    let _configurator_handle = launch_configurator(&compute);
+    let _monitor_handle = launch_monitor(compute.clone());
+    let _configurator_handle = launch_configurator(compute.clone());
 
     // Start Postgres
     let mut delay_exit = false;

--- a/compute_tools/src/checker.rs
+++ b/compute_tools/src/checker.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use tokio_postgres::NoTls;
 use tracing::{error, instrument};
@@ -8,7 +10,7 @@ use crate::compute::ComputeNode;
 /// that we can actually write some data in this particular timeline.
 /// Create table if it's missing.
 #[instrument(skip_all)]
-pub async fn check_writability(compute: &ComputeNode) -> Result<()> {
+pub async fn check_writability(compute: Arc<ComputeNode>) -> Result<()> {
     // Connect to the database.
     let (client, connection) = tokio_postgres::connect(compute.connstr.as_str(), NoTls).await?;
     if client.is_closed() {

--- a/compute_tools/src/configurator.rs
+++ b/compute_tools/src/configurator.rs
@@ -8,46 +8,47 @@ use compute_api::responses::ComputeStatus;
 use crate::compute::ComputeNode;
 
 #[instrument(skip_all)]
-fn configurator_main_loop(compute: &Arc<ComputeNode>) {
+fn configurator_main_loop(compute: Arc<ComputeNode>) {
     info!("waiting for reconfiguration requests");
     loop {
         let state = compute.state.lock().unwrap();
         let mut state = compute.state_changed.wait(state).unwrap();
 
-        if state.status == ComputeStatus::ConfigurationPending {
-            info!("got configuration request");
-            state.status = ComputeStatus::Configuration;
-            compute.state_changed.notify_all();
-            drop(state);
+        match state.status {
+            ComputeStatus::ConfigurationPending => {
+                info!("got configuration request");
+                state.status = ComputeStatus::Configuration;
+                compute.state_changed.notify_all();
+                drop(state);
 
-            let mut new_status = ComputeStatus::Failed;
-            if let Err(e) = compute.reconfigure() {
-                error!("could not configure compute node: {}", e);
-            } else {
-                new_status = ComputeStatus::Running;
-                info!("compute node configured");
+                let new_status = if let Err(e) = compute.reconfigure() {
+                    error!("could not configure compute node: {}", e);
+                    ComputeStatus::Failed
+                } else {
+                    info!("compute node configured");
+                    ComputeStatus::Running
+                };
+
+                // XXX: used to test that API is blocking
+                // std::thread::sleep(std::time::Duration::from_millis(10000));
+
+                compute.set_status(new_status);
             }
-
-            // XXX: used to test that API is blocking
-            // std::thread::sleep(std::time::Duration::from_millis(10000));
-
-            compute.set_status(new_status);
-        } else if state.status == ComputeStatus::Failed {
-            info!("compute node is now in Failed state, exiting");
-            break;
-        } else {
-            info!("woken up for compute status: {:?}, sleeping", state.status);
+            ComputeStatus::Failed => {
+                info!("compute node is in Failed state, exiting");
+                break;
+            }
+            _ => info!("woken up for compute status: {:?}, sleeping", state.status),
         }
     }
 }
 
-pub fn launch_configurator(compute: &Arc<ComputeNode>) -> thread::JoinHandle<()> {
-    let compute = Arc::clone(compute);
 
+pub fn launch_configurator(compute: Arc<ComputeNode>) -> thread::JoinHandle<()> {
     thread::Builder::new()
         .name("compute-configurator".into())
         .spawn(move || {
-            configurator_main_loop(&compute);
+            configurator_main_loop(compute);
             info!("configurator thread is exited");
         })
         .expect("cannot launch configurator thread")

--- a/compute_tools/src/configurator.rs
+++ b/compute_tools/src/configurator.rs
@@ -43,7 +43,6 @@ fn configurator_main_loop(compute: Arc<ComputeNode>) {
     }
 }
 
-
 pub fn launch_configurator(compute: Arc<ComputeNode>) -> thread::JoinHandle<()> {
     thread::Builder::new()
         .name("compute-configurator".into())

--- a/compute_tools/src/http/api.rs
+++ b/compute_tools/src/http/api.rs
@@ -143,8 +143,7 @@ async fn handle_configure_request(
     }
 
     let body_bytes = hyper::body::to_bytes(req.into_body()).await.unwrap();
-    let spec_raw = str::from_utf8(&body_bytes).unwrap();
-    if let Ok(request) = serde_json::from_str::<ConfigurationRequest>(spec_raw) {
+    if let Ok(request) = serde_json::from_slice::<ConfigurationRequest>(body_bytes) {
         let spec = request.spec;
 
         let parsed_spec = match ParsedSpec::try_from(spec) {

--- a/compute_tools/src/http/api.rs
+++ b/compute_tools/src/http/api.rs
@@ -1,6 +1,5 @@
 use std::convert::Infallible;
 use std::net::SocketAddr;
-use std::str;
 use std::sync::Arc;
 use std::thread;
 
@@ -143,7 +142,7 @@ async fn handle_configure_request(
     }
 
     let body_bytes = hyper::body::to_bytes(req.into_body()).await.unwrap();
-    if let Ok(request) = serde_json::from_slice::<ConfigurationRequest>(body_bytes) {
+    if let Ok(request) = serde_json::from_slice::<ConfigurationRequest>(&body_bytes) {
         let spec = request.spec;
 
         let parsed_spec = match ParsedSpec::try_from(spec) {

--- a/compute_tools/src/monitor.rs
+++ b/compute_tools/src/monitor.rs
@@ -12,7 +12,7 @@ const MONITOR_CHECK_INTERVAL: u64 = 500; // milliseconds
 // Spin in a loop and figure out the last activity time in the Postgres.
 // Then update it in the shared state. This function never errors out.
 // XXX: the only expected panic is at `RwLock` unwrap().
-fn watch_compute_activity(compute: &ComputeNode) {
+fn watch_compute_activity(compute: Arc<ComputeNode>) {
     // Suppose that `connstr` doesn't change
     let connstr = compute.connstr.as_str();
     // Define `client` outside of the loop to reuse existing connection if it's active.
@@ -104,11 +104,9 @@ fn watch_compute_activity(compute: &ComputeNode) {
 }
 
 /// Launch a separate compute monitor thread and return its `JoinHandle`.
-pub fn launch_monitor(state: &Arc<ComputeNode>) -> thread::JoinHandle<()> {
-    let state = Arc::clone(state);
-
+pub fn launch_monitor(state: Arc<ComputeNode>) -> thread::JoinHandle<()> {
     thread::Builder::new()
         .name("compute-monitor".into())
-        .spawn(move || watch_compute_activity(&state))
+        .spawn(move || watch_compute_activity(state))
         .expect("cannot launch compute monitor thread")
 }


### PR DESCRIPTION
## Changes
1. Replaced `&Arc<ComputeState>` with `Arc<ComputeState>`
2. Replace the `if` statements in the loop with a `match` expression (more readable)
3. Replace converting `bytes` to `String` through `vec` when specification came through API. It decreases the number of memory allocations because we already have a bytes


