### PR TITLE
pageserver: avoid incrementing access time when reading layers for compaction

### DIFF
--- a/pageserver/src/context.rs
+++ b/pageserver/src/context.rs
@@ -141,6 +141,18 @@ impl RequestContextBuilder {
         }
     }
 
+    pub fn extend(original: &RequestContext) -> Self {
+        Self {
+            // This is like a Copy, but avoid implementing Copy because ordinary users of
+            // RequestContext should always move or ref it.
+            inner: RequestContext {
+                task_kind: original.task_kind,
+                download_behavior: original.download_behavior,
+                atime_behavior: original.atime_behavior,
+            },
+        }
+    }
+
     /// Configure the DownloadBehavior of the context: whether to
     /// download missing layers, and/or warn on the download.
     pub fn download_behavior(mut self, b: DownloadBehavior) -> Self {

--- a/pageserver/src/context.rs
+++ b/pageserver/src/context.rs
@@ -93,7 +93,7 @@ use crate::task_mgr::TaskKind;
 pub struct RequestContext {
     task_kind: TaskKind,
     download_behavior: DownloadBehavior,
-    atime_behavior: ATimeBehavior,
+    access_stats_behavior: AccessStatsBehavior,
 }
 
 /// Desired behavior if the operation requires an on-demand download
@@ -113,7 +113,7 @@ pub enum DownloadBehavior {
 
 /// Whether this request should update access times used in LRU eviction
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum ATimeBehavior {
+pub(crate) enum AccessStatsBehavior {
     /// Update access times: this request's access to data should be taken
     /// as a hint that the accessed layer is likely to be accessed again
     Update,
@@ -136,7 +136,7 @@ impl RequestContextBuilder {
             inner: RequestContext {
                 task_kind,
                 download_behavior: DownloadBehavior::Download,
-                atime_behavior: ATimeBehavior::Update,
+                access_stats_behavior: AccessStatsBehavior::Update,
             },
         }
     }
@@ -148,7 +148,7 @@ impl RequestContextBuilder {
             inner: RequestContext {
                 task_kind: original.task_kind,
                 download_behavior: original.download_behavior,
-                atime_behavior: original.atime_behavior,
+                access_stats_behavior: original.access_stats_behavior,
             },
         }
     }
@@ -160,10 +160,10 @@ impl RequestContextBuilder {
         self
     }
 
-    /// Configure the ATimeBehavior of the context: whether layer
+    /// Configure the AccessStatsBehavior of the context: whether layer
     /// accesses should update the access time of the layer.
-    pub fn atime_behavior(mut self, b: ATimeBehavior) -> Self {
-        self.inner.atime_behavior = b;
+    pub(crate) fn access_stats_behavior(mut self, b: AccessStatsBehavior) -> Self {
+        self.inner.access_stats_behavior = b;
         self
     }
 
@@ -260,7 +260,7 @@ impl RequestContext {
         self.download_behavior
     }
 
-    pub fn atime_behavior(&self) -> ATimeBehavior {
-        self.atime_behavior
+    pub(crate) fn access_stats_behavior(&self) -> AccessStatsBehavior {
+        self.access_stats_behavior
     }
 }

--- a/pageserver/src/context.rs
+++ b/pageserver/src/context.rs
@@ -113,7 +113,7 @@ pub enum DownloadBehavior {
 
 /// Whether this request should update access times used in LRU eviction
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum ATimeBehavior {
+pub(crate) enum ATimeBehavior {
     /// Update access times: this request's access to data should be taken
     /// as a hint that the accessed layer is likely to be accessed again
     Update,

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -8,7 +8,7 @@ mod layer_desc;
 mod remote_layer;
 
 use crate::config::PageServerConf;
-use crate::context::{ATimeBehavior, RequestContext};
+use crate::context::{AccessStatsBehavior, RequestContext};
 use crate::repository::Key;
 use crate::task_mgr::TaskKind;
 use crate::walrecord::NeonWalRecord;
@@ -242,7 +242,7 @@ impl LayerAccessStats {
     }
 
     fn record_access(&self, access_kind: LayerAccessKind, ctx: &RequestContext) {
-        if ctx.atime_behavior() == ATimeBehavior::Skip {
+        if ctx.access_stats_behavior() == AccessStatsBehavior::Skip {
             return;
         }
 

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -452,8 +452,7 @@ impl DeltaLayer {
         access_kind: LayerAccessKind,
         ctx: &RequestContext,
     ) -> Result<&Arc<DeltaLayerInner>> {
-        self.access_stats
-            .record_access(access_kind, ctx.task_kind());
+        self.access_stats.record_access(access_kind, ctx);
         // Quick exit if already loaded
         self.inner
             .get_or_try_init(|| self.load_inner())

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -323,8 +323,7 @@ impl ImageLayer {
         access_kind: LayerAccessKind,
         ctx: &RequestContext,
     ) -> Result<&ImageLayerInner> {
-        self.access_stats
-            .record_access(access_kind, ctx.task_kind());
+        self.access_stats.record_access(access_kind, ctx);
         self.inner
             .get_or_try_init(|| self.load_inner())
             .await

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -35,7 +35,9 @@ use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant, SystemTime};
 
-use crate::context::{ATimeBehavior, DownloadBehavior, RequestContext, RequestContextBuilder};
+use crate::context::{
+    AccessStatsBehavior, DownloadBehavior, RequestContext, RequestContextBuilder,
+};
 use crate::tenant::remote_timeline_client::{self, index::LayerFileMetadata};
 use crate::tenant::storage_layer::{
     DeltaFileName, DeltaLayerWriter, ImageFileName, ImageLayerWriter, InMemoryLayer,
@@ -799,10 +801,9 @@ impl Timeline {
             .await
         {
             Ok((partitioning, lsn)) => {
-                // Use a modified RequestContext that disables atime updates, so that generating image files
-                // doesn't spuriously move old delta layers up the LRU queue for eviction
+                // Disables access_stats updates, so that the files we read remain candidates for eviction after we're done with them
                 let image_ctx = RequestContextBuilder::extend(ctx)
-                    .atime_behavior(ATimeBehavior::Skip)
+                    .access_stats_behavior(AccessStatsBehavior::Skip)
                     .build();
 
                 // 2. Create new image layers for partitions that have been modified


### PR DESCRIPTION
## Problem

Currently, image generation reads delta layers before writing out subsequent image layers, which updates the access time of the delta layers and effectively puts them at the back of the queue for eviction.  This is the opposite of what we want, because after a delta layer is covered by a later image layer, it's likely that subsequent reads of latest data will hit the image rather than the delta layer, so the delta layer should be quite a good candidate for eviction.

## Summary of changes

`RequestContext` gets a new `ATimeBehavior` field, and a `RequestContextBuilder` helper so that we can optionally add the new field without growing `RequestContext::new` every time we add something like this.

Request context is passed into the `record_access` function, and the access time is not updated if `ATimeBehavior::Skip` is set.

The compaction background task constructs its request context with this skip policy.

Closes: https://github.com/neondatabase/neon/issues/4969

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
