### PR TITLE
test_startup: increase timeout

### DIFF
--- a/test_runner/performance/test_startup.py
+++ b/test_runner/performance/test_startup.py
@@ -84,7 +84,7 @@ def test_startup_simple(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenc
 
 
 # This test sometimes runs for longer than the global 5 minute timeout.
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(900)
 def test_startup(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenchmarker):
     neon_env_builder.num_safekeepers = 3
     env = neon_env_builder.init_start()


### PR DESCRIPTION
## Problem

`test_runner/performance/test_startup.py::test_startup` started to fail more frequently because of the timeout.
Let's increase the timeout to see the failures on the perf dashboard.

## Summary of changes
- Increase timeout for`test_startup` from 600 to 900 seconds

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
