### PR TITLE
pagekeeper: suppress error logs in shutdown/detach

### DIFF
--- a/pageserver/src/tenant/tasks.rs
+++ b/pageserver/src/tenant/tasks.rs
@@ -103,6 +103,11 @@ async fn compaction_loop(tenant: Arc<Tenant>, cancel: CancellationToken) {
                 }
             }
 
+            if cancel.is_cancelled() {
+                info!("received cancellation request");
+                break;
+            }
+
             let started_at = Instant::now();
 
             let sleep_duration = if period == Duration::ZERO {


### PR DESCRIPTION
## Problem

Error messages like this coming up during normal operations:
```
        Compaction failed, retrying in 2s: timeline is Stopping

       Compaction failed, retrying in 2s: Cannot run compaction iteration on inactive tenant
```


## Summary of changes

Add explicit handling for the shutdown case in these locations, to suppress error logs.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [x] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
