### PR TITLE
Remove wal from basebackup

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -10,7 +10,7 @@
 //! This module is responsible for creation of such tarball
 //! from data stored in object storage.
 //!
-use anyhow::{anyhow, bail, ensure, Context};
+use anyhow::{bail, ensure, Context};
 use bytes::{BufMut, BytesMut};
 use fail::fail_point;
 use std::fmt::Write as FmtWrite;
@@ -29,9 +29,7 @@ use postgres_ffi::pg_constants::{DEFAULTTABLESPACE_OID, GLOBALTABLESPACE_OID};
 use postgres_ffi::pg_constants::{PGDATA_SPECIAL_FILES, PGDATA_SUBDIRS, PG_HBA};
 use postgres_ffi::relfile_utils::{INIT_FORKNUM, MAIN_FORKNUM};
 use postgres_ffi::TransactionId;
-use postgres_ffi::XLogFileName;
-use postgres_ffi::PG_TLI;
-use postgres_ffi::{BLCKSZ, RELSEG_SIZE, WAL_SEGMENT_SIZE};
+use postgres_ffi::{BLCKSZ, RELSEG_SIZE};
 use utils::lsn::Lsn;
 
 /// Create basebackup with non-rel data in it.
@@ -440,7 +438,7 @@ where
             .await
             .context("failed get control bytes")?;
 
-        let (pg_control_bytes, system_identifier) = postgres_ffi::generate_pg_control(
+        let (pg_control_bytes, _system_identifier) = postgres_ffi::generate_pg_control(
             &pg_control_bytes,
             &checkpoint_bytes,
             self.lsn,
@@ -450,6 +448,7 @@ where
         //send pg_control
         let header = new_tar_header("global/pg_control", pg_control_bytes.len() as u64)?;
         self.ar.append(&header, &pg_control_bytes[..]).await?;
+
         Ok(())
     }
 }

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -450,22 +450,6 @@ where
         //send pg_control
         let header = new_tar_header("global/pg_control", pg_control_bytes.len() as u64)?;
         self.ar.append(&header, &pg_control_bytes[..]).await?;
-
-        //send wal segment
-        let segno = self.lsn.segment_number(WAL_SEGMENT_SIZE);
-        let wal_file_name = XLogFileName(PG_TLI, segno, WAL_SEGMENT_SIZE);
-        let wal_file_path = format!("pg_wal/{}", wal_file_name);
-        let header = new_tar_header(&wal_file_path, WAL_SEGMENT_SIZE as u64)?;
-
-        let wal_seg = postgres_ffi::generate_wal_segment(
-            segno,
-            system_identifier,
-            self.timeline.pg_version,
-            self.lsn,
-        )
-        .map_err(|e| anyhow!(e).context("Failed generating wal segment"))?;
-        ensure!(wal_seg.len() == WAL_SEGMENT_SIZE);
-        self.ar.append(&header, &wal_seg[..]).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Speed up basebackup from 30ms to 8ms (on laptop, 0.5ms emulated latency) by not sending wal. Since our p50 startup time in us-east-2 is 100ms, 20ms is quite significant!

Why it's faster: The wal is 16MB, and even though it compresses to nothing, it takes time to compress and takes time to write to disk at the compute node. The effect on p90 and p99 startup times should be much bigger than 20ms.

BUT: Even though basebackup time improves, total time doesn't improve that much because postgres later creates this file anyway. I think we should debug this and remove the postgres code that writes this WAL.

Are there any **correctness** issues with not sending the wal? cc @knizhnik

If this is correct as is, I propose we release the change as is to see if there's any improvement. Yes, the file still ends up on disk, so postgres startup time might increase, but there would be no compression on the pageserver side and that could speed things up (currently basebackup time depends on pageserver, and can go up to 200ms!).

If it's not correct (maybe there are a few bytes of useful data in this empty wal), then let's find an alternative way to send this data without writing 16MB.