### PR TITLE
test: less flaky test_threshold_based_eviction

### DIFF
--- a/test_runner/regress/test_threshold_based_eviction.py
+++ b/test_runner/regress/test_threshold_based_eviction.py
@@ -37,6 +37,9 @@ def test_threshold_based_eviction(
     metrics_refused_log_line = ".*metrics endpoint refused the sent metrics.*/nonexistent.*"
     env = neon_env_builder.init_start()
     env.pageserver.allowed_errors.append(metrics_refused_log_line)
+    env.pageserver.allowed_errors.append(
+        r".+ failed to calculate (logical size at \S+: cancelled .+|some logical_sizes)"
+    )
 
     tenant_id, timeline_id = env.initial_tenant, env.initial_timeline
     assert isinstance(timeline_id, TimelineId)


### PR DESCRIPTION
test_threshold_based_eviction is flaky: https://neon-github-public-dev.s3.amazonaws.com/reports/pr-4801/5668048402/index.html#/testresult/620e8d68854817ad 

Allow the errors.