### PR TITLE
proxy: breakdown wake up failure metrics

### DIFF
--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -407,28 +407,36 @@ impl ConnectMechanism for TcpMechanism<'_> {
     }
 }
 
+const fn bool_to_str(x: bool) -> &'static str {
+    if x {
+        "true"
+    } else {
+        "false"
+    }
+}
+
 fn report_error(e: &WakeComputeError, retry: bool) {
     use crate::console::errors::ApiError;
-    let retry = retry.to_string();
+    let retry = bool_to_str(retry);
     match e {
         WakeComputeError::BadComputeAddress(_) => NUM_WAKEUP_FAILURES
-            .with_label_values(&[&retry, "bad_compute_address"])
+            .with_label_values(&[retry, "bad_compute_address"])
             .inc(),
         WakeComputeError::ApiError(ApiError::Transport(_)) => NUM_WAKEUP_FAILURES
-            .with_label_values(&[&retry, "api_transport_error"])
+            .with_label_values(&[retry, "api_transport_error"])
             .inc(),
         WakeComputeError::ApiError(ApiError::Console { status, .. }) => match status {
             &http::StatusCode::BAD_REQUEST => NUM_WAKEUP_FAILURES
-                .with_label_values(&[&retry, "api_console_bad_request"])
+                .with_label_values(&[retry, "api_console_bad_request"])
                 .inc(),
             &http::StatusCode::LOCKED => NUM_WAKEUP_FAILURES
-                .with_label_values(&[&retry, "api_console_locked"])
+                .with_label_values(&[retry, "api_console_locked"])
                 .inc(),
             x if x.is_server_error() => NUM_WAKEUP_FAILURES
-                .with_label_values(&[&retry, "api_console_other_server_error"])
+                .with_label_values(&[retry, "api_console_other_server_error"])
                 .inc(),
             _ => NUM_WAKEUP_FAILURES
-                .with_label_values(&[&retry, "api_console_other_error"])
+                .with_label_values(&[retry, "api_console_other_error"])
                 .inc(),
         },
     }


### PR DESCRIPTION
## Problem

close https://github.com/neondatabase/neon/issues/4702

## Summary of changes

This PR adds a new metrics for wake up errors and breaks it down by most common reasons (mostly follows the `could_retry` implementation).

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
