### PR TITLE
consumption_metrics: send timeline_written_size_delta

### DIFF
--- a/libs/consumption_metrics/src/lib.rs
+++ b/libs/consumption_metrics/src/lib.rs
@@ -17,6 +17,16 @@ pub enum EventType {
     },
 }
 
+impl EventType {
+    pub fn absolute_time(&self) -> Option<&DateTime<Utc>> {
+        use EventType::*;
+        match self {
+            Absolute { time } => Some(time),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Serialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Event<Extra> {
     #[serde(flatten)]

--- a/libs/consumption_metrics/src/lib.rs
+++ b/libs/consumption_metrics/src/lib.rs
@@ -26,6 +26,18 @@ impl EventType {
         }
     }
 
+    pub fn incremental_timerange(&self) -> Option<std::ops::Range<&DateTime<Utc>>> {
+        // these can most likely be thought of as Range or RangeFull
+        use EventType::*;
+        match self {
+            Incremental {
+                start_time,
+                stop_time,
+            } => Some(start_time..stop_time),
+            _ => None,
+        }
+    }
+
     pub fn is_incremental(&self) -> bool {
         matches!(self, EventType::Incremental { .. })
     }

--- a/libs/consumption_metrics/src/lib.rs
+++ b/libs/consumption_metrics/src/lib.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use rand::Rng;
 use serde::Serialize;
 
-#[derive(Serialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Serialize, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(tag = "type")]
 pub enum EventType {
     #[serde(rename = "absolute")]

--- a/libs/consumption_metrics/src/lib.rs
+++ b/libs/consumption_metrics/src/lib.rs
@@ -25,6 +25,10 @@ impl EventType {
             _ => None,
         }
     }
+
+    pub fn is_incremental(&self) -> bool {
+        matches!(self, EventType::Incremental { .. })
+    }
 }
 
 #[derive(Serialize, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]

--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -97,14 +97,14 @@ impl PageserverConsumptionMetricsKey {
 
     /// Values will be the difference of the latest written_size (last_record_lsn) to what we
     /// previously sent.
-    const fn written_size_delta_bytes(
+    const fn written_size_delta(
         tenant_id: TenantId,
         timeline_id: TimelineId,
     ) -> IncrementalValueFactory {
         PageserverConsumptionMetricsKey {
             tenant_id,
             timeline_id: Some(timeline_id),
-            metric: "written_size_delta_bytes",
+            metric: "written_size_bytes_delta",
         }
         .incremental_values()
     }
@@ -303,7 +303,7 @@ pub async fn collect_metrics_iteration(
                             .0
                             .absolute_time()
                             .expect("never create EventType::Incremental for written_size");
-                        let key_value = PageserverConsumptionMetricsKey::written_size_delta_bytes(
+                        let key_value = PageserverConsumptionMetricsKey::written_size_delta(
                             tenant_id,
                             timeline.timeline_id,
                         )

--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -21,7 +21,7 @@ use utils::id::{NodeId, TenantId, TimelineId};
 const WRITTEN_SIZE: &str = "written_size";
 /// Values will be the difference of the latest written_size (last_record_lsn) to what we
 /// previously sent.
-const WRITTEN_SIZE_DELTA: &str = "written_size_delta";
+const WRITTEN_SIZE_DELTA: &str = "written_size_delta_bytes";
 const SYNTHETIC_STORAGE_SIZE: &str = "synthetic_storage_size";
 const RESIDENT_SIZE: &str = "resident_size";
 const REMOTE_STORAGE_SIZE: &str = "remote_storage_size";

--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -300,13 +300,13 @@ pub async fn collect_metrics_iteration(
                                 .end
                         });
 
-                // by default, use the last sent written_size_delta_bytes as the basis for
+                // by default, use the last sent written_size as the basis for
                 // calculating the delta. if we don't yet have one, use the load time value.
                 let prev = cached_metrics
                     .get(&key)
                     .map(|(prev_at, prev)| {
                         // use the prev time from our last incremental update, or default to latest
-                        // absolute update
+                        // absolute update on the first round.
                         let prev_at = prev_at
                             .absolute_time()
                             .expect("never create EventType::Incremental for written_size");

--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -18,15 +18,6 @@ use std::time::Duration;
 use tracing::*;
 use utils::id::{NodeId, TenantId, TimelineId};
 
-const WRITTEN_SIZE: &str = "written_size";
-/// Values will be the difference of the latest written_size (last_record_lsn) to what we
-/// previously sent.
-const WRITTEN_SIZE_DELTA: &str = "written_size_delta_bytes";
-const SYNTHETIC_STORAGE_SIZE: &str = "synthetic_storage_size";
-const RESIDENT_SIZE: &str = "resident_size";
-const REMOTE_STORAGE_SIZE: &str = "remote_storage_size";
-const TIMELINE_LOGICAL_SIZE: &str = "timeline_logical_size";
-
 const DEFAULT_HTTP_REPORTING_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[serde_as]
@@ -53,15 +44,17 @@ impl PageserverConsumptionMetricsKey {
         PageserverConsumptionMetricsKey {
             tenant_id,
             timeline_id: Some(timeline_id),
-            metric: WRITTEN_SIZE,
+            metric: "written_size",
         }
     }
 
+    /// Values will be the difference of the latest written_size (last_record_lsn) to what we
+    /// previously sent.
     const fn written_size_delta(tenant_id: TenantId, timeline_id: TimelineId) -> Self {
         PageserverConsumptionMetricsKey {
             tenant_id,
             timeline_id: Some(timeline_id),
-            metric: WRITTEN_SIZE_DELTA,
+            metric: "written_size_delta_bytes",
         }
     }
 
@@ -69,7 +62,7 @@ impl PageserverConsumptionMetricsKey {
         PageserverConsumptionMetricsKey {
             tenant_id,
             timeline_id: Some(timeline_id),
-            metric: TIMELINE_LOGICAL_SIZE,
+            metric: "timeline_logical_size",
         }
     }
 
@@ -77,7 +70,7 @@ impl PageserverConsumptionMetricsKey {
         PageserverConsumptionMetricsKey {
             tenant_id,
             timeline_id: None,
-            metric: REMOTE_STORAGE_SIZE,
+            metric: "remote_storage_size",
         }
     }
 
@@ -85,7 +78,7 @@ impl PageserverConsumptionMetricsKey {
         PageserverConsumptionMetricsKey {
             tenant_id,
             timeline_id: None,
-            metric: RESIDENT_SIZE,
+            metric: "resident_size",
         }
     }
 
@@ -93,7 +86,7 @@ impl PageserverConsumptionMetricsKey {
         PageserverConsumptionMetricsKey {
             tenant_id,
             timeline_id: None,
-            metric: SYNTHETIC_STORAGE_SIZE,
+            metric: "synthetic_storage_size",
         }
     }
 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -294,6 +294,10 @@ pub struct Timeline {
     /// Completion shared between all timelines loaded during startup; used to delay heavier
     /// background tasks until some logical sizes have been calculated.
     initial_logical_size_attempt: Mutex<Option<completion::Completion>>,
+
+    /// Load or creation time information about the disk_consistent_lsn and when the loading
+    /// happened. Used for consumption metrics.
+    pub(crate) loaded_at: (Lsn, SystemTime),
 }
 
 pub struct WalReceiverInfo {
@@ -1403,6 +1407,8 @@ impl Timeline {
 
                 last_freeze_at: AtomicLsn::new(disk_consistent_lsn.0),
                 last_freeze_ts: RwLock::new(Instant::now()),
+
+                loaded_at: (disk_consistent_lsn, SystemTime::now()),
 
                 ancestor_timeline: ancestor,
                 ancestor_lsn: metadata.ancestor_lsn(),


### PR DESCRIPTION
We want to have timeline_written_size_delta which is defined as difference to the previously sent `timeline_written_size` from the current `timeline_written_size`.

Solution is to send it. On the first round `disk_consistent_lsn` is used which is captured during `load` time. After that an incremental "event" is sent on every collection. Incremental "events" are not part of deduplication.

I've added some infrastructure to allow somewhat typesafe `EventType::Absolute` and `EventType::Incremental` factories per metrics, now that we have our first `EventType::Incremental` usage.