### PR TITLE
Improve comment in page cache

### DIFF
--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -800,7 +800,7 @@ impl PageCache {
         assert!(num_pages > 0, "page cache size must be > 0");
 
         // We could use Vec::leak here, but that potentially also leaks
-        // uninitialized reserved capcaity. With into_boxed_slice and Box::leak
+        // uninitialized reserved capacity. With into_boxed_slice and Box::leak
         // this is avoided.
         let page_buffer = Box::leak(vec![0u8; num_pages * PAGE_SZ].into_boxed_slice());
 

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -799,8 +799,9 @@ impl PageCache {
     fn new(num_pages: usize) -> Self {
         assert!(num_pages > 0, "page cache size must be > 0");
 
-        // We use Box::leak here and into_boxed_slice to avoid leaking uninitialized
-        // memory that Vec's might contain.
+        // We could use Vec::leak here, but that potentially also leaks
+        // uninitialized reserved capcaity. With into_boxed_slice and Box::leak
+        // this is avoided.
         let page_buffer = Box::leak(vec![0u8; num_pages * PAGE_SZ].into_boxed_slice());
 
         let size_metrics = &crate::metrics::PAGE_CACHE_SIZE;


### PR DESCRIPTION
It was easy to interpret comment in the page cache initialization code to be about justifying why we leak here at all, not just why this specific type of leaking is done (which the comment was actually meant to describe).

See https://github.com/neondatabase/neon/pull/5125#discussion_r1308445993