### PR TITLE
cold starts: Add sync-safekeepers fast path

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -6,13 +6,13 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::sync::{Condvar, Mutex};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use postgres::{Client, NoTls};
 use tokio_postgres;
-use tracing::{info, instrument, warn};
+use tracing::{error, info, instrument, warn};
 use utils::id::{TenantId, TimelineId};
 use utils::lsn::Lsn;
 

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -6,8 +6,10 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::sync::{Condvar, Mutex};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use postgres::{Client, NoTls};
 use tokio_postgres;
 use tracing::{info, instrument, warn};
@@ -21,6 +23,7 @@ use utils::measured_stream::MeasuredReader;
 use crate::config;
 use crate::pg_helpers::*;
 use crate::spec::*;
+use crate::sync_sk::ping_safekeeper;
 
 /// Compute node info shared across several `compute_ctl` threads.
 pub struct ComputeNode {
@@ -309,17 +312,18 @@ impl ComputeNode {
         Ok(())
     }
 
-    // Fast path for sync_safekeepers. If they're already synced we get the lsn
-    // in one roundtrip. If not, we should do a full sync_safekeepers.
-    pub fn check_safekeepers_synced(&self, compute_state: &ComputeState) -> Result<Option<Lsn>> {
+    pub async fn check_safekeepers_synced_async(
+        &self,
+        compute_state: &ComputeState,
+    ) -> Result<Option<Lsn>> {
+        // Construct a connection config for each safekeeper
         let pspec: ParsedSpec = compute_state
             .pspec
             .as_ref()
             .expect("spec must be set")
             .clone();
         let sk_connstrs: Vec<String> = pspec.spec.safekeeper_connstrings.clone();
-
-        for connstr in sk_connstrs {
+        let sk_configs = sk_connstrs.into_iter().map(|connstr| {
             // Format connstr
             let connstr = format!("postgresql://no_user@{}", connstr);
             let options = format!(
@@ -328,28 +332,79 @@ impl ComputeNode {
             );
 
             // Construct client
-            let mut config = postgres::Config::from_str(&connstr)?;
+            let mut config = tokio_postgres::Config::from_str(&connstr).unwrap();
             config.options(&&options);
             if let Some(storage_auth_token) = pspec.storage_auth_token.clone() {
                 config.password(storage_auth_token);
             }
 
-            // Connect and query
-            let mut client = config.connect(NoTls)?;
-            let result = client.simple_query("TIMELINE_STATUS")?;
+            config
+        });
 
-            // Interpret result
-            if let postgres::SimpleQueryMessage::Row(row) = &result[0] {
-                let lsn_1 = row.get("lsn_1");
-                let lsn_2 = row.get("lsn_2");
-                dbg!(lsn_1);
-                dbg!(lsn_2);
-            } else {
-                anyhow::bail!("expected SimpleQueryMessage::Row");
+        // Create task set to query all safekeepers
+        let mut tasks = FuturesUnordered::new();
+        for config in sk_configs {
+            tasks.push(tokio::spawn(ping_safekeeper(config)));
+        }
+
+        // Get a quorum of responses or errors
+        let mut responses = Vec::new();
+        let mut join_errors = Vec::new();
+        let mut task_errors = Vec::new();
+        while let Some(response) = tasks.next().await {
+            match response {
+                Ok(Ok(r)) => responses.push(r),
+                Ok(Err(e)) => task_errors.push(e),
+                Err(e) => join_errors.push(e),
+            };
+            if responses.len() >= 2 {
+                break;
+            }
+            if join_errors.len() + task_errors.len() >= 2 {
+                break;
             }
         }
 
-        Ok(None)
+        // Check for errors
+        if responses.len() < 2 {
+            // TODO better error
+            bail!(
+                "failed sync safekeepers check {:?} {:?}",
+                join_errors,
+                task_errors
+            );
+        }
+        let sk1 = responses[0].clone();
+        let sk2 = responses[1].clone();
+
+        // Decide if full sync_safekeepers can be skipped
+        // TODO this is not the correct logic
+        if sk1.is_some() && sk1 == sk2 {
+            Ok(Some(Lsn::from_str(&sk1.unwrap().1)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    // Fast path for sync_safekeepers. If they're already synced we get the lsn
+    // in one roundtrip. If not, we should do a full sync_safekeepers.
+    pub fn check_safekeepers_synced(&self, compute_state: &ComputeState) -> Result<Option<Lsn>> {
+        let start_time = Utc::now();
+
+        // Run actual work with new tokio runtime
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create rt");
+        let result = rt.block_on(self.check_safekeepers_synced_async(compute_state));
+
+        // Record runtime
+        self.state.lock().unwrap().metrics.sync_sk_check_ms = Utc::now()
+            .signed_duration_since(start_time)
+            .to_std()
+            .unwrap()
+            .as_millis() as u64;
+        result
     }
 
     // Run `postgres` in a special mode with `--sync-safekeepers` argument
@@ -415,11 +470,6 @@ impl ComputeNode {
         let lsn = match spec.mode {
             ComputeMode::Primary => {
                 info!("checking if safekeepers are synced");
-
-                if let Err(e) = self.check_safekeepers_synced(compute_state) {
-                    println!("sync check error: {:?}", e);
-                }
-
                 let lsn = if let Ok(Some(lsn)) = self.check_safekeepers_synced(compute_state) {
                     lsn
                 } else {

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -333,7 +333,7 @@ impl ComputeNode {
 
             // Construct client
             let mut config = tokio_postgres::Config::from_str(&connstr).unwrap();
-            config.options(&&options);
+            config.options(&options);
             if let Some(storage_auth_token) = pspec.storage_auth_token.clone() {
                 config.password(storage_auth_token);
             }

--- a/compute_tools/src/lib.rs
+++ b/compute_tools/src/lib.rs
@@ -13,3 +13,4 @@ pub mod monitor;
 pub mod params;
 pub mod pg_helpers;
 pub mod spec;
+pub mod sync_sk;

--- a/compute_tools/src/sync_sk.rs
+++ b/compute_tools/src/sync_sk.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+
+/// Get a safekeeper's metadata for our timeline
+pub async fn ping_safekeeper(
+    config: tokio_postgres::Config,
+) -> Result<Option<(String, String, String)>> {
+    // TODO add retries
+
+    // Connect
+    let (client, conn) = config.connect(tokio_postgres::NoTls).await?;
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    // Query
+    let result = client.simple_query("TIMELINE_STATUS").await?;
+
+    // Parse result
+    if let postgres::SimpleQueryMessage::Row(row) = &result[0] {
+        let flush_lsn = row.get("flush_lsn").unwrap().to_string();
+        let commit_lsn = row.get("commit_lsn").unwrap().to_string();
+        let peer_horizon_lsn = row.get("peer_horizon_lsn").unwrap().to_string();
+        Ok(Some((flush_lsn, commit_lsn, peer_horizon_lsn)))
+    } else {
+        // Timeline doesn't exist
+        return Ok(None);
+    }
+}

--- a/compute_tools/src/sync_sk.rs
+++ b/compute_tools/src/sync_sk.rs
@@ -1,12 +1,27 @@
+// Utils for running sync_safekeepers
 use anyhow::Result;
+use tracing::info;
+use utils::lsn::Lsn;
+
+#[derive(Copy, Clone, Debug)]
+pub enum TimelineStatusResponse {
+    NotFound,
+    Ok(TimelineStatusOkResponse),
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct TimelineStatusOkResponse {
+    flush_lsn: Lsn,
+    commit_lsn: Lsn,
+    peer_horizon_lsn: Lsn,
+}
 
 /// Get a safekeeper's metadata for our timeline
-pub async fn ping_safekeeper(
-    config: tokio_postgres::Config,
-) -> Result<Option<(String, String, String)>> {
+pub async fn ping_safekeeper(config: tokio_postgres::Config) -> Result<TimelineStatusResponse> {
     // TODO add retries
 
     // Connect
+    info!("connecting to {:?}", config);
     let (client, conn) = config.connect(tokio_postgres::NoTls).await?;
     tokio::spawn(async move {
         if let Err(e) = conn.await {
@@ -15,16 +30,39 @@ pub async fn ping_safekeeper(
     });
 
     // Query
+    info!("querying {:?}", config);
     let result = client.simple_query("TIMELINE_STATUS").await?;
 
     // Parse result
+    info!("done with {:?}", config);
     if let postgres::SimpleQueryMessage::Row(row) = &result[0] {
-        let flush_lsn = row.get("flush_lsn").unwrap().to_string();
-        let commit_lsn = row.get("commit_lsn").unwrap().to_string();
-        let peer_horizon_lsn = row.get("peer_horizon_lsn").unwrap().to_string();
-        Ok(Some((flush_lsn, commit_lsn, peer_horizon_lsn)))
+        use std::str::FromStr;
+        let response = TimelineStatusResponse::Ok(TimelineStatusOkResponse {
+            flush_lsn: Lsn::from_str(row.get("flush_lsn").unwrap())?,
+            commit_lsn: Lsn::from_str(row.get("commit_lsn").unwrap())?,
+            peer_horizon_lsn: Lsn::from_str(row.get("peer_horizon_lsn").unwrap())?,
+        });
+        Ok(response)
     } else {
         // Timeline doesn't exist
-        return Ok(None);
+        Ok(TimelineStatusResponse::NotFound)
+    }
+}
+
+/// Given a quorum of responses, check if safekeepers are synced at some Lsn
+pub fn check_if_synced(responses: &[TimelineStatusResponse; 2]) -> Option<Lsn> {
+    match (responses[0], responses[1]) {
+        (TimelineStatusResponse::Ok(r1), TimelineStatusResponse::Ok(r2)) => {
+            // TODO is this correct?
+            let max_commit = std::cmp::max(r1.commit_lsn, r2.commit_lsn);
+            let min_flush = std::cmp::min(r1.flush_lsn, r2.flush_lsn);
+            let min_peer = std::cmp::min(r1.peer_horizon_lsn, r2.peer_horizon_lsn);
+            if max_commit == min_flush && max_commit == min_peer {
+                Some(max_commit)
+            } else {
+                None
+            }
+        }
+        _ => None,
     }
 }

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -70,6 +70,7 @@ where
 pub struct ComputeMetrics {
     pub wait_for_spec_ms: u64,
     pub sync_safekeepers_ms: u64,
+    pub sync_sk_check_ms: u64,
     pub basebackup_ms: u64,
     pub basebackup_bytes: u64,
     pub start_postgres_ms: u64,

--- a/safekeeper/src/handler.rs
+++ b/safekeeper/src/handler.rs
@@ -284,7 +284,6 @@ impl SafekeeperPostgresHandler {
         pgb.write_message_noflush(&BeMessage::RowDescription(&[
             RowDescriptor::text_col(b"flush_lsn"),
             RowDescriptor::text_col(b"commit_lsn"),
-            RowDescriptor::text_col(b"peer_horizon_lsn"),
         ]))?;
 
         // Write row if timeline exists
@@ -292,11 +291,9 @@ impl SafekeeperPostgresHandler {
             let (inmem, _state) = tli.get_state().await;
             let flush_lsn = tli.get_flush_lsn().await;
             let commit_lsn = inmem.commit_lsn;
-            let peer_horizon_lsn = inmem.peer_horizon_lsn;
             pgb.write_message_noflush(&BeMessage::DataRow(&[
                 Some(flush_lsn.to_string().as_bytes()),
                 Some(commit_lsn.to_string().as_bytes()),
-                Some(peer_horizon_lsn.to_string().as_bytes()),
             ]))?;
         }
 

--- a/test_runner/performance/test_startup.py
+++ b/test_runner/performance/test_startup.py
@@ -61,6 +61,7 @@ def test_startup_simple(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenc
         durations = {
             "wait_for_spec_ms": f"{i}_wait_for_spec",
             "sync_safekeepers_ms": f"{i}_sync_safekeepers",
+            "sync_sk_check_ms": f"{i}_sync_sk_check",
             "basebackup_ms": f"{i}_basebackup",
             "start_postgres_ms": f"{i}_start_postgres",
             "config_ms": f"{i}_config",


### PR DESCRIPTION
## Problem
p90 time for sync-safekeepers is 110ms, which is too much. Some of the problms are known and difficult to avoid, some are unknown. This PR simplifies the fast path so it's faster, fewer things can go wrong, and everything that can go wrong is easily monitored and debugged without requiring familiarity with walproposer.c

## Summary of changes
The main idea: don't sync safekeepers if they're synced. Don't even start the sync safekeepers program, because that itself is slow (for postgres reasons).

All the logic is in `fn check_if_synced`, and everything else is boilerplate for concurrently querying a quorum of safekeepers over pg protocol, and adding metrics.

On my laptop with 0.5ms emulated latency (1ms ping), the check runs in 3ms: 2ms for establishing pg connection, 1ms for the status check roundtrip.