### PR TITLE
Resume tenant deletion on attach

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1887,6 +1887,7 @@ impl Tenant {
     /// This function is not cancel-safe!
     ///
     /// `allow_transition_from_loading` is needed for the special case of loading task deleting the tenant.
+    /// `allow_transition_from_attaching` is needed for the special case of attaching deleted tenant.
     async fn set_stopping(
         &self,
         progress: completion::Barrier,

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -619,6 +619,9 @@ impl Tenant {
                 .instrument(info_span!("download_index_part", %timeline_id)),
             );
         }
+
+        let mut timelines_to_resume_deletions = vec![];
+
         // Wait for all the download tasks to complete & collect results.
         let mut remote_index_and_client = HashMap::new();
         let mut timeline_ancestors = HashMap::new();
@@ -635,9 +638,12 @@ impl Tenant {
                     );
                     remote_index_and_client.insert(timeline_id, (index_part, client));
                 }
-                MaybeDeletedIndexPart::Deleted(_) => {
-                    info!("timeline {} is deleted, skipping", timeline_id);
-                    continue;
+                MaybeDeletedIndexPart::Deleted(index_part) => {
+                    info!(
+                        "timeline {} is deleted, picking to resume deletion",
+                        timeline_id
+                    );
+                    timelines_to_resume_deletions.push((timeline_id, index_part, client));
                 }
             }
         }
@@ -660,6 +666,25 @@ impl Tenant {
                         timeline_id, self.tenant_id
                     )
                 })?;
+        }
+
+        // Walk through deleted timelines, resume deletion
+        for (timeline_id, index_part, remote_timeline_client) in timelines_to_resume_deletions {
+            remote_timeline_client
+                .init_upload_queue_stopped_to_continue_deletion(&index_part)
+                .context("init queue stopped")
+                .map_err(LoadLocalTimelineError::ResumeDeletion)?;
+
+            DeleteTimelineFlow::resume_deletion(
+                Arc::clone(self),
+                timeline_id,
+                &index_part.parse_metadata().context("parse_metadata")?,
+                Some(remote_timeline_client),
+                None,
+            )
+            .await
+            .context("resume_deletion")
+            .map_err(LoadLocalTimelineError::ResumeDeletion)?;
         }
 
         std::fs::remove_file(&marker_file)

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -870,6 +870,18 @@ impl Tenant {
             "initial tenant load",
             false,
             async move {
+                // Ideally we should use Tenant::set_broken_no_wait, but it is not supposed to be used when tenant is in loading state.
+                let make_broken = |t: &Tenant, err: anyhow::Error| {
+                    error!("load failed, setting tenant state to Broken: {err:?}");
+                    t.state.send_modify(|state| {
+                        assert!(
+                            matches!(*state, TenantState::Loading | TenantState::Stopping { .. }),
+                            "the loading task owns the tenant state until activation is complete"
+                        );
+                        *state = TenantState::broken_from_reason(err.to_string());
+                    });
+                };
+
                 let mut init_order = init_order;
 
                 // take the completion because initial tenant loading will complete when all of
@@ -889,7 +901,7 @@ impl Tenant {
                     {
                         Ok(should_resume_deletion) => should_resume_deletion,
                         Err(err) => {
-                            tenant_clone.set_broken_no_wait(err.to_string());
+                            make_broken(&tenant_clone, anyhow::anyhow!(err));
                             return Ok(());
                         }
                     }
@@ -916,7 +928,7 @@ impl Tenant {
                     .await
                     {
                         Err(err) => {
-                            tenant_clone.set_broken_no_wait(err);
+                            make_broken(&tenant_clone, anyhow::anyhow!(err));
                             return Ok(());
                         }
                         Ok(()) => return Ok(()),
@@ -928,11 +940,11 @@ impl Tenant {
 
                 match tenant_clone.load(init_order.as_ref(), &ctx).await {
                     Ok(()) => {
-                        debug!("load finished",);
+                        debug!("load finished");
 
                         tenant_clone.activate(broker_client, background_jobs_can_start, &ctx);
                     }
-                    Err(err) => tenant_clone.set_broken_no_wait(err),
+                    Err(err) => make_broken(&tenant_clone, err),
                 }
 
                 Ok(())
@@ -1891,18 +1903,18 @@ impl Tenant {
         let mut err = None;
         let stopping = self.state.send_if_modified(|current_state| match current_state {
             TenantState::Activating(_) => {
-                unreachable!("we ensured above that we're done with activation, and, there is no re-activation")
+                unreachable!("1we ensured above that we're done with activation, and, there is no re-activation")
             }
             TenantState::Attaching => {
                 if !allow_transition_from_attaching {
-                    unreachable!("we ensured above that we're done with activation, and, there is no re-activation")
+                    unreachable!("2we ensured above that we're done with activation, and, there is no re-activation")
                 };
                 *current_state = TenantState::Stopping { progress };
                 true
             }
             TenantState::Loading => {
                 if !allow_transition_from_loading {
-                    unreachable!("we ensured above that we're done with activation, and, there is no re-activation")
+                    unreachable!("3we ensured above that we're done with activation, and, there is no re-activation")
                 };
                 *current_state = TenantState::Stopping { progress };
                 true

--- a/pageserver/src/tenant/delete.rs
+++ b/pageserver/src/tenant/delete.rs
@@ -275,8 +275,9 @@ pub(crate) async fn remote_delete_mark_exists(
 /// It is resumable from any step in case a crash/restart occurs.
 /// There are three entrypoints to the process:
 /// 1. [`DeleteTenantFlow::run`] this is the main one called by a management api handler.
-/// 2. [`DeleteTenantFlow::resume`] is called during restarts when local or remote deletion marks are still there.
-/// Note the only other place that messes around timeline delete mark is the `Tenant::spawn_load` function.
+/// 2. [`DeleteTenantFlow::resume_from_load`] is called during restarts when local or remote deletion marks are still there.
+/// 3. [`DeleteTenantFlow::resume_from_attach`] is called when deletion is resumed tenant is found to be deleted during attach process.
+///  Note the only other place that messes around timeline delete mark is the `Tenant::spawn_load` function.
 #[derive(Default)]
 pub enum DeleteTenantFlow {
     #[default]

--- a/test_runner/fixtures/pageserver/utils.py
+++ b/test_runner/fixtures/pageserver/utils.py
@@ -315,4 +315,4 @@ MANY_SMALL_LAYERS_TENANT_CONFIG = {
 
 
 def poll_for_remote_storage_iterations(remote_storage_kind: RemoteStorageKind) -> int:
-    return 40 if remote_storage_kind is RemoteStorageKind.REAL_S3 else 10
+    return 40 if remote_storage_kind is RemoteStorageKind.REAL_S3 else 15

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -287,9 +287,8 @@ def test_delete_tenant_exercise_crash_safety_failpoints(
         )
 
 
-# TODO resume deletion (https://github.com/neondatabase/neon/issues/5006)
 @pytest.mark.parametrize("remote_storage_kind", available_remote_storages())
-def test_deleted_tenant_ignored_on_attach(
+def test_tenant_delete_is_resumed_on_attach(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
     pg_bin: PgBin,
@@ -331,6 +330,8 @@ def test_deleted_tenant_ignored_on_attach(
         (
             # allow errors caused by failpoints
             f".*failpoint: {failpoint}",
+            # From deletion polling
+            f".*NotFound: tenant {env.initial_tenant}.*",
             # It appears when we stopped flush loop during deletion (attempt) and then pageserver is stopped
             ".*freeze_and_flush_on_shutdown.*failed to freeze and flush: cannot flush frozen layers when flush_loop is not running, state is Exited",
             # error from http response is also logged
@@ -376,20 +377,17 @@ def test_deleted_tenant_ignored_on_attach(
     env.pageserver.start()
 
     # now we call attach
-    with pytest.raises(
-        PageserverApiException, match="Tenant is marked as deleted on remote storage"
-    ):
-        ps_http.tenant_attach(tenant_id=tenant_id)
+    ps_http.tenant_attach(tenant_id=tenant_id)
 
-    # delete should be resumed (not yet)
-    # wait_tenant_status_404(ps_http, tenant_id, iterations)
+    # delete should be resumed
+    wait_tenant_status_404(ps_http, tenant_id, iterations)
 
     # we shouldn've created tenant dir on disk
     tenant_path = env.tenant_dir(tenant_id=tenant_id)
     assert not tenant_path.exists()
 
     if remote_storage_kind in available_s3_storages():
-        assert_prefix_not_empty(
+        assert_prefix_empty(
             neon_env_builder,
             prefix="/".join(
                 (


### PR DESCRIPTION
I'm still a bit nervous about attach -> crash case. But it should work. (unlike case with timeline). Ideally would be cool to cover this with test.

This continues tradition of adding bool flags for Tenant::set_stopping. Probably lifecycle project will help with fixing it.