### PR TITLE
Fix pg_config version parsing

### DIFF
--- a/compute_tools/src/extension_server.rs
+++ b/compute_tools/src/extension_server.rs
@@ -135,23 +135,29 @@ mod tests {
     fn test_parse_pg_version() {
         assert_eq!(parse_pg_version("PostgreSQL 15.4"), "v15");
         assert_eq!(parse_pg_version("PostgreSQL 15.14"), "v15");
-        assert_eq!(parse_pg_version("PostgreSQL 15.4 (Ubuntu 15.4-0ubuntu0.23.04.1)"), "v15");
+        assert_eq!(
+            parse_pg_version("PostgreSQL 15.4 (Ubuntu 15.4-0ubuntu0.23.04.1)"),
+            "v15"
+        );
 
         assert_eq!(parse_pg_version("PostgreSQL 14.15"), "v14");
         assert_eq!(parse_pg_version("PostgreSQL 14.0"), "v14");
-        assert_eq!(parse_pg_version("PostgreSQL 14.9 (Debian 14.9-1.pgdg120+1"), "v14");
+        assert_eq!(
+            parse_pg_version("PostgreSQL 14.9 (Debian 14.9-1.pgdg120+1"),
+            "v14"
+        );
     }
 
     #[test]
     #[should_panic]
     fn test_parse_pg_unsupported_version() {
-        parse_pg_version("PostgreSQL 13.14"); 
+        parse_pg_version("PostgreSQL 13.14");
     }
 
     #[test]
     #[should_panic]
     fn test_parse_pg_incorrect_version_format() {
-        parse_pg_version("PostgreSQL 14"); 
+        parse_pg_version("PostgreSQL 14");
     }
 }
 


### PR DESCRIPTION
## Problem
Fix pg_config version parsing

## Summary of changes
Use regex to capture major version of postgres
#5146

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
