### PR TITLE
fix(pageserver): add the walreceiver state to tenant timeline GET api endpoint

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -381,6 +381,8 @@ pub struct TimelineInfo {
     pub pg_version: u32,
 
     pub state: TimelineState,
+
+    pub walreceiver_status: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -273,6 +273,53 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /v1/tenant/{tenant_id}/timeline/{timeline_id}/walreceiver:
+    parameters:
+      - name: tenant_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: hex
+      - name: timeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: hex
+    get:
+      description: Get walreceiver state
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Error when no tenant id found in path, no timeline id
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Unauthorized Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: Forbidden Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "500":
+          description: Generic operation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /v1/tenant/{tenant_id}/timeline/{timeline_id}/get_lsn_by_timestamp:
     parameters:
       - name: tenant_id

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -273,53 +273,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /v1/tenant/{tenant_id}/timeline/{timeline_id}/walreceiver:
-    parameters:
-      - name: tenant_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: hex
-      - name: timeline_id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: hex
-    get:
-      description: Get walreceiver state
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: string
-        "400":
-          description: Error when no tenant id found in path, no timeline id
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "401":
-          description: Unauthorized Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UnauthorizedError"
-        "403":
-          description: Forbidden Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ForbiddenError"
-        "500":
-          description: Generic operation error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
   /v1/tenant/{tenant_id}/timeline/{timeline_id}/get_lsn_by_timestamp:
     parameters:
       - name: tenant_id

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -285,6 +285,8 @@ async fn build_timeline_info_common(
     let state = timeline.current_state();
     let remote_consistent_lsn = timeline.get_remote_consistent_lsn().unwrap_or(Lsn(0));
 
+    let walreceiver_status = timeline.walreceiver_status();
+
     let info = TimelineInfo {
         tenant_id: timeline.tenant_id,
         timeline_id: timeline.timeline_id,
@@ -305,6 +307,8 @@ async fn build_timeline_info_common(
         pg_version: timeline.pg_version,
 
         state,
+
+        walreceiver_status,
     };
     Ok(info)
 }

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -440,6 +440,39 @@ async fn timeline_detail_handler(
     json_response(StatusCode::OK, timeline_info)
 }
 
+async fn walreceiver_detail_handler(
+    request: Request<Body>,
+    _cancel: CancellationToken,
+) -> Result<Response<Body>, ApiError> {
+    let tenant_id: TenantId = parse_request_param(&request, "tenant_id")?;
+    let timeline_id: TimelineId = parse_request_param(&request, "timeline_id")?;
+    check_permission(&request, Some(tenant_id))?;
+
+    let walreceiver_info = async {
+        let tenant = mgr::get_tenant(tenant_id, true).await?;
+
+        let timeline = tenant
+            .get_timeline(timeline_id, false)
+            .map_err(|e| ApiError::NotFound(e.into()))?;
+
+        let walreceiver_status = {
+            match &*timeline.walreceiver.lock().unwrap() {
+                None => "stopping or stopped".to_string(),
+                Some(walreceiver) => match walreceiver.status() {
+                    Some(status) => status.to_human_readable_string(),
+                    None => "Not active".to_string(),
+                },
+            }
+        };
+
+        Ok::<_, ApiError>(walreceiver_status)
+    }
+    .instrument(info_span!("walreceiver_detail", %tenant_id, %timeline_id))
+    .await?;
+
+    json_response(StatusCode::OK, walreceiver_info)
+}
+
 async fn get_lsn_by_timestamp_handler(
     request: Request<Body>,
     _cancel: CancellationToken,
@@ -1420,6 +1453,10 @@ pub fn make_router(
         .get("/v1/tenant/:tenant_id/timeline/:timeline_id", |r| {
             api_handler(r, timeline_detail_handler)
         })
+        .get(
+            "/v1/tenant/:tenant_id/timeline/:timeline_id/walreceiver",
+            |r| api_handler(r, walreceiver_detail_handler),
+        )
         .get(
             "/v1/tenant/:tenant_id/timeline/:timeline_id/get_lsn_by_timestamp",
             |r| api_handler(r, get_lsn_by_timestamp_handler),

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -455,15 +455,7 @@ async fn walreceiver_detail_handler(
             .get_timeline(timeline_id, false)
             .map_err(|e| ApiError::NotFound(e.into()))?;
 
-        let walreceiver_status = {
-            match &*timeline.walreceiver.lock().unwrap() {
-                None => "stopping or stopped".to_string(),
-                Some(walreceiver) => match walreceiver.status() {
-                    Some(status) => status.to_human_readable_string(),
-                    None => "Not active".to_string(),
-                },
-            }
-        };
+        let walreceiver_status = timeline.walreceiver_status();
 
         Ok::<_, ApiError>(walreceiver_status)
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -599,7 +599,7 @@ impl Timeline {
         }
     }
 
-    pub fn walreceiver_status(&self) -> String {
+    pub(crate) fn walreceiver_status(&self) -> String {
         match &*self.walreceiver.lock().unwrap() {
             None => "stopping or stopped".to_string(),
             Some(walreceiver) => match walreceiver.status() {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -585,15 +585,7 @@ impl Timeline {
             Err(e) => {
                 // don't count the time spent waiting for lock below, and also in walreceiver.status(), towards the wait_lsn_time_histo
                 drop(_timer);
-                let walreceiver_status = {
-                    match &*self.walreceiver.lock().unwrap() {
-                        None => "stopping or stopped".to_string(),
-                        Some(walreceiver) => match walreceiver.status() {
-                            Some(status) => status.to_human_readable_string(),
-                            None => "Not active".to_string(),
-                        },
-                    }
-                };
+                let walreceiver_status = self.walreceiver_status();
                 Err(anyhow::Error::new(e).context({
                     format!(
                         "Timed out while waiting for WAL record at LSN {} to arrive, last_record_lsn {} disk consistent LSN={}, WalReceiver status: {}",
@@ -604,6 +596,16 @@ impl Timeline {
                     )
                 }))
             }
+        }
+    }
+
+    pub fn walreceiver_status(&self) -> String {
+        match &*self.walreceiver.lock().unwrap() {
+            None => "stopping or stopped".to_string(),
+            Some(walreceiver) => match walreceiver.status() {
+                Some(status) => status.to_human_readable_string(),
+                None => "Not active".to_string(),
+            },
         }
     }
 

--- a/pageserver/src/tenant/timeline/walreceiver.rs
+++ b/pageserver/src/tenant/timeline/walreceiver.rs
@@ -135,7 +135,7 @@ impl WalReceiver {
         .await;
     }
 
-    pub(super) fn status(&self) -> Option<ConnectionManagerStatus> {
+    pub fn status(&self) -> Option<ConnectionManagerStatus> {
         self.manager_status.read().unwrap().clone()
     }
 }

--- a/pageserver/src/tenant/timeline/walreceiver.rs
+++ b/pageserver/src/tenant/timeline/walreceiver.rs
@@ -135,7 +135,7 @@ impl WalReceiver {
         .await;
     }
 
-    pub fn status(&self) -> Option<ConnectionManagerStatus> {
+    pub(crate) fn status(&self) -> Option<ConnectionManagerStatus> {
         self.manager_status.read().unwrap().clone()
     }
 }


### PR DESCRIPTION
Add a `walreceiver_state` field to `TimelineInfo` (response of `GET /v1/tenant/:tenant_id/timeline/:timeline_id`) and while doing that, refactor out a common `Timeline::walreceiver_state(..)`. No OpenAPI changes, because this is an internal debugging addition.

Fixes #3115.