### PR TITLE
fix(remote_timeline_client): cancel waiting for semaphore

### DIFF
--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -20,7 +20,7 @@ use aws_sdk_s3::{
     types::{Delete, ObjectIdentifier},
     Client,
 };
-use aws_smithy_http::{body::SdkBody, result};
+use aws_smithy_http::{body::SdkBody};
 use hyper::Body;
 use tokio::{
     io::{self, AsyncRead},


### PR DESCRIPTION
## Problem

Shutdown or detach or ignore hangs if there is a long upload queue.

## Summary of changes

Use cancellation token everywhere in the remote_storage path, but only with the semaphore.

Alternatively we could had just dropped the futures, but localfs would need a bit of work to support that.
