### PR TITLE
compute_ctl: Fix switched vm-monitor args

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -278,8 +278,8 @@ fn main() -> Result<()> {
             use tokio_util::sync::CancellationToken;
             use tracing::warn;
             let vm_monitor_addr = matches.get_one::<String>("vm-monitor-addr");
-            let cgroup = matches.get_one::<String>("filecache-connstr");
-            let file_cache_connstr = matches.get_one::<String>("cgroup");
+            let file_cache_connstr = matches.get_one::<String>("filecache-connstr");
+            let cgroup = matches.get_one::<String>("cgroup");
 
             // Only make a runtime if we need to.
             // Note: it seems like you can make a runtime in an inner scope and


### PR DESCRIPTION
## Problem

On staging, autoscaling is failing for all VMs since #4946 because the args are swapped (see diff), and trying to connect to postgres with `neon-postgres` (the cgroup) as the connection string doesn't work.

The offending log line looks like:

```
2023-08-28T03:09:19.361758Z ERROR start_monitor{args=Args { cgroup: Some("host=localhost port=5432 dbname=postgres user=cloud_admin sslmode=disable"), pgconnstr: Some("neon-postgres"), addr: "0.0.0.0:10301" }}: failed to create monitor error=failed to create file cache

Caused by:
    0: failed to connect to postgres file cache
    1: failed to connect to pg client
    2: invalid connection string: unexpected EOF
    3: unexpected EOF
```

## Summary of changes

Swap the args back.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] ~~If it is a core feature, I have added thorough tests.~~
- [ ] ~~Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?~~
- [ ] ~~If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.~~

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
