### PR TITLE
fix: format warning building pgxn

### DIFF
--- a/pgxn/hnsw/hnsw.c
+++ b/pgxn/hnsw/hnsw.c
@@ -149,7 +149,7 @@ hnsw_check_available_memory(Size requested)
 	struct sysinfo si;
 	Size total;
 	if (sysinfo(&si) < 0)
-		elog(ERROR, "Failed to get amount of RAM: %n");
+		elog(ERROR, "Failed to get amount of RAM: %m");
 
 	total = si.totalram*si.mem_unit;
 	if ((Size)NBuffers*BLCKSZ + requested >= total)


### PR DESCRIPTION
## Problem

I encountered the following warning when building.

```
/home/ikedamsh/repos/neon_evaluation/neon-main//pgxn/hnsw/hnsw.c:152:15: warning: format ‘%n’ expects a matching ‘int *’ argument [-Wformat=]
  152 |   elog(ERROR, "Failed to get amount of RAM: %n");
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ikedamsh/repos/neon_evaluation/neon-main/pg_install/v14/include/postgresql/server/utils/elog.h:141:4: note: in definition of macro ‘ereport_domain’
  141 |    __VA_ARGS__, errfinish(__FILE__, __LINE__, PG_FUNCNAME_MACRO); \
      |    ^~~~~~~~~~~
/home/ikedamsh/repos/neon_evaluation/neon-main/pg_install/v14/include/postgresql/server/utils/elog.h:233:2: note: in expansion of macro ‘ereport’
  233 |  ereport(elevel, errmsg_internal(__VA_ARGS__))
      |  ^~~~~~~
/home/ikedamsh/repos/neon_evaluation/neon-main//pgxn/hnsw/hnsw.c:152:3: note: in expansion of macro ‘elog’
  152 |   elog(ERROR, "Failed to get amount of RAM: %n");
      |   ^~~~
/home/ikedamsh/repos/neon_evaluation/neon-main//pgxn/hnsw/hnsw.c:152:46: note: format string is defined here
  152 |   elog(ERROR, "Failed to get amount of RAM: %n");
      |                                             ~^
      |                                              |
      |                                              int *
```

## Summary of changes

Fix the flag to format.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
