### PR TITLE
bump vm-builder version to v0.15.0-alpha1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -794,7 +794,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.13.1
+      VM_BUILDER_VERSION: v0.15.0-alpha1
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

## Summary of changes

This is the second time bumping the version to `v0.15.0-alpha1`. The previous time there was an issue with the monitor that was hotfixed. We reran the release workflow to produce new images, even though the release _version_ is the same.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
