### PR TITLE
Prewarm compute nodes

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -193,6 +193,9 @@ fn main() -> Result<()> {
     if !spec_set {
         // No spec provided, hang waiting for it.
         info!("no compute spec provided, waiting");
+
+        compute.prewarm_postgres()?;
+
         let mut state = compute.state.lock().unwrap();
         while state.status != ComputeStatus::ConfigurationPending {
             state = compute.state_changed.wait(state).unwrap();

--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -194,6 +194,10 @@ fn main() -> Result<()> {
         // No spec provided, hang waiting for it.
         info!("no compute spec provided, waiting");
 
+        // TODO this can stall startups in the unlikely event that we bind
+        //      this compute node while it's busy prewarming. It's not too
+        //      bad because it's just 100ms and unlikely, but it's an
+        //      avoidable problem.
         compute.prewarm_postgres()?;
 
         let mut state = compute.state.lock().unwrap();

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -537,7 +537,7 @@ impl ComputeNode {
         info!("prewarming");
 
         // Create pgdata
-        let pgdata = "/home/bojan/tmp/prewarm_pgdata"; // TODO fix this
+        let pgdata = &format!("{}.warmup", self.pgdata);
         create_pgdata(pgdata)?;
 
         // Run initdb to completion
@@ -552,8 +552,8 @@ impl ComputeNode {
         use std::io::Write;
         let conf_path = Path::new(pgdata).join("postgresql.conf");
         let mut file = std::fs::File::create(conf_path)?;
-        writeln!(file, "shared_buffers=100MB")?; // TODO is this the default?
-        writeln!(file, "port=51055")?;  // Nobody should be connecting
+        writeln!(file, "shared_buffers=65536")?;
+        writeln!(file, "port=51055")?; // Nobody should be connecting
         writeln!(file, "shared_preload_libraries = 'neon'")?;
 
         // Start postgres

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -537,7 +537,7 @@ impl ComputeNode {
         info!("prewarming");
 
         // Create pgdata
-        let pgdata = "/home/bojan/tmp/prewarm_pgdata";
+        let pgdata = "/home/bojan/tmp/prewarm_pgdata"; // TODO fix this
         create_pgdata(pgdata)?;
 
         // Run initdb to completion
@@ -552,7 +552,7 @@ impl ComputeNode {
         use std::io::Write;
         let conf_path = Path::new(pgdata).join("postgresql.conf");
         let mut file = std::fs::File::create(conf_path)?;
-        writeln!(file, "shared_buffers=100MB")?;
+        writeln!(file, "shared_buffers=100MB")?; // TODO is this the default?
         writeln!(file, "port=51055")?;  // Nobody should be connecting
         writeln!(file, "shared_preload_libraries = 'neon'")?;
 


### PR DESCRIPTION
## Problem
After deploying the sync safekeepers hot path, total startup improved, but postgres startup p90 in `us-east-2` [got worse](https://neonprod.grafana.net/explore?left=%7B%22datasource%22:%22HUNg6jvVk%22,%22queries%22:%5B%7B%22refId%22:%22E%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22HUNg6jvVk%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22histogram_quantile%280.9,%20sum%28rate%28start_postgres_ms_bucket%7Brequester%21~%5C%22%28avalibility_checker%7Ccreate_project%7C%29%5C%22%7D%5B1h%5D%29%29%20by%20%28le,%20region_id,%20requester%29%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D,%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22HUNg6jvVk%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22histogram_quantile%280.9,%20sum%28rate%28compute_sync_safekeepers_ms_bucket%7Brequester%21~%5C%22%28avalibility_checker%7Ccreate_project%7C%29%5C%22,%20region_id%3D%5C%22aws-eu-west-1%5C%22%7D%5B10m%5D%29%29%20by%20%28le%29%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%221690339414743%22,%22to%22:%221690462695093%22%7D%7D&orgId=1). I'm not sure but seems that it's only for VMs. That's the only region that has VMs, and they take about 10% of starts, and only p90 starts are impacted. Grepping logs also confirms it's mostly VMs.

Now the question is, why does postgres start faster on VMs if we run walproposer.c before it? It's possible that walproposer warms up the vm:
- qemu allocates ram lazily, so walproposer breaks the ice for postgres
- our binaries are large, and walproposer puts them in os cache
- ???

## Summary of changes
When we start compute_ctl in pool mode, I run initdb and postgres to warm it up. I'm not sure if this will have an effect but it's easy to test on stage. If it doesn't work it's easy to revert.
