### PR TITLE
Misc post-merge fixes

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -476,7 +476,7 @@ jobs:
             ;;
         esac
 
-        CONNSTR_SECRET_NAME="BENCHMARK_${ENV_PLATFORM}_S${SCALE}_CONNSTR"
+        CONNSTR_SECRET_NAME="BENCHMARK_${ENV_PLATFORM}_S${TEST_OLAP_SCALE}_CONNSTR"
         echo "CONNSTR_SECRET_NAME=${CONNSTR_SECRET_NAME}" >> $GITHUB_ENV
 
     - name: Set up Connection String

--- a/scripts/comment-test-report.js
+++ b/scripts/comment-test-report.js
@@ -139,7 +139,7 @@ const reportSummary = async (params) => {
     // Print test resuls from the newest to the oldest Postgres version for release and debug builds.
     for (const pgVersion of Array.from(pgVersions).sort().reverse()) {
         if (Object.keys(failedTests[pgVersion]).length > 0) {
-            summary += `#### Failures on Posgres ${pgVersion}\n\n`
+            summary += `#### Failures on Postgres ${pgVersion}\n\n`
             for (const [testName, tests] of Object.entries(failedTests[pgVersion])) {
                 const links = []
                 for (const test of tests) {
@@ -188,7 +188,7 @@ const reportSummary = async (params) => {
 }
 
 const parseCoverageSummary = async ({ summaryJsonUrl, coverageUrl, fetch }) => {
-    let summary = `### Code coverage [full report](${coverageUrl})\n`
+    let summary = `\n### Code coverage ([full report](${coverageUrl}))\n`
 
     const coverage = await (await fetch(summaryJsonUrl)).json()
     for (const covType of Object.keys(coverage).sort()) {


### PR DESCRIPTION
## Problem
- `SCALE: unbound variable` from https://github.com/neondatabase/neon/pull/5079
- The layout of the GitHub auto-comment is broken if the code coverage section follows flaky test section from https://github.com/neondatabase/neon/pull/4999

___
**BEFORE**

<details>
<summary>Flaky tests (1)</summary>

#### Postgres 14

- `test_partial_evict_tenant`: [release](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-5217/6098548759/index.html#suites/0e58fb04d9998963e98e45fe1880af7d/64204cbf5e42e51a/retries)

</details>
### Code coverage [full report](https://neon-github-public-dev.s3.amazonaws.com/code-coverage/643c96abd5c921ec11c8d685ba94ba9c7e0551ff/lcov/index.html)
- `functions`: `52.6% (7532 of 14321 functions)`
- `lines`: `81.3% (44451 of 54644 lines)`

___
**AFTER**

<details>
<summary>Flaky tests (1)</summary>

#### Postgres 14

- `test_partial_evict_tenant`: [release](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-5217/6098548759/index.html#suites/0e58fb04d9998963e98e45fe1880af7d/64204cbf5e42e51a/retries)

</details>

### Code coverage ([full report](https://neon-github-public-dev.s3.amazonaws.com/code-coverage/643c96abd5c921ec11c8d685ba94ba9c7e0551ff/lcov/index.html))
- `functions`: `52.6% (7532 of 14321 functions)`
- `lines`: `81.3% (44451 of 54644 lines)`

___

## Summary of changes
- `benchmarking.yml`: Rename `SCALE` to `TEST_OLAP_SCALE` 
- `comment-test-report.js`: Add an extra new-line before Code coverage section 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
