### PR TITLE
Sort by (key, lsn), not just key

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3534,7 +3534,7 @@ impl Timeline {
         }
         // The current stdlib sorting implementation is designed in a way where it is
         // particularly fast where the slice is made up of sorted sub-ranges.
-        all_value_refs.sort_by_key(|(key, _lsn, _value_ref)| *key);
+        all_value_refs.sort_by_key(|(key, lsn, _value_ref)| (*key, *lsn));
 
         let mut all_keys = Vec::new();
         for l in deltas_to_compact.iter() {
@@ -3550,7 +3550,7 @@ impl Timeline {
         }
         // The current stdlib sorting implementation is designed in a way where it is
         // particularly fast where the slice is made up of sorted sub-ranges.
-        all_keys.sort_by_key(|(key, _lsn, _size)| *key);
+        all_keys.sort_by_key(|(key, lsn, _size)| (*key, *lsn));
 
         for (next_key, _next_lsn, _size) in all_keys.iter() {
             let next_key = *next_key;


### PR DESCRIPTION
## Problem

PR #4839 didn't output the keys/values in lsn order, but for a given key, the lsns were kept in incoming file order.

I think the ordering by lsn is expected.

## Summary of changes

We now also sort by `(key, lsn)`, like we did before #4839.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
