### PR TITLE
Do not attach deleted tenants

### DIFF
--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -27,7 +27,7 @@ use crate::{InitializationOrder, IGNORED_TENANT_FILE_NAME};
 use utils::fs_ext::PathExt;
 use utils::id::{TenantId, TimelineId};
 
-use super::delete::DeleteTenantError;
+use super::delete::{remote_delete_mark_exists, DeleteTenantError};
 use super::timeline::delete::DeleteTimelineFlow;
 
 /// The tenants known to the pageserver.
@@ -591,6 +591,12 @@ pub async fn attach_tenant(
     remote_storage: GenericRemoteStorage,
     ctx: &RequestContext,
 ) -> Result<(), TenantMapInsertError> {
+    // Temporary solution, proper one would be to resume deletion, but that needs more plumbing around Tenant::load/Tenant::attach
+    // Corresponding issue https://github.com/neondatabase/neon/issues/5006
+    if remote_delete_mark_exists(conf, &tenant_id, &remote_storage).await? {
+        return Err(anyhow::anyhow!("Tenant is marked as deleted on remote storage").into());
+    }
+
     tenant_map_insert(tenant_id, || {
         let tenant_dir = create_tenant_files(conf, tenant_conf, &tenant_id, CreateTenantFilesMode::Attach)?;
         // TODO: tenant directory remains on disk if we bail out from here on.

--- a/test_runner/fixtures/pageserver/utils.py
+++ b/test_runner/fixtures/pageserver/utils.py
@@ -258,6 +258,7 @@ def list_prefix(
 
     # Note that this doesnt use pagination, so list is not guaranteed to be exhaustive.
     response = neon_env_builder.remote_storage_client.list_objects_v2(
+        Delimiter="/",
         Bucket=neon_env_builder.remote_storage.bucket_name,
         Prefix=prefix or neon_env_builder.remote_storage.prefix_in_bucket or "",
     )

--- a/test_runner/fixtures/remote_storage.py
+++ b/test_runner/fixtures/remote_storage.py
@@ -92,8 +92,11 @@ def available_s3_storages() -> List[RemoteStorageKind]:
 class LocalFsStorage:
     root: Path
 
+    def tenant_path(self, tenant_id: TenantId) -> Path:
+        return self.root / "tenants" / str(tenant_id)
+
     def timeline_path(self, tenant_id: TenantId, timeline_id: TimelineId) -> Path:
-        return self.root / "tenants" / str(tenant_id) / "timelines" / str(timeline_id)
+        return self.tenant_path(tenant_id) / "timelines" / str(timeline_id)
 
     def index_path(self, tenant_id: TenantId, timeline_id: TimelineId) -> Path:
         return self.timeline_path(tenant_id, timeline_id) / TIMELINE_INDEX_PART_FILE_NAME

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -71,6 +71,17 @@ def test_tenant_delete_smoke(
             run_pg_bench_small(pg_bin, endpoint.connstr())
             wait_for_last_flush_lsn(env, endpoint, tenant=tenant_id, timeline=timeline_id)
 
+            if remote_storage_kind in available_s3_storages():
+                assert_prefix_not_empty(
+                    neon_env_builder,
+                    prefix="/".join(
+                        (
+                            "tenants",
+                            str(tenant_id),
+                        )
+                    ),
+                )
+
         parent = timeline
 
     iterations = poll_for_remote_storage_iterations(remote_storage_kind)
@@ -85,7 +96,6 @@ def test_tenant_delete_smoke(
             neon_env_builder,
             prefix="/".join(
                 (
-                    "pageserver",
                     "tenants",
                     str(tenant_id),
                 )
@@ -197,6 +207,17 @@ def test_delete_tenant_exercise_crash_safety_failpoints(
         else:
             last_flush_lsn_upload(env, endpoint, tenant_id, timeline_id)
 
+            if remote_storage_kind in available_s3_storages():
+                assert_prefix_not_empty(
+                    neon_env_builder,
+                    prefix="/".join(
+                        (
+                            "tenants",
+                            str(tenant_id),
+                        )
+                    ),
+                )
+
     ps_http.configure_failpoints((failpoint, "return"))
 
     iterations = poll_for_remote_storage_iterations(remote_storage_kind)
@@ -259,7 +280,6 @@ def test_delete_tenant_exercise_crash_safety_failpoints(
             neon_env_builder,
             prefix="/".join(
                 (
-                    "pageserver",
                     "tenants",
                     str(tenant_id),
                 )
@@ -297,7 +317,6 @@ def test_deleted_tenant_ignored_on_attach(
             neon_env_builder,
             prefix="/".join(
                 (
-                    "pageserver",
                     "tenants",
                     str(tenant_id),
                 )
@@ -335,7 +354,6 @@ def test_deleted_tenant_ignored_on_attach(
             neon_env_builder,
             prefix="/".join(
                 (
-                    "pageserver",
                     "tenants",
                     str(tenant_id),
                 )
@@ -374,7 +392,6 @@ def test_deleted_tenant_ignored_on_attach(
             neon_env_builder,
             prefix="/".join(
                 (
-                    "pageserver",
                     "tenants",
                     str(tenant_id),
                 )

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -1,5 +1,7 @@
 import enum
 import os
+import shutil
+from pathlib import Path
 
 import pytest
 from fixtures.log_helper import log
@@ -13,6 +15,7 @@ from fixtures.pageserver.http import PageserverApiException
 from fixtures.pageserver.utils import (
     MANY_SMALL_LAYERS_TENANT_CONFIG,
     assert_prefix_empty,
+    assert_prefix_not_empty,
     poll_for_remote_storage_iterations,
     tenant_delete_wait_completed,
     wait_tenant_status_404,
@@ -78,6 +81,7 @@ def test_tenant_delete_smoke(
             neon_env_builder,
             prefix="/".join(
                 (
+                    "pageserver",
                     "tenants",
                     str(tenant_id),
                 )
@@ -247,6 +251,7 @@ def test_delete_tenant_exercise_crash_safety_failpoints(
             neon_env_builder,
             prefix="/".join(
                 (
+                    "pageserver",
                     "tenants",
                     str(tenant_id),
                 )
@@ -258,5 +263,106 @@ def test_delete_tenant_exercise_crash_safety_failpoints(
     assert not tenant_dir.exists()
 
 
+# TODO resume deletion (https://github.com/neondatabase/neon/issues/5006)
+@pytest.mark.parametrize("remote_storage_kind", available_remote_storages())
+def test_deleted_tenant_ignored_on_attach(
+    neon_env_builder: NeonEnvBuilder,
+    remote_storage_kind: RemoteStorageKind,
+    pg_bin: PgBin,
+):
+    neon_env_builder.enable_remote_storage(
+        remote_storage_kind=remote_storage_kind,
+        test_name="test_deleted_tenant_ignored_on_attach",
+    )
+
+    env = neon_env_builder.init_start(initial_tenant_conf=MANY_SMALL_LAYERS_TENANT_CONFIG)
+
+    tenant_id = env.initial_tenant
+
+    ps_http = env.pageserver.http_client()
+    # create two timelines
+    for timeline in ["first", "second"]:
+        timeline_id = env.neon_cli.create_timeline(timeline, tenant_id=tenant_id)
+        with env.endpoints.create_start(timeline, tenant_id=tenant_id) as endpoint:
+            run_pg_bench_small(pg_bin, endpoint.connstr())
+            wait_for_last_flush_lsn(env, endpoint, tenant=tenant_id, timeline=timeline_id)
+
+    # failpoint before we remove index_part from s3
+    failpoint = "timeline-delete-before-index-delete"
+    ps_http.configure_failpoints((failpoint, "return"))
+
+    env.pageserver.allowed_errors.extend(
+        (
+            # allow errors caused by failpoints
+            f".*failpoint: {failpoint}",
+            # It appears when we stopped flush loop during deletion (attempt) and then pageserver is stopped
+            ".*freeze_and_flush_on_shutdown.*failed to freeze and flush: cannot flush frozen layers when flush_loop is not running, state is Exited",
+            # error from http response is also logged
+            ".*InternalServerError\\(Tenant is marked as deleted on remote storage.*",
+        )
+    )
+
+    iterations = 20 if remote_storage_kind is RemoteStorageKind.REAL_S3 else 4
+
+    ps_http.tenant_delete(tenant_id)
+
+    tenant_info = wait_until_tenant_state(
+        pageserver_http=ps_http,
+        tenant_id=tenant_id,
+        expected_state="Broken",
+        iterations=iterations,
+    )
+
+    if remote_storage_kind in [RemoteStorageKind.MOCK_S3, RemoteStorageKind.REAL_S3]:
+        assert_prefix_not_empty(
+            neon_env_builder,
+            prefix="/".join(
+                (
+                    "pageserver",
+                    "tenants",
+                    str(tenant_id),
+                )
+            ),
+        )
+
+    reason = tenant_info["state"]["data"]["reason"]
+    # failpoint may not be the only error in the stack
+    assert reason.endswith(f"failpoint: {failpoint}"), reason
+
+    # now we stop pageserver and remove local tenant state
+    env.endpoints.stop_all()
+    env.pageserver.stop()
+
+    dir_to_clear = Path(env.repo_dir) / "tenants"
+    shutil.rmtree(dir_to_clear)
+    os.mkdir(dir_to_clear)
+
+    env.pageserver.start()
+
+    # now we call attach
+    with pytest.raises(
+        PageserverApiException, match="Tenant is marked as deleted on remote storage"
+    ):
+        ps_http.tenant_attach(tenant_id=tenant_id)
+
+    # delete should be resumed (not yet)
+    # wait_tenant_status_404(ps_http, tenant_id, iterations)
+
+    # we shouldn've created tenant dir on disk
+    tenant_path = env.tenant_dir(tenant_id=tenant_id)
+    assert not tenant_path.exists()
+
+    if remote_storage_kind in [RemoteStorageKind.MOCK_S3, RemoteStorageKind.REAL_S3]:
+        assert_prefix_not_empty(
+            neon_env_builder,
+            prefix="/".join(
+                (
+                    "pageserver",
+                    "tenants",
+                    str(tenant_id),
+                )
+            ),
+        )
+
+
 # TODO test concurrent deletions with "hang" failpoint
-# TODO test tenant delete continues after attach

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -302,7 +302,7 @@ def test_deleted_tenant_ignored_on_attach(
         )
     )
 
-    iterations = 20 if remote_storage_kind is RemoteStorageKind.REAL_S3 else 4
+    iterations = poll_for_remote_storage_iterations(remote_storage_kind)
 
     ps_http.tenant_delete(tenant_id)
 

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -335,6 +335,7 @@ def test_deleted_tenant_ignored_on_attach(
             ".*freeze_and_flush_on_shutdown.*failed to freeze and flush: cannot flush frozen layers when flush_loop is not running, state is Exited",
             # error from http response is also logged
             ".*InternalServerError\\(Tenant is marked as deleted on remote storage.*",
+            '.*shutdown_pageserver{exit_code=0}: stopping left-over name="remote upload".*',
         )
     )
 

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -304,6 +304,7 @@ def test_delete_timeline_exercise_crash_safety_failpoints(
             neon_env_builder,
             prefix="/".join(
                 (
+                    "pageserver",
                     "tenants",
                     str(env.initial_tenant),
                     "timelines",
@@ -496,6 +497,7 @@ def test_timeline_delete_fail_before_local_delete(neon_env_builder: NeonEnvBuild
         neon_env_builder,
         prefix="/".join(
             (
+                "pageserver",
                 "tenants",
                 str(env.initial_tenant),
                 "timelines",
@@ -515,6 +517,7 @@ def test_timeline_delete_fail_before_local_delete(neon_env_builder: NeonEnvBuild
             neon_env_builder,
             prefix="/".join(
                 (
+                    "pageserver",
                     "tenants",
                     str(env.initial_tenant),
                     "timelines",
@@ -528,7 +531,7 @@ def test_timeline_delete_fail_before_local_delete(neon_env_builder: NeonEnvBuild
     wait_until(
         2,
         0.5,
-        lambda: assert_prefix_empty(neon_env_builder),
+        lambda: assert_prefix_empty(neon_env_builder, prefix="pageserver"),
     )
 
 
@@ -748,6 +751,7 @@ def test_timeline_delete_works_for_remote_smoke(
             neon_env_builder,
             prefix="/".join(
                 (
+                    "pageserver",
                     "tenants",
                     str(env.initial_tenant),
                     "timelines",
@@ -758,11 +762,7 @@ def test_timeline_delete_works_for_remote_smoke(
 
     # for some reason the check above doesnt immediately take effect for the below.
     # Assume it is mock server inconsistency and check twice.
-    wait_until(
-        2,
-        0.5,
-        lambda: assert_prefix_empty(neon_env_builder),
-    )
+    wait_until(2, 0.5, lambda: assert_prefix_empty(neon_env_builder, prefix="pageserver"))
 
 
 def test_delete_orphaned_objects(

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -298,7 +298,7 @@ def test_delete_timeline_exercise_crash_safety_failpoints(
             ps_http, env.initial_tenant, timeline_id, iterations=iterations
         )
 
-    # Check remote is impty
+    # Check remote is empty
     if remote_storage_kind is RemoteStorageKind.MOCK_S3:
         assert_prefix_empty(
             neon_env_builder,


### PR DESCRIPTION
Rather temporary solution before proper:
https://github.com/neondatabase/neon/issues/5006

It requires more plumbing so lets not attach deleted tenants first and then implement resume.

Additionally update `assert_prefix_empty` to match introduced `pageserver` suffix. 

Resolves [#5016](https://github.com/neondatabase/neon/issues/5016)

