### PR TITLE
Remote Extensions postgres16

### DIFF
--- a/compute_tools/src/extension_server.rs
+++ b/compute_tools/src/extension_server.rs
@@ -113,6 +113,8 @@ pub fn get_pg_version(pgbin: &str) -> String {
         return "v15".to_string();
     } else if human_version.contains("14") {
         return "v14".to_string();
+    } else if human_version.contains("16") {
+        return "v16".to_string();
     }
     panic!("Unsuported postgres version {human_version}");
 }


### PR DESCRIPTION
## Problem
@MMeent is working on enabling postgresv16: https://github.com/neondatabase/neon/pull/4761
Some changes might be necessary to make remote extensions compatible with pg16. 
This PR makes those changes. 
## Summary of changes
- TODO