### PR TITLE
remove the duplicate entries in postgresql.conf

### DIFF
--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -46,8 +46,6 @@ pub fn write_postgres_conf(
         writeln!(file, "{}", conf)?;
     }
 
-    write!(file, "{}", &spec.cluster.settings.as_pg_settings())?;
-
     // Add options for connecting to storage
     writeln!(file, "# Neon storage settings")?;
     if let Some(s) = &spec.pageserver_connstring {


### PR DESCRIPTION
## Problem
fix https://github.com/neondatabase/neon/issues/5088

## Summary of changes
After check the function `write_postgres_conf`, I only find one entry in `postgresql.conf` has been set twice. Just remove the duplicate entry.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
