### PR TITLE
remote extensions: handle timeouts / multiple downloads

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -33,7 +33,7 @@
 //!             -r {"bucket": "my-bucket", "region": "eu-central-1", "endpoint": "http:://localhost:9000"}
 //! ```
 //!
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs::File;
 use std::panic;
 use std::path::Path;

--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -38,7 +38,7 @@ use std::fs::File;
 use std::panic;
 use std::path::Path;
 use std::process::exit;
-use std::sync::{mpsc, Arc, Condvar, Mutex, OnceLock};
+use std::sync::{mpsc, Arc, Condvar, Mutex, OnceLock, RwLock};
 use std::{thread, time::Duration};
 
 use anyhow::{Context, Result};
@@ -197,7 +197,7 @@ fn main() -> Result<()> {
         state_changed: Condvar::new(),
         ext_remote_storage,
         ext_remote_paths: OnceLock::new(),
-        started_to_download_extensions: Mutex::new(HashSet::new()),
+        ext_download_progress: RwLock::new(HashMap::new()),
         library_index: OnceLock::new(),
         build_tag,
     };

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -940,7 +940,7 @@ LIMIT 100",
                     .as_millis() as u64;
 
                 // how long to wait for extension download if it was started by another process
-                const HANG_TIMEOUT = 3000;// milliseconds
+                const HANG_TIMEOUT: u64 = 3000;// milliseconds
 
                 if download_completed {
                     info!("extension already downloaded, skipping re-download");

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -939,11 +939,14 @@ LIMIT 100",
                     .unwrap()
                     .as_millis() as u64;
 
+                // how long to wait for extension download if it was started by another process
+                const HANG_TIMEOUT = 3000;// milliseconds
+
                 if download_completed {
                     info!("extension already downloaded, skipping re-download");
                     return Ok(0);
-                } else if start_time_delta < 3000 && !first_try {
-                    info!("download {ext_archive_name} already started, hanging untill completion or timeout");
+                } else if start_time_delta < HANG_TIMEOUT && !first_try {
+                    info!("download {ext_archive_name} already started by another process, hanging untill completion or timeout");
                     let mut interval =
                         tokio::time::interval(tokio::time::Duration::from_millis(500));
                     loop {

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fs;
 use std::io::BufRead;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::str::FromStr;
-use std::sync::{Condvar, Mutex, OnceLock};
+use std::sync::{Condvar, Mutex, OnceLock, RwLock};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -62,7 +61,8 @@ pub struct ComputeNode {
     // (key: extension name, value: path to extension archive in remote storage)
     pub ext_remote_paths: OnceLock<HashMap<String, RemotePath>>,
     pub library_index: OnceLock<HashMap<String, String>>,
-    pub started_to_download_extensions: Mutex<HashSet<String>>,
+    // key: ext_archive_name, value: started download time, download_completed?
+    pub ext_download_progress: RwLock<HashMap<String, (DateTime<Utc>, bool)>>,
     pub build_tag: String,
 }
 
@@ -912,37 +912,70 @@ LIMIT 100",
                         .clone();
                 }
 
+                let ext_path = &self
+                    .ext_remote_paths
+                    .get()
+                    .expect("error accessing ext_remote_paths")[&real_ext_name];
+                let ext_archive_name = ext_path.object_name().expect("bad path");
+
+                let mut first_try = false;
+                if !self
+                    .ext_download_progress
+                    .read()
+                    .expect("lock err")
+                    .contains_key(ext_archive_name)
                 {
-                    // TODO:
-                    // started_to_download_extensions maybe should store archive paths rather than extension names...
-                    // because right now if you try to download the same archive multiple times
-                    // you will get the same archive downloaded multiple times
-                    // but, this is not such an easy fix.
-                    // because now requests should maybe pause and wait if someone else started making the download
-                    let mut started_to_download_extensions = self
-                        .started_to_download_extensions
-                        .lock()
-                        .expect("bad lock");
-                    if started_to_download_extensions.contains(&real_ext_name) {
-                        info!(
-                            "extension {:?} already exists, skipping download",
-                            &ext_name
-                        );
-                        return Ok(0);
-                    } else {
-                        started_to_download_extensions.insert(real_ext_name.clone());
-                    }
+                    self.ext_download_progress
+                        .write()
+                        .expect("lock err")
+                        .insert(ext_archive_name.to_string(), (Utc::now(), false));
+                    first_try = true;
                 }
-                extension_server::download_extension(
+                let (download_start, download_completed) =
+                    self.ext_download_progress.read().expect("lock err")[ext_archive_name];
+                let start_time_delta = Utc::now()
+                    .signed_duration_since(download_start)
+                    .to_std()
+                    .unwrap()
+                    .as_millis() as u64;
+
+                if download_completed {
+                    info!("extension already downloaded, skipping re-download");
+                    return Ok(0);
+                } else if start_time_delta < 3 && !first_try {
+                    info!("download {ext_archive_name} already started, hanging untill completion or timeout");
+                    let mut interval =
+                        tokio::time::interval(tokio::time::Duration::from_millis(500));
+                    loop {
+                        info!("waiting for download");
+                        interval.tick().await;
+                        let (_, download_completed_now) =
+                            self.ext_download_progress.read().expect("lock")[ext_archive_name];
+                        if download_completed_now {
+                            info!("download finished by whoever else downloaded it");
+                            return Ok(0);
+                        }
+                    }
+                    // NOTE: the above loop will get terminated
+                    // based on the timeout of the download function
+                }
+
+                // if extension hasn't been downloaded before or recently
+                // started downloading then we download it here
+                info!("downloading new extension {ext_archive_name}");
+
+                let download_size = extension_server::download_extension(
                     &real_ext_name,
-                    &self
-                        .ext_remote_paths
-                        .get()
-                        .expect("error accessing ext_remote_paths")[&real_ext_name],
+                    ext_path,
                     remote_storage,
                     &self.pgbin,
                 )
-                .await
+                .await;
+                self.ext_download_progress
+                    .write()
+                    .expect("bad lock")
+                    .insert(ext_archive_name.to_string(), (download_start, true));
+                download_size
             }
         }
     }

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -940,7 +940,7 @@ LIMIT 100",
                     .as_millis() as u64;
 
                 // how long to wait for extension download if it was started by another process
-                const HANG_TIMEOUT: u64 = 3000;// milliseconds
+                const HANG_TIMEOUT: u64 = 3000; // milliseconds
 
                 if download_completed {
                     info!("extension already downloaded, skipping re-download");

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -942,7 +942,7 @@ LIMIT 100",
                 if download_completed {
                     info!("extension already downloaded, skipping re-download");
                     return Ok(0);
-                } else if start_time_delta < 3 && !first_try {
+                } else if start_time_delta < 3000 && !first_try {
                     info!("download {ext_archive_name} already started, hanging untill completion or timeout");
                     let mut interval =
                         tokio::time::interval(tokio::time::Duration::from_millis(500));

--- a/pgxn/neon/extension_server.c
+++ b/pgxn/neon/extension_server.c
@@ -59,7 +59,7 @@ neon_download_extension_file_http(const char *filename, bool is_library)
 
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
     curl_easy_setopt(curl, CURLOPT_URL, compute_ctl_url);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 3L /* seconds */);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 1L /* seconds */);
 
     if (curl)
     {

--- a/pgxn/neon/extension_server.c
+++ b/pgxn/neon/extension_server.c
@@ -59,7 +59,7 @@ neon_download_extension_file_http(const char *filename, bool is_library)
 
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
     curl_easy_setopt(curl, CURLOPT_URL, compute_ctl_url);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 1L /* seconds */);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 3L /* seconds */);
 
     if (curl)
     {

--- a/test_runner/regress/test_download_extensions.py
+++ b/test_runner/regress/test_download_extensions.py
@@ -74,7 +74,6 @@ def upload_files(env):
     os.chdir("../../../..")
 
 
-"""
 # Test downloading remote extension.
 @pytest.mark.parametrize("remote_storage_kind", available_s3_storages())
 def test_remote_extensions(
@@ -253,7 +252,6 @@ def test_extension_download_after_restart(
             log.info(cur.fetchall())
 
     cleanup(pg_version)
-"""
 
 
 # here we test a complex extension
@@ -295,15 +293,3 @@ def test_multiple_extensions_one_archive(
             log.info(cur.fetchall())
 
     cleanup(pg_version)
-
-
-# TODO: this complex example reveals a possible "inneficiency":
-# both calls will download the extension
-# proposed solution:
-# A: don't worry about it
-# B:
-# 1st request sets started_download = true
-# this request sets download_completed = true if it succeeds
-# subsequent requests hang and repeatedly check download_completed until it gets set or until they timeout
-# 3 seconds afterthe started_download = true was set some thread checks if download_completed was set. if not, then it sets started_download back to false
-# TODO later: investigate download timeouts

--- a/test_runner/regress/test_download_extensions.py
+++ b/test_runner/regress/test_download_extensions.py
@@ -74,6 +74,7 @@ def upload_files(env):
     os.chdir("../../../..")
 
 
+"""
 # Test downloading remote extension.
 @pytest.mark.parametrize("remote_storage_kind", available_s3_storages())
 def test_remote_extensions(
@@ -252,6 +253,7 @@ def test_extension_download_after_restart(
             log.info(cur.fetchall())
 
     cleanup(pg_version)
+"""
 
 
 # here we test a complex extension
@@ -282,7 +284,6 @@ def test_multiple_extensions_one_archive(
     )
     with closing(endpoint.connect()) as conn:
         with conn.cursor() as cur:
-            # TODO later: figure out what was going wrong with this:
             cur.execute("CREATE EXTENSION address_standardizer;")
             cur.execute("CREATE EXTENSION address_standardizer_data_us;")
             # execute query to ensure that it works
@@ -293,13 +294,11 @@ def test_multiple_extensions_one_archive(
             )
             log.info(cur.fetchall())
 
-    # remove postgis files locally
     cleanup(pg_version)
 
 
 # TODO: this complex example reveals a possible "inneficiency":
 # both calls will download the extension
-
 # proposed solution:
 # A: don't worry about it
 # B:
@@ -307,9 +306,4 @@ def test_multiple_extensions_one_archive(
 # this request sets download_completed = true if it succeeds
 # subsequent requests hang and repeatedly check download_completed until it gets set or until they timeout
 # 3 seconds afterthe started_download = true was set some thread checks if download_completed was set. if not, then it sets started_download back to false
-
-
 # TODO later: investigate download timeouts
-# Test extension downloading with mutliple connections to an endpoint.
-# this test only supports real s3 becuase postgis is too large an extension to
-# put in our github repo

--- a/test_runner/regress/test_download_extensions.py
+++ b/test_runner/regress/test_download_extensions.py
@@ -196,65 +196,6 @@ def test_remote_library(
         cleanup(pg_version)
 
 
-# Test extension downloading with mutliple connections to an endpoint.
-# this test only supports real s3 becuase postgis is too large an extension to
-# put in our github repo
-def test_extension_download_after_restart(
-    neon_env_builder: NeonEnvBuilder,
-    pg_version: PgVersion,
-):
-    if "15" in pg_version:  # SKIP v15 for now because I only built the extension for v14
-        return None
-
-    neon_env_builder.enable_remote_storage(
-        remote_storage_kind=RemoteStorageKind.MOCK_S3,
-        test_name="test_extension_download_after_restart",
-        enable_remote_extensions=True,
-    )
-    neon_env_builder.num_safekeepers = 3
-    env = neon_env_builder.init_start()
-    tenant_id, _ = env.neon_cli.create_tenant()
-    env.neon_cli.create_timeline("test_extension_download_after_restart", tenant_id=tenant_id)
-
-    assert env.ext_remote_storage is not None  # satisfy mypy
-    assert env.remote_storage_client is not None  # satisfy mypy
-
-    # For MOCK_S3 we upload test files.
-    upload_files(env)
-
-    endpoint = env.endpoints.create_start(
-        "test_extension_download_after_restart",
-        tenant_id=tenant_id,
-        remote_ext_config=env.ext_remote_storage.to_string(),
-        config_lines=["log_min_messages=debug3"],
-    )
-    with closing(endpoint.connect()) as conn:
-        with conn.cursor() as cur:
-            cur.execute("CREATE extension pg_buffercache;")
-            cur.execute("SELECT * from pg_buffercache;")
-            log.info(cur.fetchall())
-
-    # the endpoint is closed now
-    endpoint.stop()
-    # remove postgis files locally
-    cleanup(pg_version)
-
-    # spin up compute node again (there are no postgis files available, because compute is stateless)
-    endpoint = env.endpoints.create_start(
-        "test_extension_download_after_restart",
-        tenant_id=tenant_id,
-        remote_ext_config=env.ext_remote_storage.to_string(),
-        config_lines=["log_min_messages=debug3"],
-    )
-    # connect to postrgres and execute the query again
-    with closing(endpoint.connect()) as conn:
-        with conn.cursor() as cur:
-            cur.execute("SELECT * from pg_buffercache;")
-            log.info(cur.fetchall())
-
-    cleanup(pg_version)
-
-
 # here we test a complex extension
 def test_multiple_extensions_one_archive(
     neon_env_builder: NeonEnvBuilder,
@@ -296,7 +237,13 @@ def test_multiple_extensions_one_archive(
     cleanup(pg_version)
 
 
-def test_extension_download_parallel_requests(
+# Test that extension is downloaded after endpoint restart,
+# when the library is used in the query.
+#
+# Run the test with mutliple simultaneous connections to an endpoint.
+# to ensure that the extension is downloaded only once.
+#
+def test_extension_download_after_restart(
     neon_env_builder: NeonEnvBuilder,
     pg_version: PgVersion,
 ):
@@ -305,13 +252,13 @@ def test_extension_download_parallel_requests(
 
     neon_env_builder.enable_remote_storage(
         remote_storage_kind=RemoteStorageKind.MOCK_S3,
-        test_name="test_extension_download_parallel_requests",
+        test_name="test_extension_download_after_restart",
         enable_remote_extensions=True,
     )
     neon_env_builder.num_safekeepers = 3
     env = neon_env_builder.init_start()
     tenant_id, _ = env.neon_cli.create_tenant()
-    env.neon_cli.create_timeline("test_extension_download_parallel_requests", tenant_id=tenant_id)
+    env.neon_cli.create_timeline("test_extension_download_after_restart", tenant_id=tenant_id)
 
     assert env.ext_remote_storage is not None  # satisfy mypy
     assert env.remote_storage_client is not None  # satisfy mypy
@@ -320,7 +267,7 @@ def test_extension_download_parallel_requests(
     upload_files(env)
 
     endpoint = env.endpoints.create_start(
-        "test_extension_download_parallel_requests",
+        "test_extension_download_after_restart",
         tenant_id=tenant_id,
         remote_ext_config=env.ext_remote_storage.to_string(),
         config_lines=["log_min_messages=debug3"],
@@ -329,25 +276,27 @@ def test_extension_download_parallel_requests(
         with conn.cursor() as cur:
             cur.execute("CREATE extension pg_buffercache;")
             cur.execute("SELECT * from pg_buffercache;")
-            log.info(cur.fetchall())
+            res = cur.fetchall()
+            assert len(res) > 0
+            log.info(res)
 
-    # the endpoint is closed now
+    # shutdown compute node
     endpoint.stop()
-    # remove postgis files locally
+    # remove extension files locally
     cleanup(pg_version)
 
-    # spin up compute node again (there are no postgis files available, because compute is stateless)
+    # spin up compute node again (there are no extension files available, because compute is stateless)
     endpoint = env.endpoints.create_start(
-        "test_extension_download_parallel_requests",
+        "test_extension_download_after_restart",
         tenant_id=tenant_id,
         remote_ext_config=env.ext_remote_storage.to_string(),
         config_lines=["log_min_messages=debug3"],
     )
 
+    # connect to conpute node and run the query
+    # that will trigger the download of the extension
     def run_query(endpoint, thread_id: int):
         log.info("thread_id {%d} starting", thread_id)
-        # connect to postrgres and run the query
-        # that will trigger the download of the extension
         with closing(endpoint.connect()) as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT * from pg_buffercache;")
@@ -355,7 +304,7 @@ def test_extension_download_parallel_requests(
                 assert len(res) > 0
                 log.info("thread_id {%d}, res = %s", thread_id, res)
 
-    threads = [threading.Thread(target=run_query, args=(endpoint, i)) for i in range(5)]
+    threads = [threading.Thread(target=run_query, args=(endpoint, i)) for i in range(2)]
 
     for thread in threads:
         thread.start()


### PR DESCRIPTION
# Problem
- timed out downloads
- shouldn't download the same archive multiple times
# Solution:

```
if archive has already completed downloading:
	return Ok
else if another thread started downloading the archive recently:
	hang until the other thread completes
else:
	download the extension as normal
	if successful, mark extension as successfully downloaded
```