### PR TITLE
Create ext_index.json

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,4 +21,5 @@
 !workspace_hack/
 !neon_local/
 !scripts/ninstall.sh
+!scripts/combine_control_files.py
 !vm-cgconfig.conf

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -983,7 +983,7 @@ jobs:
 
       - name: Upload postgres-extensions to S3
         # TODO: Reenable step after switching to the new extensions format (tar-gzipped + index.json)
-        if: false
+        # if: false
         run: |
           for BUCKET in $(echo ${S3_BUCKETS:-[]} | jq --raw-output '.[]'); do
             aws s3 cp --recursive --only-show-errors ./extensions-to-upload s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -977,13 +977,13 @@ jobs:
           mkdir -p extensions-to-upload
 
           docker cp ${{ steps.create-container.outputs.EID }}:/extensions/ ./extensions-to-upload/
+          docker cp ${{ steps.create-container.outputs.EID }}:/ext_index.json ./extensions-to-upload/
 
           # Remove control files, they'll be replaced by an index file
-          rm -f ./extensions-to-upload/*.control
+          # TODO: this doesn't actually work because control files are in subdirectories
+          rm -f ./extensions-to-upload/extensions/*.control
 
       - name: Upload postgres-extensions to S3
-        # TODO: Reenable step after switching to the new extensions format (tar-gzipped + index.json)
-        # if: false
         run: |
           for BUCKET in $(echo ${S3_BUCKETS:-[]} | jq --raw-output '.[]'); do
             aws s3 cp --recursive --only-show-errors ./extensions-to-upload s3://${BUCKET}/${{ needs.tag.outputs.build-tag }}/${{ matrix.version }}

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -433,16 +433,16 @@ RUN apt-get update && \
     wget https://github.com/ketteq-neon/postgres-exts/archive/e0bd1a9d9313d7120c1b9c7bb15c48c0dede4c4e.tar.gz -O kq_imcx.tar.gz && \
     echo "dc93a97ff32d152d32737ba7e196d9687041cda15e58ab31344c2f2de8855336 kq_imcx.tar.gz" | sha256sum --check && \
     mkdir kq_imcx-src && cd kq_imcx-src && tar xvzf ../kq_imcx.tar.gz --strip-components=1 -C . && \
-    find /usr/local/pgsql -type f > /before.txt && \
+    find /usr/local/pgsql -type f | sed 's|^/usr/local/pgsql/||' > /before.txt &&\
     mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make -j $(getconf _NPROCESSORS_ONLN) && \
     make -j $(getconf _NPROCESSORS_ONLN) install && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/kq_imcx.control && \
-    find /usr/local/pgsql -type f > /after.txt && \
+    find /usr/local/pgsql -type f | sed 's|^/usr/local/pgsql/||' > /after.txt &&\
     mkdir -p /extensions/kq_imcx && cp /usr/local/pgsql/share/extension/kq_imcx.control /extensions/kq_imcx && \
     sort -o /before.txt /before.txt && sort -o /after.txt /after.txt && \
-    comm -13 /before.txt /after.txt | tar --zstd -cf /extensions/kq_imcx.tar.zstd -T -
+    comm -13 /before.txt /after.txt | tar --directory=/usr/local/pgsql --zstd -cf /extensions/kq_imcx.tar.zstd -T -
 
 #########################################################################################
 #
@@ -575,13 +575,13 @@ ENV PATH "/usr/local/pgsql/bin/:$PATH"
 RUN wget https://gitlab.com/dalibo/postgresql_anonymizer/-/archive/1.1.0/postgresql_anonymizer-1.1.0.tar.gz -O pg_anon.tar.gz && \
     echo "08b09d2ff9b962f96c60db7e6f8e79cf7253eb8772516998fc35ece08633d3ad pg_anon.tar.gz" | sha256sum --check && \
     mkdir pg_anon-src && cd pg_anon-src && tar xvzf ../pg_anon.tar.gz --strip-components=1 -C . && \
-    find /usr/local/pgsql -type f  > /before.txt && \
+    find /usr/local/pgsql -type f | sed 's|^/usr/local/pgsql/||' > /before.txt &&\
     make -j $(getconf _NPROCESSORS_ONLN) install PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/anon.control && \
-    find /usr/local/pgsql -type f  > /after.txt && \
+    find /usr/local/pgsql -type f | sed 's|^/usr/local/pgsql/||' > /after.txt &&\
     mkdir -p /extensions/anon && cp /usr/local/pgsql/share/extension/anon.control /extensions/anon && \
     sort -o /before.txt /before.txt && sort -o /after.txt /after.txt && \
-    comm -13 /before.txt /after.txt | tar --zstd -cf /extensions/anon.tar.zstd -T -
+    comm -13 /before.txt /after.txt | tar --directory=/usr/local/pgsql --zstd -cf /extensions/anon.tar.zstd -T -
 
 #########################################################################################
 #

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -113,7 +113,7 @@ RUN wget https://github.com/pgRouting/pgrouting/archive/v3.4.2.tar.gz -O pgrouti
     find /usr/local/pgsql -type f >> /after.txt && \
     mkdir -p /extensions/postgis && cp /usr/local/pgsql/share/extension/pgrouting.control /extensions/postgis && \
     sort -o /before.txt /before.txt && sort -o /after.txt /after.txt && \
-    comm -13 /before.txt /after.txt | tar --zstd -cf /extensions/postgis/postgis.tar.zstd -T -
+    comm -13 /before.txt /after.txt | tar --zstd -cf /extensions/postgis.tar.zstd -T -
 
 #########################################################################################
 #
@@ -442,7 +442,7 @@ RUN apt-get update && \
     find /usr/local/pgsql -type f > /after.txt && \
     mkdir -p /extensions/kq_imcx && cp /usr/local/pgsql/share/extension/kq_imcx.control /extensions/kq_imcx && \
     sort -o /before.txt /before.txt && sort -o /after.txt /after.txt && \
-    comm -13 /before.txt /after.txt | tar --zstd -cf /extensions/kq_imcx/kq_imcx.tar.zstd -T -
+    comm -13 /before.txt /after.txt | tar --zstd -cf /extensions/kq_imcx.tar.zstd -T -
 
 #########################################################################################
 #
@@ -581,7 +581,7 @@ RUN wget https://gitlab.com/dalibo/postgresql_anonymizer/-/archive/1.1.0/postgre
     find /usr/local/pgsql -type f  > /after.txt && \
     mkdir -p /extensions/anon && cp /usr/local/pgsql/share/extension/anon.control /extensions/anon && \
     sort -o /before.txt /before.txt && sort -o /after.txt /after.txt && \
-    comm -13 /before.txt /after.txt | tar --zstd -cf /extensions/anon/anon.tar.zstd -T -
+    comm -13 /before.txt /after.txt | tar --zstd -cf /extensions/anon.tar.zstd -T -
 
 #########################################################################################
 #
@@ -792,7 +792,7 @@ RUN python3 ./combine_control_files.py ${PG_VERSION} ${BUILD_TAG}
 FROM scratch AS postgres-extensions
 # After the transition this layer will include all extensitons.
 # As for now, it's only a couple for testing purposses
-COPY --from=generate-ext-index /extensions/ /extensions/
+COPY --from=generate-ext-index /extensions/*.tar.zstd /extensions/
 COPY --from=generate-ext-index /ext_index.json /ext_index.json
 
 #########################################################################################

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -794,6 +794,7 @@ FROM scratch AS postgres-extensions
 # After the transition this layer will include all extensitons.
 # As for now, it's only a couple for testing purposses
 COPY --from=alekpython /extensions/ /extensions/
+COPY --from=alekpython /ext_index.json /ext_index.json
 
 #########################################################################################
 #

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -773,13 +773,12 @@ RUN rm /usr/local/pgsql/lib/lib*.a
 # Extenstion only
 #
 #########################################################################################
-FROM python:3.11-slim-bookworm AS alekpython
+FROM python:3.11-slim-bookworm AS generate-ext-index
 ARG PG_VERSION
 ARG BUILD_TAG
-# define extension build numbers
-# NOTE: it is *not* necessary for the build tag to be BUILD_TAG in particular,
+# Define extension build numbers
+# NOTE: it is *not* necessary for the build tag to be BUILD_TAG. In particular,
 # you should update the build_tag for each extension only when you build it
-# in the future it should be something like this: 5615610098
 RUN echo "kq_imcx ${BUILD_TAG}" >>  build_numbers.txt
 RUN echo "anon ${BUILD_TAG}" >>  build_numbers.txt
 # RUN echo "postgis-build 5615610098" >>  build_numbers.txt
@@ -793,8 +792,8 @@ RUN python3 ./combine_control_files.py ${PG_VERSION} ${BUILD_TAG}
 FROM scratch AS postgres-extensions
 # After the transition this layer will include all extensitons.
 # As for now, it's only a couple for testing purposses
-COPY --from=alekpython /extensions/ /extensions/
-COPY --from=alekpython /ext_index.json /ext_index.json
+COPY --from=generate-ext-index /extensions/ /extensions/
+COPY --from=generate-ext-index /ext_index.json /ext_index.json
 
 #########################################################################################
 #

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -773,14 +773,27 @@ RUN rm /usr/local/pgsql/lib/lib*.a
 # Extenstion only
 #
 #########################################################################################
+FROM python:3.11-slim-bookworm AS alekpython
+ARG PG_VERSION
+ARG BUILD_TAG
+# define extension build numbers
+# NOTE: it is *not* necessary for the build tag to be BUILD_TAG in particular,
+# you should update the build_tag for each extension only when you build it
+# in the future it should be something like this: 5615610098
+RUN echo "kq_imcx ${BUILD_TAG}" >>  build_numbers.txt
+RUN echo "anon ${BUILD_TAG}" >>  build_numbers.txt
+# RUN echo "postgis-build 5615610098" >>  build_numbers.txt
+# copy the control files here
+COPY --from=kq-imcx-pg-build /extensions/ /extensions/
+COPY --from=pg-anon-pg-build /extensions/ /extensions/
+# COPY --from=postgis-build /extensions/ /extensions/
+COPY scripts/combine_control_files.py ./combine_control_files.py
+RUN python3 ./combine_control_files.py ${PG_VERSION} ${BUILD_TAG}
+
 FROM scratch AS postgres-extensions
 # After the transition this layer will include all extensitons.
 # As for now, it's only a couple for testing purposses
-#
-# # Default extensions
-COPY --from=kq-imcx-pg-build /extensions/ /extensions/
-COPY --from=pg-anon-pg-build /extensions/ /extensions/
-COPY --from=postgis-build /extensions/ /extensions/
+COPY --from=alekpython /extensions/ /extensions/
 
 #########################################################################################
 #

--- a/scripts/combine_control_files.py
+++ b/scripts/combine_control_files.py
@@ -1,12 +1,12 @@
+# Script to generate ext_index.json metadata file
+# that stores content of the control files and location of extension archives
+#  for all extensions in /extensions subdir.
 import json
 import os
 import sys
 from os.path import isdir, join
 
-# import shutil
-
 pg_version = sys.argv[1]
-#  build_tag = sys.argv[2]
 assert pg_version in ("v14", "v15")
 
 build_numbers = {}
@@ -27,12 +27,9 @@ for extension in os.listdir("."):
                 control_data[control_file] = f.read()
         ext_index[extension] = {
             "control_data": control_data,
-            "archive_path": f"{build_numbers[extension]}/{pg_version}/{extension}.tar.zstd",
+            "archive_path": f"{build_numbers[extension]}/{pg_version}/{extension}/{extension}.tar.zstd",
         }
 
-        # TODO: uncomment this to enable de-duplication:
-        #  if build_numbers[extension] != build_tag:
-        #      shutil.rmtree(extension)
 os.chdir("..")
 with open("ext_index.json", "w") as f:
     json.dump(ext_index, f)

--- a/scripts/combine_control_files.py
+++ b/scripts/combine_control_files.py
@@ -27,7 +27,7 @@ for extension in os.listdir("."):
                 control_data[control_file] = f.read()
         ext_index[extension] = {
             "control_data": control_data,
-            "archive_path": f"{build_numbers[extension]}/{pg_version}/{extension}/{extension}.tar.zstd",
+            "archive_path": f"{build_numbers[extension]}/{pg_version}/extensions/{extension}.tar.zstd",
         }
 
 os.chdir("..")

--- a/scripts/combine_control_files.py
+++ b/scripts/combine_control_files.py
@@ -1,0 +1,38 @@
+import json
+import os
+import sys
+from os.path import isdir, join
+
+# import shutil
+
+pg_version = sys.argv[1]
+#  build_tag = sys.argv[2]
+assert pg_version in ("v14", "v15")
+
+build_numbers = {}
+with open("build_numbers.txt", "r") as f:
+    for line in f.readlines():
+        ext_name, build_num = line.split(" ")
+        build_numbers[ext_name] = build_num
+
+ext_index = {}
+os.chdir("extensions")
+for extension in os.listdir("."):
+    if isdir(extension):
+        control_data = {}
+        for control_file in os.listdir(extension):
+            if ".control" not in control_file:
+                continue
+            with open(join(extension, control_file), "r") as f:
+                control_data[control_file] = f.read()
+        ext_index[extension] = {
+            "control_data": control_data,
+            "archive_path": f"{build_numbers[extension]}/{pg_version}/{extension}.tar.zst",
+        }
+
+        # TODO: uncomment this to enable de-duplication:
+        #  if build_numbers[extension] != build_tag:
+        #      shutil.rmtree(extension)
+
+with open("ext_index.json", "w") as f:
+    json.dump(ext_index, f)

--- a/scripts/combine_control_files.py
+++ b/scripts/combine_control_files.py
@@ -13,7 +13,7 @@ build_numbers = {}
 with open("build_numbers.txt", "r") as f:
     for line in f.readlines():
         ext_name, build_num = line.split(" ")
-        build_numbers[ext_name] = build_num
+        build_numbers[ext_name] = build_num.strip()
 
 ext_index = {}
 os.chdir("extensions")
@@ -27,12 +27,12 @@ for extension in os.listdir("."):
                 control_data[control_file] = f.read()
         ext_index[extension] = {
             "control_data": control_data,
-            "archive_path": f"{build_numbers[extension]}/{pg_version}/{extension}.tar.zst",
+            "archive_path": f"{build_numbers[extension]}/{pg_version}/{extension}.tar.zstd",
         }
 
         # TODO: uncomment this to enable de-duplication:
         #  if build_numbers[extension] != build_tag:
         #      shutil.rmtree(extension)
-
+os.chdir("..")
 with open("ext_index.json", "w") as f:
     json.dump(ext_index, f)


### PR DESCRIPTION
# Problem
`compute_ctl` expects needs a file `ext_index.json` containing the data necessary to create control files, and containing the locations of extension archives in remote storage. 
The `ext_index.json` file should be generated by `Dockerfile.compute-node`.

# Summary of Changes

The layout of the S3 bucket is as follows:
```
5615610098 // this is an extension build number
├── v14
│   ├── extensions
│   │   ├── anon.tar.zstd
│   │   └── embedding.tar.zstd
│   └── ext_index.json
└── v15
    ├── extensions
    │   ├── anon.tar.zstd
    │   └── embedding.tar.zstd
    └── ext_index.json
5615261079
├── v14
│   ├── extensions
│   │   └── anon.tar.zstd
│   └── ext_index.json
└── v15
    ├── extensions
    │   └── anon.tar.zstd
    └── ext_index.json
5623261088
├── v14
│   ├── extensions
│   │   └── embedding.tar.zstd
│   └── ext_index.json
└── v15
    ├── extensions
    │   └── embedding.tar.zstd
    └── ext_index.json
```

`ext_index.json` stores the control files and location of extension archives.

More specifically, here is an example `ext_index.json`
```
{
  "embedding": {
    "control_data": {
      "embedding.control": "comment = 'hnsw index' \ndefault_version = '0.1.0' \nmodule_pathname = '$libdir/embedding' \nrelocatable = true \ntrusted = true"
    },
    "archive_path": "5623261088/v15/extensions/embedding.tar.zstd"
  },
  "anon": {
    "control_data": {
      "anon.control": "# PostgreSQL Anonymizer (anon) extension \ncomment = 'Data anonymization tools' \ndefault_version = '1.1.0' \ndirectory='extension/anon' \nrelocatable = false \nrequires = 'pgcrypto' \nsuperuser = false \nmodule_pathname = '$libdir/anon' \ntrusted = true \n"
    },
    "archive_path": "5615261079/v15/extensions/anon.tar.zstd"
  }
}
```
