### PR TITLE
docs: add RFC for remote storage generation numbers

### DIFF
--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -636,7 +636,7 @@ unresponsive node might be network partitioned and still writing to S3.
    after the new attachment was created do not matter from the rest of the system's
    perspective: the endpoints are reading from the new attachment location. Objects
    written by node 0 are just garbage that can be cleaned up at leisure. Node 0 will
-   not do any deletions because it can't synchronize with control plane.
+   not do any deletions because it can't synchronize with control plane, or if it could, it would be informed that is no longer the most recent generation and hence not do the garbage collection.
 
 Eventually, node 0 will somehow realize it should stop running by some means, although
 this is not necessary for correctness:

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -526,7 +526,7 @@ the S3 capacity cost.
 Item 3. is an issue if safekeepers are low on disk space and the control plane is unavailable for a long time.
 
 For a managed service, the general approach should be to make sure we are monitoring & respond fast enough
-that control plane outages are bounded in time. The separate of console and control plane will also help
+that control plane outages are bounded in time. The separation of console and control plane will also help
 to keep the control plane itself simple and robust.
 
 We should also implement an "escape hatch" config for node generation numbers, where in a major disaster outage,

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -622,7 +622,9 @@ Item 1. would mean that some in-place restarts that previously would have resume
 unavailable, will now not resume service to users until the control plane is available. We could
 avoid this by having a timeout on communication with the control plane, and after some timeout,
 resume service with the node's previous generation (assuming this was persisted to disk). However,
-this is unlikely to be needed as the control plane is already an essential & highly available component.
+this is unlikely to be needed as the control plane is already an essential & highly available component. Also, having a node re-use an old generation number would complicate
+reasoning about the system, as it would break the invariant that one (node_id, generation)
+tuple uniquely identifies one process lifetime -- it is not recommended to implement this.
 
 Item 2. is a non-issue operationally: it's harmless to delay deletions, the only impact of objects pending deletion is
 the S3 capacity cost.

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -388,10 +388,10 @@ generation minus 1. However, this might not be the case: the previous
 node might have started and acquired a generation number, and then crashed
 before writing out a remote index.
 
-In the general case and as a fallback, the pageserver may list all the index*part.json
-files for a timeline, sort them by generation suffix, and pick the highest that is <=
-the suffix for its current generation numbers. The tenant should never load an index
-with an attachment generation \_newer* than its own: tenants
+In the general case and as a fallback, the pageserver may list all the `index_part.json`
+files for a timeline, sort them by generation, and pick the highest that is `<=`
+its current generation for this attachment. The tenant should never load an index
+with an attachment generation _newer_ than its own: tenants
 are allowed to be attached with stale attachment generations during a multiply-attached
 phase in a migration, and in this instance if the old location's pageserver restarts,
 it should not try and load the newer generation's index.

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -126,8 +126,6 @@ split-brain issues in storage:
   while attaching the second one.
 - If there are multiple pageservers running with the same node ID, they are guaranteed to have different generation numbers, because the generation would increment
   when the second node started and re-attached its tenants.
-- If there are multiple pageservers running with the same node ID, we may unambiguously know which
-  of them "wins" by picking the higher generation number.
 
 As long as the infrastructure does not transparently replace an underlying
 physical machine, we are totally safe. See the later [unsafe case](#unsafe-case-on-badly-behaved-infrastructure) section for details.

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -451,6 +451,17 @@ time we use it)
 - Client behavior: clients must not do deletions within a tenant's remote data until they have
   received a response indicating the generation they hold for the tenant is current.
 
+#### Use of `/load` and `/ignore` APIs
+
+Because the pageserver will be changed to only attach tenants on startup
+based on the control plane's response to a `/re-attach` request, the load/ignore
+APIs no longer make sense in their current form.
+
+The `/load` API becomes functionally equivalent to attach, and will be removed:
+any location that used `/load` before should just attach instead.
+
+The `/ignore` API is equivalent to detaching, but without deleting local files.
+
 ### Timeline/Branch creation
 
 All of the previous arguments for safety have described operations within

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -112,7 +112,7 @@ integers with a global guarantee that they will not be re-used:
 This provides some important invariants:
 
 - If there are multiple pageservers running with the same node ID, they are guaranteed to have
-  a different generation ID.
+  a different generation number.
 - If there are multiple pageservers running with the same node ID, we may unambiguously know which
   of them "wins" by picking the higher generation number.
 - If two pageservers have the same tenant attached, they are guaranteed to have different attachment

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -94,7 +94,7 @@ pageserver, control plane, safekeeper (optional)
 - **Safety for multiply-attached tenants** is provided by the
   tenant attach generation in the object key: the competing pageservers will not
   try to write to the same keys.
-- **Safety for deletions** is provided by pageservers calling out to the control plane to validate that the node & attachment generation numbers have not changed since we last updated a timeline's index.
+- **Safety for deletions** is provided by pageservers validating with control plane that neither pageserver process nor the attachment has been superseded since it last updated a timeline's index.
 - **The control plane is used to issue generation numbers** to avoid the need for
   a built-in consensus system in the pageserver, although this could in principle
   be changed without changing the storage format.

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -25,7 +25,7 @@ the unresponsive pageserver is still writing to S3.
 
 - 020-pageserver-s3-coordination.md
 - 023-the-state-of-pageserver-tenant-relocation.md
-- https://www.notion.so/neondatabase/Proposal-Pageserver-MVCC-S3-Storage-8a424c0c7ec5459e89d3e3f00e87657c
+- 026-pageserver-s3-mvcc.md
 
 This RFC has broad similarities to the proposal to implement a MVCC scheme in
 S3 object names, but this RFC avoids a general purpose transaction scheme in

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -106,7 +106,7 @@ pageserver, control plane, safekeeper (optional)
 - **Safety in split brain for multiple nodes running with
   the same node ID** is provided by the pageserver calling out to the control plane
   on startup, to increment the generations of any attached tenants
-- **Safety for deletions** is provided by pageservers validating with control plane that neither pageserver process nor the attachment has been superseded since it last updated a timeline's index.
+- **Safety for deletions** is achieved by deferring the DELETE from S3 to a point in time where the deleting node has validated with control plane that no attachment with a higher generation has a reference to the to-be-DELETEd key.
 - **The control plane is used to issue generation numbers** to avoid the need for
   a built-in consensus system in the pageserver, although this could in principle
   be changed without changing the storage format.

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -189,7 +189,7 @@ object key changes given above_
 
 Pageservers can of course list objects in S3 at any time, but in practice their
 visible set is based on the contents of their LayerMap, which is initialized
-from the `index_part.json` that they load.
+from the `index_part.json.???` that they load.
 
 Starting with the `index_part` from the most recent previous generation
 (see [loading index_part](#finding-the-remote-indices-for-timelines)), a pageserver

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -240,7 +240,7 @@ for the lengths being sufficient are:
   a 5 year system lifetime (in practice generation increments are expected to be far rarer,
   perhaps of the order of 1 per day if we are dynamically balancing load)
 - 16 bit node ID is enough for 35 new pageservers to be deployed every day over a 5 year
-  system lifetime. In practice the frequency is likely to be more like 1 per week, and
+  system lifetime. In practice the frequency is likely to be more like 1 per week.
 
 #### Index changes
 
@@ -275,7 +275,6 @@ that deletions strictly obey the following ordering:
    of it; not an earlier one. In both cases, the `index_part.json` doesn't reference the
    key we are deleting anymore, so, the key is invisible to any later attachment / node generation.
    Hence it's safe to delete it.
-
 
 Note that at step 2 we are only confirming that deletions of objects _no longer referenced
 by the specific `index_part.json` written in step 1_ are safe. If we were attempting other deletions concurrently,

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -104,8 +104,8 @@ pageserver, control plane, safekeeper (optional)
 Two logical entities will get new "generation numbers", which are monotonically increasing
 integers with a global guarantee that they will not be re-used:
 
-- Pageservers: a node generation ID is acquired at startup and lasts until the process ends or another
-  process with the same node ID starts.
+- Pageserver processes: for a given pageserver node ID, each time a pageserver process starts,
+  the per-node-ID generation number increases.
 - Tenant attachments: for a given tenant, each time its attachment is changed, a per-tenant generation
   number increases.
 

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -177,7 +177,7 @@ from the `index_part.json.???` that they load.
 
 Starting with the `index_part` from the most recent previous generation
 (see [loading index_part](#finding-the-remote-indices-for-timelines)), a pageserver
-initially has visibility of all the objects that its predecessor generation referenced.
+initially has visibility of all the objects that were referenced in the loaded index.
 These objects are guaranteed to remain visible until the current generation is
 superseded, via pageservers in older generations avoiding deletions (see [deletion](#deletion)).
 

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -157,7 +157,7 @@ The node generation is useful other ways, beyond it's core correctness purpose:
 - node generation numbers enable building fencing into any network protocol (for example
   communication with safekeepers) to refuse to communicate with stale/partitioned nodes.
 
-Node that the two generation numbers have a different behavior for stale generations:
+Note that the two generation numbers have a different behavior for stale generations:
 
 - A pageserver with a stale generation number should immediately terminate: it is never intended
   to have two pageservers with the same node ID.

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -170,70 +170,6 @@ Note that the two generation numbers have a different behavior for stale generat
   should not be done over long periods of time, as the data in the stale generation has to avoid
   doing operations involving deletion, like remote compaction.
 
-#### Visibility
-
-##### Visibility of objects to pageservers
-
-Pageservers can of course list objects in S3 at any time, but in practice their
-visible set is based on the contents of their LayerMap, which is initialized
-from the `index_part.json` that they load.
-
-Starting with the `index_part` from the most recent previous generation suffix
-(see [loading index_part](#finding-the-remote-indices-for-timelines)), a pageserver
-initially has visibility of all the objects that its predecessor generation referenced.
-These objects are guaranteed to remain visible until the current generation is
-superseded, via pageservers in older generations avoiding deletions (see [deletion](#deletion)).
-
-The "most recent previous generation suffix" is _not_ necessarily the most recent
-in terms of walltime, it is the one that is readable at the time a new generation
-starts. Consider the following sequence of a tenant being re-attached to different
-pageserver nodes:
-
-- Create + attach on PS1 in attach generation 1
-- PS1 Do some work, write out index_part.json-0001
-- Attach to PS2 in attach generation 2
-- Read index_part.json-0001
-- PS2 starts doing some work...
-- Attach to PS3 in attach generation 3
-- Read index_part.json-0001
-- **...PS2 finishes its work: now it writes index_part.json-0002**
-- PS3 writes out index_part.json-0003
-
-In the above sequence, the ancestry of indices is:
-
-```
-0001 -> 0002
-     |
-     -> 0003
-```
-
-This is not an issue for safety: if the 0002 references some object that is
-not in 0001, then 0003 simply does not see it, and will re-do whatever
-work was required (e.g. ingesting WAL or doing compaction). Objects referenced
-by only the 0002 index will never be read by future attachment generations, and
-will eventually be cleaned up by a scrub (see [scrubbing](#cleaning-up-orphan-objects-scrubbing)).
-
-##### Visibility of LSNs to clients
-
-Because index_part.json is now written with a generation suffix, which data
-is visible depends on which generation the reader is operating in:
-
-- If one was passively reading from S3 from outside of a pageserver, the
-  visibility of data would depend on which index_part.json-<suffix> file
-  one had chosen to read from.
-- If two pageservers have the same tenant attached, they may have different
-  data visible as they're independently replaying the WAL, and maintaining
-  independent LayerMaps that are written to independent index_part.json files.
-  Data does not have to be remotely committed to be visible.
-- For a pageserver writing with a stale generation suffix, historic LSNs
-  remain readable until another pageserver (with a higher generation suffix)
-  decides to execute GC deletions. At this point, we may think of the stale
-  attachment's generation as having logically ended: during its existence
-  the generation had a consistent view of the world.
-- For a newly attached pageserver, its highest visible LSN may appears to
-  go backwards with respect to an earlier attachment, if that earlier
-  attachment had not uploaded all data to S3 before the new attachment.
-
 ### Object Key Changes
 
 #### Generation suffix
@@ -299,6 +235,73 @@ extended to store the suffix as well.
 This will increase the size of the file, but only modestly: layers are already encoded as
 their string-ized form, so the overhead is about 20 bytes per layer. This will be less if/when
 the index storage format is migrated to a binary format from JSON.
+
+#### Visibility
+
+_This section doesn't describe code changes, but extends on the consequences of the
+object key changes given above_
+
+##### Visibility of objects to pageservers
+
+Pageservers can of course list objects in S3 at any time, but in practice their
+visible set is based on the contents of their LayerMap, which is initialized
+from the `index_part.json` that they load.
+
+Starting with the `index_part` from the most recent previous generation suffix
+(see [loading index_part](#finding-the-remote-indices-for-timelines)), a pageserver
+initially has visibility of all the objects that its predecessor generation referenced.
+These objects are guaranteed to remain visible until the current generation is
+superseded, via pageservers in older generations avoiding deletions (see [deletion](#deletion)).
+
+The "most recent previous generation suffix" is _not_ necessarily the most recent
+in terms of walltime, it is the one that is readable at the time a new generation
+starts. Consider the following sequence of a tenant being re-attached to different
+pageserver nodes:
+
+- Create + attach on PS1 in attach generation 1
+- PS1 Do some work, write out index_part.json-0001
+- Attach to PS2 in attach generation 2
+- Read index_part.json-0001
+- PS2 starts doing some work...
+- Attach to PS3 in attach generation 3
+- Read index_part.json-0001
+- **...PS2 finishes its work: now it writes index_part.json-0002**
+- PS3 writes out index_part.json-0003
+
+In the above sequence, the ancestry of indices is:
+
+```
+0001 -> 0002
+     |
+     -> 0003
+```
+
+This is not an issue for safety: if the 0002 references some object that is
+not in 0001, then 0003 simply does not see it, and will re-do whatever
+work was required (e.g. ingesting WAL or doing compaction). Objects referenced
+by only the 0002 index will never be read by future attachment generations, and
+will eventually be cleaned up by a scrub (see [scrubbing](#cleaning-up-orphan-objects-scrubbing)).
+
+##### Visibility of LSNs to clients
+
+Because index_part.json is now written with a generation suffix, which data
+is visible depends on which generation the reader is operating in:
+
+- If one was passively reading from S3 from outside of a pageserver, the
+  visibility of data would depend on which index_part.json-<suffix> file
+  one had chosen to read from.
+- If two pageservers have the same tenant attached, they may have different
+  data visible as they're independently replaying the WAL, and maintaining
+  independent LayerMaps that are written to independent index_part.json files.
+  Data does not have to be remotely committed to be visible.
+- For a pageserver writing with a stale generation suffix, historic LSNs
+  remain readable until another pageserver (with a higher generation suffix)
+  decides to execute GC deletions. At this point, we may think of the stale
+  attachment's generation as having logically ended: during its existence
+  the generation had a consistent view of the world.
+- For a newly attached pageserver, its highest visible LSN may appears to
+  go backwards with respect to an earlier attachment, if that earlier
+  attachment had not uploaded all data to S3 before the new attachment.
 
 ### Deletion
 

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -148,7 +148,7 @@ an old pod is dead before starting a new one.
 
 The node generation is useful other ways, beyond it's core correctness purpose:
 
-- Including both generations (and the node ID) in object keys also provides some flexibility in
+- Including both generations (and the node ID) in object keys (see [object keys](#object-key-changes)) also provides some flexibility in
   how HA should work in future: we could move to a model where failover can happen within one
   attachment generation number (i.e. without control plane coordination) without changing the
   storage format, because node IDs/generations would de-conflict writes from peers.

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -321,7 +321,7 @@ deletions are slightly more challenging: if a pageserver A is isolated, and the 
 pageserver B, then it is dangerous for A to do any object deletions, even of objects that it wrote
 itself, because pageserver's B metadata might reference those objects.
 
-We may solve this by inserting a "generation validation" step between the write of a remote index
+We solve this by inserting a "generation validation" step between the write of a remote index
 that un-links a particular object from the index, and the actual deletion of the object, such
 that deletions strictly obey the following ordering:
 

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -122,7 +122,7 @@ The node generation number defines a global "in" definition for pageserver nodes
 node generation matches the node generation the control plane most recently issued is a member of the cluster
 in good standing. Any node with any older generation number is not.
 
-Distinction between generation numbers and Node ID:
+#### Distinction between generation numbers and Node ID
 
 - The purpose of a node generation ID is to provide a stronger guarantee of uniqueness than a Node ID.
 - Node generation ID is guaranteed to be globally unique across space and time. Node ID is not, e.g.,

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -268,8 +268,7 @@ that deletions strictly obey the following ordering:
 
 1. Write out index_part.json: this guarantees that any subsequent reader of the metadata will
    not try and read the object we unlinked.
-2. Call out to control plane to validate that the attachment generation number we hold for the tenant
-   is still the latest, and that our node generation number is the latest for this node_id.
+2. Call out to control plane to validate that the suffix which we just used is still the latest.
 3. If step 2 passes, it is safe to delete the object. We have guaranteed that any future
    attachment of the tenant to a different node will happen _after_ Step 1, and therefore
    that future attached node will start from the metadata that does not reference the key

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -183,8 +183,9 @@ enabling safe multi-attachment of tenants:
   some rogue pageserver still running) will not try to write to the same objects.
 - Multiple attachments of the same tenant will not try to write to the same objects, as
   each attachment would have a distinct attachment generation.
-  To avoid coupling our storage format tightly with the way we manage generation numbers,
-  they will be packed into a single u64 that must obey just the following properties:
+
+To avoid coupling our storage format tightly with the way we manage generation numbers,
+they will be packed into a single u64 that must obey just the following properties:
 
 - On a node restart, the suffix must increase
 - On a change to the attachment, the suffix must increase

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -168,6 +168,20 @@ Note that the two generation numbers have a different behavior for stale generat
 
 #### Visibility
 
+##### Visibility of objects to pageservers
+
+Pageservers can of course list objects in S3 at any time, but in practice their
+visible set is based on the contents of their LayerMap, which is initialized
+from the `index_part.json` that they load.
+
+Starting with the `index_part` from the most recent previous generation suffix
+(see [loading index_part](#finding-the-remote-indices-for-timelines)), a pageserver
+initially has visibility of all the objects that its predecessor generation referenced.
+These objects are guaranteed to remain visible until the current generation is
+superseded, via pageservers in older generations avoiding deletions (see [deletion](#deletion)).
+
+##### Visibility of LSNs to clients
+
 Because index_part.json is now written with a generation suffix, which data
 is visible depends on which generation the reader is operating in:
 
@@ -205,7 +219,7 @@ enabling safe multi-attachment of tenants:
 
 - On a node restart, the suffix must increase
 - On a change to the attachment, the suffix must increase
-- Sorting the suffixes numerically must give the most logically recent data.
+- Sorting the suffixes numerically must give the most logically recent data ([visibility](#visibility))
 
 ```
 000000 0000 000000

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -65,9 +65,6 @@ These are not requirements, but are ideas that guide the following design:
   have a Paxos implementation in the safekeeper.
 - Avoiding locking in to specific models of how failover will work (e.g. do not assume that
   all the tenants on a pageserver will fail over as a unit).
-- Avoid doing synchronization that scales with the number of tenants, unless absolutely
-  necessary. For example, a pageserver should be able to start up without having to
-  have each tenant individually re-attached.
 - Be strictly correct when it comes to data integrity. Occasional failures of availability
   are tolerable, occasional data loss is not.
 

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -276,7 +276,7 @@ that deletions strictly obey the following ordering:
    we are deleting.
 
 Note that at step 2 we are only confirming that deletions of objects _no longer referenced
-by the metadata written in step 1_ are safe. If we were attempting other deletions concurrently,
+by the specific `index_part.json` written in step 1_ are safe. If we were attempting other deletions concurrently,
 these would need their own generation validation step.
 
 If step 2 fails, we may leak the object. This is safe, but has a cost: see [scrubbing](#cleaning-up-orphan-objects-scrubbing). We may avoid this entirely outside of node

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -125,9 +125,8 @@ in good standing. Any node with any older generation number is not.
 Distinction between generation numbers and Node ID:
 
 - The purpose of a node generation ID is to provide a stronger guarantee of uniqueness than a Node ID.
-- Node generation ID is guaranteed to be globally unique across space and time. Node ID is not unique
-  in the event of starting a replacement node after an original node is network partitioned, or
-  in the event of a human error starting a replacement node that re-uses a node ID.
+- Node generation ID is guaranteed to be globally unique across space and time. Node ID is not, e.g.,
+  if a human provisions a replacement instance for a dead node and accidentally re-uses the node ID.
 - Node ID is written to disk in a pageserver's configuration, whereas node generation number is
   received at runtime just after startup (this does incur an availability dependency, see [availability](#availability)).
 - The two concepts could be collapsed into one if we used ephemeral node IDs that were only ever used one time,

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -124,7 +124,7 @@ in good standing. Any node with any older generation number is not.
 
 #### Distinction between generation numbers and Node ID
 
-- The purpose of a node generation ID is to provide a stronger guarantee of uniqueness than a Node ID.
+- The purpose of a node generation number is to provide a stronger guarantee of uniqueness than a Node ID.
 - Node generation ID is guaranteed to be globally unique across space and time. Node ID is not, e.g.,
   if a human provisions a replacement instance for a dead node and accidentally re-uses the node ID.
 - Node ID is written to disk in a pageserver's configuration, whereas node generation number is

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -950,6 +950,9 @@ to S3.
 
 #### Case A: re-attachment to other nodes
 
+In this section we use the <attach_gen>-<node_id>-<node_gen> shorthand for object
+suffixes, see [generation numbers](#generation-numbers)
+
 1. Let's say node 0 fails in a cluster of three nodes 0, 1, 2.
 2. Some external mechanism notices that the node is unavailable and initiates
    movement of all tenants attached to that node to a different node. In

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -291,12 +291,12 @@ For the same reasons that deletion of objects must be guarded by an attachment g
 validation step, updates to `remote_consistent_lsn` are subject to the same rules, using
 an ordering as follows:
 
-1. persist index_part that covers data up to LSN `L0`
+1. upload the index_part that covers data up to LSN `L0` to S3
 2. call to control plane to validate their attachment generation
 3. update the `remote_consistent_lsn` that they send to the safekeepers to `L0`
 
 **Note:** at step 3 we are not advertising the _latest_ remote_consistent_lsn, we are
-advertising the value immediately before we started the validation RPC. This provides
+advertising the value in the index_part that we uploaded in step 1. This provides
 a strong ordering guarantee.
 
 Internally to the pageserver, each timeline will have two remote_consistent_lsn values: the one that

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -72,7 +72,7 @@ These are not requirements, but are ideas that guide the following design:
 ## Non Goals
 
 The changes in this RFC intentionally isolate the design decision of how to define
-logical generations IDs and object storage format in a way that is somewhat flexible with
+logical generations numbers and object storage format in a way that is somewhat flexible with
 respect to how actual orchestration of failover works.
 
 This RFC intentionally does not cover:

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -104,7 +104,7 @@ pageserver, control plane, safekeeper (optional)
   try to write to the same keys.
 - **Safety in split brain for multiple nodes running with
   the same node ID** is provided by the pageserver calling out to the control plane
-  on startup, to increment the generations of any attached tenants
+  on startup, to re-attach and thereby increment the generations of any attached tenants
 - **Safety for deletions** is achieved by deferring the DELETE from S3 to a point in time where the deleting node has validated with control plane that no attachment with a higher generation has a reference to the to-be-DELETEd key.
 - **The control plane is used to issue generation numbers** to avoid the need for
   a built-in consensus system in the pageserver, although this could in principle

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -136,7 +136,7 @@ in good standing. Any node with any older generation number is not.
   guaranteeing that the cluster manager (e.g. k8s) doesn't run two concurrent instances with the same
   node ID is much harder.
 
-#### Why use per-tenant _and_ per-node generation numbers?
+#### Distinction between attachment and node generation id
 
 The most important generation number is the tenant attachment number: this alone would be sufficient
 to implement safe migration and failover, if we assume that our control plane will never concurrently

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -125,7 +125,7 @@ in good standing. Any node with any older generation number is not.
 #### Distinction between generation numbers and Node ID
 
 - The purpose of a node generation number is to provide a stronger guarantee of uniqueness than a Node ID.
-- Node generation ID is guaranteed to be globally unique across space and time. Node ID is not, e.g.,
+- Node generation number is guaranteed to be globally unique across space and time. Node ID is not, e.g.,
   if a human provisions a replacement instance for a dead node and accidentally re-uses the node ID.
 - Node ID is written to disk in a pageserver's configuration, whereas node generation number is
   received at runtime just after startup (this does incur an availability dependency, see [availability](#availability)).
@@ -687,7 +687,7 @@ above, for background validation), and to record the next sequence number in
 case there are no deletion lists at present.
 
 Deletion queue objects will be stored outside the `tenants/` path, and
-with the node generation ID in the name. The paths would look something like:
+with the node generation number in the name. The paths would look something like:
 
 ```bash
   # Deletion List
@@ -1052,7 +1052,7 @@ disk capacity on keeping standby locations populated with local disk data.
 
 There's no conflict between this RFC and that: implementing warm secondary locations on a per-tenant basis
 would be a separate change to the control plane to store standby location(s) for a tenant. Because
-the standbys do not write to S3, they do not need to be assigned generation IDs. When a tenant is
+the standbys do not write to S3, they do not need to be assigned generation numbers. When a tenant is
 re-attached to a standby location, that would increment the tenant attachment generation and this
 would work the same as any other attachment change, but with a warm cache.
 

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -118,7 +118,7 @@ and each time the attachment status of the tenant changes, this is incremented.
 Changes in attachment status include:
 
 - Attaching the tenant to a different pageserver
-- A page server restarting, and "re-attaching" its tenants on startup
+- A pageserver restarting, and "re-attaching" its tenants on startup
 
 These increments of attachment generation provide invariants we need to avoid
 split-brain issues in storage:

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -22,7 +22,9 @@ network partition, pathologically long delays (e.g. suspended VM), or software b
 In the current deployment model, control plane guarantees that a tenant is attached to one
 pageserver at a time, thereby ruling out split-brain conditions resulting from dual
 attachment (however, there is always the risk of a control plane bug). This control
-plane guarantee prevents robust response to failures, as if a pageserver is unresponsive we may not detach from it. The mechanism in this RFC
+plane guarantee prevents robust response to failures, as if a pageserver is unresponsive
+we may not detach from it. The mechanism in this RFC fixes this, by making it safe to
+attach to a new, different pageserver even if an unresponsive pageserver may be running.
 
 Futher, lack of safety during split-brain conditions blocks two important features where occasional
 split-brain conditions are part of the design assumptions:

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -120,7 +120,7 @@ This provides some important invariants:
 
 The node generation number defines a global "in" definition for pageserver nodes: a node whose
 node generation matches the node generation the control plane most recently issued is a member of the cluster
-in good standing. Any node with any older generation ID is not.
+in good standing. Any node with any older generation number is not.
 
 Distinction between generation numbers and Node ID:
 

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -269,10 +269,13 @@ that deletions strictly obey the following ordering:
 1. Write out index_part.json: this guarantees that any subsequent reader of the metadata will
    not try and read the object we unlinked.
 2. Call out to control plane to validate that the suffix which we just used is still the latest.
-3. If step 2 passes, it is safe to delete the object. We have guaranteed that any future
-   attachment of the tenant to a different node will happen _after_ Step 1, and therefore
-   that future attached node will start from the metadata that does not reference the key
-   we are deleting.
+3. If step 2 passes, it is safe to delete the object. Why? The check-in with control plane
+   together with our visibility rules guarantees that any later attachment / node generation
+   will use either the exact `index_part.json` that we uploaded in step 1, or a successor
+   of it; not an earlier one. In both cases, the `index_part.json` doesn't reference the
+   key we are deleting anymore, so, the key is invisible to any later attachment / node generation.
+   Hence it's safe to delete it.
+
 
 Note that at step 2 we are only confirming that deletions of objects _no longer referenced
 by the specific `index_part.json` written in step 1_ are safe. If we were attempting other deletions concurrently,

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -820,7 +820,7 @@ Backward compatibility with existing data is straightforward:
 - When locating the index file on attachment, we may use the "fallback" listing path
   and if there is only a generation-less index, that is the one we load.
 
-It is not necessary to re-write an existing layers: even new index files will be able
+It is not necessary to re-write existing layers: even new index files will be able
 to represent generation-less layers.
 
 ### On-disk forward compatibility

--- a/docs/rfcs/025-generation-numbers.md
+++ b/docs/rfcs/025-generation-numbers.md
@@ -123,7 +123,7 @@ Changes in attachment status include:
 These increments of attachment generation provide invariants we need to avoid
 split-brain issues in storage:
 
-- If two pageservers have the same tenant attached, they are guaranteed to have different attachment generation numbers, because the generation would increment
+- If two pageservers have the same tenant attached, they are guaranteed to have different generation numbers, because the generation would increment
   while attaching the second one.
 - If there are multiple pageservers running with the same node ID, they are guaranteed to have different generation numbers, because the generation would increment
   when the second node started and re-attached its tenants.


### PR DESCRIPTION
## Summary

A scheme of logical "generation numbers" for pageservers and their attachments is proposed, along with
changes to the remote storage format to include these generation numbers in S3 keys.

Using the control plane as the issuer of these generation numbers enables strong anti-split-brain
properties in the pageserver cluster without implementing a consensus mechanism directly
in the pageservers.

## Motivation

Currently, the pageserver's remote storage format does not provide a mechanism for addressing
split brain conditions that may happen when replacing a node during failover or when migrating
a tenant from one pageserver to another. From a remote storage perspective, a split brain condition
occurs whenever two nodes both think they have the same tenant attached, and both can write to S3. This
can happen in the case of a network partition, pathologically long delays (e.g. suspended VM), or software
bugs.

This blocks robust implementation of failover from unresponsive pageservers, due to the risk that
the unresponsive pageserver is still writing to S3.