### PR TITLE
chore: fix copypaste caused flakyness

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4839,8 +4839,7 @@ mod tests {
 
     #[tokio::test]
     async fn layer_eviction_aba_fails() {
-        let harness =
-            TenantHarness::create("two_layer_eviction_attempts_at_the_same_time").unwrap();
+        let harness = TenantHarness::create("layer_eviction_aba_fails").unwrap();
 
         let remote_storage = {
             // this is never used for anything, because of how the create_test_timeline works, but


### PR DESCRIPTION
I introduced a copypaste error leading to flaky [test failure][report] in #4737. Solution is to use correct/unique test name.

I also looked into providing a proper fn name via macro but ... Yeah, it's probably not a great idea.

[report]: https://github.com/neondatabase/neon/actions/runs/5612473297/job/15206293430#step:15:197