### PR TITLE
cold starts: Don't distract startup with background threads

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -222,11 +222,6 @@ fn main() -> Result<()> {
     compute.state_changed.notify_all();
     drop(state);
 
-    // Launch remaining service threads
-    let _monitor_handle = launch_monitor(&compute).expect("cannot launch compute monitor thread");
-    let _configurator_handle =
-        launch_configurator(&compute).expect("cannot launch configurator thread");
-
     // Start Postgres
     let mut delay_exit = false;
     let mut exit_code = None;
@@ -242,6 +237,14 @@ fn main() -> Result<()> {
             None
         }
     };
+
+    // Launch remaining service threads
+    //
+    // NOTE we do this after starting postgres so that these two extra threads
+    //      don't blow the cpu budget and throttle the startup process.
+    let _monitor_handle = launch_monitor(&compute).expect("cannot launch compute monitor thread");
+    let _configurator_handle =
+        launch_configurator(&compute).expect("cannot launch configurator thread");
 
     // Wait for the child Postgres process forever. In this state Ctrl+C will
     // propagate to Postgres and it will be shut down as well.


### PR DESCRIPTION
There's a chance this improves p90 startup times. See https://neondb.slack.com/archives/C04BLQ4LW7K/p1689904870713369?thread_ts=1689863776.367609&cid=C04BLQ4LW7K

It's hard to test this locally but we have good enough metrics to notice if something changes on stage