### PR TITLE
proxy: refactor how and when connections are returned to the pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,7 +3561,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d#a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d#a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d#a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d"
 dependencies = [
  "base64 0.20.0",
  "byteorder",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d#a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -5407,7 +5407,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d#a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5422,7 +5422,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio",
  "tokio-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,7 +3561,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
 dependencies = [
  "base64 0.20.0",
  "byteorder",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -5407,7 +5407,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/neondatabase/rust-postgres.git?rev=9011f7110db12b5e15afaf98f8ac834501d50ddc#9011f7110db12b5e15afaf98f8ac834501d50ddc"
+source = "git+https://github.com/neondatabase/rust-postgres.git?rev=3752d39fd75f3cdb979a100c38e50a20145c3080#3752d39fd75f3cdb979a100c38e50a20145c3080"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6497,7 +6497,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "socket2 0.4.9",
  "standback",
  "syn 1.0.109",
  "syn 2.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,11 +160,11 @@ env_logger = "0.10"
 log = "0.4"
 
 ## Libraries from neondatabase/ git forks, ideally with changes to be upstreamed
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
-postgres-native-tls = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
-postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
-postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
+postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
+postgres-native-tls = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
+postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
+postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
 
 ## Other git libraries
 heapless = { default-features=false, features=[], git = "https://github.com/japaric/heapless.git", rev = "644653bf3b831c6bb4963be2de24804acf5e5001" } # upstream release pending
@@ -200,7 +200,7 @@ tonic-build = "0.9"
 
 # This is only needed for proxy's tests.
 # TODO: we should probably fork `tokio-postgres-rustls` instead.
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="9011f7110db12b5e15afaf98f8ac834501d50ddc" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
 
 ################# Binary contents sections
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,11 +160,11 @@ env_logger = "0.10"
 log = "0.4"
 
 ## Libraries from neondatabase/ git forks, ideally with changes to be upstreamed
-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
-postgres-native-tls = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
-postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
-postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
+postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d" }
+postgres-native-tls = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d" }
+postgres-protocol = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d" }
+postgres-types = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d" }
 
 ## Other git libraries
 heapless = { default-features=false, features=[], git = "https://github.com/japaric/heapless.git", rev = "644653bf3b831c6bb4963be2de24804acf5e5001" } # upstream release pending
@@ -200,7 +200,7 @@ tonic-build = "0.9"
 
 # This is only needed for proxy's tests.
 # TODO: we should probably fork `tokio-postgres-rustls` instead.
-tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="3752d39fd75f3cdb979a100c38e50a20145c3080" }
+tokio-postgres = { git = "https://github.com/neondatabase/rust-postgres.git", rev="a2d0652ec3f8f710ff8cfc2e7c68f096fb852d9d" }
 
 ################# Binary contents sections
 

--- a/proxy/src/http/conn_pool.rs
+++ b/proxy/src/http/conn_pool.rs
@@ -494,7 +494,7 @@ struct ClientInner {
 
 impl Client {
     pub fn metrics(&self) -> Arc<MetricCounter> {
-        USAGE_METRICS.register(self.ids.clone())
+        USAGE_METRICS.register(self.inner.as_ref().unwrap().ids.clone())
     }
 }
 

--- a/proxy/src/http/conn_pool.rs
+++ b/proxy/src/http/conn_pool.rs
@@ -8,14 +8,17 @@ use pbkdf2::{
     Params, Pbkdf2,
 };
 use pq_proto::StartupMessageParams;
-use std::sync::atomic::{self, AtomicUsize};
 use std::{collections::HashMap, sync::Arc};
 use std::{
     fmt,
     task::{ready, Poll},
 };
+use std::{
+    ops::Deref,
+    sync::atomic::{self, AtomicUsize},
+};
 use tokio::time;
-use tokio_postgres::AsyncMessage;
+use tokio_postgres::{AsyncMessage, ReadyForQueryStatus};
 
 use crate::{
     auth, console,
@@ -26,13 +29,13 @@ use crate::{compute, config};
 
 use crate::proxy::ConnectMechanism;
 
-use tracing::{error, warn};
+use tracing::{error, warn, Span};
 use tracing::{info, info_span, Instrument};
 
 pub const APP_NAME: &str = "sql_over_http";
 const MAX_CONNS_PER_ENDPOINT: usize = 20;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConnInfo {
     pub username: String,
     pub dbname: String,
@@ -55,7 +58,7 @@ impl fmt::Display for ConnInfo {
 }
 
 struct ConnPoolEntry {
-    conn: Client,
+    conn: ClientInner,
     _last_access: std::time::Instant,
 }
 
@@ -133,13 +136,19 @@ impl GlobalConnPool {
     }
 
     pub async fn get(
-        &self,
+        self: &Arc<Self>,
         conn_info: &ConnInfo,
         force_new: bool,
         session_id: uuid::Uuid,
     ) -> anyhow::Result<Client> {
-        let mut client: Option<Client> = None;
+        let mut client: Option<ClientInner> = None;
         let mut latency_timer = LatencyTimer::new("http");
+
+        let pool = if force_new {
+            None
+        } else {
+            Some((conn_info.clone(), self.clone()))
+        };
 
         let mut hash_valid = false;
         if !force_new {
@@ -188,7 +197,10 @@ impl GlobalConnPool {
                 latency_timer.pool_hit();
                 info!("pool: reusing connection '{conn_info}'");
                 client.session.send(session_id)?;
-                return Ok(client);
+                return Ok(Client {
+                    inner: Some(client),
+                    pool,
+                });
             }
         } else {
             info!("pool: opening a new connection '{conn_info}'");
@@ -228,10 +240,13 @@ impl GlobalConnPool {
             _ => {}
         }
 
-        new_client
+        new_client.map(|inner| Client {
+            inner: Some(inner),
+            pool,
+        })
     }
 
-    pub fn put(&self, conn_info: &ConnInfo, client: Client) -> anyhow::Result<()> {
+    fn put(&self, conn_info: &ConnInfo, client: ClientInner) -> anyhow::Result<()> {
         // We want to hold this open while we return. This ensures that the pool can't close
         // while we are in the middle of returning the connection.
         let closed = self.closed.read();
@@ -326,7 +341,7 @@ struct TokioMechanism<'a> {
 
 #[async_trait]
 impl ConnectMechanism for TokioMechanism<'_> {
-    type Connection = Client;
+    type Connection = ClientInner;
     type ConnectError = tokio_postgres::Error;
     type Error = anyhow::Error;
 
@@ -350,7 +365,7 @@ async fn connect_to_compute(
     conn_info: &ConnInfo,
     session_id: uuid::Uuid,
     latency_timer: LatencyTimer,
-) -> anyhow::Result<Client> {
+) -> anyhow::Result<ClientInner> {
     let tls = config.tls_config.as_ref();
     let common_names = tls.and_then(|tls| tls.common_names.clone());
 
@@ -399,7 +414,7 @@ async fn connect_to_compute_once(
     conn_info: &ConnInfo,
     timeout: time::Duration,
     mut session: uuid::Uuid,
-) -> Result<Client, tokio_postgres::Error> {
+) -> Result<ClientInner, tokio_postgres::Error> {
     let mut config = (*node_info.config).clone();
 
     let (client, mut connection) = config
@@ -462,15 +477,17 @@ async fn connect_to_compute_once(
         .instrument(span)
     );
 
-    Ok(Client {
+    Ok(ClientInner {
+        span: Span::current(),
         inner: client,
         session: tx,
         ids,
     })
 }
 
-pub struct Client {
-    pub inner: tokio_postgres::Client,
+struct ClientInner {
+    span: Span,
+    inner: tokio_postgres::Client,
     session: tokio::sync::watch::Sender<uuid::Uuid>,
     ids: Ids,
 }
@@ -478,5 +495,87 @@ pub struct Client {
 impl Client {
     pub fn metrics(&self) -> Arc<MetricCounter> {
         USAGE_METRICS.register(self.ids.clone())
+    }
+}
+
+pub struct Client {
+    inner: Option<ClientInner>,
+    pool: Option<(ConnInfo, Arc<GlobalConnPool>)>,
+}
+
+pub struct Discard<'a> {
+    pool: &'a mut Option<(ConnInfo, Arc<GlobalConnPool>)>,
+}
+
+impl Client {
+    pub fn inner(&mut self) -> (&mut tokio_postgres::Client, Discard<'_>) {
+        let Self { inner, pool } = self;
+        (
+            &mut inner
+                .as_mut()
+                .expect("client inner should not be removed")
+                .inner,
+            Discard { pool },
+        )
+    }
+
+    pub fn check_idle(&mut self, status: ReadyForQueryStatus) {
+        self.inner().1.check_idle(status)
+    }
+    pub fn discard(&mut self) {
+        self.inner().1.discard()
+    }
+}
+
+impl Discard<'_> {
+    pub fn check_idle(&mut self, status: ReadyForQueryStatus) {
+        if status != ReadyForQueryStatus::Idle {
+            if let Some((conn_info, _)) = self.pool.take() {
+                info!("pool: throwing away connection '{conn_info}' because connection is not idle")
+            }
+        }
+    }
+    pub fn discard(&mut self) {
+        if let Some((conn_info, _)) = self.pool.take() {
+            info!("pool: throwing away connection '{conn_info}' because connection is potentially in a broken state")
+        }
+    }
+}
+
+impl Deref for Client {
+    type Target = tokio_postgres::Client;
+
+    fn deref(&self) -> &Self::Target {
+        &self
+            .inner
+            .as_ref()
+            .expect("client inner should not be removed")
+            .inner
+    }
+}
+// impl DerefMut for Client<'_> {
+//     fn deref_mut(&mut self) -> &mut Self::Target {
+//         &mut self
+//             .inner
+//             .as_mut()
+//             .expect("client inner should not be removed")
+//             .inner
+//     }
+// }
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        let client = self
+            .inner
+            .take()
+            .expect("client inner should not be removed");
+        if let Some((conn_info, conn_pool)) = self.pool.take() {
+            let current_span = client.span.clone();
+            // return connection to the pool
+            tokio::task::spawn_blocking(move || {
+                let _span = current_span.enter();
+                let _ = conn_pool.put(&conn_info, client);
+            });
+        }
     }
 }

--- a/test_runner/regress/test_proxy.py
+++ b/test_runner/regress/test_proxy.py
@@ -7,6 +7,8 @@ import pytest
 import requests
 from fixtures.neon_fixtures import PSQL, NeonProxy, VanillaPostgres
 
+GET_CONNECTION_PID_QUERY = "SELECT pid FROM pg_stat_activity WHERE state = 'active'"
+
 
 def test_proxy_select_1(static_proxy: NeonProxy):
     """
@@ -353,7 +355,7 @@ def test_sql_over_http_pool(static_proxy: NeonProxy):
 
     def get_pid(status: int, pw: str) -> Any:
         return static_proxy.http_query(
-            "SELECT pid FROM pg_stat_activity WHERE state = 'active'",
+            GET_CONNECTION_PID_QUERY,
             [],
             user="http_auth",
             password=pw,
@@ -403,3 +405,21 @@ def test_http_pool_begin(static_proxy: NeonProxy):
     query(200, "BEGIN;")
     query(400, "garbage-lol(&(&(&(&")  # Intentional error to break the transaction
     query(200, "SELECT 1;")  # Query that should succeed regardless of the transaction
+
+
+def test_sql_over_http_pool_idle(static_proxy: NeonProxy):
+    static_proxy.safe_psql("create user http_auth2 with password 'http' superuser")
+
+    def query(status: int, query: str) -> Any:
+        return static_proxy.http_query(
+            query,
+            [],
+            user="http_auth2",
+            password="http",
+            expected_code=status,
+        )
+
+    pid1 = query(200, GET_CONNECTION_PID_QUERY)["rows"][0]["pid"]
+    query(200, "BEGIN")
+    pid2 = query(200, GET_CONNECTION_PID_QUERY)["rows"][0]["pid"]
+    assert pid1 != pid2

--- a/test_runner/regress/test_proxy.py
+++ b/test_runner/regress/test_proxy.py
@@ -389,7 +389,6 @@ def test_sql_over_http_pool(static_proxy: NeonProxy):
 
 # Beginning a transaction should not impact the next query,
 # which might come from a completely different client.
-@pytest.mark.xfail(reason="not implemented")
 def test_http_pool_begin(static_proxy: NeonProxy):
     static_proxy.safe_psql("create user http_auth with password 'http' superuser")
 

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -55,7 +55,6 @@ scopeguard = { version = "1" }
 serde = { version = "1", features = ["alloc", "derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
 smallvec = { version = "1", default-features = false, features = ["write"] }
-socket2 = { version = "0.4", default-features = false, features = ["all"] }
 standback = { version = "0.2", default-features = false, features = ["std"] }
 time = { version = "0.3", features = ["local-offset", "macros", "serde-well-known"] }
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "test-util"] }


### PR DESCRIPTION
## Problem

Transactions break connections in the pool

fixes #4698 

## Summary of changes

* Pool `Client`s are smart object that return themselves to the pool
* Pool `Client`s can be 'discard'ed
* Pool `Client`s are discarded when certain errors are encountered.
* Pool `Client`s are discarded when ReadyForQuery returns a non-idle state.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
