### PR TITLE
fix: format context

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1104,8 +1104,9 @@ impl Tenant {
             {
                 match e {
                     LoadLocalTimelineError::Load(source) => {
-                        return Err(anyhow::anyhow!(source)
-                            .context("Failed to load local timeline: {timeline_id}"))
+                        return Err(anyhow::anyhow!(source).with_context(|| {
+                            format!("Failed to load local timeline: {timeline_id}")
+                        }))
                     }
                     LoadLocalTimelineError::ResumeDeletion(source) => {
                         // Make sure resumed deletion wont fail loading for entire tenant.

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1104,9 +1104,9 @@ impl Tenant {
             {
                 match e {
                     LoadLocalTimelineError::Load(source) => {
-                        return Err(anyhow::anyhow!(source).with_context(|| {
+                        return Err(anyhow::anyhow!(source)).with_context(|| {
                             format!("Failed to load local timeline: {timeline_id}")
-                        }))
+                        })
                     }
                     LoadLocalTimelineError::ResumeDeletion(source) => {
                         // Make sure resumed deletion wont fail loading for entire tenant.


### PR DESCRIPTION
We return an error with unformatted `{timeline_id}`.