### PR TITLE
Measure compute-pageserver latency

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -302,7 +302,7 @@ impl ComputeNode {
         // Connect to pageserver
         let mut client = config.connect(NoTls)?;
         let pageserver_connect_micros =
-            Instant::now().duration_since(start_time).as_micros() as u64;
+           start_time.elapsed().as_micros() as u64;
 
         let basebackup_cmd = match lsn {
             // HACK We don't use compression on first start (Lsn(0)) because there's no API for it

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -300,11 +300,11 @@ impl ComputeNode {
 
         // Connect to pageserver
         let mut client = config.connect(NoTls)?;
-        let pageserver_connect_ms = Utc::now()
+        let pageserver_connect_micros = Utc::now()
             .signed_duration_since(start_time)
             .to_std()
             .unwrap()
-            .as_millis() as u64;
+            .as_micros() as u64;
 
         let basebackup_cmd = match lsn {
             // HACK We don't use compression on first start (Lsn(0)) because there's no API for it
@@ -352,7 +352,7 @@ impl ComputeNode {
 
         // Report metrics
         let mut state = self.state.lock().unwrap();
-        state.metrics.pageserver_connect_ms = pageserver_connect_ms;
+        state.metrics.pageserver_connect_micros = pageserver_connect_micros;
         state.metrics.basebackup_bytes = measured_reader.get_byte_count() as u64;
         state.metrics.basebackup_ms = Utc::now()
             .signed_duration_since(start_time)

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -301,8 +301,7 @@ impl ComputeNode {
 
         // Connect to pageserver
         let mut client = config.connect(NoTls)?;
-        let pageserver_connect_micros =
-           start_time.elapsed().as_micros() as u64;
+        let pageserver_connect_micros = start_time.elapsed().as_micros() as u64;
 
         let basebackup_cmd = match lsn {
             // HACK We don't use compression on first start (Lsn(0)) because there's no API for it

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::sync::{Condvar, Mutex, OnceLock, RwLock};
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -285,7 +286,7 @@ impl ComputeNode {
     #[instrument(skip_all, fields(%lsn))]
     fn get_basebackup(&self, compute_state: &ComputeState, lsn: Lsn) -> Result<()> {
         let spec = compute_state.pspec.as_ref().expect("spec must be set");
-        let start_time = Utc::now();
+        let start_time = Instant::now();
 
         let mut config = postgres::Config::from_str(&spec.pageserver_connstr)?;
 
@@ -300,11 +301,8 @@ impl ComputeNode {
 
         // Connect to pageserver
         let mut client = config.connect(NoTls)?;
-        let pageserver_connect_micros = Utc::now()
-            .signed_duration_since(start_time)
-            .to_std()
-            .unwrap()
-            .as_micros() as u64;
+        let pageserver_connect_micros =
+            Instant::now().duration_since(start_time).as_micros() as u64;
 
         let basebackup_cmd = match lsn {
             // HACK We don't use compression on first start (Lsn(0)) because there's no API for it
@@ -354,11 +352,7 @@ impl ComputeNode {
         let mut state = self.state.lock().unwrap();
         state.metrics.pageserver_connect_micros = pageserver_connect_micros;
         state.metrics.basebackup_bytes = measured_reader.get_byte_count() as u64;
-        state.metrics.basebackup_ms = Utc::now()
-            .signed_duration_since(start_time)
-            .to_std()
-            .unwrap()
-            .as_millis() as u64;
+        state.metrics.basebackup_ms = Instant::now().duration_since(start_time).as_millis() as u64;
         Ok(())
     }
 

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -352,7 +352,7 @@ impl ComputeNode {
         let mut state = self.state.lock().unwrap();
         state.metrics.pageserver_connect_micros = pageserver_connect_micros;
         state.metrics.basebackup_bytes = measured_reader.get_byte_count() as u64;
-        state.metrics.basebackup_ms = Instant::now().duration_since(start_time).as_millis() as u64;
+        state.metrics.basebackup_ms = start_time.elapsed().as_millis() as u64;
         Ok(())
     }
 

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -68,13 +68,40 @@ where
 /// Response of the /metrics.json API
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct ComputeMetrics {
+    /// Time spent waiting in pool
     pub wait_for_spec_ms: u64,
-    pub sync_safekeepers_ms: u64,
+
+    /// Time spent checking if safekeepers are synced
     pub sync_sk_check_ms: u64,
+
+    /// Time spent syncing safekeepers (walproposer.c).
+    /// In most cases this should be zero.
+    pub sync_safekeepers_ms: u64,
+
+    /// Time it took to establish a pg connection to the pageserver.
+    /// This is two roundtrips, so it's a good proxy for compute-pageserver
+    /// latency. The latency is usually 0.2ms, but it's not safe to assume
+    /// that.
+    pub pageserver_connect_ms: u64,
+
+    /// Time to get basebackup from pageserver and write it to disk.
     pub basebackup_ms: u64,
+
+    /// Compressed size of basebackup received.
     pub basebackup_bytes: u64,
+
+    /// Time spent starting potgres. This includes initialization of shared
+    /// buffers, preloading extensions, and other pg operations.
     pub start_postgres_ms: u64,
+
+    /// Time spent applying pg catalog updates that were made in the console
+    /// UI. This should be 0 when startup time matters, since cplane tries
+    /// to do these updates eagerly, and passes the skip_pg_catalog_updates
+    /// when it's safe to skip this step.
     pub config_ms: u64,
+
+    /// Total time, from when we receive the spec to when we're ready to take
+    /// pg connections.
     pub total_startup_ms: u64,
     pub load_ext_ms: u64,
     pub num_ext_downloaded: u64,

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -82,7 +82,7 @@ pub struct ComputeMetrics {
     /// This is two roundtrips, so it's a good proxy for compute-pageserver
     /// latency. The latency is usually 0.2ms, but it's not safe to assume
     /// that.
-    pub pageserver_connect_ms: u64,
+    pub pageserver_connect_micros: u64,
 
     /// Time to get basebackup from pageserver and write it to disk.
     pub basebackup_ms: u64,


### PR DESCRIPTION
Latency should be 0.2 but sometimes compute and ps are not in the same AZ and that can cause perf problems that we waste time debugging elsewhere.

Adding metrics to this json is not expensive. They get sent to cplane but are not processed by default. But they also go in structured logs and can be queried easily.