### PR TITLE
monitor: listen on correct port to accept agent connections

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -465,7 +465,7 @@ fn cli() -> clap::Command {
         .arg(
             Arg::new("vm-monitor-addr")
                 .long("vm-monitor-addr")
-                .default_value("127.0.0.1:10369")
+                .default_value("0.0.0.0:10301")
                 .value_name("VM_MONITOR_ADDR"),
         )
         .arg(


### PR DESCRIPTION
## Problem
The previous arguments have the monitor listen on `localhost`, which the informant can connect to since it's also in the VM, but which the agent cannot. Also, the port is wrong.

## Summary of changes
Listen on `0.0.0.0:10301`

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
