### PR TITLE
InMemoryLayer: move end_lsn out of the lock

### DIFF
--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -100,11 +100,11 @@ impl InMemoryLayer {
     }
 
     fn assert_writable(&self) {
-        assert!(!self.end_lsn.get().is_some());
+        assert!(self.end_lsn.get().is_none());
     }
 
     fn end_lsn_or_max(&self) -> Lsn {
-        self.end_lsn.get().map(|l| *l).unwrap_or(Lsn::MAX)
+        self.end_lsn.get().copied().unwrap_or(Lsn::MAX)
     }
 }
 
@@ -255,7 +255,7 @@ impl InMemoryLayer {
             timeline_id,
             tenant_id,
             start_lsn,
-            end_lsn: Lsn::INVALID.into(),
+            end_lsn: OnceLock::new(),
             inner: RwLock::new(InMemoryLayerInner {
                 index: HashMap::new(),
                 file,

--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -51,8 +51,8 @@ pub struct InMemoryLayer {
     /// Writes are only allowed when this is [`Lsn::INVALID`].
     end_lsn: OnceLock<Lsn>,
 
-    /// The above fields never change. The parts that do change are in 'inner',
-    /// and protected by mutex.
+    /// The above fields never change, except for `end_lsn`. All other changing parts are in `inner`,
+    /// and protected by a mutex.
     inner: RwLock<InMemoryLayerInner>,
 }
 

--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -48,11 +48,11 @@ pub struct InMemoryLayer {
     start_lsn: Lsn,
 
     /// Frozen layers have an exclusive end LSN.
-    /// Writes are only allowed when this is [`Lsn::INVALID`].
+    /// Writes are only allowed when this is `None`.
     end_lsn: OnceLock<Lsn>,
 
-    /// The above fields never change, except for `end_lsn`. All other changing parts are in `inner`,
-    /// and protected by a mutex.
+    /// The above fields never change, except for `end_lsn`, which is only set once.
+    /// All other changing parts are in `inner`, and protected by a mutex.
     inner: RwLock<InMemoryLayerInner>,
 }
 


### PR DESCRIPTION
## Problem

In some places, the lock on `InMemoryLayerInner` is only created to obtain `end_lsn`. This is not needed however, if we move `end_lsn` to `InMemoryLayer` instead.

## Summary of changes

Make `end_lsn` a member of `InMemoryLayer`, and do less locking of `InMemoryLayerInner`. `end_lsn` is changed from `Option<Lsn>` into an `OnceLock<Lsn>`. Thanks to this change, we don't need to lock any more in three functions.

Part of #4743 . Suggested in https://github.com/neondatabase/neon/pull/4905#issuecomment-1666458428 .

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
