### PR TITLE
vm-monitor: Add flag for when file cache on disk

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -579,7 +579,7 @@ jobs:
           --user "${{ secrets.CI_ACCESS_TOKEN }}" \
           --data \
             "{
-              \"ref\": \"main\",
+              \"ref\": \"sharnoff/vm-file-cache-on-disk\",
               \"inputs\": {
                 \"ci_job_name\": \"neon-cloud-e2e\",
                 \"commit_hash\": \"$COMMIT_SHA\",

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -579,7 +579,7 @@ jobs:
           --user "${{ secrets.CI_ACCESS_TOKEN }}" \
           --data \
             "{
-              \"ref\": \"sharnoff/vm-file-cache-on-disk\",
+              \"ref\": \"main\",
               \"inputs\": {
                 \"ci_job_name\": \"neon-cloud-e2e\",
                 \"commit_hash\": \"$COMMIT_SHA\",

--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -313,7 +313,7 @@ fn main() -> Result<()> {
                         cgroup: cgroup.cloned(),
                         pgconnstr: file_cache_connstr.cloned(),
                         addr: vm_monitor_addr.cloned().unwrap(),
-                        file_cache_not_in_memory: file_cache_not_in_memory,
+                        file_cache_not_in_memory,
                     })),
                     token.clone(),
                 ))

--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -280,7 +280,7 @@ fn main() -> Result<()> {
             let vm_monitor_addr = matches.get_one::<String>("vm-monitor-addr");
             let file_cache_connstr = matches.get_one::<String>("filecache-connstr");
             let cgroup = matches.get_one::<String>("cgroup");
-            let file_cache_not_in_memory = matches.get_flag("file-cache-not-in-memory");
+            let file_cache_on_disk = matches.get_flag("file-cache-on-disk");
 
             // Only make a runtime if we need to.
             // Note: it seems like you can make a runtime in an inner scope and
@@ -313,7 +313,7 @@ fn main() -> Result<()> {
                         cgroup: cgroup.cloned(),
                         pgconnstr: file_cache_connstr.cloned(),
                         addr: vm_monitor_addr.cloned().unwrap(),
-                        file_cache_not_in_memory,
+                        file_cache_on_disk,
                     })),
                     token.clone(),
                 ))
@@ -485,8 +485,8 @@ fn cli() -> clap::Command {
                 .value_name("FILECACHE_CONNSTR"),
         )
         .arg(
-            Arg::new("file-cache-not-in-memory")
-                .long("file-cache-not-in-memory")
+            Arg::new("file-cache-on-disk")
+                .long("file-cache-on-disk")
                 .action(clap::ArgAction::SetTrue),
         )
 }

--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -280,6 +280,7 @@ fn main() -> Result<()> {
             let vm_monitor_addr = matches.get_one::<String>("vm-monitor-addr");
             let file_cache_connstr = matches.get_one::<String>("filecache-connstr");
             let cgroup = matches.get_one::<String>("cgroup");
+            let file_cache_not_in_memory = matches.get_flag("file-cache-not-in-memory");
 
             // Only make a runtime if we need to.
             // Note: it seems like you can make a runtime in an inner scope and
@@ -312,6 +313,7 @@ fn main() -> Result<()> {
                         cgroup: cgroup.cloned(),
                         pgconnstr: file_cache_connstr.cloned(),
                         addr: vm_monitor_addr.cloned().unwrap(),
+                        file_cache_not_in_memory: file_cache_not_in_memory,
                     })),
                     token.clone(),
                 ))
@@ -481,6 +483,11 @@ fn cli() -> clap::Command {
                     "host=localhost port=5432 dbname=postgres user=cloud_admin sslmode=disable",
                 )
                 .value_name("FILECACHE_CONNSTR"),
+        )
+        .arg(
+            Arg::new("file-cache-not-in-memory")
+                .long("file-cache-not-in-memory")
+                .action(clap::ArgAction::SetTrue),
         )
 }
 

--- a/libs/vm_monitor/src/filecache.rs
+++ b/libs/vm_monitor/src/filecache.rs
@@ -59,8 +59,15 @@ pub struct FileCacheConfig {
     spread_factor: f64,
 }
 
-impl Default for FileCacheConfig {
-    fn default() -> Self {
+impl FileCacheConfig {
+    pub fn new(in_memory: bool) -> Self {
+        match in_memory {
+            true => Self::default_in_memory(),
+            false => Self::default_on_disk(),
+        }
+    }
+
+    fn default_in_memory() -> Self {
         Self {
             in_memory: true,
             // 75 %
@@ -71,9 +78,19 @@ impl Default for FileCacheConfig {
             spread_factor: 0.1,
         }
     }
-}
 
-impl FileCacheConfig {
+    fn default_on_disk() -> Self {
+        Self {
+            in_memory: false,
+            resource_multiplier: 0.75,
+            // 256 MiB - lower than when in memory because overcommitting is safe; if we don't have
+            // memory, the kernel will just evict from its page cache, rather than e.g. killing
+            // everything.
+            min_remaining_after_cache: NonZeroU64::new(256 * MiB).unwrap(),
+            spread_factor: 0.1,
+        }
+    }
+
     /// Make sure fields of the config are consistent.
     pub fn validate(&self) -> anyhow::Result<()> {
         // Single field validity

--- a/libs/vm_monitor/src/filecache.rs
+++ b/libs/vm_monitor/src/filecache.rs
@@ -60,14 +60,7 @@ pub struct FileCacheConfig {
 }
 
 impl FileCacheConfig {
-    pub fn new(in_memory: bool) -> Self {
-        match in_memory {
-            true => Self::default_in_memory(),
-            false => Self::default_on_disk(),
-        }
-    }
-
-    fn default_in_memory() -> Self {
+    pub fn default_in_memory() -> Self {
         Self {
             in_memory: true,
             // 75 %
@@ -79,7 +72,7 @@ impl FileCacheConfig {
         }
     }
 
-    fn default_on_disk() -> Self {
+    pub fn default_on_disk() -> Self {
         Self {
             in_memory: false,
             resource_multiplier: 0.75,

--- a/libs/vm_monitor/src/lib.rs
+++ b/libs/vm_monitor/src/lib.rs
@@ -39,14 +39,15 @@ pub struct Args {
     #[arg(short, long)]
     pub pgconnstr: Option<String>,
 
-    /// Flag to signal that the Postgres file cache is not in memory, and therefore should not
-    /// count against available memory.
+    /// Flag to signal that the Postgres file cache is on disk (i.e. not in memory aside from the
+    /// kernel's page cache), and therefore should not count against available memory.
     //
-    // NB: Making this flag positive (i.e. "file cache in memory", instead of "... not in memory")
-    // would have been easier to deal with, but in order to be backwards compatible during the
-    // switch away from an in-memory file cache, we had to default to the previous behavior.
+    // NB: Ideally this flag would directly refer to whether the file cache is in memory (rather
+    // than a roundabout way, via whether it's on disk), but in order to be backwards compatible
+    // during the switch away from an in-memory file cache, we had to default to the previous
+    // behavior.
     #[arg(long)]
-    pub file_cache_not_in_memory: bool,
+    pub file_cache_on_disk: bool,
 
     /// The address we should listen on for connection requests. For the
     /// agent, this is 0.0.0.0:10301. For the informant, this is 127.0.0.1:10369.

--- a/libs/vm_monitor/src/lib.rs
+++ b/libs/vm_monitor/src/lib.rs
@@ -39,6 +39,15 @@ pub struct Args {
     #[arg(short, long)]
     pub pgconnstr: Option<String>,
 
+    /// Flag to signal that the Postgres file cache is not in memory, and therefore should not
+    /// count against available memory.
+    //
+    // NB: Making this flag positive (i.e. "file cache in memory", instead of "... not in memory")
+    // would have been easier to deal with, but in order to be backwards compatible during the
+    // switch away from an in-memory file cache, we had to default to the previous behavior.
+    #[arg(long)]
+    pub file_cache_not_in_memory: bool,
+
     /// The address we should listen on for connection requests. For the
     /// agent, this is 0.0.0.0:10301. For the informant, this is 127.0.0.1:10369.
     #[arg(short, long)]

--- a/libs/vm_monitor/src/runner.rs
+++ b/libs/vm_monitor/src/runner.rs
@@ -110,7 +110,10 @@ impl Runner {
         // memory limits.
         if let Some(connstr) = &args.pgconnstr {
             info!("initializing file cache");
-            let config = FileCacheConfig::new(!args.file_cache_on_disk);
+            let config = match args.file_cache_on_disk {
+                true => FileCacheConfig::default_on_disk(),
+                false => FileCacheConfig::default_in_memory(),
+            };
 
             let mut file_cache = FileCacheState::new(connstr, config, token.clone())
                 .await

--- a/libs/vm_monitor/src/runner.rs
+++ b/libs/vm_monitor/src/runner.rs
@@ -110,10 +110,7 @@ impl Runner {
         // memory limits.
         if let Some(connstr) = &args.pgconnstr {
             info!("initializing file cache");
-            let config: FileCacheConfig = Default::default();
-            if !config.in_memory {
-                panic!("file cache not in-memory implemented")
-            }
+            let config = FileCacheConfig::new(!args.file_cache_not_in_memory);
 
             let mut file_cache = FileCacheState::new(connstr, config, token.clone())
                 .await
@@ -140,7 +137,10 @@ impl Runner {
             if actual_size != new_size {
                 info!("file cache size actually got set to {actual_size}")
             }
-            file_cache_reserved_bytes = actual_size;
+            // Mark the resources given to the file cache as reserved, but only if it's in memory.
+            if !args.file_cache_not_in_memory {
+                file_cache_reserved_bytes = actual_size;
+            }
 
             state.filecache = Some(file_cache);
         }

--- a/libs/vm_monitor/src/runner.rs
+++ b/libs/vm_monitor/src/runner.rs
@@ -110,7 +110,7 @@ impl Runner {
         // memory limits.
         if let Some(connstr) = &args.pgconnstr {
             info!("initializing file cache");
-            let config = FileCacheConfig::new(!args.file_cache_not_in_memory);
+            let config = FileCacheConfig::new(!args.file_cache_on_disk);
 
             let mut file_cache = FileCacheState::new(connstr, config, token.clone())
                 .await
@@ -138,7 +138,7 @@ impl Runner {
                 info!("file cache size actually got set to {actual_size}")
             }
             // Mark the resources given to the file cache as reserved, but only if it's in memory.
-            if !args.file_cache_not_in_memory {
+            if !args.file_cache_on_disk {
                 file_cache_reserved_bytes = actual_size;
             }
 

--- a/libs/vm_monitor/src/runner.rs
+++ b/libs/vm_monitor/src/runner.rs
@@ -227,18 +227,17 @@ impl Runner {
         let mut status = vec![];
         let mut file_cache_mem_usage = 0;
         if let Some(file_cache) = &mut self.filecache {
-            if !file_cache.config.in_memory {
-                panic!("file cache not in-memory unimplemented")
-            }
-
             let actual_usage = file_cache
                 .set_file_cache_size(expected_file_cache_mem_usage)
                 .await
                 .context("failed to set file cache size")?;
-            file_cache_mem_usage = actual_usage;
+            if file_cache.config.in_memory {
+                file_cache_mem_usage = actual_usage;
+            }
             let message = format!(
-                "set file cache size to {} MiB",
-                bytes_to_mebibytes(actual_usage)
+                "set file cache size to {} MiB (in memory = {})",
+                bytes_to_mebibytes(actual_usage),
+                file_cache.config.in_memory,
             );
             info!("downscale: {message}");
             status.push(message);
@@ -289,10 +288,6 @@ impl Runner {
         // Get the file cache's expected contribution to the memory usage
         let mut file_cache_mem_usage = 0;
         if let Some(file_cache) = &mut self.filecache {
-            if !file_cache.config.in_memory {
-                panic!("file cache not in-memory unimplemented");
-            }
-
             let expected_usage = file_cache.config.calculate_cache_size(usable_system_memory);
             info!(
                 target = bytes_to_mebibytes(expected_usage),
@@ -304,6 +299,9 @@ impl Runner {
                 .set_file_cache_size(expected_usage)
                 .await
                 .context("failed to set file cache size")?;
+            if file_cache.config.in_memory {
+                file_cache_mem_usage = actual_usage;
+            }
 
             if actual_usage != expected_usage {
                 warn!(
@@ -312,7 +310,6 @@ impl Runner {
                     bytes_to_mebibytes(actual_usage)
                 )
             }
-            file_cache_mem_usage = actual_usage;
         }
 
         if let Some(cgroup) = &self.cgroup {


### PR DESCRIPTION
Part 1 of 2, for moving the file cache onto disk.

Because VMs are created by the control plane (and that's where the filesystem for the file cache is defined), we can't rely on any kind of synchronization between releases, so the change needs to be feature-gated (kind of), with the default remaining the same for now.

---

**NB:** This PR temporarily uses the branch for the associated cloud PR for e2e tests, in order to make sure that the whole thing works, at least at a basic level.

See also: neondatabase/cloud#6593