### PR TITLE
metrics: chunked responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4867,6 +4867,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-error",
  "tracing-subscriber",

--- a/libs/metrics/src/lib.rs
+++ b/libs/metrics/src/lib.rs
@@ -6,6 +6,7 @@ use once_cell::sync::Lazy;
 use prometheus::core::{AtomicU64, Collector, GenericGauge, GenericGaugeVec};
 pub use prometheus::opts;
 pub use prometheus::register;
+pub use prometheus::Error;
 pub use prometheus::{core, default_registry, proto};
 pub use prometheus::{exponential_buckets, linear_buckets};
 pub use prometheus::{register_counter_vec, Counter, CounterVec};

--- a/libs/utils/Cargo.toml
+++ b/libs/utils/Cargo.toml
@@ -42,6 +42,10 @@ workspace_hack.workspace = true
 
 const_format.workspace = true
 
+# to use tokio channels as streams, this is faster to compile than async_stream
+# why is it only here? no other crate should use it, streams are rarely needed.
+tokio-stream = { version = "0.1.14" }
+
 [dev-dependencies]
 byteorder.workspace = true
 bytes.workspace = true

--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -213,6 +213,8 @@ async fn prometheus_metrics_handler(_req: Request<Body>) -> Result<Response<Body
 
             let out_of_space = remaining < buf.len();
 
+            let original_len = buf.len();
+
             if out_of_space {
                 let can_still_fit = buf.len() - remaining;
                 self.buffer.extend_from_slice(&buf[..can_still_fit]);
@@ -224,7 +226,7 @@ async fn prometheus_metrics_handler(_req: Request<Body>) -> Result<Response<Body
             // beginning of allocation, because previous split off parts are already sent and
             // dropped.
             self.buffer.extend_from_slice(buf);
-            Ok(buf.len())
+            Ok(original_len)
         }
 
         fn flush(&mut self) -> std::io::Result<()> {

--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -9,7 +9,6 @@ use metrics::{register_int_counter, Encoder, IntCounter, TextEncoder};
 use once_cell::sync::Lazy;
 use routerify::ext::RequestExt;
 use routerify::{Middleware, RequestInfo, Router, RouterBuilder};
-use tokio::task::JoinError;
 use tracing::{self, debug, info, info_span, warn, Instrument};
 
 use std::future::Future;
@@ -148,23 +147,158 @@ impl Drop for RequestCancelled {
 }
 
 async fn prometheus_metrics_handler(_req: Request<Body>) -> Result<Response<Body>, ApiError> {
+    use bytes::BufMut;
+
     SERVE_METRICS_COUNT.inc();
 
-    let response = tokio::task::spawn_blocking(move || {
-        // Currently we take a lot of mutexes while collecting metrics, so it's
-        // better to spawn a blocking task to avoid blocking the event loop.
-        let metrics = metrics::gather();
-        let mut buffer = vec![];
-        let encoder = TextEncoder::new();
-        encoder.encode(&metrics, &mut buffer).unwrap();
-        Response::builder()
-            .status(200)
-            .header(CONTENT_TYPE, encoder.format_type())
-            .body(Body::from(buffer))
-            .unwrap()
-    })
-    .await
-    .map_err(|e: JoinError| ApiError::InternalServerError(e.into()))?;
+    let started_at = std::time::Instant::now();
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+    let (mut sender, body) = Body::channel();
+
+    struct ChannelWriter {
+        buffer: bytes::BytesMut,
+        tx: tokio::sync::mpsc::Sender<Message>,
+    }
+
+    enum Message {
+        Done,
+        Chunk(bytes::Bytes),
+    }
+
+    impl std::fmt::Debug for Message {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Done => write!(f, "Done"),
+                Self::Chunk(_) => write!(f, "Chunk"),
+            }
+        }
+    }
+
+    impl ChannelWriter {
+        fn flush0(&mut self) -> std::io::Result<usize> {
+            let n = self.buffer.len();
+            if n > 0 {
+                let ready = self.buffer.split().freeze();
+                tracing::info!(n = ready.len(), "flushing");
+                let ready = Message::Chunk(ready);
+
+                // not ideal to call from blocking code to block_on, but we are sure that this
+                // operation does not spawn_blocking other tasks
+                if self.tx.blocking_send(ready).is_err() {
+                    return Err(std::io::ErrorKind::BrokenPipe.into());
+                }
+            }
+            Ok(n)
+        }
+
+        fn done(mut self) -> std::io::Result<()> {
+            self.flush0()?;
+            self.tx
+                .blocking_send(Message::Done)
+                .map_err(|_| std::io::ErrorKind::BrokenPipe.into())
+        }
+    }
+
+    impl std::io::Write for ChannelWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let remaining = self.buffer.capacity() - self.buffer.len();
+
+            // hopefully free up space right away; but these are not expected to happen
+            let out_of_space = remaining < buf.len();
+
+            // in the best case, we could prep up the *other* half while we are still busy
+            // shoveling the first half, and BytesMut resizing would work like a charm.
+            //
+            // most of the writes seem really small coming out of TextEncoder.
+            let optimistic_at_half =
+                self.buffer.capacity() == 128 * 1024 && self.buffer.len() >= 64 * 1024;
+
+            if out_of_space || optimistic_at_half {
+                self.flush0()?;
+            }
+
+            self.buffer.put(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flush0().map(|_| ())
+        }
+    }
+
+    let buffer = bytes::BytesMut::with_capacity(128 * 1024);
+    let mut writer = ChannelWriter { buffer, tx };
+
+    let encoder = TextEncoder::new();
+
+    let response = Response::builder()
+        .status(200)
+        .header(CONTENT_TYPE, encoder.format_type())
+        .body(body)
+        .unwrap();
+
+    let jh: tokio::task::JoinHandle<Result<(), metrics::Error>> =
+        tokio::task::spawn_blocking(move || {
+            // Currently we take a lot of mutexes while collecting metrics, so it's
+            // better to spawn a blocking task to avoid blocking the event loop.
+            let metrics = metrics::gather();
+            encoder.encode(&metrics, &mut writer)?;
+            writer.done().map_err(|e| e.into())
+        });
+
+    tokio::task::spawn(
+        async move {
+            // shoveling task for the chunked body
+            let mut bytes = 0;
+            let mut clean_shutdown = false;
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Message::Chunk(chunk) if !clean_shutdown => {
+                        let n = chunk.len();
+
+                        match sender.send_data(chunk).await {
+                            Ok(()) => {
+                                bytes += n;
+                            }
+                            Err(e) => {
+                                tracing::warn!("failed to write out /metrics response: {e:#}");
+                                break;
+                            }
+                        }
+                    }
+                    Message::Done if !clean_shutdown => {
+                        clean_shutdown = true;
+                    }
+                    msg => unreachable!("unexpected message after Done: {msg:?}"),
+                }
+            }
+
+            drop(rx);
+
+            let res = jh
+                .await
+                .context("join spawn_blocking")
+                .and_then(|res| res.context("writing out metrics failed"));
+
+            match res {
+                Ok(()) if clean_shutdown => {
+                    tracing::info!(
+                        bytes,
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        "responded /metrics"
+                    );
+                }
+                Ok(()) => tracing::warn!("BUG: ChannelWriter::Done was not called"),
+                Err(e) => {
+                    tracing::warn!("failed to write out /metrics response: {e:#}");
+                    sender.abort();
+                }
+            }
+        }
+        .instrument(tracing::info_span!("response")),
+    );
 
     Ok(response)
 }

--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -232,6 +232,8 @@ async fn prometheus_metrics_handler(_req: Request<Body>) -> Result<Response<Body
         }
     }
 
+    let started_at = std::time::Instant::now();
+
     let (tx, rx) = mpsc::channel(1);
 
     let body = Body::wrap_stream(ReceiverStream::new(rx));

--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -244,19 +244,7 @@ async fn prometheus_metrics_handler(_req: Request<Body>) -> Result<Response<Body
                 let out_of_space = remaining < buf.len();
 
                 if out_of_space {
-                    let pre_len = self.buffer.len();
-                    let pre_cap = self.buffer.capacity();
                     self.flush0()?;
-
-                    tracing::info!(
-                        out_of_space,
-                        buf.len = buf.len(),
-                        pre_len,
-                        pre_cap,
-                        post_len = self.buffer.len(),
-                        post_cap = self.buffer.capacity(),
-                        "flushing"
-                    );
                 }
 
                 // assume that this will often under normal operation just move the pointer back to the

--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -154,115 +154,169 @@ async fn prometheus_metrics_handler(_req: Request<Body>) -> Result<Response<Body
 
     SERVE_METRICS_COUNT.inc();
 
+    // we need to first test this out with vmagent on staging, if it works, we can get turn this to
+    // true or maybe get rid of the fully buffering path altogether
+    const CHUNKED_IS_DEFAULT: bool = false;
+
+    let chunked = super::request::parse_query_param::<_, bool>(&_req, "allow_chunked")?
+        .unwrap_or(CHUNKED_IS_DEFAULT);
+
     let started_at = std::time::Instant::now();
 
-    let (tx, rx) = mpsc::channel(1);
+    if !chunked {
+        let span = info_span!("blocking");
 
-    let body = Body::wrap_stream(ReceiverStream::new(rx));
+        tokio::task::spawn_blocking(move || {
+            let _span = span.entered();
+            // Currently we take a lot of mutexes while collecting metrics, so it's
+            // better to spawn a blocking task to avoid blocking the event loop.
+            let metrics = metrics::gather();
+            let mut buffer = Vec::new();
+            let encoder = TextEncoder::new();
+            encoder
+                .encode(&metrics, &mut buffer)
+                .map_err(|e| ApiError::InternalServerError(e.into()))?;
 
-    struct ChannelWriter {
-        buffer: bytes::BytesMut,
-        tx: tokio::sync::mpsc::Sender<std::io::Result<bytes::Bytes>>,
-        written: usize,
-    }
+            Ok(Response::builder()
+                .status(200)
+                .header(CONTENT_TYPE, encoder.format_type())
+                .body(Body::from(buffer))
+                .unwrap())
+        })
+        .await
+        .map_err(|e| ApiError::InternalServerError(e.into()))
+        .and_then(|e| e)
+    } else {
+        let (tx, rx) = mpsc::channel(1);
 
-    impl ChannelWriter {
-        fn new(buf_len: usize, tx: mpsc::Sender<std::io::Result<Bytes>>) -> Self {
-            ChannelWriter {
-                buffer: BytesMut::with_capacity(buf_len),
-                tx,
-                written: 0,
-            }
+        let body = Body::wrap_stream(ReceiverStream::new(rx));
+
+        struct ChannelWriter {
+            buffer: bytes::BytesMut,
+            tx: tokio::sync::mpsc::Sender<std::io::Result<bytes::Bytes>>,
+            written: usize,
         }
 
-        fn flush0(&mut self) -> std::io::Result<usize> {
-            let n = self.buffer.len();
-            if n > 0 {
-                let ready = self.buffer.split().freeze();
-                tracing::info!(n = ready.len(), "flushing");
-
-                // not ideal to call from blocking code to block_on, but we are sure that this
-                // operation does not spawn_blocking other tasks
-                if self.tx.blocking_send(Ok(ready)).is_err() {
-                    return Err(std::io::ErrorKind::BrokenPipe.into());
+        impl ChannelWriter {
+            fn new(buf_len: usize, tx: mpsc::Sender<std::io::Result<Bytes>>) -> Self {
+                ChannelWriter {
+                    buffer: BytesMut::with_capacity(buf_len),
+                    tx,
+                    written: 0,
                 }
-                self.written += n;
             }
-            Ok(n)
+
+            fn flush0(&mut self) -> std::io::Result<usize> {
+                let n = self.buffer.len();
+                if n > 0 {
+                    let ready = self.buffer.split().freeze();
+                    tracing::trace!(n = ready.len(), "flushing");
+
+                    // not ideal to call from blocking code to block_on, but we are sure that this
+                    // operation does not spawn_blocking other tasks
+                    let res: Result<(), ()> = tokio::runtime::Handle::current().block_on(async {
+                        self.tx.send(Ok(ready)).await.map_err(|_| ())?;
+
+                        // throttle sending to allow reuse of our buffer in `write`.
+                        self.tx.reserve().await.map_err(|_| ())?;
+
+                        // now the response task has picked up the buffer and hopefully started
+                        // sending it to the client.
+                        Ok(())
+                    });
+                    if res.is_err() {
+                        return Err(std::io::ErrorKind::BrokenPipe.into());
+                    }
+                    self.written += n;
+                }
+                Ok(n)
+            }
+
+            fn flushed_bytes(&self) -> usize {
+                self.written
+            }
         }
 
-        fn flushed_bytes(&self) -> usize {
-            self.written
+        impl std::io::Write for ChannelWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                let remaining = self.buffer.capacity() - self.buffer.len();
+
+                let out_of_space = remaining < buf.len();
+
+                if out_of_space {
+                    let pre_len = self.buffer.len();
+                    let pre_cap = self.buffer.capacity();
+                    self.flush0()?;
+
+                    tracing::info!(
+                        out_of_space,
+                        buf.len = buf.len(),
+                        pre_len,
+                        pre_cap,
+                        post_len = self.buffer.len(),
+                        post_cap = self.buffer.capacity(),
+                        "flushing"
+                    );
+                }
+
+                // assume that this will often under normal operation just move the pointer back to the
+                // beginning of allocation, because previous split off parts are already sent and
+                // dropped.
+                self.buffer.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                self.flush0().map(|_| ())
+            }
         }
+
+        let mut writer = ChannelWriter::new(128 * 1024, tx);
+
+        let encoder = TextEncoder::new();
+
+        let response = Response::builder()
+            .status(200)
+            .header(CONTENT_TYPE, encoder.format_type())
+            .body(body)
+            .unwrap();
+
+        let span = info_span!("blocking");
+
+        tokio::task::spawn_blocking(move || {
+            let _span = span.entered();
+            // Currently we take a lot of mutexes while collecting metrics, so it's
+            // better to spawn a blocking task to avoid blocking the event loop.
+            let metrics = metrics::gather();
+            let res = encoder
+                .encode(&metrics, &mut writer)
+                .and_then(|_| writer.flush().map_err(|e| e.into()));
+
+            match res {
+                Ok(()) => {
+                    tracing::info!(
+                        bytes = writer.flushed_bytes(),
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        "responded /metrics"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!("failed to write out /metrics response: {e:#}");
+                    // semantics of this error are quite... unclear. we want to error the stream out to
+                    // abort the response to somehow notify the client that we failed.
+                    //
+                    // though, most likely the reason for failure is that the receiver is already gone.
+                    drop(
+                        writer
+                            .tx
+                            .blocking_send(Err(std::io::ErrorKind::BrokenPipe.into())),
+                    );
+                }
+            }
+        });
+
+        Ok(response)
     }
-
-    impl std::io::Write for ChannelWriter {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            let remaining = self.buffer.capacity() - self.buffer.len();
-
-            let out_of_space = remaining < buf.len();
-
-            if out_of_space {
-                self.flush0()?;
-            }
-
-            // assume that this will often under normal operation just move the pointer back to the
-            // beginning of allocation, because previous split off parts are already sent and
-            // dropped.
-            self.buffer.extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            self.flush0().map(|_| ())
-        }
-    }
-
-    let mut writer = ChannelWriter::new(128 * 1024, tx);
-
-    let encoder = TextEncoder::new();
-
-    let response = Response::builder()
-        .status(200)
-        .header(CONTENT_TYPE, encoder.format_type())
-        .body(body)
-        .unwrap();
-
-    let span = info_span!("blocking");
-
-    tokio::task::spawn_blocking(move || {
-        let _span = span.entered();
-        // Currently we take a lot of mutexes while collecting metrics, so it's
-        // better to spawn a blocking task to avoid blocking the event loop.
-        let metrics = metrics::gather();
-        let res = encoder
-            .encode(&metrics, &mut writer)
-            .and_then(|_| writer.flush().map_err(|e| e.into()));
-
-        match res {
-            Ok(()) => {
-                tracing::info!(
-                    bytes = writer.flushed_bytes(),
-                    elapsed_ms = started_at.elapsed().as_millis(),
-                    "responded /metrics"
-                );
-            }
-            Err(e) => {
-                tracing::warn!("failed to write out /metrics response: {e:#}");
-                // semantics of this error are quite... unclear. we want to error the stream out to
-                // abort the response to somehow notify the client that we failed.
-                //
-                // though, most likely the reason for failure is that the receiver is already gone.
-                drop(
-                    writer
-                        .tx
-                        .blocking_send(Err(std::io::ErrorKind::BrokenPipe.into())),
-                );
-            }
-        }
-    });
-
-    Ok(response)
 }
 
 pub fn add_request_id_middleware<B: hyper::body::HttpBody + Send + Sync + 'static>(


### PR DESCRIPTION
Metrics can get really large in the order of hundreds of megabytes, which we currently buffer completly (after a few rounds of growing the buffer).