### PR TITLE
delta_layer: Restore generic from last week

### DIFF
--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -1018,10 +1018,11 @@ impl<'a> AsRef<DeltaLayerInner> for Ref<&'a DeltaLayerInner> {
 
 impl<'a, T> Clone for Ref<&'a T> {
     fn clone(&self) -> Self {
-        // this is just a copy
-        Self(self.0)
+        *self
     }
 }
+
+impl<'a, T> Copy for Ref<&'a T> {}
 
 /// A set of data associated with a delta layer key and its value
 pub struct DeltaEntry<T: AsRef<DeltaLayerInner>> {

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -1010,8 +1010,8 @@ impl DeltaLayerInner {
 /// cloning DeltaLayerInner.
 pub(crate) struct Ref<T>(T);
 
-impl<'a> AsRef<DeltaLayerInner> for Ref<&'a DeltaLayerInner> {
-    fn as_ref(&self) -> &DeltaLayerInner {
+impl<'a, T> AsRef<T> for Ref<&'a T> {
+    fn as_ref(&self) -> &T {
         self.0
     }
 }


### PR DESCRIPTION
Restores #4937 work relating to the ability to use `ResidentDeltaLayer` (which is an Arc wrapper) in #4938 for the ValueRef's by removing the borrow from `ValueRef` and providing it from an upper layer.

This should not have any functional changes, most importantly, the `main` will continue to use the borrowed `DeltaLayerInner`. It might be that I can change #4938 to be like this. If that is so, I'll gladly rip out the `Ref` and move the borrow back. But I'll first want to look at the current test failures.