### PR TITLE
test: make pg_regress less flaky, hopefully

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2819,6 +2819,13 @@ def check_restored_datadir_content(
     # Get the timeline ID. We need it for the 'basebackup' command
     timeline = TimelineId(endpoint.safe_psql("SHOW neon.timeline_id")[0][0])
 
+    # flush xlogs just in case
+    # hopefully fixes https://github.com/neondatabase/neon/issues/559
+    with closing(endpoint.connect()) as conn:
+        with conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION neon_test_utils;")
+            cur.execute("SELECT neon_xlogflush('0/FFFFFF'::pg_lsn);")
+
     # stop postgres to ensure that files won't change
     endpoint.stop()
 

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -69,7 +69,6 @@ def test_pg_regress(
         check_restored_datadir_content(test_output_dir, env, endpoint)
 
 
-"""
 # Run the PostgreSQL "isolation" tests, in src/test/isolation.
 #
 def test_isolation(
@@ -179,4 +178,3 @@ def test_sql_regress(
 
         # Check that we restore the content of the datadir correctly
         check_restored_datadir_content(test_output_dir, env, endpoint)
-"""

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -3,7 +3,6 @@
 #
 from pathlib import Path
 
-from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, check_restored_datadir_content
 
 
@@ -34,11 +33,6 @@ def test_pg_regress(
     bindir = pg_distrib_dir / f"v{env.pg_version}/bin"
     schedule = src_path / "parallel_schedule"
     pg_regress = build_path / "pg_regress"
-
-    with open(schedule, "r") as f:
-        # note: I suspect you have to recompile to apply the schedule?
-        log.info(f"Here is the test schedule {schedule}:")
-        log.info(f.read())
 
     pg_regress_command = [
         str(pg_regress),

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -56,10 +56,6 @@ def test_pg_regress(
     with capsys.disabled():
         pg_bin.run(pg_regress_command, env=env_vars, cwd=runpath)
 
-        # checkpoint one more time to ensure that the lsn we get is the latest one
-        endpoint.safe_psql("CHECKPOINT")
-
-        # Check that we restore the content of the datadir correctly
         check_restored_datadir_content(test_output_dir, env, endpoint)
 
 
@@ -166,9 +162,4 @@ def test_sql_regress(
     with capsys.disabled():
         pg_bin.run(pg_regress_command, env=env_vars, cwd=runpath)
 
-        # checkpoint one more time to ensure that the lsn we get is the latest one
-        endpoint.safe_psql("CHECKPOINT")
-        endpoint.safe_psql("select pg_current_wal_insert_lsn()")[0][0]
-
-        # Check that we restore the content of the datadir correctly
         check_restored_datadir_content(test_output_dir, env, endpoint)

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -69,6 +69,7 @@ def test_pg_regress(
         check_restored_datadir_content(test_output_dir, env, endpoint)
 
 
+"""
 # Run the PostgreSQL "isolation" tests, in src/test/isolation.
 #
 def test_isolation(
@@ -178,3 +179,4 @@ def test_sql_regress(
 
         # Check that we restore the content of the datadir correctly
         check_restored_datadir_content(test_output_dir, env, endpoint)
+"""

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -3,6 +3,7 @@
 #
 from pathlib import Path
 
+from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, check_restored_datadir_content
 
 
@@ -33,6 +34,11 @@ def test_pg_regress(
     bindir = pg_distrib_dir / f"v{env.pg_version}/bin"
     schedule = src_path / "parallel_schedule"
     pg_regress = build_path / "pg_regress"
+
+    with open(schedule, "r") as f:
+        # note: I suspect you have to recompile to apply the schedule?
+        log.info(f"Here is the test schedule {schedule}:")
+        log.info(f.read())
 
     pg_regress_command = [
         str(pg_regress),

--- a/test_runner/regress/test_subxacts.py
+++ b/test_runner/regress/test_subxacts.py
@@ -33,8 +33,4 @@ def test_subxacts(neon_simple_env: NeonEnv, test_output_dir):
             cur.execute(f"insert into t1 values ({i}, {j})")
         cur.execute("commit")
 
-    # force wal flush
-    cur.execute("checkpoint")
-
-    # Check that we can restore the content of the datadir correctly
     check_restored_datadir_content(test_output_dir, env, endpoint)


### PR DESCRIPTION
`pg_regress` is flaky: https://github.com/neondatabase/neon/issues/559

Consolidated `CHECKPOINT` to `check_restored_datadir_content`, add a wait for `wait_for_last_flush_lsn`.

Some recently introduced flakyness was fixed with #4948.