### PR TITLE
rfc: Crash-Consistent Layer Map Updates By Leveraging index_part.json

### DIFF
--- a/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
+++ b/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
@@ -18,7 +18,7 @@ If we crash or restart pageserver, we reconstruct the layer map from:
 1. local timeline directory contents
 2. remote `index_part.json` contents.
 
-The function that is responsible for this is called `reconcile_with_remote()`.
+The function that is responsible for this is called `Timeline::load_layer_map()`.
 The reconciliation process's behavior is the following:
 * local-only files will become part of the layer map as local-only layers and rescheduled for upload
 * For a file name that, by its name, is present locally and in the remote `index_part.json`, but where the local file has a different size (future: checksum) than the remote file, we will delete the local file and leave the remote file as a `RemoteLayer` in the layer map.

--- a/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
+++ b/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
@@ -41,7 +41,7 @@ We cannot roll back or complete the timeline directory update during which we cr
 The implications of the above are primarily problematic for compaction.
 Specifically, the part of it that compats L0 layers into L1 layers.
 
-* Recap: compaction takes a set of L0 layers and reshuffels the delta records in them into L1 layer files.
+* Recap: compaction takes a set of L0 layers and reshuffles the delta records in them into L1 layer files.
   Once the L1 layer files are written to disk, it atomically removes the L0 layers from the layer map and adds the L1 layers to the layer map.
   It then deletes the L0 layers locally, and schedules an upload of the L1 layers and and updated index part.
 * If we crash before deleting L0s, but after writing out L1s, the next compaction after restart will re-digest the L0s and produce new L1s.
@@ -209,7 +209,7 @@ Note that the test case introduced in https://github.com/neondatabase/neon/pull/
 
 1. Remove support for `remote_storage=None`, because we now rely on the existence of an index part.
 
-    - The nasty part here is to fix all the tests that fiddle with the loca timeline directory.
+    - The nasty part here is to fix all the tests that fiddle with the local timeline directory.
       Possibly they are just irrelevant with this change, but, each case will require inspection.
 
 2. Implement the design above.

--- a/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
+++ b/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
@@ -160,10 +160,9 @@ We can mitigate this problem as follows:
 
 ## Limitations
 
-Multi-object changes that span multiple timelines aren't covered.
-We currently have:
-1. GC (but, it doesn't require atomicity across timelines, so, it doesn't really count)
-2. Timeline deletion (covered by `deleted_at` marker)
+Multi-object changes that span multiple timelines aren't covered by this RFC.
+That's fine because we currently don't need them, as evidenced by the absence
+of a Pageserver operation that holds multiple timelines' layer map lock at a time.
 
 ## Impacted components
 

--- a/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
+++ b/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
@@ -36,10 +36,10 @@ We will reconstruct the layer map according to the reconciliation process, takin
 
 We cannot roll back or complete the timeline directory update during which we crashed, because we keep no record of the changes we plan to make.
 
-### Problem's Implications For Comapction
+### Problem's Implications For Compaction
 
 The implications of the above are primarily problematic for compaction.
-Specifically, the part of it that compats L0 layers into L1 layers.
+Specifically, the part of it that compacts L0 layers into L1 layers.
 
 Remember that compaction takes a set of L0 layers and reshuffles the delta records in them into L1 layer files.
 Once the L1 layer files are written to disk, it atomically removes the L0 layers from the layer map and adds the L1 layers to the layer map.
@@ -76,7 +76,7 @@ Given the above considerations, we should avoid making correctness of split-brai
 
 ## Design
 
-Instead of reonciling a layer map from local timeline directory contents and remote index part, this RFC proposes to view the remote index part as authoritative during timeline load.
+Instead of reconciling a layer map from local timeline directory contents and remote index part, this RFC proposes to view the remote index part as authoritative during timeline load.
 Local layer files will be recognized if they match what's listed in remote index part, and removed otherwise.
 
 During **timeline load**, the only thing that matter is the remote index part content.
@@ -84,7 +84,7 @@ Essentially, timeline load becomes much like attach, except we don't need to pre
 The local timeline dir's `metadata` file does not matter.
 The layer files in the local timeline dir are seen as a nice-to-have cache of layer files that are in the remote index part.
 Any layer files in the local timeline dir that aren't in the remote index part are removed during startup.
-The `reconcile_with_remote()` no longer "merges" local timeline dir contents with the remote index part.
+The `Timeline::load_layer_map()` no longer "merges" local timeline dir contents with the remote index part.
 Instead, it treats the remote index part as the authoritative layer map.
 If the local timeline dir contains a layer that is in the remote index part, that's nice, and we'll re-use it if file size (and in the future, check sum) match what's stated in the index part.
 If it doesn't match, we remove the file from the local timeline dir.

--- a/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
+++ b/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
@@ -76,7 +76,7 @@ Given the above considerations, we should avoid making correctness of split-brai
 
 ## Design
 
-Instead of reonciling a layer map from local timeline directory contents and remote index part, this RFC proposed to view the remote index part as authoritative during timeline load.
+Instead of reonciling a layer map from local timeline directory contents and remote index part, this RFC proposes to view the remote index part as authoritative during timeline load.
 Local layer files will be recognized if they match what's listed in remote index part, and removed otherwise.
 
 During **timeline load**, the only thing that matter is the remote index part content.

--- a/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
+++ b/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
@@ -61,7 +61,7 @@ The items above are a problem for the [split-brain protection RFC](https://githu
 For example, if an unresponsive node A becomes active again after control plane has relocated the tenant to a new node B, the node A may overwrite some L1s.
 But node B based its world view on the version of node A's `index_part.json` from _before_ the overwrite.
 That earlier `index_part.json`` contained the file size of the pre-overwrite L1.
-Pageserver currently treat file size as a checksum, and because it mismatches, the node B will refuse to read data from the L1.
+If the overwritten L1 has a different file size, node B will refuse to read data from the overwritten L1.
 Effectively, the data in the L1 has become inaccessible to node B.
 If node B already uploaded an index part itself, all subsequent attachments will use node B's index part, and run into the same probem.
 
@@ -79,7 +79,7 @@ Given the above considerations, we should avoid making correctness of split-brai
 Instead of reconciling a layer map from local timeline directory contents and remote index part, this RFC proposes to view the remote index part as authoritative during timeline load.
 Local layer files will be recognized if they match what's listed in remote index part, and removed otherwise.
 
-During **timeline load**, the only thing that matter is the remote index part content.
+During **timeline load**, the only thing that matters is the remote index part content.
 Essentially, timeline load becomes much like attach, except we don't need to prefix-list the remote timelines.
 The local timeline dir's `metadata` file does not matter.
 The layer files in the local timeline dir are seen as a nice-to-have cache of layer files that are in the remote index part.

--- a/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
+++ b/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
@@ -102,7 +102,11 @@ The procedure for single- and multi-object changes is reproduced here for refere
     * PUT layer files inserted by the change.
     * PUT an index part that has insertions and deletions of the change.
     * DELETE the layer files that are deleted by the change.
-      * With the [split-brain protection RFC](https://github.com/neondatabase/neon/pull/4919), the deletions will be written to deletion queue instead of scheduled.
+
+Note that it is safe for the DELETE to be deferred arbitrarily.
+* If it never happens, we leak the object, but, that's not a correctness concern.
+* As of #4938, we don't schedule the remote timeline client operation for deletion immediately, but, only when we drop the `LayerInner`.
+* With the [split-brain protection RFC](https://github.com/neondatabase/neon/pull/4919), the deletions will be written to deletion queue for processing when it's safe to do so (see the RFC for details).
 
 ## How This Solves The Problem
 

--- a/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
+++ b/docs/rfcs/027-crash-consistent-layer-map-through-index-part.md
@@ -53,7 +53,7 @@ If the compaction algorithm doesn't change between the two compaction runs, is d
 
 *However*:
 1. the file size of the overwritten L1s may not be identical, and
-2. the bit pattern of the overwritten L1s may not be identical, and, and, and, and
+2. the bit pattern of the overwritten L1s may not be identical, and,
 3. in the future, we may want to make the compaction code non-determinstic, influenced by past access patterns, or otherwise change it, resulting in L1 overwrites with a different set of delta records than before the overwrite
 
 The items above are a problem for the [split-brain protection RFC](https://github.com/neondatabase/neon/pull/4919) because it assumes that layer files in S3 are only ever deleted, but never replaced (overPUTted).


### PR DESCRIPTION
This RFC describes a simple scheme to make layer map updates crash
consistent by leveraging the index_part.json in remote storage. Without
such a mechanism, crashes can induce certain edge cases in which broadly
held assumptions about system invariants don't hold.
