### PR TITLE
Improve startup python test

### DIFF
--- a/test_runner/performance/test_startup.py
+++ b/test_runner/performance/test_startup.py
@@ -43,7 +43,13 @@ def test_startup_simple(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenc
             if endpoint:
                 endpoint.start()
             else:
-                endpoint = env.endpoints.create_start("test_startup")
+                endpoint = env.endpoints.create_start(
+                    "test_startup",
+                    # Shared buffers need to be allocated during startup, so they
+                    # impact startup time. This is the default value we use for
+                    # 1CPU pods (maybe different for VMs).
+                    config_lines=["shared_buffers=262144"],
+                )
             endpoint.safe_psql("select 1;")
 
         # Get metrics

--- a/test_runner/performance/test_startup.py
+++ b/test_runner/performance/test_startup.py
@@ -48,6 +48,10 @@ def test_startup_simple(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenc
                     # Shared buffers need to be allocated during startup, so they
                     # impact startup time. This is the default value we use for
                     # 1CPU pods (maybe different for VMs).
+                    #
+                    # TODO extensions also contribute to shared memory allocation,
+                    #      and this test doesn't include all default extensions we
+                    #      load.
                     config_lines=["shared_buffers=262144"],
                 )
             endpoint.safe_psql("select 1;")


### PR DESCRIPTION
With specified shared_buffers to match prod defaults, runtime is more realistic. Now it's 34ms on my laptop, not 20. That's a bit closer to the 70ms we see on 1cpu pods.