### PR TITLE
test: allow future image layer warning

### DIFF
--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -348,6 +348,9 @@ def test_remote_storage_upload_queue_retries(
     # XXX: should vary this test to selectively fail just layer uploads, index uploads, deletions
     #      but how do we validate the result after restore?
 
+    # these are always possible when we do an immediate stop. perhaps something with compacting has changed since.
+    env.pageserver.allowed_errors.append(r".*found future (delta|image) layer.*")
+
     env.pageserver.stop(immediate=True)
     env.endpoints.stop_all()
 


### PR DESCRIPTION
https://neon-github-public-dev.s3.amazonaws.com/reports/main/5670795960/index.html#suites/837740b64a53e769572c4ed7b7a7eeeb/5a73fa4a69399123/retries

Allow it because we are doing immediate stop.