### PR TITLE
test: cleanup remote_timeline_client tests

### DIFF
--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1486,9 +1486,9 @@ mod tests {
 
         let TestSetup {
             harness,
-            tenant,
+            tenant: _tenant,
             timeline,
-            tenant_ctx,
+            tenant_ctx: _tenant_ctx,
             remote_fs_dir,
             client,
         } = TestSetup::new("upload_scheduling").await.unwrap();
@@ -1504,11 +1504,6 @@ mod tests {
         let metadata = dummy_metadata(Lsn(0x10));
         client
             .init_upload_queue_for_empty_remote(&metadata)
-            .unwrap();
-
-        let timeline = tenant
-            .create_test_timeline(TimelineId::generate(), Lsn(0x100), 14, &tenant_ctx)
-            .await
             .unwrap();
 
         // Create a couple of dummy files,  schedule upload for them
@@ -1642,7 +1637,7 @@ mod tests {
 
         let TestSetup {
             harness,
-            tenant,
+            tenant: _tenant,
             timeline,
             client,
             ..

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1563,7 +1563,7 @@ mod tests {
         }
 
         // Wait for the uploads to finish
-        client.wait_completion().await;
+        client.wait_completion().await.unwrap();
         {
             let mut guard = client.upload_queue.lock().unwrap();
             let upload_queue = guard.initialized_mut().unwrap();

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1486,7 +1486,7 @@ mod tests {
         let TestSetup {
             harness,
             tenant: _tenant,
-            timeline,
+            timeline: _timeline,
             tenant_ctx: _tenant_ctx,
             remote_fs_dir,
             client,
@@ -1637,7 +1637,7 @@ mod tests {
         let TestSetup {
             harness,
             tenant: _tenant,
-            timeline,
+            timeline: _timeline,
             client,
             ..
         } = TestSetup::new("metrics").await.unwrap();

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1346,7 +1346,6 @@ mod tests {
         context::RequestContext,
         tenant::{
             harness::{TenantHarness, TIMELINE_ID},
-            storage_layer::{LayerE, PersistentLayerDesc},
             Tenant, Timeline,
         },
         DEFAULT_PG_VERSION,

--- a/pageserver/src/tenant/storage_layer/layer_desc.rs
+++ b/pageserver/src/tenant/storage_layer/layer_desc.rs
@@ -103,6 +103,23 @@ impl PersistentLayerDesc {
         }
     }
 
+    pub fn from_filename(
+        tenant_id: TenantId,
+        timeline_id: TimelineId,
+        filename: LayerFileName,
+        file_size: u64,
+    ) -> Self {
+        match filename {
+            LayerFileName::Image(i) => {
+                // FIXME: can we incremental image layers or is this ffu?
+                Self::new_img(tenant_id, timeline_id, i.key_range, i.lsn, false, file_size)
+            }
+            LayerFileName::Delta(d) => {
+                Self::new_delta(tenant_id, timeline_id, d.key_range, d.lsn_range, file_size)
+            }
+        }
+    }
+
     /// Get the LSN that the image layer covers.
     pub fn image_layer_lsn(&self) -> Lsn {
         assert!(!self.is_delta);

--- a/pageserver/src/tenant/storage_layer/layer_desc.rs
+++ b/pageserver/src/tenant/storage_layer/layer_desc.rs
@@ -103,23 +103,6 @@ impl PersistentLayerDesc {
         }
     }
 
-    pub fn from_filename(
-        tenant_id: TenantId,
-        timeline_id: TimelineId,
-        filename: LayerFileName,
-        file_size: u64,
-    ) -> Self {
-        match filename {
-            LayerFileName::Image(i) => {
-                // FIXME: can we incremental image layers or is this ffu?
-                Self::new_img(tenant_id, timeline_id, i.key_range, i.lsn, false, file_size)
-            }
-            LayerFileName::Delta(d) => {
-                Self::new_delta(tenant_id, timeline_id, d.key_range, d.lsn_range, file_size)
-            }
-        }
-    }
-
     /// Get the LSN that the image layer covers.
     pub fn image_layer_lsn(&self) -> Lsn {
         assert!(!self.is_delta);


### PR DESCRIPTION
I will have to change these as I change remote_timeline_client api in #4938. So a bit of cleanup, handle my comments which were just resolved during initial review.

Cleanup:
- use unwrap in tests instead of mixed `?` and `unwrap`
- use `Handle` instead of `&'static Reactor` to make the RemoteTimelineClient more natural
- use arrays in tests
- use plain `#[tokio::test]`