### PR TITLE
Ingore DISK_FULL error when performing availability check for client

### DIFF
--- a/compute_tools/src/checker.rs
+++ b/compute_tools/src/checker.rs
@@ -71,7 +71,7 @@ pub async fn check_writability(compute: &ComputeNode) -> Result<()> {
                     return Ok(());
                 }
             }
-            error!("connection error: {}", err);
+            return Err(e.into());
         }
     }
 

--- a/compute_tools/src/checker.rs
+++ b/compute_tools/src/checker.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Ok, Result};
 use postgres::Client;
 use tokio_postgres::NoTls;
-use tracing::{error, warn, instrument};
+use tracing::{error, instrument, warn};
 
 use crate::compute::ComputeNode;
 

--- a/compute_tools/src/checker.rs
+++ b/compute_tools/src/checker.rs
@@ -56,7 +56,7 @@ pub async fn check_writability(compute: &ComputeNode) -> Result<()> {
          SET updated_at = now();";
 
     match client.simple_query(query).await {
-        Ok(result) => {
+        Result::Ok(result) => {
             if result.len() != 1 {
                 return Err(anyhow::format_err!(
                     "expected 1 query results, but got {}",
@@ -71,7 +71,7 @@ pub async fn check_writability(compute: &ComputeNode) -> Result<()> {
                     return Ok(());
                 }
             }
-            return Err(e.into());
+            return Err(err.into());
         }
     }
 

--- a/compute_tools/src/checker.rs
+++ b/compute_tools/src/checker.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Ok, Result};
 use postgres::Client;
 use tokio_postgres::NoTls;
-use tracing::{error, instrument};
+use tracing::{error, warn, instrument};
 
 use crate::compute::ComputeNode;
 
@@ -55,13 +55,24 @@ pub async fn check_writability(compute: &ComputeNode) -> Result<()> {
         ON CONFLICT (id) DO UPDATE
          SET updated_at = now();";
 
-    let result = client.simple_query(query).await?;
-
-    if result.len() != 1 {
-        return Err(anyhow::format_err!(
-            "expected 1 query result, but got {}",
-            result.len()
-        ));
+    match client.simple_query(query).await {
+        Ok(result) => {
+            if result.len() != 1 {
+                return Err(anyhow::format_err!(
+                    "expected 1 query results, but got {}",
+                    result.len()
+                ));
+            }
+        }
+        Err(err) => {
+            if let Some(state) = err.code() {
+                if state == &tokio_postgres::error::SqlState::DISK_FULL {
+                    warn!("Tenant disk is full");
+                    return Ok(());
+                }
+            }
+            error!("connection error: {}", err);
+        }
     }
 
     Ok(())

--- a/compute_tools/src/checker.rs
+++ b/compute_tools/src/checker.rs
@@ -58,7 +58,7 @@ pub async fn check_writability(compute: &ComputeNode) -> Result<()> {
     match client.simple_query(query).await {
         Result::Ok(result) => {
             if result.len() != 1 {
-                return Err(anyhow::format_err!(
+                return Err(anyhow::anyhow!(
                     "expected 1 query results, but got {}",
                     result.len()
                 ));


### PR DESCRIPTION
See #5001

No space is what's expected if we're at size limit.
Of course if SK incorrectly returned "no space", the availability check wouldn't fire.
But  users would notice such a bug quite soon anyways.
So  ignoring "no space" is the right trade-off.


## Problem

## Summary of changes

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
