### PR TITLE
fix wrong regex of allowed errors in on-demand download tests

### DIFF
--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -712,10 +712,10 @@ def test_ondemand_download_failure_to_replace(
     env.pageserver.allowed_errors.append(actual_message)
 
     env.pageserver.allowed_errors.append(
-        ".* ERROR .*Error processing HTTP request: InternalServerError\\(get local timeline info"
+        ".* ERROR .*Error processing HTTP request: InternalServerError\\(get local timeline info.*"
     )
     # this might get to run and attempt on-demand, but not always
-    env.pageserver.allowed_errors.append(".* ERROR .*Task 'initial size calculation'")
+    env.pageserver.allowed_errors.append(".* ERROR .*Task 'initial size calculation'.*")
 
     # if the above returned, then we didn't have a livelock, and all is well
 


### PR DESCRIPTION
## Problem

These two errors should be allowed, but the test script rejects them as in https://neon-github-public-dev.s3.amazonaws.com/reports/main/5669956577/index.html#/testresult/6388e31182cc2d6e, due to the wrong regex being used.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
