### PR TITLE
Misc workflows: fixes to make CI friendly for external contributors 

### DIFF
--- a/.github/workflows/approved-for-ci-run.yml
+++ b/.github/workflows/approved-for-ci-run.yml
@@ -74,7 +74,7 @@ jobs:
             Feel free to review/comment/discuss the original PR #${PR_NUMBER}.
           EOF
 
-          ALREADY_CREATED="$(gh pr --repo '${GITHUB_REPOSITORY}' list --head '${HEAD}' --base 'main' --json 'number' --jq '.[].number')"
+          ALREADY_CREATED="$(gh pr --repo ${GITHUB_REPOSITORY} list --head ${HEAD} --base main --json number --jq '.[].number')"
           if [ -z "${ALREADY_CREATED}" ]; then
             gh pr --repo "${GITHUB_REPOSITORY}" create --title "CI run for PR #${PR_NUMBER}" \
                                                        --body-file "body.md" \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
         if [ "${{ contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}" = "true" ]; then
           MESSAGE="Please create a PR from a branch of ${GITHUB_REPOSITORY} instead of a fork"
         else
-          MESSAGE="The PR should be reviewed and labelled with `approved-for-ci-run` to trigger a CI run"
+          MESSAGE="The PR should be reviewed and labelled with 'approved-for-ci-run' to trigger a CI run"
         fi
 
         echo >&2 "We don't run CI for PRs from forks"

--- a/scripts/comment-test-report.js
+++ b/scripts/comment-test-report.js
@@ -205,20 +205,22 @@ const parseCoverageSummary = async ({ summaryJsonUrl, coverageUrl, fetch }) => {
 }
 
 module.exports = async ({ github, context, fetch, report, coverage }) => {
+    // If we run the script in the PR or in the branch (main/release/...)
+    const isPullRequest = !!context.payload.pull_request
     // Which PR to comment (for ci-run/pr-* it will comment the parent PR, not the ci-run/pr-* PR)
     let prToComment
-    const branchName = context.payload.pull_request.base.ref.replace(/^refs\/heads\//, "")
-    const match = branchName.match(/^ci-run\/pr-(?<prNumber>\d+)$/)?.groups
-    if (match) {
-        ({ prNumber } = match)
-        prToComment = parseInt(prNumber, 10)
-    } else {
-        prToComment = context.payload.number
+    if (isPullRequest) {
+        const branchName = context.payload.pull_request.base.ref.replace(/^refs\/heads\//, "")
+        const match = branchName.match(/ci-run\/pr-(?<prNumber>\d+)/)?.groups
+        if (match) {
+            ({ prNumber } = match)
+            prToComment = parseInt(prNumber, 10)
+        } else {
+            prToComment = context.payload.number
+        }
     }
     // Marker to find the comment in the subsequent runs
     const startMarker = `<!--AUTOMATIC COMMENT START #${prToComment}-->`
-    // If we run the script in the PR or in the branch (main/release/...)
-    const isPullRequest = !!context.payload.pull_request
     // Latest commit in PR or in the branch
     const commitSha = isPullRequest ? context.payload.pull_request.head.sha : context.sha
     // Let users know that the comment is updated automatically


### PR DESCRIPTION
## Problem


- `expected the "[HOST/]OWNER/REPO" format, got "${GITHUB_REPOSITORY}"` while running: `gh pr --repo '${GITHUB_REPOSITORY}' list <...>`

- `TypeError: Cannot read properties of undefined (reading 'base')` while GitHub Autocomment creation for a branch

## Summary of changes
- Fix variable interpolation in bash scripts in workflows
- Fix `scripts/comment-test-report.js`

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
