### PR TITLE
test: allow race with flush and stopped queue

### DIFF
--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -48,6 +48,9 @@ def test_tenant_delete_smoke(
 
     env = neon_env_builder.init_start()
 
+    # lucky race with stopping from flushing a layer we fail to schedule any uploads
+    env.pageserver.allowed_errors.append(".*layer flush task.+: could not flush frozen layer: update_metadata_file")
+
     ps_http = env.pageserver.http_client()
 
     # first try to delete non existing tenant

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -49,7 +49,9 @@ def test_tenant_delete_smoke(
     env = neon_env_builder.init_start()
 
     # lucky race with stopping from flushing a layer we fail to schedule any uploads
-    env.pageserver.allowed_errors.append(".*layer flush task.+: could not flush frozen layer: update_metadata_file")
+    env.pageserver.allowed_errors.append(
+        ".*layer flush task.+: could not flush frozen layer: update_metadata_file"
+    )
 
     ps_http = env.pageserver.http_client()
 


### PR DESCRIPTION
A lucky race can happen with the shutdown order I guess right now. Seen in [test_tenant_delete_smoke].

The message is not the greatest to match against.

[test_tenant_delete_smoke]: https://neon-github-public-dev.s3.amazonaws.com/reports/main/5892262320/index.html#suites/3556ed71f2d69272a7014df6dcb02317/189a0d1245fb5a8c