### PR TITLE
WIP: log a deprecation WARNING if no remote storage is configured

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -615,7 +615,7 @@ fn create_remote_storage_client(
     let config = if let Some(config) = &conf.remote_storage_config {
         config
     } else {
-        // No remote storage configured.
+        tracing::warn!("no remote storage configured, this is a deprecated configuration");
         return Ok(None);
     };
 


### PR DESCRIPTION
a full test suite run will unvail the set of test cases that don't use remote storage

part of https://github.com/neondatabase/neon/pull/5086#issuecomment-1701331777