### PR TITLE
Make the compaction warning more tolerant

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3778,7 +3778,10 @@ impl Timeline {
         // Sync layers
         if !new_layers.is_empty() {
             // Print a warning if the created layer is larger than double the target size
-            let warn_limit = target_file_size * 2;
+            // Add two pages for potential overhead. This should in theory be already
+            // accounted for in the target calculation, but for very small targets,
+            // we still might easily hit the limit otherwise.
+            let warn_limit = target_file_size * 2 + page_cache::PAGE_SZ as u64 * 2;
             for layer in new_layers.iter() {
                 if layer.desc.file_size > warn_limit {
                     warn!(


### PR DESCRIPTION
## Problem

The performance benchmark in `test_runner/performance/test_layer_map.py` is currently failing due to the warning added in #4888.

## Summary of changes

The test mentioned has a `compaction_target_size` of 8192, which is just one page size. This is an unattainable goal, as we generate at least three pages: one for the header, one for the b-tree (minimally sized ones have just the root node in a single page), one for the data.

Therefore, we add two pages to the warning limit. The warning text becomes a bit less accurate but I think this is okay.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
