### PR TITLE
fix: add context for ancestor lsn wait

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2269,7 +2269,7 @@ impl Timeline {
                     .await
                     .with_context(|| {
                         format!(
-                            "failed to wait for lsn {} on ancestor timeline_id={}",
+                            "wait for lsn {} on ancestor timeline_id={}",
                             timeline.ancestor_lsn, ancestor.timeline_id
                         )
                     })?;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2264,7 +2264,12 @@ impl Timeline {
                         )));
                     }
                 }
-                ancestor.wait_lsn(timeline.ancestor_lsn, ctx).await?;
+                ancestor
+                    .wait_lsn(timeline.ancestor_lsn, ctx)
+                    .await
+                    .with_context(|| {
+                        format!("failed to wait for ancestor lsn {}", timeline.ancestor_lsn)
+                    })?;
 
                 timeline_owned = ancestor;
                 timeline = &*timeline_owned;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2268,7 +2268,10 @@ impl Timeline {
                     .wait_lsn(timeline.ancestor_lsn, ctx)
                     .await
                     .with_context(|| {
-                        format!("failed to wait for ancestor lsn {}", timeline.ancestor_lsn)
+                        format!(
+                            "failed to wait for lsn {} on ancestor timeline_id={}",
+                            timeline.ancestor_lsn, ancestor.timeline_id
+                        )
                     })?;
 
                 timeline_owned = ancestor;


### PR DESCRIPTION
In logs it is confusing to see seqwait timeouts which seemingly arise from the branched lsn but actually are about the ancestor, leading to questions like "has the last_record_lsn went back".

Noticed by @problame.