### PR TITLE
debug_tool: get page at lsn and keyspace via http api

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1718,7 +1718,7 @@ pub fn make_router(
             testing_api_handler("getpage@lsn", r, getpage_at_lsn_handler)
         })
         .get(
-            "/v1/tenant/:tenant_id/timeline/:timeline_id/partitioning",
+            "/v1/tenant/:tenant_id/timeline/:timeline_id/keyspace",
             |r| testing_api_handler("read out the keyspace", r, timeline_collect_keyspace),
         )
         .any(handler_404))

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1279,7 +1279,7 @@ async fn getpage_at_lsn_handler(
     .await
 }
 
-async fn timeline_get_partitioning(
+async fn timeline_collect_keyspace(
     request: Request<Body>,
     _cancel: CancellationToken,
 ) -> Result<Response<Body>, ApiError> {
@@ -1363,7 +1363,7 @@ async fn timeline_get_partitioning(
 
         json_response(StatusCode::OK, Partitioning { keys, at_lsn })
     }
-    .instrument(info_span!("timeline_get_partitioning", %tenant_id, %timeline_id))
+    .instrument(info_span!("timeline_collect_keyspace", %tenant_id, %timeline_id))
     .await
 }
 
@@ -1719,7 +1719,7 @@ pub fn make_router(
         })
         .get(
             "/v1/tenant/:tenant_id/timeline/:timeline_id/partitioning",
-            |r| testing_api_handler("read out the partitioning", r, timeline_get_partitioning),
+            |r| testing_api_handler("read out the keyspace", r, timeline_collect_keyspace),
         )
         .any(handler_404))
 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -443,12 +443,12 @@ impl Timeline {
     }
 
     pub(crate) fn partitioning(&self) -> Option<(KeyPartitioning, Lsn)> {
-        let (partitioning, at_lsn) = self.partitioning.lock().unwrap();
+        let g = self.partitioning.lock().unwrap();
 
-        if partitioning.parts.is_empty() || !at_lsn.is_valid() {
+        if g.0.parts.is_empty() || !g.1.is_valid() {
             None
         } else {
-            Some((partitioning.clone(), at_lsn))
+            Some((g.0.clone(), g.1))
         }
     }
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -442,6 +442,16 @@ impl Timeline {
         self.latest_gc_cutoff_lsn.read()
     }
 
+    pub(crate) fn partitioning(&self) -> Option<(KeyPartitioning, Lsn)> {
+        let (partitioning, at_lsn) = self.partitioning.lock().unwrap();
+
+        if partitioning.parts.is_empty() || !at_lsn.is_valid() {
+            None
+        } else {
+            Some((partitioning.clone(), at_lsn))
+        }
+    }
+
     /// Look up given page version.
     ///
     /// If a remote layer file is needed, it is downloaded as part of this

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -442,16 +442,6 @@ impl Timeline {
         self.latest_gc_cutoff_lsn.read()
     }
 
-    pub(crate) fn partitioning(&self) -> Option<(KeyPartitioning, Lsn)> {
-        let g = self.partitioning.lock().unwrap();
-
-        if g.0.parts.is_empty() || !g.1.is_valid() {
-            None
-        } else {
-            Some((g.0.clone(), g.1))
-        }
-    }
-
     /// Look up given page version.
     ///
     /// If a remote layer file is needed, it is downloaded as part of this


### PR DESCRIPTION
If there are any layermap or layer file related problems, having a reproducable `get_page@lsn` easily usable for fast debugging iteration is helpful.

Split off from #4938.

Later evolved to add http apis for:
- `get_page@lsn` at `/v1/tenant/:tenant_id/timeline/:timeline_id/get?key=<hex>&lsn=<lsn string>`
- collecting the keyspace at `/v1/tenant/:tenant_id/timeline/:timeline_id/keyspace?[at_lsn=<lsn string>]`
    - defaults to `last_record_lsn`

collecting the keyspace seems to yield some ranges for which there is no key.