### PR TITLE
refactor: check webidentity provider before imds

### DIFF
--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -68,9 +68,6 @@ impl S3Bucket {
             aws_config.bucket_name
         );
 
-        let provider_conf = ProviderConfig::without_region()
-            .with_region(Some(Region::new(aws_config.bucket_region.clone())));
-
         let credentials_provider = {
             // uses "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"
             CredentialsProviderChain::first_try(
@@ -79,12 +76,14 @@ impl S3Bucket {
             )
             // uses "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_ROLE_SESSION_NAME"
             // needed to access remote extensions bucket
-            .or_else(
-                "token",
+            .or_else("token", {
+                let provider_conf = ProviderConfig::without_region()
+                    .with_region(Some(Region::new(aws_config.bucket_region.clone())));
+
                 WebIdentityTokenCredentialsProvider::builder()
                     .configure(&provider_conf)
-                    .build(),
-            )
+                    .build()
+            })
             // uses imds v2
             .or_else("imds", ImdsCredentialsProvider::builder().build())
         };

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -77,8 +77,6 @@ impl S3Bucket {
                 "env",
                 EnvironmentVariableCredentialsProvider::new(),
             )
-            // uses imds v2
-            .or_else("imds", ImdsCredentialsProvider::builder().build())
             // uses "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_ROLE_SESSION_NAME"
             // needed to access remote extensions bucket
             .or_else(
@@ -87,6 +85,8 @@ impl S3Bucket {
                     .configure(&provider_conf)
                     .build(),
             )
+            // uses imds v2
+            .or_else("imds", ImdsCredentialsProvider::builder().build())
         };
 
         let mut config_builder = Config::builder()

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -68,6 +68,8 @@ impl S3Bucket {
             aws_config.bucket_name
         );
 
+        let region = Some(Region::new(aws_config.bucket_region.clone()));
+
         let credentials_provider = {
             // uses "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"
             CredentialsProviderChain::first_try(
@@ -77,8 +79,7 @@ impl S3Bucket {
             // uses "AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_ROLE_SESSION_NAME"
             // needed to access remote extensions bucket
             .or_else("token", {
-                let provider_conf = ProviderConfig::without_region()
-                    .with_region(Some(Region::new(aws_config.bucket_region.clone())));
+                let provider_conf = ProviderConfig::without_region().with_region(region.clone());
 
                 WebIdentityTokenCredentialsProvider::builder()
                     .configure(&provider_conf)
@@ -89,7 +90,7 @@ impl S3Bucket {
         };
 
         let mut config_builder = Config::builder()
-            .region(Region::new(aws_config.bucket_region.clone()))
+            .region(region)
             .credentials_cache(CredentialsCache::lazy())
             .credentials_provider(credentials_provider);
 


### PR DESCRIPTION
Review comments on #4921:
- check the WebIdentity provider before imdsv2 because imds will do a http request which will cost more than checking local env variables
- move provider config to be nearer to webidentity provider
- refactor out the common wrapping of `aws_config::...::Region`