### PR TITLE
Allow $ as password hack separator

### DIFF
--- a/proxy/src/auth/password_hack.rs
+++ b/proxy/src/auth/password_hack.rs
@@ -13,7 +13,7 @@ pub struct PasswordHackPayload {
 impl PasswordHackPayload {
     pub fn parse(bytes: &[u8]) -> Option<Self> {
         // The format is `project=<utf-8>;<password-bytes>`.
-        let mut iter = bytes.splitn_str(2, [';', '$']);
+        let mut iter = bytes.splitn_str(2, &[';', '$']);
         let endpoint = iter.next()?.to_str().ok()?;
         let endpoint = parse_endpoint_param(endpoint)?.to_owned();
         let password = iter.next()?.to_owned();


### PR DESCRIPTION
## Problem
AWS DMS service doesn't support SNI and forbid `: ;+%` symbols in password.

## Summary of changes
Allow `$` as alternative endpoint and password separator character in password hack.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
