### PR TITLE
refactor(rename_to_backup): Less exists checks

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4697,7 +4697,7 @@ fn rename_to_backup(path: &Path) -> anyhow::Result<()> {
 
         new_path.set_file_name(&file_name);
 
-        // FIXME: this will be std::fs::File::create_new once/if ever stabilized
+        // this will be std::fs::File::create_new once/if ever stabilized
         let res = std::fs::File::options()
             .read(true)
             .write(true)
@@ -4718,7 +4718,7 @@ fn rename_to_backup(path: &Path) -> anyhow::Result<()> {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // the path to be renamed never existed
                 if let Err(e) = std::fs::remove_file(&new_path) {
-                    // this failure should not happen
+                    // this failure should not happen, but do not hide the original with it
                     tracing::error!(
                         "failed to remove the created backup file at {new_path:?}: {e}"
                     );

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4681,14 +4681,20 @@ fn is_send() {
 /// Add a suffix to a layer file's name: .{num}.old
 /// Uses the first available num (starts at 0)
 fn rename_to_backup(path: &Path) -> anyhow::Result<()> {
+    use std::fmt::Write as _;
     let filename = path
         .file_name()
         .ok_or_else(|| anyhow!("Path {} don't have a file name", path.display()))?
         .to_string_lossy();
     let mut new_path = path.to_owned();
 
+    let mut file_name = String::new();
+
     for i in 0u32.. {
-        new_path.set_file_name(format!("{filename}.{i}.old"));
+        file_name.clear();
+        write!(file_name, "{filename}.{i}.old").expect("string grows, cannot fail");
+
+        new_path.set_file_name(&file_name);
         if !new_path.exists() {
             std::fs::rename(path, &new_path)
                 .with_context(|| format!("rename {path:?} to {new_path:?}"))?;


### PR DESCRIPTION
We have `std::path::Path::exists` usage. In a now hopefully abandoned PR I was looking at this and thinking this is wildly unsafe, but have since realized that any two threads having the possibility of executing at the same time for the same file would fail cleanly, because only one would win the `rename` (or hopefully fail for any reason the `std::path::Path::exists` hid from us).

Changes:
- reuse more buffers
- use `File::create_new` instead of `Path::exists` to check for free names

Probably not really needed but would help towards denylisting `std::path::Path::exists`. No tests added because the `exists` usage case cannot really be found except via stress testing or additional failpoints.