### PR TITLE
Fix DeltaLayer dumping

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3938,7 +3938,7 @@ mod tests {
         let layer_map = tline.layers.read().await;
         let level0_deltas = layer_map.layer_map().get_level0_deltas()?;
 
-        assert!(level0_deltas.len() > 0);
+        assert!(!level0_deltas.is_empty());
 
         for delta in level0_deltas {
             let delta = layer_map.get_from_desc(&delta);

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3935,13 +3935,16 @@ mod tests {
             .await?;
         make_some_layers(tline.as_ref(), Lsn(0x20)).await?;
 
-        let layers = tline.layers.read().await;
-        let level0_deltas = layers.layer_map().get_level0_deltas()?;
+        let layer_map = tline.layers.read().await;
+        let level0_deltas = layer_map.layer_map().get_level0_deltas()?;
 
         assert!(level0_deltas.len() > 0);
 
         for delta in level0_deltas {
-            let delta = layers.get_from_desc(&delta);
+            let delta = layer_map.get_from_desc(&delta);
+            // Ensure we are dumping a delta layer here
+            let delta = delta.downcast_delta_layer().unwrap();
+
             delta.dump(false, &ctx).await.unwrap();
             delta.dump(true, &ctx).await.unwrap();
         }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3928,7 +3928,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn layer_dumping() -> anyhow::Result<()> {
+    async fn delta_layer_dumping() -> anyhow::Result<()> {
         let (tenant, ctx) = TenantHarness::create("test_layer_dumping")?.load().await;
         let tline = tenant
             .create_test_timeline(TIMELINE_ID, Lsn(0x10), DEFAULT_PG_VERSION, &ctx)


### PR DESCRIPTION
## Problem

Before, DeltaLayer dumping (via `cargo run --release -p pagectl -- print-layer-file` ) would crash as one can't call `Handle::block_on` in an async executor thread.

## Summary of changes

Avoid the problem by using `DeltaLayerInner::load_keys` to load the keys into RAM (which we already do during compaction), and then load the values one by one during dumping.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
