### PR TITLE
Fix allure report overwriting for different Postgres versions

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -209,4 +209,4 @@ runs:
       uses: ./.github/actions/allure-report-store
       with:
         report-dir: /tmp/test_output/allure/results
-        unique-key: ${{ inputs.build_type }}
+        unique-key: ${{ inputs.build_type }}-${{ inputs.pg_version }}


### PR DESCRIPTION
## Problem

We've got an example of Allure reports from 2 different runners for the same build that started to upload at the exact second, making one overwrite another:

- https://github.com/neondatabase/neon/actions/runs/5623580167/job/15238718568?#step:4:40277
- https://github.com/neondatabase/neon/actions/runs/5623580167/job/15238718397#step:4:40236

## Summary of changes
- Use the Postgres version to distinguish artifacts (along with build type)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
