### PR TITLE
Speed up compute shutdown

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -294,6 +294,14 @@ fn main() -> Result<()> {
         info!("synced safekeepers at lsn {lsn}");
     }
 
+    // Change status to GracefulShutdown
+    {
+        let mut state = compute.state.lock().unwrap();
+        if matches!(state.status, ComputeStatus::Running) {
+            state.status = ComputeStatus::GracefulShutdown;
+        }
+    }
+
     if let Err(err) = compute.check_for_core_dumps() {
         error!("error while checking for core dumps: {err:?}");
     }

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -568,6 +568,7 @@ impl Endpoint {
                         }
                         ComputeStatus::Empty
                         | ComputeStatus::ConfigurationPending
+                        | ComputeStatus::GracefulShutdown
                         | ComputeStatus::Configuration => {
                             bail!("unexpected compute status: {:?}", state.status)
                         }

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -52,6 +52,10 @@ pub enum ComputeStatus {
     // compute will exit soon or is waiting for
     // control-plane to terminate it.
     Failed,
+    // Wrapping up without blocking the next compute
+    // start, which might be scheduled on a different
+    // compute node
+    GracefulShutdown,
 }
 
 fn rfc3339_serialize<S>(x: &Option<DateTime<Utc>>, s: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
The compute shutdown operation takes multiple seconds.

This is not a big deal, and not a priority compared to other things, but nice to fix because:
- if we start during shutdown, that start will be delayed. It's rare, but not nice
- people wonder why startup takes 200ms but shutdown 4s. Easier to fix than explain

The solution is to declare shutdown successful earlier and let the compute node upload traces (or whatever else it needs to do) without blocking starts.

I'm leaving this PR in draft state because it adds a new compute status variant that cplane wouldn't recognize. So if this is the approach we go with we should start with a cplane PR (no rush)
