### PR TITLE
Merge custom extension CI jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -899,11 +899,8 @@ jobs:
       - name: Cleanup ECR folder
         run: rm -rf ~/.ecr
 
-  trigger-custom-extensions-build:
-    runs-on: [ self-hosted, gen3, small ]
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
-      options: --init
+  trigger-custom-extensions-build-and-wait:
+    runs-on: ubuntu-latest
     needs: [ tag ]
     steps:
       - name: Set PR's status to pending and request a remote CI test
@@ -938,11 +935,6 @@ jobs:
               }
             }"
 
-  wait-for-extensions-build:
-    runs-on: ubuntu-latest
-    needs: [ trigger-custom-extensions-build ]
-
-    steps:
       - name: Wait for extension build to finish
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
@@ -984,7 +976,7 @@ jobs:
   deploy:
     runs-on: [ self-hosted, gen3, small ]
     container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/ansible:latest
-    needs: [ promote-images, tag, regress-tests, wait-for-extensions-build ]
+    needs: [ promote-images, tag, regress-tests, trigger-custom-extensions-build-and-wait ]
     if: ( github.ref_name == 'main' || github.ref_name == 'release' ) && github.event_name != 'workflow_dispatch'
     steps:
       - name: Fix git ownership

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -939,7 +939,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          TIMEOUT=600 # 10 minutes, currently it takes ~2-3 minutes
+          TIMEOUT=1800 # 30 minutes, usually it takes ~2-3 minutes, but if runners are busy, it might take longer
           INTERVAL=15 # try each N seconds
 
           last_status="" # a variable to carry the last status of the "build-and-upload-extensions" context


### PR DESCRIPTION
## Problem

When a remote custom extension build fails, it looks a bit confusing on neon CI:
- `trigger-custom-extensions-build` is 🟢 
- `wait-for-extensions-build` is 🔴 
- `build-and-upload-extensions` is 🔴 

But to restart the build (to get everything green) you need to restart the only passed `trigger-custom-extensions-build`.

## Summary of changes
- Merge `trigger-custom-extensions-build` and `wait-for-extensions-build` jobs into `trigger-custom-extensions-build-and-wait` 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
