### PR TITLE
Update vm-builder v0.12.1 -> v0.13.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -794,7 +794,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.12.1
+      VM_BUILDER_VERSION: v0.13.1
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This should only affect the version of the vm-informant used. The only change to the vm-informant from v0.12.1 to v0.13.1 was:

* https://github.com/neondatabase/autoscaling/pull/407

Just a typo fix; worth getting in anyways.