### PR TITLE
pageserver: generation number support in keys and indices

### DIFF
--- a/libs/utils/src/generation.rs
+++ b/libs/utils/src/generation.rs
@@ -1,0 +1,73 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Generation(u32);
+
+/// The Generation type represents a number associated with a Tenant, which
+/// increments every time the tenant is attached to a new pageserver, or
+/// an attached pageserver restarts.
+///
+/// It is included as a suffix in S3 keys, as a protection against split-brain
+/// scenarios where pageservers might otherwise issue conflicting writes to
+/// remote storage
+impl Generation {
+    // Generations with this magic value may never be used to construct S3 keys:
+    // we will panic if someone tries to.  This is for Tenants in the "Broken" state,
+    // so that we can satisfy their constructor with a Generation without risking
+    // a code bug using it in an S3 write (broken tenants should never write)
+    const BROKEN: u32 = u32::MAX;
+
+    // Generations with this magic value will not add a suffix to S3 keys, and will not
+    // be included in persisted index_part.json.  This value is only to be used
+    // during migration from pre-generation metadata to generation-aware metadata,
+    // and should eventually go away.
+    //
+    // A special Generation is used rather than always wrapping Generation in an Option,
+    // so that code handling generations doesn't have to be aware of the legacy
+    // case everywhere it touches a generation.
+    const NONE: u32 = u32::MAX - 1;
+
+    /// Create a new Generation that represents a legacy key format with
+    /// no generation suffix
+    pub fn none() -> Self {
+        Self(Self::NONE)
+    }
+
+    // Create a new generation that will panic if you try to use get_suffix
+    pub fn broken() -> Self {
+        Self(Self::BROKEN)
+    }
+
+    pub fn new(v: u32) -> Self {
+        assert!(v != Self::BROKEN);
+
+        Self(v)
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.0 == Self::NONE
+    }
+
+    pub fn get_suffix(&self) -> String {
+        assert!(self.0 != Self::BROKEN, "Tried to use a broken generation");
+        if self.0 == Self::NONE {
+            "".into()
+        } else {
+            format!("-{:08x}", self.0).into()
+        }
+    }
+}
+
+impl Display for Generation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0 == Self::BROKEN {
+            write!(f, "<broken>")
+        } else if self.0 == Self::NONE {
+            write!(f, "<none>")
+        } else {
+            write!(f, "{:08x}", self.0)
+        }
+    }
+}

--- a/libs/utils/src/generation.rs
+++ b/libs/utils/src/generation.rs
@@ -2,8 +2,24 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct Generation(u32);
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Generation {
+    // Generations with this magic value will not add a suffix to S3 keys, and will not
+    // be included in persisted index_part.json.  This value is only to be used
+    // during migration from pre-generation metadata to generation-aware metadata,
+    // and should eventually go away.
+    //
+    // A special Generation is used rather than always wrapping Generation in an Option,
+    // so that code handling generations doesn't have to be aware of the legacy
+    // case everywhere it touches a generation.
+    None,
+    // Generations with this magic value may never be used to construct S3 keys:
+    // we will panic if someone tries to.  This is for Tenants in the "Broken" state,
+    // so that we can satisfy their constructor with a Generation without risking
+    // a code bug using it in an S3 write (broken tenants should never write)
+    Broken,
+    Valid(u32),
+}
 
 /// The Generation type represents a number associated with a Tenant, which
 /// increments every time the tenant is attached to a new pageserver, or
@@ -13,61 +29,77 @@ pub struct Generation(u32);
 /// scenarios where pageservers might otherwise issue conflicting writes to
 /// remote storage
 impl Generation {
-    // Generations with this magic value may never be used to construct S3 keys:
-    // we will panic if someone tries to.  This is for Tenants in the "Broken" state,
-    // so that we can satisfy their constructor with a Generation without risking
-    // a code bug using it in an S3 write (broken tenants should never write)
-    const BROKEN: u32 = u32::MAX;
-
-    // Generations with this magic value will not add a suffix to S3 keys, and will not
-    // be included in persisted index_part.json.  This value is only to be used
-    // during migration from pre-generation metadata to generation-aware metadata,
-    // and should eventually go away.
-    //
-    // A special Generation is used rather than always wrapping Generation in an Option,
-    // so that code handling generations doesn't have to be aware of the legacy
-    // case everywhere it touches a generation.
-    const NONE: u32 = u32::MAX - 1;
-
     /// Create a new Generation that represents a legacy key format with
     /// no generation suffix
     pub fn none() -> Self {
-        Self(Self::NONE)
+        Self::None
     }
 
     // Create a new generation that will panic if you try to use get_suffix
     pub fn broken() -> Self {
-        Self(Self::BROKEN)
+        Self::Broken
     }
 
     pub fn new(v: u32) -> Self {
-        assert!(v != Self::BROKEN);
-
-        Self(v)
+        Self::Valid(v)
     }
 
     pub fn is_none(&self) -> bool {
-        self.0 == Self::NONE
+        matches!(self, Self::None)
     }
 
     pub fn get_suffix(&self) -> String {
-        assert!(self.0 != Self::BROKEN, "Tried to use a broken generation");
-        if self.0 == Self::NONE {
-            "".into()
-        } else {
-            format!("-{:08x}", self.0)
+        match self {
+            Self::Valid(v) => {
+                format!("-{:08x}", v)
+            }
+            Self::None => "".into(),
+            Self::Broken => {
+                panic!("Tried to use a broken generation");
+            }
         }
+    }
+}
+
+impl Serialize for Generation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if let Self::Valid(v) = self {
+            v.serialize(serializer)
+        } else {
+            // We should never be asked to serialize a None or Broken.  Structures
+            // that include an optional generation should convert None to an
+            // Option<Generation>::None
+            Err(serde::ser::Error::custom(
+                "Tried to serialize invalid generation",
+            ))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Generation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::Valid(u32::deserialize(deserializer)?))
     }
 }
 
 impl Display for Generation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.0 == Self::BROKEN {
-            write!(f, "<broken>")
-        } else if self.0 == Self::NONE {
-            write!(f, "<none>")
-        } else {
-            write!(f, "{:08x}", self.0)
+        match self {
+            Self::Valid(v) => {
+                write!(f, "{:08x}", v)
+            }
+            Self::None => {
+                write!(f, "<none>")
+            }
+            Self::Broken => {
+                write!(f, "<broken>")
+            }
         }
     }
 }

--- a/libs/utils/src/generation.rs
+++ b/libs/utils/src/generation.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// See docs/rfcs/025-generation-numbers.md for detail on how generation
 /// numbers are used.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Generation {
     // Generations with this magic value will not add a suffix to S3 keys, and will not
     // be included in persisted index_part.json.  This value is only to be used
@@ -93,7 +93,10 @@ impl<'de> Deserialize<'de> for Generation {
     }
 }
 
-impl Display for Generation {
+// We intentionally do not implement Display for Generation, to reduce the
+// risk of a bug where the generation is used in a format!() string directly
+// instead of using get_suffix().
+impl Debug for Generation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Valid(v) => {

--- a/libs/utils/src/generation.rs
+++ b/libs/utils/src/generation.rs
@@ -55,7 +55,7 @@ impl Generation {
         if self.0 == Self::NONE {
             "".into()
         } else {
-            format!("-{:08x}", self.0).into()
+            format!("-{:08x}", self.0)
         }
     }
 }

--- a/libs/utils/src/generation.rs
+++ b/libs/utils/src/generation.rs
@@ -2,6 +2,11 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
+/// Tenant generations are used to provide split-brain safety and allow
+/// multiple pageservers to attach the same tenant concurrently.
+///
+/// See docs/rfcs/025-generation-numbers.md for detail on how generation
+/// numbers are used.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Generation {
     // Generations with this magic value will not add a suffix to S3 keys, and will not
@@ -73,7 +78,7 @@ impl Serialize for Generation {
             // that include an optional generation should convert None to an
             // Option<Generation>::None
             Err(serde::ser::Error::custom(
-                "Tried to serialize invalid generation",
+                "Tried to serialize invalid generation ({self})",
             ))
         }
     }

--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -27,6 +27,9 @@ pub mod id;
 // http endpoint utils
 pub mod http;
 
+// definition of the Generation type for pageserver attachment APIs
+pub mod generation;
+
 // common log initialisation routine
 pub mod logging;
 

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -643,23 +643,6 @@ impl PageServerConf {
             .join(METADATA_FILE_NAME)
     }
 
-    /// Files on the remote storage are stored with paths, relative to the workdir.
-    /// That path includes in itself both tenant and timeline ids, allowing to have a unique remote storage path.
-    ///
-    /// Errors if the path provided does not start from pageserver's workdir.
-    pub fn remote_path(&self, local_path: &Path) -> anyhow::Result<RemotePath> {
-        local_path
-            .strip_prefix(&self.workdir)
-            .context("Failed to strip workdir prefix")
-            .and_then(RemotePath::new)
-            .with_context(|| {
-                format!(
-                    "Failed to resolve remote part of path {:?} for base {:?}",
-                    local_path, self.workdir
-                )
-            })
-    }
-
     /// Turns storage remote path of a file into its local path.
     pub fn local_path(&self, remote_path: &RemotePath) -> PathBuf {
         remote_path.with_base(&self.workdir)

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -655,12 +655,8 @@ impl Tenant {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("cannot attach without remote storage"))?;
 
-        let remote_timeline_ids = remote_timeline_client::list_remote_timelines(
-            remote_storage,
-            self.conf,
-            self.tenant_id,
-        )
-        .await?;
+        let remote_timeline_ids =
+            remote_timeline_client::list_remote_timelines(remote_storage, self.tenant_id).await?;
 
         info!("found {} timelines", remote_timeline_ids.len());
 
@@ -672,6 +668,7 @@ impl Tenant {
                 self.conf,
                 self.tenant_id,
                 timeline_id,
+                self.generation,
             );
             part_downloads.spawn(
                 async move {
@@ -2944,6 +2941,7 @@ impl Tenant {
                 self.conf,
                 self.tenant_id,
                 timeline_id,
+                self.generation,
             );
             Some(remote_client)
         } else {

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -180,7 +180,8 @@ pub struct Tenant {
 
     tenant_id: TenantId,
 
-    /// The remote storage generation, used to protect S3 objects from split-brain
+    /// The remote storage generation, used to protect S3 objects from split-brain.
+    /// Does not change over the lifetime of the [`Tenant`] object.
     generation: Generation,
 
     timelines: Mutex<HashMap<TimelineId, Arc<Timeline>>>,

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -180,7 +180,7 @@ pub struct Tenant {
 
     tenant_id: TenantId,
 
-    // The remote storage generation, used to protect S3 objects from split-brain
+    /// The remote storage generation, used to protect S3 objects from split-brain
     generation: Generation,
 
     timelines: Mutex<HashMap<TimelineId, Arc<Timeline>>>,

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -25,6 +25,7 @@ use crate::tenant::{create_tenant_files, CreateTenantFilesMode, Tenant, TenantSt
 use crate::{InitializationOrder, IGNORED_TENANT_FILE_NAME};
 
 use utils::fs_ext::PathExt;
+use utils::generation::Generation;
 use utils::id::{TenantId, TimelineId};
 
 use super::delete::DeleteTenantError;
@@ -202,6 +203,7 @@ pub(crate) fn schedule_local_tenant_processing(
             match Tenant::spawn_attach(
                 conf,
                 tenant_id,
+                Generation::none(),
                 resources.broker_client,
                 tenants,
                 remote_storage,
@@ -224,7 +226,15 @@ pub(crate) fn schedule_local_tenant_processing(
     } else {
         info!("tenant {tenant_id} is assumed to be loadable, starting load operation");
         // Start loading the tenant into memory. It will initially be in Loading state.
-        Tenant::spawn_load(conf, tenant_id, resources, init_order, tenants, ctx)
+        Tenant::spawn_load(
+            conf,
+            tenant_id,
+            Generation::none(),
+            resources,
+            init_order,
+            tenants,
+            ctx,
+        )
     };
     Ok(tenant)
 }

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1433,21 +1433,17 @@ pub fn remote_index_path(
 pub fn remote_path(
     conf: &PageServerConf,
     local_path: &Path,
-    generation: Option<Generation>,
+    generation: Generation,
 ) -> anyhow::Result<RemotePath> {
     let stripped = local_path
         .strip_prefix(&conf.workdir)
         .context("Failed to strip workdir prefix")?;
 
-    let suffixed = if let Some(generation) = generation {
-        format!(
-            "{0}{1}",
-            stripped.to_string_lossy(),
-            generation.get_suffix()
-        )
-    } else {
-        stripped.to_string_lossy().to_string()
-    };
+    let suffixed = format!(
+        "{0}{1}",
+        stripped.to_string_lossy(),
+        generation.get_suffix()
+    );
 
     RemotePath::new(&PathBuf::from(suffixed)).with_context(|| {
         format!(

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -454,7 +454,6 @@ impl RemoteTimelineClient {
         );
 
         let index_part = download::download_index_part(
-            self.conf,
             &self.storage_impl,
             &self.tenant_id,
             &self.timeline_id,
@@ -1447,7 +1446,7 @@ pub fn remote_path(
 
     RemotePath::new(&PathBuf::from(suffixed)).with_context(|| {
         format!(
-            "resolve remote part of path {:?} for base {:?}",
+            "to resolve remote part of path {:?} for base {:?}",
             local_path, conf.workdir
         )
     })

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1367,7 +1367,7 @@ mod tests {
         context::RequestContext,
         tenant::{
             harness::{TenantHarness, TIMELINE_ID},
-            Tenant, Timeline,
+            Generation, Tenant, Timeline,
         },
         DEFAULT_PG_VERSION,
     };
@@ -1542,16 +1542,18 @@ mod tests {
             std::fs::write(timeline_path.join(filename.file_name()), content).unwrap();
         }
 
+        let generation = Generation::new(0xdeadbeef);
+
         client
             .schedule_layer_file_upload(
                 &layer_file_name_1,
-                &LayerFileMetadata::new(content_1.len() as u64),
+                &LayerFileMetadata::new(content_1.len() as u64, generation),
             )
             .unwrap();
         client
             .schedule_layer_file_upload(
                 &layer_file_name_2,
-                &LayerFileMetadata::new(content_2.len() as u64),
+                &LayerFileMetadata::new(content_2.len() as u64, generation),
             )
             .unwrap();
 
@@ -1615,7 +1617,7 @@ mod tests {
         client
             .schedule_layer_file_upload(
                 &layer_file_name_3,
-                &LayerFileMetadata::new(content_3.len() as u64),
+                &LayerFileMetadata::new(content_3.len() as u64, generation),
             )
             .unwrap();
         client
@@ -1703,12 +1705,14 @@ mod tests {
 
         // Test
 
+        let generation = Generation::new(0xdeadbeef);
+
         let init = get_bytes_started_stopped();
 
         client
             .schedule_layer_file_upload(
                 &layer_file_name_1,
-                &LayerFileMetadata::new(content_1.len() as u64),
+                &LayerFileMetadata::new(content_1.len() as u64, generation),
             )
             .unwrap();
 

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -667,8 +667,8 @@ impl RemoteTimelineClient {
                         upload_queue.latest_files_changes_since_metadata_upload_scheduled += 1;
                         Some((name, meta.generation))
                     } else {
-                        // This can happen if we are deleting a file that we never
-                        // successfully uploaded.  We log it because it is a rare/strange
+                        // This can only happen if we forgot to to schedule the file upload
+                        // before scheduling the delete. Log it because it is a rare/strange
                         // situation, and in case something is misbehaving, we'd like to know which
                         // layers experienced this.
                         info!(

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -668,10 +668,13 @@ impl RemoteTimelineClient {
                         upload_queue.latest_files_changes_since_metadata_upload_scheduled += 1;
                         Some((name, meta.generation))
                     } else {
-                        // This is unexpected: latest_files is meant to be kept up to
-                        // date.  We can't delete the layer if we have forgotten what
-                        // generation it was in.
-                        warn!("Deleting layer {name} not found in latest_files list");
+                        // This can happen if we are deleting a file that we never
+                        // successfully uploaded.  We log it because it is a rare/strange
+                        // situation, and in case something is misbehaving, we'd like to know which
+                        // layers experienced this.
+                        info!(
+                            "Deleting layer {name} not found in latest_files list, never uploaded?"
+                        );
                         None
                     }
                 })

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1447,7 +1447,7 @@ pub fn remote_path(
 
     RemotePath::new(&PathBuf::from(suffixed)).with_context(|| {
         format!(
-            "Failed to resolve remote part of path {:?} for base {:?}",
+            "resolve remote part of path {:?} for base {:?}",
             local_path, conf.workdir
         )
     })

--- a/pageserver/src/tenant/remote_timeline_client/delete.rs
+++ b/pageserver/src/tenant/remote_timeline_client/delete.rs
@@ -5,7 +5,10 @@ use tracing::debug;
 
 use remote_storage::GenericRemoteStorage;
 
-use crate::config::PageServerConf;
+use crate::{
+    config::PageServerConf,
+    tenant::{remote_timeline_client::remote_path, Generation},
+};
 
 pub(super) async fn delete_layer<'a>(
     conf: &'static PageServerConf,
@@ -17,7 +20,9 @@ pub(super) async fn delete_layer<'a>(
     });
     debug!("Deleting layer from remote storage: {local_layer_path:?}",);
 
-    let path_to_delete = conf.remote_path(local_layer_path)?;
+    // FIXME: once we start writing out keys with generations, this will
+    // need updating (or, in the deletion queue branch, it is already gone)
+    let path_to_delete = remote_path(conf, local_layer_path, Generation::placeholder())?;
 
     // We don't want to print an error if the delete failed if the file has
     // already been deleted. Thankfully, in this situation S3 already

--- a/pageserver/src/tenant/remote_timeline_client/delete.rs
+++ b/pageserver/src/tenant/remote_timeline_client/delete.rs
@@ -14,15 +14,14 @@ pub(super) async fn delete_layer<'a>(
     conf: &'static PageServerConf,
     storage: &'a GenericRemoteStorage,
     local_layer_path: &'a Path,
+    generation: Option<Generation>,
 ) -> anyhow::Result<()> {
     fail::fail_point!("before-delete-layer", |_| {
         anyhow::bail!("failpoint before-delete-layer")
     });
     debug!("Deleting layer from remote storage: {local_layer_path:?}",);
 
-    // FIXME: once we start writing out keys with generations, this will
-    // need updating (or, in the deletion queue branch, it is already gone)
-    let path_to_delete = remote_path(conf, local_layer_path, Generation::placeholder())?;
+    let path_to_delete = remote_path(conf, local_layer_path, generation)?;
 
     // We don't want to print an error if the delete failed if the file has
     // already been deleted. Thankfully, in this situation S3 already

--- a/pageserver/src/tenant/remote_timeline_client/delete.rs
+++ b/pageserver/src/tenant/remote_timeline_client/delete.rs
@@ -14,14 +14,14 @@ pub(super) async fn delete_layer<'a>(
     conf: &'static PageServerConf,
     storage: &'a GenericRemoteStorage,
     local_layer_path: &'a Path,
-    generation: Option<Generation>,
+    generation: Generation,
 ) -> anyhow::Result<()> {
     fail::fail_point!("before-delete-layer", |_| {
         anyhow::bail!("failpoint before-delete-layer")
     });
     debug!("Deleting layer from remote storage: {local_layer_path:?}",);
 
-    let path_to_delete = remote_path(conf, local_layer_path, generation)?;
+    let path_to_delete = remote_path(conf, local_layer_path, Some(generation))?;
 
     // We don't want to print an error if the delete failed if the file has
     // already been deleted. Thankfully, in this situation S3 already

--- a/pageserver/src/tenant/remote_timeline_client/delete.rs
+++ b/pageserver/src/tenant/remote_timeline_client/delete.rs
@@ -27,7 +27,8 @@ pub(super) async fn delete_layer<'a>(
     // already been deleted. Thankfully, in this situation S3 already
     // does not yield an error. While OS-provided local file system APIs do yield
     // errors, we avoid them in the `LocalFs` wrapper.
-    storage.delete(&path_to_delete).await.with_context(|| {
-        format!("Failed to delete remote layer from storage at {path_to_delete:?}")
-    })
+    storage
+        .delete(&path_to_delete)
+        .await
+        .with_context(|| format!("delete remote layer from storage at {path_to_delete:?}"))
 }

--- a/pageserver/src/tenant/remote_timeline_client/delete.rs
+++ b/pageserver/src/tenant/remote_timeline_client/delete.rs
@@ -21,7 +21,7 @@ pub(super) async fn delete_layer<'a>(
     });
     debug!("Deleting layer from remote storage: {local_layer_path:?}",);
 
-    let path_to_delete = remote_path(conf, local_layer_path, Some(generation))?;
+    let path_to_delete = remote_path(conf, local_layer_path, generation)?;
 
     // We don't want to print an error if the delete failed if the file has
     // already been deleted. Thankfully, in this situation S3 already

--- a/pageserver/src/tenant/remote_timeline_client/download.rs
+++ b/pageserver/src/tenant/remote_timeline_client/download.rs
@@ -173,8 +173,8 @@ pub fn is_temp_download_file(path: &Path) -> bool {
 }
 
 /// List timelines of given tenant in remote storage
-pub async fn list_remote_timelines<'a>(
-    storage: &'a GenericRemoteStorage,
+pub async fn list_remote_timelines(
+    storage: &GenericRemoteStorage,
     tenant_id: TenantId,
 ) -> anyhow::Result<HashSet<TimelineId>> {
     let remote_path = remote_timelines_path(&tenant_id);

--- a/pageserver/src/tenant/remote_timeline_client/download.rs
+++ b/pageserver/src/tenant/remote_timeline_client/download.rs
@@ -220,16 +220,11 @@ pub async fn list_remote_timelines(
 }
 
 pub(super) async fn download_index_part(
-    conf: &'static PageServerConf,
     storage: &GenericRemoteStorage,
     tenant_id: &TenantId,
     timeline_id: &TimelineId,
     generation: Generation,
 ) -> Result<IndexPart, DownloadError> {
-    let local_path = conf
-        .metadata_path(tenant_id, timeline_id)
-        .with_file_name(IndexPart::FILE_NAME);
-
     let remote_path = remote_index_path(tenant_id, timeline_id, generation);
 
     let index_part_bytes = download_retry(
@@ -242,7 +237,7 @@ pub(super) async fn download_index_part(
                 &mut index_part_bytes,
             )
             .await
-            .with_context(|| format!("download index part into file {local_path:?}"))
+            .with_context(|| format!("download index part at {remote_path:?}"))
             .map_err(DownloadError::Other)?;
             Ok(index_part_bytes)
         },
@@ -251,7 +246,7 @@ pub(super) async fn download_index_part(
     .await?;
 
     let index_part: IndexPart = serde_json::from_slice(&index_part_bytes)
-        .with_context(|| format!("download index part file into file {local_path:?}"))
+        .with_context(|| format!("download index part file at {remote_path:?}"))
         .map_err(DownloadError::Other)?;
 
     Ok(index_part)

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -26,7 +26,7 @@ pub struct LayerFileMetadata {
     file_size: u64,
 
     // Optional for backward compatibility: older data will not have a generation set
-    generation: Option<Generation>,
+    pub(crate) generation: Option<Generation>,
 }
 
 impl From<&'_ IndexLayerMetadata> for LayerFileMetadata {
@@ -142,13 +142,17 @@ impl TryFrom<&UploadQueueInitialized> for IndexPart {
     }
 }
 
+fn generation_is_none(g: &Option<Generation>) -> bool {
+    g.map(|g| g.is_none()).unwrap_or(true)
+}
+
 /// Serialized form of [`LayerFileMetadata`].
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Default)]
 pub struct IndexLayerMetadata {
     pub(super) file_size: u64,
 
     #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "generation_is_none")]
     pub(super) generation: Option<Generation>,
 }
 

--- a/pageserver/src/tenant/remote_timeline_client/upload.rs
+++ b/pageserver/src/tenant/remote_timeline_client/upload.rs
@@ -58,7 +58,7 @@ pub(super) async fn upload_timeline_layer<'a>(
         bail!("failpoint before-upload-layer")
     });
 
-    let storage_path = remote_path(conf, source_path, generation)?;
+    let storage_path = remote_path(conf, source_path, Some(generation))?;
     let source_file_res = fs::File::open(&source_path).await;
     let source_file = match source_file_res {
         Ok(source_file) => source_file,

--- a/pageserver/src/tenant/remote_timeline_client/upload.rs
+++ b/pageserver/src/tenant/remote_timeline_client/upload.rs
@@ -58,7 +58,7 @@ pub(super) async fn upload_timeline_layer<'a>(
         bail!("failpoint before-upload-layer")
     });
 
-    let storage_path = remote_path(conf, source_path, Some(generation))?;
+    let storage_path = remote_path(conf, source_path, generation)?;
     let source_file_res = fs::File::open(&source_path).await;
     let source_file = match source_file_res {
         Ok(source_file) => source_file,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -153,7 +153,8 @@ pub struct Timeline {
     pub tenant_id: TenantId,
     pub timeline_id: TimelineId,
 
-    // The generation of the tenant that instantiated us: this is used for safety when writing remote objects
+    /// The generation of the tenant that instantiated us: this is used for safety when writing remote objects.
+    /// Never changes for the lifetime of this [`Timeline`] object.
     generation: Generation,
 
     pub pg_version: u32,

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -147,7 +147,11 @@ pub(super) fn reconcile(
                 Err(FutureLayer { local })
             } else {
                 Ok(match (local, remote) {
-                    (Some(local), Some(remote)) if local != remote => UseRemote { local, remote },
+                    (Some(local), Some(remote)) if local != remote => {
+                        assert_eq!(local.generation, remote.generation);
+
+                        UseRemote { local, remote }
+                    }
                     (Some(x), Some(_)) => UseLocal(x),
                     (None, Some(x)) => Evicted(x),
                     (Some(x), None) => NeedsUpload(x),

--- a/pageserver/src/tenant/timeline/init.rs
+++ b/pageserver/src/tenant/timeline/init.rs
@@ -7,6 +7,7 @@ use crate::{
             index::{IndexPart, LayerFileMetadata},
         },
         storage_layer::LayerFileName,
+        Generation,
     },
     METADATA_FILE_NAME,
 };
@@ -104,6 +105,7 @@ pub(super) fn reconcile(
     discovered: Vec<(LayerFileName, u64)>,
     index_part: Option<&IndexPart>,
     disk_consistent_lsn: Lsn,
+    generation: Generation,
 ) -> Vec<(LayerFileName, Result<Decision, FutureLayer>)> {
     use Decision::*;
 
@@ -112,7 +114,15 @@ pub(super) fn reconcile(
 
     let mut discovered = discovered
         .into_iter()
-        .map(|(name, file_size)| (name, (Some(LayerFileMetadata::new(file_size)), None)))
+        .map(|(name, file_size)| {
+            (
+                name,
+                // The generation here will be corrected to match IndexPart in the merge below, unless
+                // it is not in IndexPart, in which case using our current generation makes sense
+                // because it will be uploaded in this generation.
+                (Some(LayerFileMetadata::new(file_size, generation)), None),
+            )
+        })
         .collect::<Collected>();
 
     // merge any index_part information, when available

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -1,6 +1,7 @@
 use crate::metrics::RemoteOpFileKind;
 
 use super::storage_layer::LayerFileName;
+use super::Generation;
 use crate::tenant::metadata::TimelineMetadata;
 use crate::tenant::remote_timeline_client::index::IndexPart;
 use crate::tenant::remote_timeline_client::index::LayerFileMetadata;
@@ -205,6 +206,7 @@ pub(crate) struct Delete {
     pub(crate) file_kind: RemoteOpFileKind,
     pub(crate) layer_file_name: LayerFileName,
     pub(crate) scheduled_from_timeline_delete: bool,
+    pub(crate) generation: Option<Generation>,
 }
 
 #[derive(Debug)]
@@ -238,9 +240,10 @@ impl std::fmt::Display for UploadOp {
             }
             UploadOp::Delete(delete) => write!(
                 f,
-                "Delete(path: {}, scheduled_from_timeline_delete: {})",
+                "Delete(path: {}, scheduled_from_timeline_delete: {}, gen: {})",
                 delete.layer_file_name.file_name(),
-                delete.scheduled_from_timeline_delete
+                delete.scheduled_from_timeline_delete,
+                delete.generation.unwrap_or(Generation::none())
             ),
             UploadOp::Barrier(_) => write!(f, "Barrier"),
         }

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -233,7 +233,9 @@ impl std::fmt::Display for UploadOp {
                     metadata.file_size()
                 )
             }
-            UploadOp::UploadMetadata(_, lsn) => write!(f, "UploadMetadata(lsn: {})", lsn),
+            UploadOp::UploadMetadata(_, lsn) => {
+                write!(f, "UploadMetadata(lsn: {})", lsn)
+            }
             UploadOp::Delete(delete) => write!(
                 f,
                 "Delete(path: {}, scheduled_from_timeline_delete: {})",

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -230,9 +230,10 @@ impl std::fmt::Display for UploadOp {
             UploadOp::UploadLayer(path, metadata) => {
                 write!(
                     f,
-                    "UploadLayer({}, size={:?})",
+                    "UploadLayer({}, size={:?}, gen={})",
                     path.file_name(),
-                    metadata.file_size()
+                    metadata.file_size(),
+                    metadata.generation,
                 )
             }
             UploadOp::UploadMetadata(_, lsn) => {

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -206,7 +206,7 @@ pub(crate) struct Delete {
     pub(crate) file_kind: RemoteOpFileKind,
     pub(crate) layer_file_name: LayerFileName,
     pub(crate) scheduled_from_timeline_delete: bool,
-    pub(crate) generation: Option<Generation>,
+    pub(crate) generation: Generation,
 }
 
 #[derive(Debug)]
@@ -243,7 +243,7 @@ impl std::fmt::Display for UploadOp {
                 "Delete(path: {}, scheduled_from_timeline_delete: {}, gen: {})",
                 delete.layer_file_name.file_name(),
                 delete.scheduled_from_timeline_delete,
-                delete.generation.unwrap_or(Generation::none())
+                delete.generation
             ),
             UploadOp::Barrier(_) => write!(f, "Barrier"),
         }

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -230,7 +230,7 @@ impl std::fmt::Display for UploadOp {
             UploadOp::UploadLayer(path, metadata) => {
                 write!(
                     f,
-                    "UploadLayer({}, size={:?}, gen={})",
+                    "UploadLayer({}, size={:?}, gen={:?})",
                     path.file_name(),
                     metadata.file_size(),
                     metadata.generation,
@@ -241,7 +241,7 @@ impl std::fmt::Display for UploadOp {
             }
             UploadOp::Delete(delete) => write!(
                 f,
-                "Delete(path: {}, scheduled_from_timeline_delete: {}, gen: {})",
+                "Delete(path: {}, scheduled_from_timeline_delete: {}, gen: {:?})",
                 delete.layer_file_name.file_name(),
                 delete.scheduled_from_timeline_delete,
                 delete.generation


### PR DESCRIPTION
## Problem

To implement split brain protection, we need tenants and timelines to be aware of their current generation, and use it when composing S3 keys.


## Summary of changes

- A `Generation` type is introduced in the `utils` crate -- it is in this broadly-visible location because it will later be used from `control_plane/` as well as `pageserver/`.  Generations can be a number, None, or Broken, to support legacy content (None), and Tenants in the broken state (Broken).
- Tenant, Timeline, and RemoteTimelineClient all get a generation attribute
- IndexPart's IndexLayerMetadata has a new `generation` attribute.  Legacy layers' metadata will deserialize to Generation::none().
- Remote paths are composed with a trailing generation suffix.  If a generation is equal to Generation::none() (as it currently always is), then this suffix is an empty string.
- Functions for composing remote storage paths added in remote_timeline_client: these avoid the way that we currently always compose a local path and then strip the prefix, and avoid requiring a PageserverConf reference on functions that want to create remote paths (the conf is only needed for local paths).  These are less DRY than the old functions, but remote storage paths are a very rarely changing thing, so it's better to write out our paths clearly in the functions than to compose timeline paths from tenant paths, etc.
- Code paths that construct a Tenant take a `generation` argument in anticipation that we will soon load generations on startup before constructing Tenant.

Until the whole feature is done, we don't want any generation-ful keys though: so initially we will carry this everywhere with the special Generation::none() value.

Closes: https://github.com/neondatabase/neon/issues/5135

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
