### PR TITLE
proxy: locked is not retriable

### DIFF
--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -81,7 +81,7 @@ pub mod errors {
                 // retry some temporary failures because the compute was in a bad state
                 // (bad request can be returned when the endpoint was in transition)
                 Self::Console {
-                    status: http::StatusCode::BAD_REQUEST | http::StatusCode::LOCKED,
+                    status: http::StatusCode::BAD_REQUEST,
                     ..
                 } => true,
                 // retry server errors


### PR DESCRIPTION
## Problem

Management service returns Locked when quotas are exhausted. We cannot retry on those

## Summary of changes

Makes Locked status unretriable

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
