### PR TITLE
Deduplicate Extension Archives

### DIFF
--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -776,6 +776,13 @@ ARG PG_VERSION
 ARG BUILD_TAG
 RUN apt update && apt install -y zstd
 
+# Define extension build numbers
+# NOTE: it is *not* necessary for the build_tag to be BUILD_TAG. In particular,
+# you should update the build_tag for each extension only when you build it
+RUN echo "kq_imcx 5670669815" >>  build_tags.txt
+RUN echo "anon 5670669815" >>  build_tags.txt
+RUN echo "postgis 5670669815" >>  build_tags.txt
+
 # copy the control files here
 COPY --from=kq-imcx-pg-build /extensions/ /extensions/
 COPY --from=pg-anon-pg-build /extensions/ /extensions/


### PR DESCRIPTION
## Problem
Currently, every time someone pushes to `main` or `release` the same extensions are re-uploaded to S3 each time. We do need to re-upload extensions if they are modified, but otherwise we should be able to save space on S3 by not duplicating identical files. 
## Summary of changes
The rust code is already set up to make de-duplication very easy. 
The only necessary change is to put a different path as the archive path for the extension. 
The way I propose to do this is in `Dockerfile` you specify a build number. If that matches with the build number of the build then we upload it. 
I'm not totally sure my idea makes sense. Interested in suggestions to make this better. 