### PR TITLE
approved-for-ci-run.yml: use our bot

### DIFF
--- a/.github/workflows/approved-for-ci-run.yml
+++ b/.github/workflows/approved-for-ci-run.yml
@@ -17,7 +17,7 @@ on:
       - labeled
 
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
 
 concurrency:
@@ -33,7 +33,6 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'approved-for-ci-run')
 
     runs-on: ubuntu-latest
-    permissions: write-all
 
     steps:
       - run: gh pr --repo "${GITHUB_REPOSITORY}" edit "${PR_NUMBER}" --remove-label "approved-for-ci-run"
@@ -46,7 +45,6 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'approved-for-ci-run')
 
     runs-on: ubuntu-latest
-    permissions: write-all
 
     steps:
       - run: gh pr --repo "${GITHUB_REPOSITORY}" edit "${PR_NUMBER}" --remove-label "approved-for-ci-run"


### PR DESCRIPTION
## Problem

Pull Requests created by GitHub Actions bot doesn't have access to secrets (https://github.com/neondatabase/neon/pull/5214), so we need to use our bot for it.

See previous PRs  #4663, #5210, #5212

## Summary of changes
- Use our bot to create PR

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
