### PR TITLE
approved-for-ci-run.yml: trigger on pull_request_target

### DIFF
--- a/.github/workflows/approved-for-ci-run.yml
+++ b/.github/workflows/approved-for-ci-run.yml
@@ -2,7 +2,7 @@ name: Handle `approved-for-ci-run` label
 # This workflow helps to run CI pipeline for PRs made by external contributors (from forks).
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types:


### PR DESCRIPTION
## Problem

Continuation of #4663, #5210

We're still getting an error ([a link](https://github.com/neondatabase/neon/actions/runs/6095184171/job/16538225725)):
```
GraphQL: Resource not accessible by integration (removeLabelsFromLabelable)
```

## Summary of changes
- trigger `approved-for-ci-run.yml` workflow on `pull_request_target` instead of `pull_request`

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
