### PR TITLE
support isolation level + read only for http batch sql

### DIFF
--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -250,8 +250,8 @@ pub async fn handle(
             Ok(json!({
                 "results": results,
                 "options": {
-                    "isolationLevel": txn_isolation_level.map(|l| format!("{:?}", l)),
-                    "readOnly": txn_read_only
+                    "isolation_level": txn_isolation_level.map(|l| format!("{:?}", l)),
+                    "read_only": txn_read_only
                 }
             }))
         }

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -192,10 +192,10 @@ pub async fn handle(
     // isolation level and read only
     let txn_isolation_level = match headers.get(&TXN_ISOLATION_LEVEL) {
         Some(x) => Some(match x.as_bytes() {
-            b"serializable" => IsolationLevel::Serializable,
-            b"read-uncommitted" => IsolationLevel::ReadUncommitted,
-            b"read-committed" => IsolationLevel::ReadCommitted,
-            b"repeatable-read" => IsolationLevel::RepeatableRead,
+            b"Serializable" => IsolationLevel::Serializable,
+            b"ReadUncommitted" => IsolationLevel::ReadUncommitted,
+            b"ReadCommitted" => IsolationLevel::ReadCommitted,
+            b"RepeatableRead" => IsolationLevel::RepeatableRead,
             _ => bail!("invalid isolation level"),
         }),
         None => None,
@@ -247,7 +247,13 @@ pub async fn handle(
                 }
             }
             transaction.commit().await?;
-            Ok(json!({ "results": results }))
+            Ok(json!({
+                "results": results,
+                "options": {
+                    "isolationLevel": txn_isolation_level.map(|l| format!("{:?}", l)),
+                    "readOnly": txn_read_only
+                }
+            }))
         }
     };
 

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -255,9 +255,10 @@ pub async fn handle(
             }
             transaction.commit().await?;
             let mut headers = HashMap::default();
-            if let Some(txn_read_only_raw) = txn_read_only_raw {
-                headers.insert(TXN_READ_ONLY.clone(), txn_read_only_raw);
-            }
+            headers.insert(
+                TXN_READ_ONLY.clone(),
+                HeaderValue::try_from(txn_read_only.to_string())?,
+            );
             if let Some(txn_isolation_level_raw) = txn_isolation_level_raw {
                 headers.insert(TXN_ISOLATION_LEVEL.clone(), txn_isolation_level_raw);
             }

--- a/test_runner/regress/test_proxy.py
+++ b/test_runner/regress/test_proxy.py
@@ -274,7 +274,7 @@ def test_sql_over_http_batch(static_proxy: NeonProxy):
                 "Content-Type": "application/sql",
                 "Neon-Connection-String": connstr,
                 "Neon-Batch-Isolation-Level": "Serializable",
-                "Neon-Batch-Read-Only": "true" if read_only else None,
+                "Neon-Batch-Read-Only": "true" if read_only else "false",
             },
             verify=str(static_proxy.test_output_dir / "proxy.crt"),
         )

--- a/test_runner/regress/test_proxy.py
+++ b/test_runner/regress/test_proxy.py
@@ -324,7 +324,7 @@ def test_sql_over_http_batch(static_proxy: NeonProxy):
         [
             ("select 42 as answer", None),
         ],
-        True
+        True,
     )
     assert headers["Neon-Batch-Isolation-Level"] == "Serializable"
     assert headers["Neon-Batch-Read-Only"] == "true"


### PR DESCRIPTION
## Problem

## Summary of changes

We will retrieve `neon-batch-isolation-level` and `neon-batch-read-only` from the http header, which sets the txn properties. https://github.com/neondatabase/serverless/pull/38#issuecomment-1653130981

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
