### PR TITLE
refactor: single phase Timeline::load_layer_map

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -441,7 +441,7 @@ impl Tenant {
                 .remote_client
                 .as_ref()
                 .unwrap()
-                .init_upload_queue(&index_part)?;
+                .init_upload_queue(index_part)?;
         } else if self.remote_storage.is_some() {
             // No data on the remote storage, no local layers, local metadata file.
             //

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -455,11 +455,9 @@ impl Tenant {
                 .unwrap()
                 .init_upload_queue(index_part)?;
         } else if self.remote_storage.is_some() {
-            // No data on the remote storage, no local layers, local metadata file.
-            //
-            // TODO(#5075): pageserver should rather remove the branch which failed to upload to
-            // remote storage. because absence on remote storage means we did not acknowledge the
-            // branch creation and console will have to retry, no need to keep the old files.
+            // No data on the remote storage, local metadata file. We might end up
+            // here with timeline_create right before restart. the timeline creation will be
+            // retried, and that http handler will wait for these uploads to complete.
             let rtc = timeline.remote_client.as_ref().unwrap();
             rtc.init_upload_queue_for_empty_remote(up_to_date_metadata)?;
             rtc.schedule_index_upload_for_metadata_update(up_to_date_metadata)?;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -433,6 +433,18 @@ impl Tenant {
             "these are used interchangeably"
         );
 
+        // Save the metadata file to local disk.
+        if !picked_local {
+            save_metadata(
+                self.conf,
+                &tenant_id,
+                &timeline_id,
+                up_to_date_metadata,
+                first_save,
+            )
+            .context("save_metadata")?;
+        }
+
         let index_part = remote_startup_data.as_ref().map(|x| &x.index_part);
 
         // FIXME: it seems that we shouldn't have "mutable init" for RemoteTimelineClient either
@@ -491,18 +503,6 @@ impl Tenant {
                     .is_some(),
             "Timeline has no ancestor and no layer files"
         );
-
-        // Save the metadata file to local disk.
-        if !picked_local {
-            save_metadata(
-                self.conf,
-                &tenant_id,
-                &timeline_id,
-                up_to_date_metadata,
-                first_save,
-            )
-            .context("save_metadata")?;
-        }
 
         Ok(())
     }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -422,13 +422,18 @@ impl Tenant {
             init_order,
             CreateTimelineCause::Load,
         )?;
-        let new_disk_consistent_lsn = timeline.get_disk_consistent_lsn();
+        let disk_consistent_lsn = timeline.get_disk_consistent_lsn();
+        assert_eq!(
+            disk_consistent_lsn,
+            up_to_date_metadata.disk_consistent_lsn(),
+            "these are used interchangeably; need to move layer map loading before Timeline creation to avoid drifting"
+        );
         anyhow::ensure!(
-            new_disk_consistent_lsn.is_valid(),
+            disk_consistent_lsn.is_valid(),
             "Timeline {tenant_id}/{timeline_id} has invalid disk_consistent_lsn"
         );
         timeline
-            .load_layer_map(new_disk_consistent_lsn)
+            .load_layer_map(disk_consistent_lsn)
             .await
             .with_context(|| {
                 format!("Failed to load layermap for timeline {tenant_id}/{timeline_id}")

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -445,16 +445,9 @@ impl Tenant {
         } else if self.remote_storage.is_some() {
             // No data on the remote storage, no local layers, local metadata file.
             //
-            // TODO https://github.com/neondatabase/neon/issues/3865
-            // Currently, console does not wait for the timeline data upload to the remote storage
-            // and considers the timeline created, expecting other pageserver nodes to work with it.
-            // Branch metadata upload could get interrupted (e.g pageserver got killed),
-            // hence any locally existing branch metadata with no remote counterpart should be uploaded,
-            // otherwise any other pageserver won't see the branch on `attach`.
-            //
-            // After the issue gets implemented, pageserver should rather remove the branch,
-            // since absence on S3 means we did not acknowledge the branch creation and console will have to retry,
-            // no need to keep the old files.
+            // TODO(#5075): pageserver should rather remove the branch which failed to upload to
+            // remote storage. because absence on remote storage means we did not acknowledge the
+            // branch creation and console will have to retry, no need to keep the old files.
             let rtc = timeline.remote_client.as_ref().unwrap();
             rtc.init_upload_queue_for_empty_remote(up_to_date_metadata)?;
             rtc.schedule_index_upload_for_metadata_update(up_to_date_metadata)?;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -447,7 +447,6 @@ impl Tenant {
 
         let index_part = remote_startup_data.as_ref().map(|x| &x.index_part);
 
-        // FIXME: it seems that we shouldn't have "mutable init" for RemoteTimelineClient either
         if let Some(index_part) = index_part {
             timeline
                 .remote_client

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -330,7 +330,7 @@ impl Debug for SetStoppingError {
 }
 
 struct RemoteStartupData {
-    index_part: Arc<IndexPart>,
+    index_part: IndexPart,
     remote_metadata: TimelineMetadata,
 }
 
@@ -465,7 +465,10 @@ impl Tenant {
         }
 
         timeline
-            .load_layer_map(disk_consistent_lsn, index_part.cloned())
+            .load_layer_map(
+                disk_consistent_lsn,
+                remote_startup_data.map(|x| x.index_part),
+            )
             .await
             .with_context(|| {
                 format!("Failed to load layermap for timeline {tenant_id}/{timeline_id}")
@@ -823,7 +826,7 @@ impl Tenant {
             timeline_id,
             resources,
             Some(RemoteStartupData {
-                index_part: Arc::new(index_part),
+                index_part: index_part,
                 remote_metadata,
             }),
             local_metadata,
@@ -1317,7 +1320,7 @@ impl Tenant {
                         .map_err(LoadLocalTimelineError::Load)?;
                     (
                         Some(RemoteStartupData {
-                            index_part: Arc::new(index_part),
+                            index_part: index_part,
                             remote_metadata,
                         }),
                         Some(remote_client),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -423,14 +423,14 @@ impl Tenant {
             CreateTimelineCause::Load,
         )?;
         let disk_consistent_lsn = timeline.get_disk_consistent_lsn();
-        assert_eq!(
-            disk_consistent_lsn,
-            up_to_date_metadata.disk_consistent_lsn(),
-            "these are used interchangeably; need to move layer map loading before Timeline creation to avoid drifting"
-        );
         anyhow::ensure!(
             disk_consistent_lsn.is_valid(),
             "Timeline {tenant_id}/{timeline_id} has invalid disk_consistent_lsn"
+        );
+        assert_eq!(
+            disk_consistent_lsn,
+            up_to_date_metadata.disk_consistent_lsn(),
+            "these are used interchangeably"
         );
 
         let index_part = remote_startup_data.as_ref().map(|x| &x.index_part);

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -826,7 +826,7 @@ impl Tenant {
             timeline_id,
             resources,
             Some(RemoteStartupData {
-                index_part: index_part,
+                index_part,
                 remote_metadata,
             }),
             local_metadata,
@@ -1320,7 +1320,7 @@ impl Tenant {
                         .map_err(LoadLocalTimelineError::Load)?;
                     (
                         Some(RemoteStartupData {
-                            index_part: index_part,
+                            index_part,
                             remote_metadata,
                         }),
                         Some(remote_client),

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -135,7 +135,7 @@
 //! - Initiate upload queue with that [`IndexPart`].
 //! - Reschedule all lost operations by comparing the local filesystem state
 //!   and remote state as per [`IndexPart`]. This is done in
-//!   [`Tenant::timeline_init_and_sync`] and [`Timeline::reconcile_with_remote`].
+//!   [`Tenant::timeline_init_and_sync`].
 //!
 //! Note that if we crash during file deletion between the index update
 //! that removes the file from the list of files, and deleting the remote file,
@@ -199,7 +199,6 @@
 //! But note that we don't test any of this right now.
 //!
 //! [`Tenant::timeline_init_and_sync`]: super::Tenant::timeline_init_and_sync
-//! [`Timeline::reconcile_with_remote`]: super::Timeline::reconcile_with_remote
 
 mod delete;
 mod download;

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -353,6 +353,10 @@ impl RemoteTimelineClient {
         let mut upload_queue = self.upload_queue.lock().unwrap();
         upload_queue.initialize_with_current_remote_index_part(index_part)?;
         self.update_remote_physical_size_gauge(Some(index_part));
+        info!(
+            "initialized upload queue from remote index with {} layer files",
+            index_part.layer_metadata.len()
+        );
         Ok(())
     }
 
@@ -365,6 +369,7 @@ impl RemoteTimelineClient {
         let mut upload_queue = self.upload_queue.lock().unwrap();
         upload_queue.initialize_empty_remote(local_metadata)?;
         self.update_remote_physical_size_gauge(None);
+        info!("initialized upload queue as empty");
         Ok(())
     }
 

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -172,7 +172,6 @@
 //!   transitioning it from `TenantState::Attaching` to `TenantState::Active` state.
 //!   This starts the timelines' WAL-receivers and the tenant's GC & Compaction loops.
 //!
-//! Most of the above steps happen in [`Timeline::reconcile_with_remote`] or its callers.
 //! We keep track of the fact that a client is in `Attaching` state in a marker
 //! file on the local disk. This is critical because, when we restart the pageserver,
 //! we do not want to do the `List timelines` step for each tenant that has already
@@ -192,7 +191,7 @@
 //! not created and the uploads are skipped.
 //! Theoretically, it should be ok to remove and re-add remote storage configuration to
 //! the pageserver config at any time, since it doesn't make a difference to
-//! `reconcile_with_remote`.
+//! `Timeline::load_layer_map`.
 //! Of course, the remote timeline dir must not change while we have de-configured
 //! remote storage, i.e., the pageserver must remain the owner of the given prefix
 //! in remote storage.

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -191,13 +191,14 @@
 //! not created and the uploads are skipped.
 //! Theoretically, it should be ok to remove and re-add remote storage configuration to
 //! the pageserver config at any time, since it doesn't make a difference to
-//! `Timeline::load_layer_map`.
+//! [`Timeline::load_layer_map`].
 //! Of course, the remote timeline dir must not change while we have de-configured
 //! remote storage, i.e., the pageserver must remain the owner of the given prefix
 //! in remote storage.
 //! But note that we don't test any of this right now.
 //!
 //! [`Tenant::timeline_init_and_sync`]: super::Tenant::timeline_init_and_sync
+//! [`Timeline::load_layer_map`]: super::Timeline::load_layer_map
 
 mod delete;
 mod download;

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -41,8 +41,6 @@ pub use inmemory_layer::InMemoryLayer;
 pub use layer_desc::{PersistentLayerDesc, PersistentLayerKey};
 pub use remote_layer::RemoteLayer;
 
-use super::timeline::layer_manager::LayerManager;
-
 pub fn range_overlaps<T>(a: &Range<T>, b: &Range<T>) -> bool
 where
     T: PartialOrd<T>,
@@ -175,16 +173,9 @@ impl LayerAccessStats {
     ///
     /// [`LayerLoad`]: LayerResidenceEventReason::LayerLoad
     /// [`record_residence_event`]: Self::record_residence_event
-    pub(crate) fn for_loading_layer(
-        layer_map_lock_held_witness: &LayerManager,
-        status: LayerResidenceStatus,
-    ) -> Self {
+    pub(crate) fn for_loading_layer(status: LayerResidenceStatus) -> Self {
         let new = LayerAccessStats(Mutex::new(LayerAccessStatsLocked::default()));
-        new.record_residence_event(
-            layer_map_lock_held_witness,
-            status,
-            LayerResidenceEventReason::LayerLoad,
-        );
+        new.record_residence_event(status, LayerResidenceEventReason::LayerLoad);
         new
     }
 
@@ -197,7 +188,6 @@ impl LayerAccessStats {
     /// [`record_residence_event`]: Self::record_residence_event
     pub(crate) fn clone_for_residence_change(
         &self,
-        layer_map_lock_held_witness: &LayerManager,
         new_status: LayerResidenceStatus,
     ) -> LayerAccessStats {
         let clone = {
@@ -205,11 +195,7 @@ impl LayerAccessStats {
             inner.clone()
         };
         let new = LayerAccessStats(Mutex::new(clone));
-        new.record_residence_event(
-            layer_map_lock_held_witness,
-            new_status,
-            LayerResidenceEventReason::ResidenceChange,
-        );
+        new.record_residence_event(new_status, LayerResidenceEventReason::ResidenceChange);
         new
     }
 
@@ -229,7 +215,6 @@ impl LayerAccessStats {
     ///
     pub(crate) fn record_residence_event(
         &self,
-        _layer_map_lock_held_witness: &LayerManager,
         status: LayerResidenceStatus,
         reason: LayerResidenceEventReason,
     ) {

--- a/pageserver/src/tenant/storage_layer/filename.rs
+++ b/pageserver/src/tenant/storage_layer/filename.rs
@@ -215,6 +215,17 @@ impl LayerFileName {
     pub fn file_name(&self) -> String {
         self.to_string()
     }
+
+    /// Determines if this layer file is considered to be in future meaning we will discard these
+    /// layers during timeline initialization from the given disk_consistent_lsn.
+    pub(crate) fn is_in_future(&self, disk_consistent_lsn: Lsn) -> bool {
+        use LayerFileName::*;
+        match self {
+            Image(file_name) if file_name.lsn > disk_consistent_lsn => true,
+            Delta(file_name) if file_name.lsn_range.end > disk_consistent_lsn + 1 => true,
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for LayerFileName {

--- a/pageserver/src/tenant/storage_layer/remote_layer.rs
+++ b/pageserver/src/tenant/storage_layer/remote_layer.rs
@@ -186,7 +186,7 @@ impl RemoteLayer {
     /// Create a Layer struct representing this layer, after it has been downloaded.
     pub(crate) fn create_downloaded_layer(
         &self,
-        layer_map_lock_held_witness: &LayerManager,
+        _layer_map_lock_held_witness: &LayerManager,
         conf: &'static PageServerConf,
         file_size: u64,
     ) -> Arc<dyn PersistentLayer> {
@@ -198,10 +198,8 @@ impl RemoteLayer {
                 self.desc.tenant_id,
                 &fname,
                 file_size,
-                self.access_stats.clone_for_residence_change(
-                    layer_map_lock_held_witness,
-                    LayerResidenceStatus::Resident,
-                ),
+                self.access_stats
+                    .clone_for_residence_change(LayerResidenceStatus::Resident),
             ))
         } else {
             let fname = self.desc.image_file_name();
@@ -211,10 +209,8 @@ impl RemoteLayer {
                 self.desc.tenant_id,
                 &fname,
                 file_size,
-                self.access_stats.clone_for_residence_change(
-                    layer_map_lock_held_witness,
-                    LayerResidenceStatus::Resident,
-                ),
+                self.access_stats
+                    .clone_for_residence_change(LayerResidenceStatus::Resident),
             ))
         }
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1599,7 +1599,7 @@ impl Timeline {
     pub(super) async fn load_layer_map(
         &self,
         disk_consistent_lsn: Lsn,
-        index_part: Option<Arc<IndexPart>>,
+        index_part: Option<IndexPart>,
     ) -> anyhow::Result<()> {
         use init::{Decision::*, Discovered, FutureLayer};
         use LayerFileName::*;
@@ -1655,11 +1655,8 @@ impl Timeline {
                     );
                 }
 
-                let decided = init::reconcile(
-                    discovered_layers,
-                    index_part.as_deref(),
-                    disk_consistent_lsn,
-                );
+                let decided =
+                    init::reconcile(discovered_layers, index_part.as_ref(), disk_consistent_lsn);
 
                 let mut loaded_layers = Vec::new();
                 let mut needs_upload = Vec::new();

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1644,7 +1644,7 @@ impl Timeline {
                     path.pop();
                 }
 
-                let decided = init::recoincile(
+                let decided = init::reconcile(
                     discovered_layers,
                     index_part.as_deref(),
                     disk_consistent_lsn,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1658,17 +1658,17 @@ impl Timeline {
                 let mut needs_upload = Vec::new();
                 let mut total_physical_size = 0;
 
-                for (name, maybe_decision) in decided {
-                    let decision = match maybe_decision {
-                        Some(UseRemote { local, remote }) => {
+                for (name, decision) in decided {
+                    let decision = match decision {
+                        Ok(UseRemote { local, remote }) => {
                             path.push(name.file_name());
                             init::cleanup_local_file_for_remote(&path, &local, &remote)?;
                             path.pop();
 
                             UseRemote { local, remote }
                         }
-                        Some(decision) => decision,
-                        None => {
+                        Ok(decision) => decision,
+                        Err(_future_layer) => {
                             path.push(name.file_name());
                             init::cleanup_future_layer(&path, name, disk_consistent_lsn)?;
                             path.pop();

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1647,8 +1647,7 @@ impl Timeline {
                 }
 
                 if !unrecognized_files.is_empty() {
-                    // assume that if there are any which are not there because of debugging there
-                    // are many.
+                    // assume that if there are any there are many many.
                     let n = unrecognized_files.len();
                     let first = &unrecognized_files[..n.min(10)];
                     anyhow::bail!(

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1675,11 +1675,17 @@ impl Timeline {
                             UseRemote { local, remote }
                         }
                         Ok(decision) => decision,
-                        Err(FutureLayer {}) => {
-                            path.push(name.file_name());
-                            init::cleanup_future_layer(&path, name, disk_consistent_lsn)?;
-                            path.pop();
-                            // no futher processing possible
+                        Err(FutureLayer { local }) => {
+                            if local.is_some() {
+                                path.push(name.file_name());
+                                init::cleanup_future_layer(&path, name, disk_consistent_lsn)?;
+                                path.pop();
+                            } else {
+                                // we cannot do anything for remote layers, but not continuing to
+                                // process it will leave it out index_part.json as well.
+                            }
+                            //
+                            // we do not currently schedule deletions for these.
                             continue;
                         }
                     };

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1616,9 +1616,11 @@ impl Timeline {
         // structs representing all files on disk
         let timeline_path = self.conf.timeline_path(&self.tenant_id, &self.timeline_id);
         let (conf, tenant_id, timeline_id) = (self.conf, self.tenant_id, self.timeline_id);
+        let span = tracing::Span::current();
 
         let (loaded_layers, needs_upload, total_physical_size) = tokio::task::spawn_blocking({
             move || {
+                let _g = span.entered();
                 let discovered = init::scan_timeline_dir(&timeline_path)?;
                 let mut discovered_layers = Vec::with_capacity(discovered.len());
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1709,7 +1709,9 @@ impl Timeline {
             .iter()
             .map(|x| x.layer_desc().file_size)
             .sum::<u64>();
-        guard.initialize_local_layers(loaded_layers, Lsn(disk_consistent_lsn.0) + 1);
+
+        // we initialize the layer map up to ..(disk_consistent_lsn+1)
+        guard.initialize_local_layers(loaded_layers, disk_consistent_lsn + 1);
 
         info!(
             "loaded layer map with {} layers at {}, total physical size: {}",

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1685,7 +1685,6 @@ impl Timeline {
 
                     let stats = LayerAccessStats::for_loading_layer(status);
 
-                    // this is not that much code, but we but rustfmt does not enjoy it
                     let layer: Arc<dyn PersistentLayer> = match (name, &decision) {
                         (Delta(d), UseLocal(m) | NeedsUpload(m)) => {
                             total_physical_size += m.file_size();

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1210,7 +1210,7 @@ impl Timeline {
                 &layer_metadata,
                 local_layer
                     .access_stats()
-                    .clone_for_residence_change(layer_mgr, LayerResidenceStatus::Evicted),
+                    .clone_for_residence_change(LayerResidenceStatus::Evicted),
             ),
             LayerFileName::Delta(delta_name) => RemoteLayer::new_delta(
                 self.tenant_id,
@@ -1219,7 +1219,7 @@ impl Timeline {
                 &layer_metadata,
                 local_layer
                     .access_stats()
-                    .clone_for_residence_change(layer_mgr, LayerResidenceStatus::Evicted),
+                    .clone_for_residence_change(LayerResidenceStatus::Evicted),
             ),
         });
 
@@ -1634,8 +1634,7 @@ impl Timeline {
                     }
 
                     let file_size = direntry_path.metadata()?.len();
-                    let stats =
-                        LayerAccessStats::for_loading_layer(&guard, LayerResidenceStatus::Resident);
+                    let stats = LayerAccessStats::for_loading_layer(LayerResidenceStatus::Resident);
 
                     let layer = ImageLayer::new(
                         self.conf,
@@ -1666,8 +1665,7 @@ impl Timeline {
                     }
 
                     let file_size = direntry_path.metadata()?.len();
-                    let stats =
-                        LayerAccessStats::for_loading_layer(&guard, LayerResidenceStatus::Resident);
+                    let stats = LayerAccessStats::for_loading_layer(LayerResidenceStatus::Resident);
 
                     let layer = DeltaLayer::new(
                         self.conf,
@@ -1809,8 +1807,7 @@ impl Timeline {
                     );
                         continue;
                     }
-                    let stats =
-                        LayerAccessStats::for_loading_layer(&guard, LayerResidenceStatus::Evicted);
+                    let stats = LayerAccessStats::for_loading_layer(LayerResidenceStatus::Evicted);
 
                     let remote_layer = RemoteLayer::new_img(
                         self.tenant_id,
@@ -1836,8 +1833,7 @@ impl Timeline {
                         );
                         continue;
                     }
-                    let stats =
-                        LayerAccessStats::for_loading_layer(&guard, LayerResidenceStatus::Evicted);
+                    let stats = LayerAccessStats::for_loading_layer(LayerResidenceStatus::Evicted);
 
                     let remote_layer = RemoteLayer::new_delta(
                         self.tenant_id,
@@ -2856,7 +2852,6 @@ impl Timeline {
             if let Some(ref l) = delta_layer_to_add {
                 // TODO: move access stats, metrics update, etc. into layer manager.
                 l.access_stats().record_residence_event(
-                    &guard,
                     LayerResidenceStatus::Resident,
                     LayerResidenceEventReason::LayerCreate,
                 );
@@ -3246,7 +3241,6 @@ impl Timeline {
                 .add(metadata.len());
             let l = Arc::new(l);
             l.access_stats().record_residence_event(
-                &guard,
                 LayerResidenceStatus::Resident,
                 LayerResidenceEventReason::LayerCreate,
             );
@@ -3926,7 +3920,6 @@ impl Timeline {
 
             new_layer_paths.insert(new_delta_path, LayerFileMetadata::new(metadata.len()));
             l.access_stats().record_residence_event(
-                &guard,
                 LayerResidenceStatus::Resident,
                 LayerResidenceEventReason::LayerCreate,
             );

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1746,12 +1746,10 @@ impl Timeline {
         guard.initialize_local_layers(loaded_layers, disk_consistent_lsn + 1);
 
         if let Some(rtc) = self.remote_client.as_ref() {
-            if !needs_upload.is_empty() {
-                for (layer, m) in needs_upload {
-                    rtc.schedule_layer_file_upload(&layer.layer_desc().filename(), &m)?;
-                }
-                rtc.schedule_index_upload_for_file_changes()?;
+            for (layer, m) in needs_upload {
+                rtc.schedule_layer_file_upload(&layer.layer_desc().filename(), &m)?;
             }
+            rtc.schedule_index_upload_for_file_changes()?;
         }
 
         info!(

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1601,8 +1601,7 @@ impl Timeline {
         disk_consistent_lsn: Lsn,
         index_part: Option<Arc<IndexPart>>,
     ) -> anyhow::Result<()> {
-        use init::Decision::*;
-        use init::Discovered;
+        use init::{Decision::*, Discovered, FutureLayer};
         use LayerFileName::*;
 
         let mut guard = self.layers.write().await;
@@ -1665,7 +1664,7 @@ impl Timeline {
                             UseRemote { local, remote }
                         }
                         Ok(decision) => decision,
-                        Err(_future_layer) => {
+                        Err(FutureLayer {}) => {
                             path.push(name.file_name());
                             init::cleanup_future_layer(&path, name, disk_consistent_lsn)?;
                             path.pop();

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1744,16 +1744,13 @@ impl Timeline {
 
         guard.initialize_local_layers(loaded_layers, disk_consistent_lsn + 1);
 
-        if !needs_upload.is_empty() {
-            let rtc = self
-                .remote_client
-                .as_ref()
-                .expect("we had index_part => we have remote timeline client");
-
-            for (layer, m) in needs_upload {
-                rtc.schedule_layer_file_upload(&layer.layer_desc().filename(), &m)?;
+        if let Some(rtc) = self.remote_client.as_ref() {
+            if !needs_upload.is_empty() {
+                for (layer, m) in needs_upload {
+                    rtc.schedule_layer_file_upload(&layer.layer_desc().filename(), &m)?;
+                }
+                rtc.schedule_index_upload_for_file_changes()?;
             }
-            rtc.schedule_index_upload_for_file_changes()?;
         }
 
         info!(

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1739,13 +1739,7 @@ impl Timeline {
         })
         .await
         .map_err(anyhow::Error::new)
-        .and_then(|x| x)
-        .with_context(|| {
-            format!(
-                "process tenant {} timeline {} directory",
-                self.tenant_id, self.timeline_id
-            )
-        })?;
+        .and_then(|x| x)?;
 
         let num_layers = loaded_layers.len();
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4652,7 +4652,8 @@ fn rename_to_backup(path: &Path) -> anyhow::Result<()> {
     for i in 0u32.. {
         new_path.set_file_name(format!("{filename}.{i}.old"));
         if !new_path.exists() {
-            std::fs::rename(path, &new_path)?;
+            std::fs::rename(path, &new_path)
+                .with_context(|| format!("rename {path:?} to {new_path:?}"))?;
             return Ok(());
         }
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1586,9 +1586,7 @@ impl Timeline {
         ));
     }
 
-    ///
     /// Initialize with an empty layer map. Used when creating a new timeline.
-    ///
     pub(super) fn init_empty_layer_map(&self, start_lsn: Lsn) {
         let mut layers = self.layers.try_write().expect(
             "in the context where we call this function, no other task has access to the object",
@@ -1596,9 +1594,8 @@ impl Timeline {
         layers.initialize_empty(Lsn(start_lsn.0));
     }
 
-    ///
-    /// Scan the timeline directory to populate the layer map.
-    ///
+    /// Scan the timeline directory, cleanup, populate the layer map, and schedule uploads for local-only
+    /// files.
     pub(super) async fn load_layer_map(
         &self,
         disk_consistent_lsn: Lsn,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1612,58 +1612,72 @@ impl Timeline {
 
         let mut loaded_layers = Vec::<Arc<dyn PersistentLayer>>::new();
 
-        for direntry in fs::read_dir(timeline_path)? {
+        enum Discovered {
+            Layer(LayerFileName, u64),
+            FutureLayer(LayerFileName),
+            Ephemeral,
+            Temporary,
+            TemporaryDownload,
+            Metadata,
+            IgnoredBackup,
+            Unknown,
+            // NonUtf8(std::ffi::OsString),
+        }
+
+        for direntry in fs::read_dir(&timeline_path)? {
             let direntry = direntry?;
             let direntry_path = direntry.path();
-            let fname = direntry.file_name();
-            let fname = fname.to_string_lossy();
+            let file_name = direntry.file_name();
 
-            use std::str::FromStr;
-            match LayerFileName::from_str(&fname) {
-                Ok(LayerFileName::Image(filename)) if filename.lsn > disk_consistent_lsn => {
-                    info!(
-                        "found future image layer {} on timeline {} disk_consistent_lsn is {}",
-                        filename, self.timeline_id, disk_consistent_lsn
-                    );
+            let discovered = {
+                let fname = file_name.to_string_lossy();
 
-                    rename_to_backup(&direntry_path)?;
+                use std::str::FromStr;
+                match LayerFileName::from_str(&fname) {
+                    Ok(LayerFileName::Image(file_name)) if file_name.lsn > disk_consistent_lsn => {
+                        Discovered::FutureLayer(file_name.into())
+                    }
+                    Ok(LayerFileName::Delta(file_name))
+                        if file_name.lsn_range.end > disk_consistent_lsn + 1 =>
+                    {
+                        // The end-LSN is exclusive, while disk_consistent_lsn is
+                        // inclusive. For example, if disk_consistent_lsn is 100, it is
+                        // OK for a delta layer to have end LSN 101, but if the end LSN
+                        // is 102, then it might not have been fully flushed to disk
+                        // before crash.
+                        Discovered::FutureLayer(file_name.into())
+                    }
+                    Ok(LayerFileName::Image(file_name)) => {
+                        assert!(file_name.lsn <= disk_consistent_lsn);
+                        let file_size = direntry_path.metadata()?.len();
+                        Discovered::Layer(file_name.into(), file_size)
+                    }
+                    Ok(LayerFileName::Delta(file_name)) => {
+                        assert!(file_name.lsn_range.end <= disk_consistent_lsn + 1);
+                        let file_size = direntry_path.metadata()?.len();
+                        Discovered::Layer(file_name.into(), file_size)
+                    }
+                    Err(_) => {
+                        if fname == METADATA_FILE_NAME {
+                            Discovered::Metadata
+                        } else if fname.ends_with(".old") {
+                            // ignore these
+                            Discovered::IgnoredBackup
+                        } else if remote_timeline_client::is_temp_download_file(&direntry_path) {
+                            Discovered::TemporaryDownload
+                        } else if is_ephemeral_file(&fname) {
+                            Discovered::Ephemeral
+                        } else if is_temporary(&direntry_path) {
+                            Discovered::Temporary
+                        } else {
+                            Discovered::Unknown
+                        }
+                    }
                 }
-                Ok(LayerFileName::Image(filename)) => {
-                    assert!(filename.lsn <= disk_consistent_lsn);
+            };
 
-                    let file_size = direntry_path.metadata()?.len();
-                    let stats = LayerAccessStats::for_loading_layer(LayerResidenceStatus::Resident);
-
-                    let layer = ImageLayer::new(
-                        self.conf,
-                        self.timeline_id,
-                        self.tenant_id,
-                        &filename,
-                        file_size,
-                        stats,
-                    );
-
-                    loaded_layers.push(Arc::new(layer));
-                }
-                Ok(LayerFileName::Delta(filename))
-                    if filename.lsn_range.end > disk_consistent_lsn + 1 =>
-                {
-                    // The end-LSN is exclusive, while disk_consistent_lsn is
-                    // inclusive. For example, if disk_consistent_lsn is 100, it is
-                    // OK for a delta layer to have end LSN 101, but if the end LSN
-                    // is 102, then it might not have been fully flushed to disk
-                    // before crash.
-                    info!(
-                        "found future delta layer {} on timeline {} disk_consistent_lsn is {}",
-                        filename, self.timeline_id, disk_consistent_lsn
-                    );
-
-                    rename_to_backup(&direntry_path)?;
-                }
-                Ok(LayerFileName::Delta(filename)) => {
-                    assert!(filename.lsn_range.end <= disk_consistent_lsn + 1);
-
-                    let file_size = direntry_path.metadata()?.len();
+            match discovered {
+                Discovered::Layer(LayerFileName::Delta(filename), file_size) => {
                     let stats = LayerAccessStats::for_loading_layer(LayerResidenceStatus::Resident);
 
                     let layer = DeltaLayer::new(
@@ -1677,29 +1691,55 @@ impl Timeline {
 
                     loaded_layers.push(Arc::new(layer));
                 }
-                Err(_) => {
-                    if fname == METADATA_FILE_NAME || fname.ends_with(".old") {
-                        // ignore these
-                    } else if remote_timeline_client::is_temp_download_file(&direntry_path) {
-                        info!(
-                            "skipping temp download file, reconcile_with_remote will resume / clean up: {}",
-                            fname
-                        );
-                    } else if is_ephemeral_file(&fname) {
-                        // Delete any old ephemeral files
-                        trace!("deleting old ephemeral file in timeline dir: {}", fname);
-                        fs::remove_file(&direntry_path)?;
-                    } else if is_temporary(&direntry_path) {
-                        info!("removing temp timeline file at {}", direntry_path.display());
-                        fs::remove_file(&direntry_path).with_context(|| {
-                            format!(
-                                "failed to remove temp download file at {}",
-                                direntry_path.display()
-                            )
-                        })?;
-                    } else {
-                        warn!("unrecognized filename in timeline dir: {}", fname);
-                    }
+                Discovered::Layer(LayerFileName::Image(filename), file_size) => {
+                    let stats = LayerAccessStats::for_loading_layer(LayerResidenceStatus::Resident);
+
+                    let layer = ImageLayer::new(
+                        self.conf,
+                        self.timeline_id,
+                        self.tenant_id,
+                        &filename,
+                        file_size,
+                        stats,
+                    );
+
+                    loaded_layers.push(Arc::new(layer));
+                }
+                Discovered::FutureLayer(file_name) => {
+                    let kind = match file_name {
+                        LayerFileName::Delta(_) => "delta",
+                        LayerFileName::Image(_) => "image",
+                    };
+
+                    info!(
+                        "found future {kind} layer {file_name} on timeline {} disk_consistent_lsn is {}",
+                        self.timeline_id, disk_consistent_lsn
+                    );
+
+                    rename_to_backup(&direntry_path)?;
+                }
+                Discovered::Ephemeral => {
+                    trace!("deleting old ephemeral file in timeline dir: {file_name:?}");
+                    fs::remove_file(&direntry_path)?;
+                }
+                Discovered::Temporary => {
+                    info!("removing temp timeline file at {}", direntry_path.display());
+                    fs::remove_file(&direntry_path).with_context(|| {
+                        format!(
+                            "failed to remove temp download file at {}",
+                            direntry_path.display()
+                        )
+                    })?;
+                }
+                Discovered::TemporaryDownload => {
+                    info!(
+                        "skipping temp download file, reconcile_with_remote will resume / clean up: {:?}",
+                        file_name
+                    );
+                }
+                Discovered::Metadata | Discovered::IgnoredBackup => {}
+                Discovered::Unknown => {
+                    warn!("unrecognized filename in timeline dir: {file_name:?}");
                 }
             }
         }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1515,7 +1515,7 @@ impl Timeline {
         let layer_flush_start_rx = self.layer_flush_start_tx.subscribe();
         let self_clone = Arc::clone(self);
 
-        info!("spawning flush loop");
+        debug!("spawning flush loop");
         *flush_loop_state = FlushLoopState::Running {
             #[cfg(test)]
             expect_initdb_optimization: false,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1714,10 +1714,10 @@ impl Timeline {
                             ))
                         }
                         (Delta(d), Evicted(remote) | UseRemote { remote, .. }) => Arc::new(
-                            RemoteLayer::new_delta(tenant_id, timeline_id, &d, &remote, stats),
+                            RemoteLayer::new_delta(tenant_id, timeline_id, &d, remote, stats),
                         ),
                         (Image(i), Evicted(remote) | UseRemote { remote, .. }) => Arc::new(
-                            RemoteLayer::new_img(tenant_id, timeline_id, &i, &remote, stats),
+                            RemoteLayer::new_img(tenant_id, timeline_id, &i, remote, stats),
                         ),
                     };
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1749,6 +1749,8 @@ impl Timeline {
                 rtc.schedule_layer_file_upload(&layer.layer_desc().filename(), &m)?;
             }
             rtc.schedule_index_upload_for_file_changes()?;
+            // Tenant::create_timeline will wait for these uploads to happen before returning, or
+            // on retry.
         }
 
         info!(

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -100,6 +100,9 @@ pub(super) enum Decision {
 pub(super) struct FutureLayer;
 
 /// Merges local discoveries and remote [`IndexPart`] to a collection of decisions.
+///
+/// This function should not gain additional reasons to fail than [`FutureLayer`], consider adding
+/// the checks earlier to [`scan_timeline_dir`].
 pub(super) fn recoincile(
     discovered: Vec<(LayerFileName, u64)>,
     index_part: Option<&IndexPart>,

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -141,13 +141,13 @@ pub(super) fn recoincile(
     discovered
         .into_iter()
         .map(|(name, (local, remote))| {
-            let future = match &name {
+            let is_in_future = match &name {
                 Image(file_name) if file_name.lsn > disk_consistent_lsn => true,
                 Delta(file_name) if file_name.lsn_range.end > disk_consistent_lsn + 1 => true,
                 _ => false,
             };
 
-            let decision = if future {
+            let decision = if is_in_future {
                 Err(FutureLayer)
             } else {
                 Ok(match (local, remote) {

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -119,7 +119,7 @@ pub(super) fn recoincile(
         .map(|(name, file_size)| (name, (Some(LayerFileMetadata::new(file_size)), None)))
         .collect::<Collected>();
 
-    // merge any index_part information, if we would have such
+    // merge any index_part information, when available
     index_part
         .as_ref()
         .map(|ip| ip.layer_metadata.iter())
@@ -134,8 +134,9 @@ pub(super) fn recoincile(
             }
         });
 
-    // must not use the index_part presence here as a proxy for remote timeline client
-    // it might be that we have local file(s), but the index upload was stopped with failpoint
+    // must not use the index_part presence here as a proxy for remote timeline client. it might be
+    // that we have local file(s), but the index upload was stopped with failpoint. See #5075 and
+    // search for related TODO; this will need to change.
 
     discovered
         .into_iter()

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -140,6 +140,9 @@ pub(super) fn reconcile(
                 _ => false,
             };
 
+            // future image layers are allowed to be produced always for not yet flushed to disk
+            // lsns stored in InMemoryLayer.
+
             let decision = if is_in_future {
                 Err(FutureLayer { local })
             } else {

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -131,10 +131,6 @@ pub(super) fn reconcile(
             }
         });
 
-    // must not use the index_part presence here as a proxy for remote timeline client. it might be
-    // that we have local file(s), but the index upload was stopped with failpoint. See #5075 and
-    // search for related TODO; this will need to change.
-
     discovered
         .into_iter()
         .map(|(name, (local, remote))| {

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -103,7 +103,7 @@ pub(super) struct FutureLayer;
 ///
 /// This function should not gain additional reasons to fail than [`FutureLayer`], consider adding
 /// the checks earlier to [`scan_timeline_dir`].
-pub(super) fn recoincile(
+pub(super) fn reconcile(
     discovered: Vec<(LayerFileName, u64)>,
     index_part: Option<&IndexPart>,
     disk_consistent_lsn: Lsn,

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -22,7 +22,6 @@ pub(super) enum Discovered {
     Metadata,
     IgnoredBackup,
     Unknown(OsString),
-    // NonUtf8(std::ffi::OsString),
 }
 
 /// Scans the timeline directory for interesting files.

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -29,7 +29,7 @@ pub(super) enum Discovered {
 pub(super) fn scan_timeline_dir(path: &Path) -> anyhow::Result<Vec<Discovered>> {
     let mut ret = Vec::new();
 
-    for direntry in std::fs::read_dir(&path)? {
+    for direntry in std::fs::read_dir(path)? {
         let direntry = direntry?;
         let direntry_path = direntry.path();
         let file_name = direntry.file_name();
@@ -157,7 +157,7 @@ pub(super) fn recoincile(
 pub(super) fn cleanup(path: &Path, kind: &str) -> anyhow::Result<()> {
     let file_name = path.file_name().expect("must be file path");
     tracing::debug!(kind, ?file_name, "cleaning up");
-    std::fs::remove_file(&path)
+    std::fs::remove_file(path)
         .with_context(|| format!("failed to remove temp download file at {}", path.display()))
 }
 
@@ -170,7 +170,7 @@ pub(super) fn cleanup_local_file_for_remote(
     let remote_size = remote.file_size();
 
     tracing::warn!("removing local file {path:?} because it has unexpected length {local_size}; length in remote index is {remote_size}");
-    if let Err(err) = crate::tenant::timeline::rename_to_backup(&path) {
+    if let Err(err) = crate::tenant::timeline::rename_to_backup(path) {
         assert!(
             path.exists(),
             "we would leave the local_layer without a file if this does not hold: {}",
@@ -193,6 +193,6 @@ pub(super) fn cleanup_future_layer(
         Image(_) => "image",
     };
     tracing::info!("found future {kind} layer {name} disk_consistent_lsn is {disk_consistent_lsn}");
-    crate::tenant::timeline::rename_to_backup(&path)?;
+    crate::tenant::timeline::rename_to_backup(path)?;
     Ok(())
 }

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -44,13 +44,9 @@ pub(super) fn scan_timeline_dir(path: &Path) -> anyhow::Result<Vec<Discovered>> 
         let fname = file_name.to_string_lossy();
 
         let discovered = match LayerFileName::from_str(&fname) {
-            Ok(LayerFileName::Image(file_name)) => {
-                let file_size = direntry_path.metadata()?.len();
-                Discovered::Layer(file_name.into(), file_size)
-            }
-            Ok(LayerFileName::Delta(file_name)) => {
-                let file_size = direntry_path.metadata()?.len();
-                Discovered::Layer(file_name.into(), file_size)
+            Ok(file_name) => {
+                let file_size = direntry.metadata()?.len();
+                Discovered::Layer(file_name, file_size)
             }
             Err(_) => {
                 if fname == METADATA_FILE_NAME {

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -72,7 +72,7 @@ pub(super) fn scan_timeline_dir(path: &Path) -> anyhow::Result<Vec<Discovered>> 
     Ok(ret)
 }
 
-/// Decision on what to do with a layer file after considering it's local and remote metadata.
+/// Decision on what to do with a layer file after considering its local and remote metadata.
 #[derive(Clone)]
 pub(super) enum Decision {
     /// The layer is not present locally.

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -121,6 +121,9 @@ pub(super) fn recoincile(
             }
         });
 
+    // must not use the index_part presence here as a proxy for remote timeline client
+    // it might be that we have local file(s), but the index upload was stopped with failpoint
+
     discovered
         .into_iter()
         .map(|(name, (local, remote))| {

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -41,33 +41,31 @@ pub(super) fn scan_timeline_dir(path: &Path) -> anyhow::Result<Vec<Discovered>> 
         let direntry_path = direntry.path();
         let file_name = direntry.file_name();
 
-        let discovered = {
-            let fname = file_name.to_string_lossy();
+        let fname = file_name.to_string_lossy();
 
-            match LayerFileName::from_str(&fname) {
-                Ok(LayerFileName::Image(file_name)) => {
-                    let file_size = direntry_path.metadata()?.len();
-                    Discovered::Layer(file_name.into(), file_size)
-                }
-                Ok(LayerFileName::Delta(file_name)) => {
-                    let file_size = direntry_path.metadata()?.len();
-                    Discovered::Layer(file_name.into(), file_size)
-                }
-                Err(_) => {
-                    if fname == METADATA_FILE_NAME {
-                        Discovered::Metadata
-                    } else if fname.ends_with(".old") {
-                        // ignore these
-                        Discovered::IgnoredBackup
-                    } else if remote_timeline_client::is_temp_download_file(&direntry_path) {
-                        Discovered::TemporaryDownload(file_name)
-                    } else if is_ephemeral_file(&fname) {
-                        Discovered::Ephemeral(file_name)
-                    } else if is_temporary(&direntry_path) {
-                        Discovered::Temporary(file_name)
-                    } else {
-                        Discovered::Unknown(file_name)
-                    }
+        let discovered = match LayerFileName::from_str(&fname) {
+            Ok(LayerFileName::Image(file_name)) => {
+                let file_size = direntry_path.metadata()?.len();
+                Discovered::Layer(file_name.into(), file_size)
+            }
+            Ok(LayerFileName::Delta(file_name)) => {
+                let file_size = direntry_path.metadata()?.len();
+                Discovered::Layer(file_name.into(), file_size)
+            }
+            Err(_) => {
+                if fname == METADATA_FILE_NAME {
+                    Discovered::Metadata
+                } else if fname.ends_with(".old") {
+                    // ignore these
+                    Discovered::IgnoredBackup
+                } else if remote_timeline_client::is_temp_download_file(&direntry_path) {
+                    Discovered::TemporaryDownload(file_name)
+                } else if is_ephemeral_file(&fname) {
+                    Discovered::Ephemeral(file_name)
+                } else if is_temporary(&direntry_path) {
+                    Discovered::Temporary(file_name)
+                } else {
+                    Discovered::Unknown(file_name)
                 }
             }
         };

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -166,7 +166,7 @@ pub(super) fn cleanup(path: &Path, kind: &str) -> anyhow::Result<()> {
     let file_name = path.file_name().expect("must be file path");
     tracing::debug!(kind, ?file_name, "cleaning up");
     std::fs::remove_file(path)
-        .with_context(|| format!("failed to remove temp download file at {}", path.display()))
+        .with_context(|| format!("failed to remove {kind} at {}", path.display()))
 }
 
 pub(super) fn cleanup_local_file_for_remote(

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -1,0 +1,127 @@
+use crate::{
+    is_temporary,
+    tenant::{
+        ephemeral_file::is_ephemeral_file,
+        remote_timeline_client,
+        storage_layer::{LayerFileName, PersistentLayer},
+        timeline::rename_to_backup,
+    },
+    METADATA_FILE_NAME,
+};
+use anyhow::Context;
+use std::{path::Path, str::FromStr, sync::Arc};
+use utils::lsn::Lsn;
+
+pub(super) async fn load_layer_map(
+    path: &Path,
+    disk_consistent_lsn: Lsn,
+) -> anyhow::Result<Vec<(LayerFileName, u64)>> {
+    enum Discovered {
+        Layer(LayerFileName, u64),
+        FutureLayer(LayerFileName),
+        Ephemeral,
+        Temporary,
+        TemporaryDownload,
+        Metadata,
+        IgnoredBackup,
+        Unknown,
+        // NonUtf8(std::ffi::OsString),
+    }
+
+    let mut ret = Vec::new();
+
+    for direntry in std::fs::read_dir(&path)? {
+        let direntry = direntry?;
+        let direntry_path = direntry.path();
+        let file_name = direntry.file_name();
+        let discovered = {
+            let fname = file_name.to_string_lossy();
+
+            match LayerFileName::from_str(&fname) {
+                Ok(LayerFileName::Image(file_name)) if file_name.lsn > disk_consistent_lsn => {
+                    Discovered::FutureLayer(file_name.into())
+                }
+                Ok(LayerFileName::Delta(file_name))
+                    if file_name.lsn_range.end > disk_consistent_lsn + 1 =>
+                {
+                    // The end-LSN is exclusive, while disk_consistent_lsn is
+                    // inclusive. For example, if disk_consistent_lsn is 100, it is
+                    // OK for a delta layer to have end LSN 101, but if the end LSN
+                    // is 102, then it might not have been fully flushed to disk
+                    // before crash.
+                    Discovered::FutureLayer(file_name.into())
+                }
+                Ok(LayerFileName::Image(file_name)) => {
+                    assert!(file_name.lsn <= disk_consistent_lsn);
+                    let file_size = direntry_path.metadata()?.len();
+                    Discovered::Layer(file_name.into(), file_size)
+                }
+                Ok(LayerFileName::Delta(file_name)) => {
+                    assert!(file_name.lsn_range.end <= disk_consistent_lsn + 1);
+                    let file_size = direntry_path.metadata()?.len();
+                    Discovered::Layer(file_name.into(), file_size)
+                }
+                Err(_) => {
+                    if fname == METADATA_FILE_NAME {
+                        Discovered::Metadata
+                    } else if fname.ends_with(".old") {
+                        // ignore these
+                        Discovered::IgnoredBackup
+                    } else if remote_timeline_client::is_temp_download_file(&direntry_path) {
+                        Discovered::TemporaryDownload
+                    } else if is_ephemeral_file(&fname) {
+                        Discovered::Ephemeral
+                    } else if is_temporary(&direntry_path) {
+                        Discovered::Temporary
+                    } else {
+                        Discovered::Unknown
+                    }
+                }
+            }
+        };
+
+        match discovered {
+            Discovered::Layer(file_name, file_size) => {
+                ret.push((file_name, file_size));
+            }
+            Discovered::FutureLayer(file_name) => {
+                let kind = match file_name {
+                    LayerFileName::Delta(_) => "delta",
+                    LayerFileName::Image(_) => "image",
+                };
+
+                tracing::info!(
+                    "found future {kind} layer {file_name} disk_consistent_lsn is {}",
+                    disk_consistent_lsn
+                );
+
+                rename_to_backup(&direntry_path)?;
+            }
+            Discovered::Ephemeral => {
+                tracing::trace!("deleting old ephemeral file in timeline dir: {file_name:?}");
+                std::fs::remove_file(&direntry_path)?;
+            }
+            Discovered::Temporary => {
+                tracing::info!("removing temp timeline file at {}", direntry_path.display());
+                std::fs::remove_file(&direntry_path).with_context(|| {
+                    format!(
+                        "failed to remove temp download file at {}",
+                        direntry_path.display()
+                    )
+                })?;
+            }
+            Discovered::TemporaryDownload => {
+                tracing::info!(
+                        "skipping temp download file, reconcile_with_remote will resume / clean up: {:?}",
+                        file_name
+                    );
+            }
+            Discovered::Metadata | Discovered::IgnoredBackup => {}
+            Discovered::Unknown => {
+                tracing::warn!("unrecognized filename in timeline dir: {file_name:?}");
+            }
+        }
+    }
+
+    Ok(ret)
+}

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -14,13 +14,21 @@ use anyhow::Context;
 use std::{collections::HashMap, ffi::OsString, path::Path, str::FromStr};
 use utils::lsn::Lsn;
 
+/// Identified files in the timeline directory.
 pub(super) enum Discovered {
+    /// The only one we care about
     Layer(LayerFileName, u64),
+    /// Old ephmeral files from previous launches, should be removed
     Ephemeral(OsString),
+    /// Old temporary timeline files, unsure what these really are, should be removed
     Temporary(OsString),
+    /// Temporary on-demand download files, should be removed
     TemporaryDownload(OsString),
+    /// "metadata" file we persist locally and include in `index_part.json`
     Metadata,
+    /// Backup file from previously future layers
     IgnoredBackup,
+    /// Unrecognized, warn about these
     Unknown(OsString),
 }
 
@@ -70,6 +78,7 @@ pub(super) fn scan_timeline_dir(path: &Path) -> anyhow::Result<Vec<Discovered>> 
     Ok(ret)
 }
 
+/// Decision on what to do with a layer file after considering it's local and remote metadata.
 #[derive(Clone)]
 pub(super) enum Decision {
     /// The layer is not present locally.

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -177,7 +177,8 @@ pub(super) fn cleanup_local_file_for_remote(
     let local_size = local.file_size();
     let remote_size = remote.file_size();
 
-    tracing::warn!("removing local file {path:?} because it has unexpected length {local_size}; length in remote index is {remote_size}");
+    let file_name = path.file_name().expect("must be file path");
+    tracing::warn!("removing local file {file_name:?} because it has unexpected length {local_size}; length in remote index is {remote_size}");
     if let Err(err) = crate::tenant::timeline::rename_to_backup(path) {
         assert!(
             path.exists(),

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -91,7 +91,10 @@ pub(super) enum Decision {
 
 /// The related layer is is in future compared to disk_consistent_lsn, it must not be loaded.
 #[derive(Debug)]
-pub(super) struct FutureLayer;
+pub(super) struct FutureLayer {
+    /// The local metadata. `None` if the layer is only known through [`IndexPart`].
+    pub(super) local: Option<LayerFileMetadata>,
+}
 
 /// Merges local discoveries and remote [`IndexPart`] to a collection of decisions.
 ///
@@ -142,7 +145,7 @@ pub(super) fn reconcile(
             };
 
             let decision = if is_in_future {
-                Err(FutureLayer)
+                Err(FutureLayer { local })
             } else {
                 Ok(match (local, remote) {
                     (Some(local), Some(remote)) if local != remote => UseRemote { local, remote },

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -106,7 +106,6 @@ pub(super) fn reconcile(
     disk_consistent_lsn: Lsn,
 ) -> Vec<(LayerFileName, Result<Decision, FutureLayer>)> {
     use Decision::*;
-    use LayerFileName::*;
 
     // name => (local, remote)
     type Collected = HashMap<LayerFileName, (Option<LayerFileMetadata>, Option<LayerFileMetadata>)>;

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -369,7 +369,7 @@ def test_download_remote_layers_api(
     filled_current_physical = get_api_current_physical_size()
     log.info(filled_current_physical)
     filled_size = get_resident_physical_size()
-    log.info(filled_size)
+    log.info(f"filled_size: {filled_size}")
     assert filled_current_physical == filled_size, "we don't yet do layer eviction"
 
     env.pageserver.stop()
@@ -377,7 +377,7 @@ def test_download_remote_layers_api(
     # remove all the layer files
     # XXX only delete some of the layer files, to show that it really just downloads all the layers
     for layer in (Path(env.repo_dir) / "tenants").glob("*/timelines/*/*-*_*"):
-        log.info(f"unlinking layer {layer}")
+        log.info(f"unlinking layer {layer.name}")
         layer.unlink()
 
     # Shut down safekeepers before starting the pageserver.
@@ -403,7 +403,7 @@ def test_download_remote_layers_api(
         filled_current_physical == get_api_current_physical_size()
     ), "current_physical_size is sum of loaded layer sizes, independent of whether local or remote"
     post_unlink_size = get_resident_physical_size()
-    log.info(post_unlink_size)
+    log.info(f"post_unlink_size: {post_unlink_size}")
     assert (
         post_unlink_size < filled_size
     ), "we just deleted layers and didn't cause anything to re-download them yet"


### PR DESCRIPTION
Current implementation first calls `load_layer_map`, which loads all local layers, cleans up files, leave cleaning up stuff to "second function". Then the "second function" is finally called, it does not do the cleanup and some of the first functions setup can torn down. "Second function" is actually both `reconcile_with_remote` and `create_remote_layers`.

This change makes it a bit more verbose but in one phase with the following sub-steps:
1. scan the timeline directory
2. delete extra files
    - now including on-demand download files
    - fixes #3660
3. recoincile the two sources of layers (directory, index_part)
4. rename_to_backup future layers, short layers
5. create the remaining as layers

Needed by #4938.

It was also noticed that this is blocking code in an `async fn` so just do it in a `spawn_blocking`, which should be healthy for our startup times. Other effects includes hopefully halving of `stat` calls; extra calls which were not done previously are now done for the future layers.