### PR TITLE
use read lock for compaction

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3780,7 +3780,7 @@ impl Timeline {
                 .context("wait for layer upload ops to complete")?;
         }
 
-        let mut guard = self.layers.modify().await;
+        let guard = self.layers.modify().await;
         let mut new_layer_paths = HashMap::with_capacity(new_layers.len());
 
         // In some rare cases, we may generate a file with exactly the same key range / LSN as before the compaction.

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -224,6 +224,11 @@ impl LayerManagerWriteGuard {
         on_disk_layers: Vec<Arc<dyn PersistentLayer>>,
         next_open_layer_at: Lsn,
     ) {
+        assert!(
+            self.pseudo_lock.is_left(),
+            "should use `write` guard for this function."
+        );
+
         self.layer_manager
             .initialize_update(|mut layer_map| {
                 let mut updates = layer_map.batch_update();
@@ -252,6 +257,11 @@ impl LayerManagerWriteGuard {
         corrupted_local_layers: Vec<Arc<dyn PersistentLayer>>,
         remote_layers: Vec<Arc<RemoteLayer>>,
     ) {
+        assert!(
+            self.pseudo_lock.is_left(),
+            "should use `write` guard for this function."
+        );
+
         self.layer_manager
             .initialize_update(|mut layer_map| {
                 let mut updates = layer_map.batch_update();
@@ -278,6 +288,11 @@ impl LayerManagerWriteGuard {
         timeline_id: TimelineId,
         tenant_id: TenantId,
     ) -> Result<Arc<InMemoryLayer>> {
+        assert!(
+            self.pseudo_lock.is_left(),
+            "should use `write` guard for this function."
+        );
+
         ensure!(lsn.is_aligned());
 
         ensure!(
@@ -334,6 +349,11 @@ impl LayerManagerWriteGuard {
         Lsn(last_record_lsn): Lsn,
         last_freeze_at: &AtomicLsn,
     ) {
+        assert!(
+            self.pseudo_lock.is_left(),
+            "should use `write` guard for this function."
+        );
+
         let end_lsn = Lsn(last_record_lsn + 1);
 
         if let Some(open_layer) = &self.snapshot.layer_map.open_layer {
@@ -359,6 +379,10 @@ impl LayerManagerWriteGuard {
 
     /// Add image layers to the layer map, called from `create_image_layers`.
     pub(crate) async fn track_new_image_layers(&mut self, image_layers: Vec<ImageLayer>) {
+        assert!(
+            self.pseudo_lock.is_left(),
+            "should use `write` guard for this function."
+        );
         self.layer_manager
             .update(|mut layer_map| {
                 let mut updates: BatchedUpdates<'_> = layer_map.batch_update();
@@ -382,6 +406,10 @@ impl LayerManagerWriteGuard {
         delta_layer: Option<DeltaLayer>,
         frozen_layer_for_check: &Arc<InMemoryLayer>,
     ) {
+        assert!(
+            self.pseudo_lock.is_left(),
+            "should use `write` guard for this function."
+        );
         self.layer_manager
             .update(|mut layer_map| {
                 let l = layer_map.frozen_layers.pop_front();
@@ -414,6 +442,10 @@ impl LayerManagerWriteGuard {
         compact_to: Vec<Arc<dyn PersistentLayer>>,
         metrics: &TimelineMetrics,
     ) -> Result<()> {
+        assert!(
+            self.pseudo_lock.is_right(),
+            "should use `modify` guard for this function."
+        );
         let compact_from = self
             .layer_manager
             .update(|mut layer_map| {
@@ -459,6 +491,10 @@ impl LayerManagerWriteGuard {
         gc_layers: Vec<Arc<dyn PersistentLayer>>,
         metrics: &TimelineMetrics,
     ) -> Result<()> {
+        assert!(
+            self.pseudo_lock.is_left(),
+            "should use `write` guard for this function."
+        );
         self.layer_manager
             .update(|mut layer_map| {
                 let mut updates = layer_map.batch_update();


### PR DESCRIPTION
## Problem

Based on the immutable storage state refactor, this is the first optimization we can do.

ref https://github.com/neondatabase/neon/pull/4766 https://github.com/neondatabase/neon/issues/4754

## Summary of changes

We do not actually need to hold the write lock when removing the file. As long as no thread will be able to read the layer file from the layer map, we can safely remove it without taking any locks. This is done by (1) having a lock that protects that, currently `pseudo_lock` (2) ensure all read threads are taking the read lock (3) if we want to ensure all threads use the new version of the layer map, try acquire the write lock, and if it succeeds, all read threads are blocked and will switch to the new version.

An optimal solution would be using watermark to track lowest use version when dropping the layer object, but it's still too far so we go with this simple approach for now.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
