### PR TITLE
test: Remote storage refactorings

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -514,11 +514,8 @@ class NeonEnvBuilder:
         remote_storage_kind: RemoteStorageKind,
     ):
         assert self.pageserver_remote_storage is None, "remote storage is enabled already"
-
         ret = self._configure_and_create_remote_storage(remote_storage_kind, "pageserver")
-
         self.pageserver_remote_storage = ret
-        self.pageserver_remote_storage_kind = remote_storage_kind
 
     def enable_extensions_remote_storage(self, kind: RemoteStorageKind):
         assert self.ext_remote_storage is None, "already configured extensions remote storage"

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -572,37 +572,6 @@ class NeonEnvBuilder:
 
         return ret
 
-    def enable_local_fs_remote_storage(self):
-        """
-        Sets up the pageserver to use the local fs at the `test_dir/local_fs_remote_storage` path.
-        Errors, if the pageserver has some remote storage configuration already, unless `force_enable` is not set to `True`.
-        """
-        self.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
-
-    def enable_mock_s3_remote_storage(
-        self,
-        enable_remote_extensions: bool = False,
-    ):
-        """
-        Sets up the pageserver to use the S3 mock server, creates the bucket, if it's not present already.
-        Starts up the mock server, if that does not run yet.
-        Also creates the bucket for extensions, self.ext_remote_storage bucket
-        """
-        self.enable_remote_storage(
-            RemoteStorageKind.MOCK_S3, enable_remote_extensions=enable_remote_extensions
-        )
-
-    def enable_real_s3_remote_storage(
-        self,
-        enable_remote_extensions: bool = False,
-    ):
-        """
-        Sets up configuration to use real s3 endpoint without mock server
-        """
-        self.enable_remote_storage(
-            RemoteStorageKind.REAL_S3, enable_remote_extensions=enable_remote_extensions
-        )
-
     def cleanup_local_storage(self):
         if self.preserve_database_files:
             return

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -532,6 +532,7 @@ class NeonEnvBuilder:
             # there is an assumption that REAL_S3 for extensions is never cleaned up
             ext = self._configure_and_create_remote_storage(remote_storage_kind, "ext")
             assert isinstance(ext, S3Storage)
+            ext.cleanup = False
             self.ext_remote_storage = ext
 
     def enable_safekeeper_remote_storage(self, kind: RemoteStorageKind):

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -48,6 +48,7 @@ from fixtures.remote_storage import (
     MockS3Server,
     RemoteStorage,
     RemoteStorageKind,
+    RemoteStorageUser,
     S3Storage,
     remote_storage_to_toml_inline_table,
 )
@@ -513,7 +514,9 @@ class NeonEnvBuilder:
         remote_storage_kind: RemoteStorageKind,
     ):
         assert self.pageserver_remote_storage is None, "remote storage is enabled already"
-        ret = self._configure_and_create_remote_storage(remote_storage_kind, "pageserver")
+        ret = self._configure_and_create_remote_storage(
+            remote_storage_kind, RemoteStorageUser.PAGESERVER
+        )
         self.pageserver_remote_storage = ret
 
     def enable_extensions_remote_storage(self, kind: RemoteStorageKind):
@@ -524,7 +527,7 @@ class NeonEnvBuilder:
         # bucket and region, which is most likely the same as our normal
         ext = self._configure_and_create_remote_storage(
             kind,
-            "ext",
+            RemoteStorageUser.EXTENSIONS,
             bucket_name="neon-dev-extensions-eu-central-1",
             bucket_region="eu-central-1",
         )
@@ -537,12 +540,14 @@ class NeonEnvBuilder:
     def enable_safekeeper_remote_storage(self, kind: RemoteStorageKind):
         assert self.sk_remote_storage is None, "sk_remote_storage already configured"
 
-        self.sk_remote_storage = self._configure_and_create_remote_storage(kind, "safekeeper")
+        self.sk_remote_storage = self._configure_and_create_remote_storage(
+            kind, RemoteStorageUser.SAFEKEEPER
+        )
 
     def _configure_and_create_remote_storage(
         self,
         kind: RemoteStorageKind,
-        user: str,
+        user: RemoteStorageUser,
         bucket_name: Optional[str] = None,
         bucket_region: Optional[str] = None,
     ) -> Optional[RemoteStorage]:

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -622,55 +622,6 @@ class NeonEnvBuilder:
         if isinstance(self.safekeepers_remote_storage, S3Storage):
             self.safekeepers_remote_storage.do_cleanup()
 
-        # # Making mypy happy with allowing only `S3Storage` further.
-        # # `self.remote_storage_prefix` is coupled with `S3Storage` storage type,
-        # # so this line effectively a no-op
-        # assert isinstance(self.remote_storage, S3Storage)
-        # assert self.remote_storage_client is not None
-
-        # if self.keep_remote_storage_contents:
-        #     log.info("keep_remote_storage_contents skipping remote storage cleanup")
-        #     return
-
-        # log.info(
-        #     "removing data from test s3 bucket %s by prefix %s",
-        #     self.remote_storage.bucket_name,
-        #     self.remote_storage_prefix,
-        # )
-        # paginator = self.remote_storage_client.get_paginator("list_objects_v2")
-        # pages = paginator.paginate(
-        #     Bucket=self.remote_storage.bucket_name,
-        #     Prefix=self.remote_storage_prefix,
-        # )
-
-        # # Using Any because DeleteTypeDef (from boto3-stubs) doesn't fit our case
-        # objects_to_delete: Any = {"Objects": []}
-        # cnt = 0
-        # for item in pages.search("Contents"):
-        #     # weirdly when nothing is found it returns [None]
-        #     if item is None:
-        #         break
-
-        #     objects_to_delete["Objects"].append({"Key": item["Key"]})
-
-        #     # flush once aws limit reached
-        #     if len(objects_to_delete["Objects"]) >= 1000:
-        #         self.remote_storage_client.delete_objects(
-        #             Bucket=self.remote_storage.bucket_name,
-        #             Delete=objects_to_delete,
-        #         )
-        #         objects_to_delete = {"Objects": []}
-        #         cnt += 1
-
-        # # flush rest
-        # if len(objects_to_delete["Objects"]):
-        #     self.remote_storage_client.delete_objects(
-        #         Bucket=self.remote_storage.bucket_name,
-        #         Delete=objects_to_delete,
-        #     )
-
-        # log.info(f"deleted {cnt} objects from remote storage")
-
     def __enter__(self) -> "NeonEnvBuilder":
         return self
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -512,14 +512,13 @@ class NeonEnvBuilder:
     def enable_remote_storage(
         self,
         remote_storage_kind: RemoteStorageKind,
-        force_enable: bool = False,
     ):
         """
         Configure pageserver and possibly compute extension remote storage.
 
         Does not configure safekeeper remote storage.
         """
-        assert force_enable or self.remote_storage is None, "remote storage is enabled already"
+        assert self.remote_storage is None, "remote storage is enabled already"
 
         ret = self._configure_and_create_remote_storage(remote_storage_kind, "pageserver")
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -447,7 +447,6 @@ class NeonEnvBuilder:
         self.auth_enabled = auth_enabled
         self.default_branch_name = default_branch_name
         self.env: Optional[NeonEnv] = None
-        self.remote_storage_prefix: Optional[str] = None
         self.keep_remote_storage_contents: bool = True
         self.neon_binpath = neon_binpath
         self.pg_distrib_dir = pg_distrib_dir
@@ -589,12 +588,6 @@ class NeonEnvBuilder:
                 directory_to_clean.rmdir()
 
     def cleanup_remote_storage(self):
-        # here wee check for true remote storage, no the local one
-        # local cleanup is not needed after test because in ci all env will be destroyed anyway
-        if self.remote_storage_prefix is None:
-            log.info("no remote storage was set up, skipping cleanup")
-            return
-
         # extensions are currently not cleaned up, disabled when creating
         for x in [self.pageserver_remote_storage, self.ext_remote_storage, self.sk_remote_storage]:
             if isinstance(x, S3Storage):

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -598,11 +598,10 @@ class NeonEnvBuilder:
             log.info("no remote storage was set up, skipping cleanup")
             return
 
-        if isinstance(self.remote_storage, S3Storage):
-            self.remote_storage.do_cleanup()
-
-        if isinstance(self.sk_remote_storage, S3Storage):
-            self.sk_remote_storage.do_cleanup()
+        # extensions are currently not cleaned up, disabled when creating
+        for x in [self.pageserver_remote_storage, self.ext_remote_storage, self.sk_remote_storage]:
+            if isinstance(x, S3Storage):
+                x.do_cleanup()
 
     def __enter__(self) -> "NeonEnvBuilder":
         return self

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -513,7 +513,6 @@ class NeonEnvBuilder:
         self,
         remote_storage_kind: RemoteStorageKind,
         force_enable: bool = False,
-        enable_remote_extensions: bool = False,
     ):
         """
         Configure pageserver and possibly compute extension remote storage.
@@ -527,19 +526,19 @@ class NeonEnvBuilder:
         self.remote_storage = ret
         self.remote_storage_kind = remote_storage_kind
 
-        if enable_remote_extensions:
-            # there is an assumption that REAL_S3 for extensions is never
-            # cleaned up these are also special in that they have a hardcoded
-            # bucket and region, which is most likely the same as our normal
-            ext = self._configure_and_create_remote_storage(
-                remote_storage_kind,
-                "ext",
-                bucket_name="neon-dev-extensions-eu-central-1",
-                bucket_region="eu-central-1",
-            )
-            assert isinstance(ext, S3Storage)
-            ext.cleanup = False
-            self.ext_remote_storage = ext
+    def enable_extensions_remote_storage(self, kind: RemoteStorageKind):
+        # there is an assumption that REAL_S3 for extensions is never
+        # cleaned up these are also special in that they have a hardcoded
+        # bucket and region, which is most likely the same as our normal
+        ext = self._configure_and_create_remote_storage(
+            kind,
+            "ext",
+            bucket_name="neon-dev-extensions-eu-central-1",
+            bucket_region="eu-central-1",
+        )
+        assert isinstance(ext, S3Storage), "unsure why, but only MOCK_S3 and REAL_S3 are currently supported for extensions"
+        ext.cleanup = False
+        self.ext_remote_storage = ext
 
     def enable_safekeeper_remote_storage(self, kind: RemoteStorageKind):
         assert self.sk_remote_storage is None, "sk_remote_storage already configured"

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -509,7 +509,7 @@ class NeonEnvBuilder:
 
         self.scrub_on_exit = True
 
-    def enable_remote_storage(
+    def enable_pageserver_remote_storage(
         self,
         remote_storage_kind: RemoteStorageKind,
     ):

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -543,27 +543,16 @@ class NeonEnvBuilder:
     def _configure_and_create_remote_storage(
         self, kind: RemoteStorageKind, user: str
     ) -> Optional[RemoteStorage]:
-        if kind == RemoteStorageKind.LOCAL_FS:
-            ret = kind.configure(
-                self.repo_dir, self.mock_s3_server, str(self.run_id), self.test_name, user
-            )
-        elif kind == RemoteStorageKind.MOCK_S3:
-            ret = kind.configure(
-                self.repo_dir, self.mock_s3_server, str(self.run_id), self.test_name, user
-            )
+        ret = kind.configure(
+            self.repo_dir, self.mock_s3_server, str(self.run_id), self.test_name, user
+        )
+
+        if kind == RemoteStorageKind.MOCK_S3:
             assert isinstance(ret, S3Storage)
-            # mock_s3_server is running for single test, so we must always create the bucket
             ret.client.create_bucket(Bucket=ret.bucket_name)
         elif kind == RemoteStorageKind.REAL_S3:
-            ret = kind.configure(
-                self.repo_dir, self.mock_s3_server, str(self.run_id), self.test_name, user
-            )
             assert isinstance(ret, S3Storage)
             assert ret.cleanup, "we should not leave files in REAL_S3"
-        elif kind == RemoteStorageKind.NOOP:
-            ret = None
-        else:
-            raise RuntimeError(f"Unknown storage type: {kind}")
 
         return ret
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -528,8 +528,15 @@ class NeonEnvBuilder:
         self.remote_storage_kind = remote_storage_kind
 
         if enable_remote_extensions:
-            # there is an assumption that REAL_S3 for extensions is never cleaned up
-            ext = self._configure_and_create_remote_storage(remote_storage_kind, "ext")
+            # there is an assumption that REAL_S3 for extensions is never
+            # cleaned up these are also special in that they have a hardcoded
+            # bucket and region, which is most likely the same as our normal
+            ext = self._configure_and_create_remote_storage(
+                remote_storage_kind,
+                "ext",
+                bucket_name="neon-dev-extensions-eu-central-1",
+                bucket_region="eu-central-1",
+            )
             assert isinstance(ext, S3Storage)
             ext.cleanup = False
             self.ext_remote_storage = ext
@@ -540,10 +547,20 @@ class NeonEnvBuilder:
         self.sk_remote_storage = self._configure_and_create_remote_storage(kind, "safekeeper")
 
     def _configure_and_create_remote_storage(
-        self, kind: RemoteStorageKind, user: str
+        self,
+        kind: RemoteStorageKind,
+        user: str,
+        bucket_name: Optional[str] = None,
+        bucket_region: Optional[str] = None,
     ) -> Optional[RemoteStorage]:
         ret = kind.configure(
-            self.repo_dir, self.mock_s3_server, str(self.run_id), self.test_name, user
+            self.repo_dir,
+            self.mock_s3_server,
+            str(self.run_id),
+            self.test_name,
+            user,
+            bucket_name=bucket_name,
+            bucket_region=bucket_region,
         )
 
         if kind == RemoteStorageKind.MOCK_S3:

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -535,7 +535,9 @@ class NeonEnvBuilder:
             bucket_name="neon-dev-extensions-eu-central-1",
             bucket_region="eu-central-1",
         )
-        assert isinstance(ext, S3Storage), "unsure why, but only MOCK_S3 and REAL_S3 are currently supported for extensions"
+        assert isinstance(
+            ext, S3Storage
+        ), "unsure why, but only MOCK_S3 and REAL_S3 are currently supported for extensions"
         ext.cleanup = False
         self.ext_remote_storage = ext
 

--- a/test_runner/fixtures/pageserver/utils.py
+++ b/test_runner/fixtures/pageserver/utils.py
@@ -266,7 +266,7 @@ def list_prefix(
     )
     # For mypy
     assert isinstance(neon_env_builder.remote_storage, S3Storage)
-    assert neon_env_builder.remote_storage_client is not None
+    assert neon_env_builder.remote_storage.client is not None
 
     prefix_in_bucket = neon_env_builder.remote_storage.prefix_in_bucket or ""
     if not prefix:
@@ -277,7 +277,7 @@ def list_prefix(
         prefix = "/".join((prefix_in_bucket, prefix))
 
     # Note that this doesnt use pagination, so list is not guaranteed to be exhaustive.
-    response = neon_env_builder.remote_storage_client.list_objects_v2(
+    response = neon_env_builder.remote_storage.client.list_objects_v2(
         Delimiter="/",
         Bucket=neon_env_builder.remote_storage.bucket_name,
         Prefix=prefix,

--- a/test_runner/fixtures/pageserver/utils.py
+++ b/test_runner/fixtures/pageserver/utils.py
@@ -260,15 +260,11 @@ def list_prefix(
     Note that this function takes into account prefix_in_bucket.
     """
     # For local_fs we need to properly handle empty directories, which we currently dont, so for simplicity stick to s3 api.
-    assert neon_env_builder.remote_storage_kind in (
-        RemoteStorageKind.MOCK_S3,
-        RemoteStorageKind.REAL_S3,
-    )
-    # For mypy
-    assert isinstance(neon_env_builder.remote_storage, S3Storage)
-    assert neon_env_builder.remote_storage.client is not None
+    remote = neon_env_builder.pageserver_remote_storage
+    assert isinstance(remote, S3Storage), "localfs is currently not supported"
+    assert remote.client is not None
 
-    prefix_in_bucket = neon_env_builder.remote_storage.prefix_in_bucket or ""
+    prefix_in_bucket = remote.prefix_in_bucket or ""
     if not prefix:
         prefix = prefix_in_bucket
     else:
@@ -277,9 +273,9 @@ def list_prefix(
         prefix = "/".join((prefix_in_bucket, prefix))
 
     # Note that this doesnt use pagination, so list is not guaranteed to be exhaustive.
-    response = neon_env_builder.remote_storage.client.list_objects_v2(
+    response = remote.client.list_objects_v2(
         Delimiter="/",
-        Bucket=neon_env_builder.remote_storage.bucket_name,
+        Bucket=remote.bucket_name,
         Prefix=prefix,
     )
     return response

--- a/test_runner/fixtures/remote_storage.py
+++ b/test_runner/fixtures/remote_storage.py
@@ -320,11 +320,7 @@ def s3_storage() -> RemoteStorageKind:
 
 # serialize as toml inline table
 def remote_storage_to_toml_inline_table(remote_storage: RemoteStorage) -> str:
-    if isinstance(remote_storage, LocalFsStorage):
-        remote_storage_config = remote_storage.to_toml_inline_table()
-    elif isinstance(remote_storage, S3Storage):
-        remote_storage_config = remote_storage.to_toml_inline_table()
-    else:
+    if not isinstance(remote_storage, (LocalFsStorage, S3Storage)):
         raise Exception("invalid remote storage type")
 
-    return f"{{{remote_storage_config}}}"
+    return f"{{{remote_storage.to_toml_inline_table()}}}"

--- a/test_runner/fixtures/remote_storage.py
+++ b/test_runner/fixtures/remote_storage.py
@@ -185,7 +185,14 @@ class RemoteStorageKind(str, enum.Enum):
     NOOP = "noop"
 
     def configure(
-        self, repo_dir: Path, mock_s3_server, run_id: str, test_name: str, user: str
+        self,
+        repo_dir: Path,
+        mock_s3_server,
+        run_id: str,
+        test_name: str,
+        user: str,
+        bucket_name: Optional[str] = None,
+        bucket_region: Optional[str] = None,
     ) -> Optional[RemoteStorage]:
         if self == RemoteStorageKind.NOOP:
             return None
@@ -251,24 +258,24 @@ class RemoteStorageKind(str, enum.Enum):
         # session token is needed for local runs with sso auth
         session_token = os.getenv("AWS_SESSION_TOKEN")
 
-        env_bucket_name = os.getenv("REMOTE_STORAGE_S3_BUCKET")
-        assert env_bucket_name is not None, "no remote storage bucket name provided"
-        env_region = os.getenv("REMOTE_STORAGE_S3_REGION")
-        assert env_region is not None, "no remote storage region provided"
+        bucket_name = bucket_name or os.getenv("REMOTE_STORAGE_S3_BUCKET")
+        assert bucket_name is not None, "no remote storage bucket name provided"
+        bucket_region = bucket_region or os.getenv("REMOTE_STORAGE_S3_REGION")
+        assert bucket_region is not None, "no remote storage region provided"
 
         prefix_in_bucket = f"{run_id}/{test_name}/{user}"
 
         client = boto3.client(
             "s3",
-            region_name=env_region,
+            region_name=bucket_region,
             aws_access_key_id=env_access_key,
             aws_secret_access_key=env_secret_key,
             aws_session_token=session_token,
         )
 
         return S3Storage(
-            bucket_name="neon-dev-extensions-eu-central-1",
-            bucket_region="eu-central-1",
+            bucket_name=bucket_name,
+            bucket_region=bucket_region,
             access_key=env_access_key,
             secret_key=env_secret_key,
             prefix_in_bucket=prefix_in_bucket,

--- a/test_runner/fixtures/remote_storage.py
+++ b/test_runner/fixtures/remote_storage.py
@@ -192,7 +192,9 @@ class RemoteStorageKind(str, enum.Enum):
         if self == RemoteStorageKind.LOCAL_FS:
             return LocalFsStorage(Path(repo_dir / "local_fs_remote_storage" / user))
 
-        # real_s3 uses this as part of prefix, mock_s3 uses this as part of bucket name, giving all users unique buckets because we have to create them
+        # real_s3 uses this as part of prefix, mock_s3 uses this as part of
+        # bucket name, giving all users unique buckets because we have to
+        # create them
         test_name = re.sub(r"[_\[\]]", "-", test_name)[:63]
 
         def shrink(s: str) -> str:

--- a/test_runner/fixtures/remote_storage.py
+++ b/test_runner/fixtures/remote_storage.py
@@ -116,16 +116,18 @@ class S3Storage:
         )
 
     def to_toml_inline_table(self) -> str:
-        s = f"bucket_name='{self.bucket_name}',\
-            bucket_region='{self.bucket_region}'"
+        s = [
+            f"bucket_name='{self.bucket_name}'",
+            f"bucket_region='{self.bucket_region}'",
+        ]
 
         if self.prefix_in_bucket is not None:
-            s += f",prefix_in_bucket='{self.prefix_in_bucket}'"
+            s.append(f"prefix_in_bucket='{self.prefix_in_bucket}'")
 
         if self.endpoint is not None:
-            s += f",endpoint='{self.endpoint}'"
+            s.append(f"endpoint='{self.endpoint}'")
 
-        return s
+        return ",".join(s)
 
     def do_cleanup(self):
         if not self.cleanup:
@@ -213,7 +215,6 @@ class RemoteStorageKind(str, enum.Enum):
                 suffix = hashlib.sha256(test_name.encode()).hexdigest()[:32]
                 s = f"{prefix}-{suffix}"
                 assert len(s) == 63
-                return s
 
             return s
 

--- a/test_runner/fixtures/remote_storage.py
+++ b/test_runner/fixtures/remote_storage.py
@@ -93,10 +93,10 @@ class S3Storage:
     bucket_region: str
     access_key: str
     secret_key: str
-    endpoint: Optional[str] = None
     prefix_in_bucket: str
     client: S3Client
     cleanup: bool
+    endpoint: Optional[str] = None
 
     def access_env_vars(self) -> Dict[str, str]:
         return {
@@ -236,9 +236,9 @@ class RemoteStorageKind(str, enum.Enum):
         session_token = os.getenv("AWS_SESSION_TOKEN")
 
         env_bucket_name = os.getenv("REMOTE_STORAGE_S3_BUCKET")
-        assert env_bucket_name is str, "no remote storage bucket name provided"
+        assert env_bucket_name is not None, "no remote storage bucket name provided"
         env_region = os.getenv("REMOTE_STORAGE_S3_REGION")
-        assert env_region is str, "no remote storage region provided"
+        assert env_region is not None, "no remote storage region provided"
 
         prefix_in_bucket = f"{run_id}/{test_name}/{user}"
 

--- a/test_runner/fixtures/remote_storage.py
+++ b/test_runner/fixtures/remote_storage.py
@@ -200,6 +200,7 @@ class RemoteStorageKind(str, enum.Enum):
             return None
 
         if self == RemoteStorageKind.LOCAL_FS:
+            # FIXME: test_compatibility.py expects needs this to be fixed
             return LocalFsStorage(Path(repo_dir / "local_fs_remote_storage" / user))
 
         # real_s3 uses this as part of prefix, mock_s3 uses this as part of

--- a/test_runner/regress/test_attach_tenant_config.py
+++ b/test_runner/regress/test_attach_tenant_config.py
@@ -14,7 +14,7 @@ from fixtures.utils import wait_until
 
 @pytest.fixture
 def positive_env(neon_env_builder: NeonEnvBuilder) -> NeonEnv:
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=RemoteStorageKind.LOCAL_FS,
     )
     env = neon_env_builder.init_start()
@@ -36,7 +36,7 @@ class NegativeTests:
 
 @pytest.fixture
 def negative_env(neon_env_builder: NeonEnvBuilder) -> Generator[NegativeTests, None, None]:
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=RemoteStorageKind.LOCAL_FS,
     )
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_attach_tenant_config.py
+++ b/test_runner/regress/test_attach_tenant_config.py
@@ -14,9 +14,7 @@ from fixtures.utils import wait_until
 
 @pytest.fixture
 def positive_env(neon_env_builder: NeonEnvBuilder) -> NeonEnv:
-    neon_env_builder.enable_pageserver_remote_storage(
-        RemoteStorageKind.LOCAL_FS,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     # eviction might be the first one after an attach to access the layers
@@ -36,9 +34,7 @@ class NegativeTests:
 
 @pytest.fixture
 def negative_env(neon_env_builder: NeonEnvBuilder) -> Generator[NegativeTests, None, None]:
-    neon_env_builder.enable_pageserver_remote_storage(
-        RemoteStorageKind.LOCAL_FS,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
     assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
 

--- a/test_runner/regress/test_attach_tenant_config.py
+++ b/test_runner/regress/test_attach_tenant_config.py
@@ -23,7 +23,7 @@ def positive_env(neon_env_builder: NeonEnvBuilder) -> NeonEnv:
     env.pageserver.allowed_errors.append(
         ".*unexpectedly on-demand downloading remote layer remote.* for task kind Eviction"
     )
-    assert isinstance(env.remote_storage, LocalFsStorage)
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
     return env
 
 
@@ -40,7 +40,7 @@ def negative_env(neon_env_builder: NeonEnvBuilder) -> Generator[NegativeTests, N
         remote_storage_kind=RemoteStorageKind.LOCAL_FS,
     )
     env = neon_env_builder.init_start()
-    assert isinstance(env.remote_storage, LocalFsStorage)
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
 
     ps_http = env.pageserver.http_client()
     (tenant_id, _) = env.neon_cli.create_tenant()

--- a/test_runner/regress/test_attach_tenant_config.py
+++ b/test_runner/regress/test_attach_tenant_config.py
@@ -15,7 +15,7 @@ from fixtures.utils import wait_until
 @pytest.fixture
 def positive_env(neon_env_builder: NeonEnvBuilder) -> NeonEnv:
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=RemoteStorageKind.LOCAL_FS,
+        RemoteStorageKind.LOCAL_FS,
     )
     env = neon_env_builder.init_start()
 
@@ -37,7 +37,7 @@ class NegativeTests:
 @pytest.fixture
 def negative_env(neon_env_builder: NeonEnvBuilder) -> Generator[NegativeTests, None, None]:
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=RemoteStorageKind.LOCAL_FS,
+        RemoteStorageKind.LOCAL_FS,
     )
     env = neon_env_builder.init_start()
     assert isinstance(env.pageserver_remote_storage, LocalFsStorage)

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -261,7 +261,10 @@ def prepare_snapshot(
     # Update paths and ports in config files
     pageserver_toml = repo_dir / "pageserver.toml"
     pageserver_config = toml.load(pageserver_toml)
-    pageserver_config["remote_storage"]["local_path"] = str(repo_dir / "local_fs_remote_storage")
+    # FIXME: this needs to be changed if the path changes
+    pageserver_config["remote_storage"]["local_path"] = str(
+        repo_dir / "local_fs_remote_storage" / "pageserver"
+    )
     for param in ("listen_http_addr", "listen_pg_addr", "broker_endpoint"):
         pageserver_config[param] = port_distributor.replace_with_new_port(pageserver_config[param])
 

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -62,7 +62,7 @@ def test_create_snapshot(
     # There's no cleanup here, it allows to adjust the data in `test_backward_compatibility` itself without re-collecting it.
     neon_env_builder.pg_version = pg_version
     neon_env_builder.num_safekeepers = 3
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     env = neon_env_builder.init_start()
     endpoint = env.endpoints.create_start("main")

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -339,6 +339,8 @@ def check_neon_works(
     config.initial_tenant = snapshot_config["default_tenant_id"]
     config.pg_distrib_dir = pg_distrib_dir
     config.remote_storage = None
+    config.ext_remote_storage = None
+    config.sk_remote_storage = None
 
     # Use the "target" binaries to launch the storage nodes
     config_target = config

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -22,7 +22,7 @@ from fixtures.pageserver.utils import (
 )
 from fixtures.pg_version import PgVersion
 from fixtures.port_distributor import PortDistributor
-from fixtures.remote_storage import RemoteStorageKind
+from fixtures.remote_storage import LocalFsStorage, RemoteStorageKind, RemoteStorageUser
 from fixtures.types import Lsn
 from pytest import FixtureRequest
 
@@ -261,9 +261,8 @@ def prepare_snapshot(
     # Update paths and ports in config files
     pageserver_toml = repo_dir / "pageserver.toml"
     pageserver_config = toml.load(pageserver_toml)
-    # FIXME: this needs to be changed if the path changes
-    pageserver_config["remote_storage"]["local_path"] = str(
-        repo_dir / "local_fs_remote_storage" / "pageserver"
+    pageserver_config["remote_storage"]["local_path"] = LocalFsStorage.component_path(
+        repo_dir, RemoteStorageUser.PAGESERVER
     )
     for param in ("listen_http_addr", "listen_pg_addr", "broker_endpoint"):
         pageserver_config[param] = port_distributor.replace_with_new_port(pageserver_config[param])

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -22,6 +22,7 @@ from fixtures.pageserver.utils import (
 )
 from fixtures.pg_version import PgVersion
 from fixtures.port_distributor import PortDistributor
+from fixtures.remote_storage import RemoteStorageKind
 from fixtures.types import Lsn
 from pytest import FixtureRequest
 
@@ -61,7 +62,7 @@ def test_create_snapshot(
     # There's no cleanup here, it allows to adjust the data in `test_backward_compatibility` itself without re-collecting it.
     neon_env_builder.pg_version = pg_version
     neon_env_builder.num_safekeepers = 3
-    neon_env_builder.enable_local_fs_remote_storage()
+    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     env = neon_env_builder.init_start()
     endpoint = env.endpoints.create_start("main")

--- a/test_runner/regress/test_disk_usage_eviction.py
+++ b/test_runner/regress/test_disk_usage_eviction.py
@@ -135,7 +135,7 @@ def eviction_env(request, neon_env_builder: NeonEnvBuilder, pg_bin: PgBin) -> Ev
 
     log.info(f"setting up eviction_env for test {request.node.name}")
 
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     # initial tenant will not be present on this pageserver
     env = neon_env_builder.init_configs()

--- a/test_runner/regress/test_download_extensions.py
+++ b/test_runner/regress/test_download_extensions.py
@@ -10,7 +10,11 @@ from fixtures.neon_fixtures import (
     NeonEnvBuilder,
 )
 from fixtures.pg_version import PgVersion
-from fixtures.remote_storage import RemoteStorage, RemoteStorageKind, S3Storage, available_s3_storages
+from fixtures.remote_storage import (
+    RemoteStorageKind,
+    S3Storage,
+    available_s3_storages,
+)
 
 
 # Cleaning up downloaded files is important for local tests

--- a/test_runner/regress/test_download_extensions.py
+++ b/test_runner/regress/test_download_extensions.py
@@ -76,8 +76,8 @@ def upload_files(env):
 
             with open(full_path, "rb") as f:
                 log.info(f"UPLOAD {full_path} to ext/{full_path}")
-                assert isinstance(env.remote_storage, S3Storage)
-                env.remote_storage.client.upload_fileobj(
+                assert isinstance(env.pageserver_remote_storage, S3Storage)
+                env.pageserver_remote_storage.client.upload_fileobj(
                     f,
                     env.ext_remote_storage.bucket_name,
                     f"ext/{full_path}",

--- a/test_runner/regress/test_download_extensions.py
+++ b/test_runner/regress/test_download_extensions.py
@@ -10,7 +10,7 @@ from fixtures.neon_fixtures import (
     NeonEnvBuilder,
 )
 from fixtures.pg_version import PgVersion
-from fixtures.remote_storage import RemoteStorageKind, available_s3_storages
+from fixtures.remote_storage import RemoteStorageKind, S3Storage, available_s3_storages
 
 
 # Cleaning up downloaded files is important for local tests
@@ -72,7 +72,8 @@ def upload_files(env):
 
             with open(full_path, "rb") as f:
                 log.info(f"UPLOAD {full_path} to ext/{full_path}")
-                env.remote_storage_client.upload_fileobj(
+                assert isinstance(env.remote_storage, S3Storage)
+                env.remote_storage.client.upload_fileobj(
                     f,
                     env.ext_remote_storage.bucket_name,
                     f"ext/{full_path}",
@@ -89,7 +90,7 @@ def test_remote_extensions(
     pg_version: PgVersion,
 ):
     neon_env_builder.enable_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
         enable_remote_extensions=True,
     )
     env = neon_env_builder.init_start()
@@ -97,7 +98,6 @@ def test_remote_extensions(
     env.neon_cli.create_timeline("test_remote_extensions", tenant_id=tenant_id)
 
     assert env.ext_remote_storage is not None  # satisfy mypy
-    assert env.remote_storage_client is not None  # satisfy mypy
 
     # For MOCK_S3 we upload test files.
     # For REAL_S3 we use the files already in the bucket
@@ -155,7 +155,7 @@ def test_remote_library(
     pg_version: PgVersion,
 ):
     neon_env_builder.enable_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
         enable_remote_extensions=True,
     )
     env = neon_env_builder.init_start()
@@ -163,7 +163,6 @@ def test_remote_library(
     env.neon_cli.create_timeline("test_remote_library", tenant_id=tenant_id)
 
     assert env.ext_remote_storage is not None  # satisfy mypy
-    assert env.remote_storage_client is not None  # satisfy mypy
 
     # For MOCK_S3 we upload test files.
     # For REAL_S3 we use the files already in the bucket
@@ -215,7 +214,7 @@ def test_multiple_extensions_one_archive(
     pg_version: PgVersion,
 ):
     neon_env_builder.enable_remote_storage(
-        remote_storage_kind=RemoteStorageKind.REAL_S3,
+        RemoteStorageKind.REAL_S3,
         enable_remote_extensions=True,
     )
     env = neon_env_builder.init_start()
@@ -223,7 +222,6 @@ def test_multiple_extensions_one_archive(
     env.neon_cli.create_timeline("test_multiple_extensions_one_archive", tenant_id=tenant_id)
 
     assert env.ext_remote_storage is not None  # satisfy mypy
-    assert env.remote_storage_client is not None  # satisfy mypy
 
     endpoint = env.endpoints.create_start(
         "test_multiple_extensions_one_archive",
@@ -262,7 +260,7 @@ def test_extension_download_after_restart(
         return None
 
     neon_env_builder.enable_remote_storage(
-        remote_storage_kind=RemoteStorageKind.MOCK_S3,
+        RemoteStorageKind.MOCK_S3,
         enable_remote_extensions=True,
     )
     env = neon_env_builder.init_start()
@@ -270,7 +268,6 @@ def test_extension_download_after_restart(
     env.neon_cli.create_timeline("test_extension_download_after_restart", tenant_id=tenant_id)
 
     assert env.ext_remote_storage is not None  # satisfy mypy
-    assert env.remote_storage_client is not None  # satisfy mypy
 
     # For MOCK_S3 we upload test files.
     upload_files(env)

--- a/test_runner/regress/test_download_extensions.py
+++ b/test_runner/regress/test_download_extensions.py
@@ -10,7 +10,7 @@ from fixtures.neon_fixtures import (
     NeonEnvBuilder,
 )
 from fixtures.pg_version import PgVersion
-from fixtures.remote_storage import RemoteStorageKind, S3Storage, available_s3_storages
+from fixtures.remote_storage import RemoteStorage, RemoteStorageKind, S3Storage, available_s3_storages
 
 
 # Cleaning up downloaded files is important for local tests
@@ -89,10 +89,7 @@ def test_remote_extensions(
     remote_storage_kind: RemoteStorageKind,
     pg_version: PgVersion,
 ):
-    neon_env_builder.enable_remote_storage(
-        remote_storage_kind,
-        enable_remote_extensions=True,
-    )
+    neon_env_builder.enable_extensions_remote_storage(remote_storage_kind)
     env = neon_env_builder.init_start()
     tenant_id, _ = env.neon_cli.create_tenant()
     env.neon_cli.create_timeline("test_remote_extensions", tenant_id=tenant_id)
@@ -154,10 +151,7 @@ def test_remote_library(
     remote_storage_kind: RemoteStorageKind,
     pg_version: PgVersion,
 ):
-    neon_env_builder.enable_remote_storage(
-        remote_storage_kind,
-        enable_remote_extensions=True,
-    )
+    neon_env_builder.enable_extensions_remote_storage(remote_storage_kind)
     env = neon_env_builder.init_start()
     tenant_id, _ = env.neon_cli.create_tenant()
     env.neon_cli.create_timeline("test_remote_library", tenant_id=tenant_id)
@@ -213,10 +207,7 @@ def test_multiple_extensions_one_archive(
     neon_env_builder: NeonEnvBuilder,
     pg_version: PgVersion,
 ):
-    neon_env_builder.enable_remote_storage(
-        RemoteStorageKind.REAL_S3,
-        enable_remote_extensions=True,
-    )
+    neon_env_builder.enable_extensions_remote_storage(RemoteStorageKind.REAL_S3)
     env = neon_env_builder.init_start()
     tenant_id, _ = env.neon_cli.create_tenant()
     env.neon_cli.create_timeline("test_multiple_extensions_one_archive", tenant_id=tenant_id)
@@ -259,10 +250,7 @@ def test_extension_download_after_restart(
     if "15" in pg_version:  # SKIP v15 for now because test set only has extension built for v14
         return None
 
-    neon_env_builder.enable_remote_storage(
-        RemoteStorageKind.MOCK_S3,
-        enable_remote_extensions=True,
-    )
+    neon_env_builder.enable_extensions_remote_storage(RemoteStorageKind.MOCK_S3)
     env = neon_env_builder.init_start()
     tenant_id, _ = env.neon_cli.create_tenant()
     env.neon_cli.create_timeline("test_extension_download_after_restart", tenant_id=tenant_id)

--- a/test_runner/regress/test_gc_aggressive.py
+++ b/test_runner/regress/test_gc_aggressive.py
@@ -100,9 +100,7 @@ def test_gc_index_upload(neon_env_builder: NeonEnvBuilder, remote_storage_kind: 
     # Disable time-based pitr, we will use LSN-based thresholds in the manual GC calls
     neon_env_builder.pageserver_config_override = "tenant_config={pitr_interval = '0 sec'}"
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
     tenant_id = env.initial_tenant

--- a/test_runner/regress/test_gc_aggressive.py
+++ b/test_runner/regress/test_gc_aggressive.py
@@ -100,7 +100,7 @@ def test_gc_index_upload(neon_env_builder: NeonEnvBuilder, remote_storage_kind: 
     # Disable time-based pitr, we will use LSN-based thresholds in the manual GC calls
     neon_env_builder.pageserver_config_override = "tenant_config={pitr_interval = '0 sec'}"
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_gc_aggressive.py
+++ b/test_runner/regress/test_gc_aggressive.py
@@ -101,7 +101,7 @@ def test_gc_index_upload(neon_env_builder: NeonEnvBuilder, remote_storage_kind: 
     neon_env_builder.pageserver_config_override = "tenant_config={pitr_interval = '0 sec'}"
 
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_import.py
+++ b/test_runner/regress/test_import.py
@@ -19,6 +19,7 @@ from fixtures.pageserver.utils import (
     wait_for_last_record_lsn,
     wait_for_upload,
 )
+from fixtures.remote_storage import RemoteStorageKind
 from fixtures.types import Lsn, TenantId, TimelineId
 from fixtures.utils import subprocess_capture
 
@@ -80,7 +81,7 @@ def test_import_from_vanilla(test_output_dir, pg_bin, vanilla_pg, neon_env_build
     timeline = TimelineId.generate()
 
     # Set up pageserver for import
-    neon_env_builder.enable_local_fs_remote_storage()
+    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     client = env.pageserver.http_client()
@@ -163,7 +164,7 @@ def test_import_from_vanilla(test_output_dir, pg_bin, vanilla_pg, neon_env_build
 
 
 def test_import_from_pageserver_small(pg_bin: PgBin, neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_local_fs_remote_storage()
+    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     # FIXME: Is this expected?
@@ -185,7 +186,7 @@ def test_import_from_pageserver_small(pg_bin: PgBin, neon_env_builder: NeonEnvBu
 # @pytest.mark.skipif(os.environ.get('BUILD_TYPE') == "debug", reason="only run with release build")
 @pytest.mark.skip("See https://github.com/neondatabase/neon/issues/2255")
 def test_import_from_pageserver_multisegment(pg_bin: PgBin, neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_local_fs_remote_storage()
+    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     timeline = env.neon_cli.create_branch("test_import_from_pageserver_multisegment")

--- a/test_runner/regress/test_import.py
+++ b/test_runner/regress/test_import.py
@@ -81,7 +81,7 @@ def test_import_from_vanilla(test_output_dir, pg_bin, vanilla_pg, neon_env_build
     timeline = TimelineId.generate()
 
     # Set up pageserver for import
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     client = env.pageserver.http_client()
@@ -164,7 +164,7 @@ def test_import_from_vanilla(test_output_dir, pg_bin, vanilla_pg, neon_env_build
 
 
 def test_import_from_pageserver_small(pg_bin: PgBin, neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     # FIXME: Is this expected?
@@ -186,7 +186,7 @@ def test_import_from_pageserver_small(pg_bin: PgBin, neon_env_builder: NeonEnvBu
 # @pytest.mark.skipif(os.environ.get('BUILD_TYPE') == "debug", reason="only run with release build")
 @pytest.mark.skip("See https://github.com/neondatabase/neon/issues/2255")
 def test_import_from_pageserver_multisegment(pg_bin: PgBin, neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     timeline = env.neon_cli.create_branch("test_import_from_pageserver_multisegment")

--- a/test_runner/regress/test_layer_eviction.py
+++ b/test_runner/regress/test_layer_eviction.py
@@ -19,9 +19,7 @@ def test_basic_eviction(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start(
         initial_tenant_conf={
@@ -155,7 +153,7 @@ def test_basic_eviction(
 
 def test_gc_of_remote_layers(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=RemoteStorageKind.LOCAL_FS,
+        RemoteStorageKind.LOCAL_FS,
     )
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_layer_eviction.py
+++ b/test_runner/regress/test_layer_eviction.py
@@ -19,7 +19,7 @@ def test_basic_eviction(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -154,7 +154,7 @@ def test_basic_eviction(
 
 
 def test_gc_of_remote_layers(neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=RemoteStorageKind.LOCAL_FS,
     )
 

--- a/test_runner/regress/test_layer_eviction.py
+++ b/test_runner/regress/test_layer_eviction.py
@@ -152,9 +152,7 @@ def test_basic_eviction(
 
 
 def test_gc_of_remote_layers(neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_pageserver_remote_storage(
-        RemoteStorageKind.LOCAL_FS,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     env = neon_env_builder.init_start()
 

--- a/test_runner/regress/test_metric_collection.py
+++ b/test_runner/regress/test_metric_collection.py
@@ -94,7 +94,7 @@ def test_metric_collection(
         + "tenant_config={pitr_interval = '0 sec'}"
     )
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_metric_collection.py
+++ b/test_runner/regress/test_metric_collection.py
@@ -94,9 +94,7 @@ def test_metric_collection(
         + "tenant_config={pitr_interval = '0 sec'}"
     )
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     log.info(f"test_metric_collection endpoint is {metric_collection_endpoint}")
 

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -52,7 +52,7 @@ def test_ondemand_download_large_rel(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -154,7 +154,7 @@ def test_ondemand_download_timetravel(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -315,7 +315,7 @@ def test_download_remote_layers_api(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -476,7 +476,7 @@ def test_compaction_downloads_on_demand_without_image_creation(
     """
     Create a few layers, then evict, then make sure compaction runs successfully.
     """
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -563,7 +563,7 @@ def test_compaction_downloads_on_demand_with_image_creation(
     Due to current implementation, this will make image creation on-demand download layers, but we cannot really
     directly test for it.
     """
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -663,7 +663,7 @@ def test_ondemand_download_failure_to_replace(
     See: https://github.com/neondatabase/neon/issues/3533
     """
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -52,9 +52,7 @@ def test_ondemand_download_large_rel(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     # thinking about using a shared environment? the test assumes that global
     # metrics are for single tenant.
@@ -154,9 +152,7 @@ def test_ondemand_download_timetravel(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     # thinking about using a shared environment? the test assumes that global
     # metrics are for single tenant.
@@ -315,9 +311,7 @@ def test_download_remote_layers_api(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     ##### First start, insert data and upload it to the remote storage
     env = neon_env_builder.init_start(
@@ -476,9 +470,7 @@ def test_compaction_downloads_on_demand_without_image_creation(
     """
     Create a few layers, then evict, then make sure compaction runs successfully.
     """
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     conf = {
         # Disable background GC & compaction
@@ -563,9 +555,7 @@ def test_compaction_downloads_on_demand_with_image_creation(
     Due to current implementation, this will make image creation on-demand download layers, but we cannot really
     directly test for it.
     """
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     conf = {
         # Disable background GC & compaction
@@ -663,9 +653,7 @@ def test_ondemand_download_failure_to_replace(
     See: https://github.com/neondatabase/neon/issues/3533
     """
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     # disable gc and compaction via default tenant config because config is lost while detaching
     # so that compaction will not be the one to download the layer but the http handler is

--- a/test_runner/regress/test_ondemand_download.py
+++ b/test_runner/regress/test_ondemand_download.py
@@ -53,7 +53,7 @@ def test_ondemand_download_large_rel(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     # thinking about using a shared environment? the test assumes that global
@@ -155,7 +155,7 @@ def test_ondemand_download_timetravel(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     # thinking about using a shared environment? the test assumes that global
@@ -316,7 +316,7 @@ def test_download_remote_layers_api(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     ##### First start, insert data and upload it to the remote storage
@@ -477,7 +477,7 @@ def test_compaction_downloads_on_demand_without_image_creation(
     Create a few layers, then evict, then make sure compaction runs successfully.
     """
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     conf = {
@@ -564,7 +564,7 @@ def test_compaction_downloads_on_demand_with_image_creation(
     directly test for it.
     """
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     conf = {
@@ -664,7 +664,7 @@ def test_ondemand_download_failure_to_replace(
     """
 
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     # disable gc and compaction via default tenant config because config is lost while detaching

--- a/test_runner/regress/test_pageserver_restart.py
+++ b/test_runner/regress/test_pageserver_restart.py
@@ -11,7 +11,7 @@ from fixtures.remote_storage import s3_storage
 @pytest.mark.parametrize("generations", [True, False])
 def test_pageserver_restart(neon_env_builder: NeonEnvBuilder, generations: bool):
     neon_env_builder.enable_generations = generations
-    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind=s3_storage())
+    neon_env_builder.enable_pageserver_remote_storage(s3_storage())
     neon_env_builder.enable_scrub_on_exit()
 
     env = neon_env_builder.init_start()
@@ -115,7 +115,7 @@ def test_pageserver_restart(neon_env_builder: NeonEnvBuilder, generations: bool)
 # safekeeper and compute node keep running.
 @pytest.mark.timeout(540)
 def test_pageserver_chaos(neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind=s3_storage())
+    neon_env_builder.enable_pageserver_remote_storage(s3_storage())
     neon_env_builder.enable_scrub_on_exit()
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_pageserver_restart.py
+++ b/test_runner/regress/test_pageserver_restart.py
@@ -11,7 +11,7 @@ from fixtures.remote_storage import s3_storage
 @pytest.mark.parametrize("generations", [True, False])
 def test_pageserver_restart(neon_env_builder: NeonEnvBuilder, generations: bool):
     neon_env_builder.enable_generations = generations
-    neon_env_builder.enable_remote_storage(remote_storage_kind=s3_storage())
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind=s3_storage())
     neon_env_builder.enable_scrub_on_exit()
 
     env = neon_env_builder.init_start()
@@ -115,7 +115,7 @@ def test_pageserver_restart(neon_env_builder: NeonEnvBuilder, generations: bool)
 # safekeeper and compute node keep running.
 @pytest.mark.timeout(540)
 def test_pageserver_chaos(neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_remote_storage(remote_storage_kind=s3_storage())
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind=s3_storage())
     neon_env_builder.enable_scrub_on_exit()
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -61,7 +61,7 @@ def test_remote_storage_backup_and_restore(
     neon_env_builder.safekeepers_id_start = 12
 
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     neon_env_builder.enable_generations = generations
@@ -225,7 +225,7 @@ def test_remote_storage_upload_queue_retries(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()
@@ -380,7 +380,7 @@ def test_remote_timeline_client_calls_started_metric(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     # thinking about using a shared environment? the test assumes that global
@@ -522,7 +522,7 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start(
@@ -639,7 +639,7 @@ def test_empty_branch_remote_storage_upload(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()
@@ -690,7 +690,7 @@ def test_empty_branch_remote_storage_upload_on_restart(
     for it even though it gets 409 Conflict.
     """
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()
@@ -787,7 +787,7 @@ def test_compaction_delete_before_upload(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start(

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -612,8 +612,8 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     assert not timeline_path.exists()
 
     # to please mypy
-    assert isinstance(env.remote_storage, LocalFsStorage)
-    remote_timeline_path = env.remote_storage.timeline_path(tenant_id, timeline_id)
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
+    remote_timeline_path = env.pageserver_remote_storage.timeline_path(tenant_id, timeline_id)
 
     assert not list(remote_timeline_path.iterdir())
 
@@ -719,9 +719,9 @@ def test_empty_branch_remote_storage_upload_on_restart(
     local_metadata = env.timeline_dir(env.initial_tenant, new_branch_timeline_id) / "metadata"
     assert local_metadata.is_file()
 
-    assert isinstance(env.remote_storage, LocalFsStorage)
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
 
-    new_branch_on_remote_storage = env.remote_storage.timeline_path(
+    new_branch_on_remote_storage = env.pageserver_remote_storage.timeline_path(
         env.initial_tenant, new_branch_timeline_id
     )
     assert (

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -60,9 +60,7 @@ def test_remote_storage_backup_and_restore(
     # and this test needs SK to write data to pageserver, so it will be visible
     neon_env_builder.safekeepers_id_start = 12
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     neon_env_builder.enable_generations = generations
 
@@ -224,9 +222,7 @@ def test_remote_storage_upload_queue_retries(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 
@@ -379,9 +375,7 @@ def test_remote_timeline_client_calls_started_metric(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     # thinking about using a shared environment? the test assumes that global
     # metrics are for single tenant.
@@ -521,9 +515,7 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start(
         initial_tenant_conf={
@@ -638,9 +630,7 @@ def test_empty_branch_remote_storage_upload(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
     client = env.pageserver.http_client()
@@ -689,9 +679,7 @@ def test_empty_branch_remote_storage_upload_on_restart(
     — the upload should be scheduled by load, and create_timeline should await
     for it even though it gets 409 Conflict.
     """
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
     client = env.pageserver.http_client()
@@ -786,9 +774,7 @@ def test_compaction_delete_before_upload(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start(
         initial_tenant_conf={

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -60,7 +60,7 @@ def test_remote_storage_backup_and_restore(
     # and this test needs SK to write data to pageserver, so it will be visible
     neon_env_builder.safekeepers_id_start = 12
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -224,7 +224,7 @@ def test_remote_storage_upload_queue_retries(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -379,7 +379,7 @@ def test_remote_timeline_client_calls_started_metric(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -521,7 +521,7 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -638,7 +638,7 @@ def test_empty_branch_remote_storage_upload(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -689,7 +689,7 @@ def test_empty_branch_remote_storage_upload_on_restart(
     — the upload should be scheduled by load, and create_timeline should await
     for it even though it gets 409 Conflict.
     """
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -786,7 +786,7 @@ def test_compaction_delete_before_upload(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_tenant_conf.py
+++ b/test_runner/regress/test_tenant_conf.py
@@ -293,7 +293,7 @@ eviction_policy = { "kind" = "LayerAccessThreshold", period = "20s", threshold =
 
 def test_creating_tenant_conf_after_attach(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=RemoteStorageKind.LOCAL_FS,
+        RemoteStorageKind.LOCAL_FS,
     )
 
     env = neon_env_builder.init_start()
@@ -337,7 +337,7 @@ def test_live_reconfig_get_evictions_low_residence_duration_metric_threshold(
     neon_env_builder: NeonEnvBuilder,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=RemoteStorageKind.LOCAL_FS,
+        RemoteStorageKind.LOCAL_FS,
     )
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_tenant_conf.py
+++ b/test_runner/regress/test_tenant_conf.py
@@ -297,7 +297,7 @@ def test_creating_tenant_conf_after_attach(neon_env_builder: NeonEnvBuilder):
     )
 
     env = neon_env_builder.init_start()
-    assert isinstance(env.remote_storage, LocalFsStorage)
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
 
     # tenant is created with defaults, as in without config file
     (tenant_id, timeline_id) = env.neon_cli.create_tenant()
@@ -341,7 +341,7 @@ def test_live_reconfig_get_evictions_low_residence_duration_metric_threshold(
     )
 
     env = neon_env_builder.init_start()
-    assert isinstance(env.remote_storage, LocalFsStorage)
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
 
     (tenant_id, timeline_id) = env.neon_cli.create_tenant()
     ps_http = env.pageserver.http_client()

--- a/test_runner/regress/test_tenant_conf.py
+++ b/test_runner/regress/test_tenant_conf.py
@@ -292,9 +292,7 @@ eviction_policy = { "kind" = "LayerAccessThreshold", period = "20s", threshold =
 
 
 def test_creating_tenant_conf_after_attach(neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_pageserver_remote_storage(
-        RemoteStorageKind.LOCAL_FS,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     env = neon_env_builder.init_start()
     assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
@@ -336,9 +334,7 @@ def test_creating_tenant_conf_after_attach(neon_env_builder: NeonEnvBuilder):
 def test_live_reconfig_get_evictions_low_residence_duration_metric_threshold(
     neon_env_builder: NeonEnvBuilder,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        RemoteStorageKind.LOCAL_FS,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     env = neon_env_builder.init_start()
     assert isinstance(env.pageserver_remote_storage, LocalFsStorage)

--- a/test_runner/regress/test_tenant_conf.py
+++ b/test_runner/regress/test_tenant_conf.py
@@ -292,7 +292,7 @@ eviction_policy = { "kind" = "LayerAccessThreshold", period = "20s", threshold =
 
 
 def test_creating_tenant_conf_after_attach(neon_env_builder: NeonEnvBuilder):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=RemoteStorageKind.LOCAL_FS,
     )
 
@@ -336,7 +336,7 @@ def test_creating_tenant_conf_after_attach(neon_env_builder: NeonEnvBuilder):
 def test_live_reconfig_get_evictions_low_residence_duration_metric_threshold(
     neon_env_builder: NeonEnvBuilder,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=RemoteStorageKind.LOCAL_FS,
     )
 

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -42,7 +42,7 @@ def test_tenant_delete_smoke(
     neon_env_builder.pageserver_config_override = "test_remote_failures=1"
 
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()
@@ -296,7 +296,7 @@ def test_tenant_delete_is_resumed_on_attach(
     pg_bin: PgBin,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start(initial_tenant_conf=MANY_SMALL_LAYERS_TENANT_CONFIG)

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -41,7 +41,7 @@ def test_tenant_delete_smoke(
 ):
     neon_env_builder.pageserver_config_override = "test_remote_failures=1"
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -176,7 +176,7 @@ def test_delete_tenant_exercise_crash_safety_failpoints(
     if simulate_failures:
         neon_env_builder.pageserver_config_override = "test_remote_failures=1"
 
-    neon_env_builder.enable_remote_storage(remote_storage_kind)
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start(initial_tenant_conf=MANY_SMALL_LAYERS_TENANT_CONFIG)
 
@@ -295,7 +295,7 @@ def test_tenant_delete_is_resumed_on_attach(
     remote_storage_kind: RemoteStorageKind,
     pg_bin: PgBin,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -41,9 +41,7 @@ def test_tenant_delete_smoke(
 ):
     neon_env_builder.pageserver_config_override = "test_remote_failures=1"
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 
@@ -295,9 +293,7 @@ def test_tenant_delete_is_resumed_on_attach(
     remote_storage_kind: RemoteStorageKind,
     pg_bin: PgBin,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start(initial_tenant_conf=MANY_SMALL_LAYERS_TENANT_CONFIG)
 

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -44,7 +44,7 @@ def test_tenant_reattach(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -228,7 +228,7 @@ def test_tenant_reattach_while_busy(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
     env = neon_env_builder.init_start()
@@ -449,7 +449,7 @@ def test_detach_while_attaching(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -532,7 +532,7 @@ def test_detach_while_attaching(
 def test_ignored_tenant_reattach(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
     env = neon_env_builder.init_start()
@@ -603,7 +603,7 @@ def test_ignored_tenant_reattach(
 def test_ignored_tenant_download_missing_layers(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
     env = neon_env_builder.init_start()
@@ -668,7 +668,7 @@ def test_ignored_tenant_download_missing_layers(
 def test_ignored_tenant_stays_broken_without_metadata(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
     env = neon_env_builder.init_start()
@@ -711,7 +711,7 @@ def test_ignored_tenant_stays_broken_without_metadata(
 def test_load_attach_negatives(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
     env = neon_env_builder.init_start()
@@ -755,7 +755,7 @@ def test_ignore_while_attaching(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -858,7 +858,7 @@ def test_metrics_while_ignoring_broken_tenant_and_reloading(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -45,7 +45,7 @@ def test_tenant_reattach(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     # Exercise retry code path by making all uploads and downloads fail for the
@@ -229,7 +229,7 @@ def test_tenant_reattach_while_busy(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
     env = neon_env_builder.init_start()
 
@@ -450,7 +450,7 @@ def test_detach_while_attaching(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     ##### First start, insert secret data and upload it to the remote storage
@@ -532,9 +532,7 @@ def test_detach_while_attaching(
 def test_ignored_tenant_reattach(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
 
@@ -604,7 +602,7 @@ def test_ignored_tenant_download_missing_layers(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
@@ -669,7 +667,7 @@ def test_ignored_tenant_stays_broken_without_metadata(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
@@ -712,7 +710,7 @@ def test_load_attach_negatives(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
@@ -756,7 +754,7 @@ def test_ignore_while_attaching(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()
@@ -859,7 +857,7 @@ def test_metrics_while_ignoring_broken_tenant_and_reloading(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -44,9 +44,7 @@ def test_tenant_reattach(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     # Exercise retry code path by making all uploads and downloads fail for the
     # first time. The retries print INFO-messages to the log; we will check
@@ -228,9 +226,7 @@ def test_tenant_reattach_while_busy(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
     env = neon_env_builder.init_start()
 
     pageserver_http = env.pageserver.http_client()
@@ -449,9 +445,7 @@ def test_detach_while_attaching(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     ##### First start, insert secret data and upload it to the remote storage
     env = neon_env_builder.init_start()
@@ -601,9 +595,7 @@ def test_ignored_tenant_reattach(
 def test_ignored_tenant_download_missing_layers(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
     endpoint = env.endpoints.create_start("main")
@@ -666,9 +658,7 @@ def test_ignored_tenant_download_missing_layers(
 def test_ignored_tenant_stays_broken_without_metadata(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
     env.endpoints.create_start("main")
@@ -709,9 +699,7 @@ def test_ignored_tenant_stays_broken_without_metadata(
 def test_load_attach_negatives(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
     env.endpoints.create_start("main")
@@ -753,9 +741,7 @@ def test_ignore_while_attaching(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()
@@ -856,9 +842,7 @@ def test_metrics_while_ignoring_broken_tenant_and_reloading(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 

--- a/test_runner/regress/test_tenant_relocation.py
+++ b/test_runner/regress/test_tenant_relocation.py
@@ -264,7 +264,7 @@ def test_tenant_relocation(
     method: str,
     with_load: str,
 ):
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     env = neon_env_builder.init_start()
 
@@ -524,7 +524,7 @@ def test_emergency_relocate_with_branches_slow_replay(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -680,7 +680,7 @@ def test_emergency_relocate_with_branches_createdb(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_tenant_relocation.py
+++ b/test_runner/regress/test_tenant_relocation.py
@@ -264,7 +264,7 @@ def test_tenant_relocation(
     method: str,
     with_load: str,
 ):
-    neon_env_builder.enable_local_fs_remote_storage()
+    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     env = neon_env_builder.init_start()
 

--- a/test_runner/regress/test_tenant_relocation.py
+++ b/test_runner/regress/test_tenant_relocation.py
@@ -525,7 +525,7 @@ def test_emergency_relocate_with_branches_slow_replay(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()
@@ -681,7 +681,7 @@ def test_emergency_relocate_with_branches_createdb(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_tenant_relocation.py
+++ b/test_runner/regress/test_tenant_relocation.py
@@ -524,9 +524,7 @@ def test_emergency_relocate_with_branches_slow_replay(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
     env.pageserver.is_testing_enabled_or_skip()
@@ -680,9 +678,7 @@ def test_emergency_relocate_with_branches_createdb(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
     pageserver_http = env.pageserver.http_client()

--- a/test_runner/regress/test_tenant_relocation.py
+++ b/test_runner/regress/test_tenant_relocation.py
@@ -22,7 +22,11 @@ from fixtures.pageserver.utils import (
     wait_tenant_status_404,
 )
 from fixtures.port_distributor import PortDistributor
-from fixtures.remote_storage import RemoteStorageKind, available_remote_storages
+from fixtures.remote_storage import (
+    LocalFsStorage,
+    RemoteStorageKind,
+    available_remote_storages,
+)
 from fixtures.types import Lsn, TenantId, TimelineId
 from fixtures.utils import (
     query_scalar,
@@ -278,8 +282,8 @@ def test_tenant_relocation(
     # Needed for detach polling.
     env.pageserver.allowed_errors.append(f".*NotFound: tenant {tenant_id}.*")
 
-    # create folder for remote storage mock
-    remote_storage_mock_path = env.repo_dir / "local_fs_remote_storage"
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
+    remote_storage_mock_path = env.pageserver_remote_storage.root
 
     # we use two branches to check that they are both relocated
     # first branch is used for load, compute for second one is used to

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -300,9 +300,7 @@ def test_pageserver_metrics_removed_after_detach(
 def test_pageserver_with_empty_tenants(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -242,7 +242,7 @@ def test_pageserver_metrics_removed_after_detach(
 ):
     """Tests that when a tenant is detached, the tenant specific metrics are not left behind"""
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -302,7 +302,7 @@ def test_pageserver_metrics_removed_after_detach(
 def test_pageserver_with_empty_tenants(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -242,9 +242,7 @@ def test_pageserver_metrics_removed_after_detach(
 ):
     """Tests that when a tenant is detached, the tenant specific metrics are not left behind"""
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     neon_env_builder.num_safekeepers = 3
 
@@ -303,7 +301,7 @@ def test_pageserver_with_empty_tenants(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_tenants_with_remote_storage.py
+++ b/test_runner/regress/test_tenants_with_remote_storage.py
@@ -62,7 +62,7 @@ async def all_tenants_workload(env: NeonEnv, tenants_endpoints):
 
 @pytest.mark.parametrize("remote_storage_kind", available_remote_storages())
 def test_tenants_many(neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -114,7 +114,7 @@ def test_tenants_many(neon_env_builder: NeonEnvBuilder, remote_storage_kind: Rem
 def test_tenants_attached_after_download(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -228,7 +228,7 @@ def test_tenant_redownloads_truncated_file_on_startup(
     remote_storage_kind = RemoteStorageKind.LOCAL_FS
 
     # since we now store the layer file length metadata, we notice on startup that a layer file is of wrong size, and proceed to redownload it.
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_tenants_with_remote_storage.py
+++ b/test_runner/regress/test_tenants_with_remote_storage.py
@@ -63,7 +63,7 @@ async def all_tenants_workload(env: NeonEnv, tenants_endpoints):
 @pytest.mark.parametrize("remote_storage_kind", available_remote_storages())
 def test_tenants_many(neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()
@@ -115,7 +115,7 @@ def test_tenants_attached_after_download(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     data_id = 1
@@ -229,7 +229,7 @@ def test_tenant_redownloads_truncated_file_on_startup(
 
     # since we now store the layer file length metadata, we notice on startup that a layer file is of wrong size, and proceed to redownload it.
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_tenants_with_remote_storage.py
+++ b/test_runner/regress/test_tenants_with_remote_storage.py
@@ -234,7 +234,7 @@ def test_tenant_redownloads_truncated_file_on_startup(
 
     env = neon_env_builder.init_start()
 
-    assert isinstance(env.remote_storage, LocalFsStorage)
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
 
     env.pageserver.allowed_errors.append(
         ".*removing local file .* because it has unexpected length.*"
@@ -278,7 +278,7 @@ def test_tenant_redownloads_truncated_file_on_startup(
     (path, expected_size) = local_layer_truncated
 
     # ensure the same size is found from the index_part.json
-    index_part = env.remote_storage.index_content(tenant_id, timeline_id)
+    index_part = env.pageserver_remote_storage.index_content(tenant_id, timeline_id)
     assert index_part["layer_metadata"][path.name]["file_size"] == expected_size
 
     ## Start the pageserver. It will notice that the file size doesn't match, and
@@ -308,7 +308,9 @@ def test_tenant_redownloads_truncated_file_on_startup(
     assert os.stat(path).st_size == expected_size, "truncated layer should had been re-downloaded"
 
     # the remote side of local_layer_truncated
-    remote_layer_path = env.remote_storage.timeline_path(tenant_id, timeline_id) / path.name
+    remote_layer_path = (
+        env.pageserver_remote_storage.timeline_path(tenant_id, timeline_id) / path.name
+    )
 
     # if the upload ever was ongoing, this check would be racy, but at least one
     # extra http request has been made in between so assume it's enough delay

--- a/test_runner/regress/test_tenants_with_remote_storage.py
+++ b/test_runner/regress/test_tenants_with_remote_storage.py
@@ -62,9 +62,7 @@ async def all_tenants_workload(env: NeonEnv, tenants_endpoints):
 
 @pytest.mark.parametrize("remote_storage_kind", available_remote_storages())
 def test_tenants_many(neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 
@@ -114,9 +112,7 @@ def test_tenants_many(neon_env_builder: NeonEnvBuilder, remote_storage_kind: Rem
 def test_tenants_attached_after_download(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     data_id = 1
     data_secret = "very secret secret"
@@ -228,9 +224,7 @@ def test_tenant_redownloads_truncated_file_on_startup(
     remote_storage_kind = RemoteStorageKind.LOCAL_FS
 
     # since we now store the layer file length metadata, we notice on startup that a layer file is of wrong size, and proceed to redownload it.
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 

--- a/test_runner/regress/test_threshold_based_eviction.py
+++ b/test_runner/regress/test_threshold_based_eviction.py
@@ -21,7 +21,7 @@ def test_threshold_based_eviction(
     pg_bin: PgBin,
     neon_env_builder: NeonEnvBuilder,
 ):
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
     # Start with metrics collection enabled, so that the eviction task
     # imitates its accesses. We'll use a non-existent endpoint to make it fail.

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -784,7 +784,7 @@ def test_delete_orphaned_objects(
         }
     )
 
-    assert isinstance(env.remote_storage, LocalFsStorage)
+    assert isinstance(env.pageserver_remote_storage, LocalFsStorage)
 
     ps_http = env.pageserver.http_client()
 
@@ -795,7 +795,9 @@ def test_delete_orphaned_objects(
         last_flush_lsn_upload(env, endpoint, env.initial_tenant, timeline_id)
 
     # write orphaned file that is missing from the index
-    remote_timeline_path = env.remote_storage.timeline_path(env.initial_tenant, timeline_id)
+    remote_timeline_path = env.pageserver_remote_storage.timeline_path(
+        env.initial_tenant, timeline_id
+    )
     orphans = [remote_timeline_path / f"orphan_{i}" for i in range(3)]
     for orphan in orphans:
         orphan.write_text("I shouldnt be there")
@@ -826,7 +828,7 @@ def test_delete_orphaned_objects(
             f"deleting a file not referenced from index_part.json name={orphan.stem}"
         )
 
-    assert env.remote_storage.index_path(env.initial_tenant, timeline_id).exists()
+    assert env.pageserver_remote_storage.index_path(env.initial_tenant, timeline_id).exists()
 
 
 @pytest.mark.parametrize("remote_storage_kind", available_remote_storages())

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -347,7 +347,7 @@ def test_timeline_resurrection_on_attach(
     """
 
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     ##### First start, insert data and upload it to the remote storage
@@ -434,7 +434,7 @@ def test_timeline_delete_fail_before_local_delete(neon_env_builder: NeonEnvBuild
     """
 
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=RemoteStorageKind.MOCK_S3,
+        RemoteStorageKind.MOCK_S3,
     )
 
     env = neon_env_builder.init_start()
@@ -553,7 +553,7 @@ def test_concurrent_timeline_delete_stuck_on(
     """
 
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=RemoteStorageKind.MOCK_S3,
+        RemoteStorageKind.MOCK_S3,
     )
 
     env = neon_env_builder.init_start()
@@ -630,7 +630,7 @@ def test_delete_timeline_client_hangup(neon_env_builder: NeonEnvBuilder):
     This tests cancel safety up to the given failpoint.
     """
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=RemoteStorageKind.MOCK_S3,
+        RemoteStorageKind.MOCK_S3,
     )
 
     env = neon_env_builder.init_start()
@@ -699,7 +699,7 @@ def test_timeline_delete_works_for_remote_smoke(
     remote_storage_kind: RemoteStorageKind,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start()
@@ -838,7 +838,7 @@ def test_timeline_delete_resumed_on_attach(
     pg_bin: PgBin,
 ):
     neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind=remote_storage_kind,
+        remote_storage_kind,
     )
 
     env = neon_env_builder.init_start(initial_tenant_conf=MANY_SMALL_LAYERS_TENANT_CONFIG)

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -191,7 +191,7 @@ def test_delete_timeline_exercise_crash_safety_failpoints(
     8. Retry or restart without the failpoint and check the result.
     """
 
-    neon_env_builder.enable_remote_storage(remote_storage_kind)
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start(
         initial_tenant_conf={
@@ -346,7 +346,7 @@ def test_timeline_resurrection_on_attach(
     Original issue: https://github.com/neondatabase/neon/issues/3560
     """
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -433,7 +433,7 @@ def test_timeline_delete_fail_before_local_delete(neon_env_builder: NeonEnvBuild
     the deletion of the local state.
     """
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=RemoteStorageKind.MOCK_S3,
     )
 
@@ -552,7 +552,7 @@ def test_concurrent_timeline_delete_stuck_on(
     signalling to console that it should retry later.
     """
 
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=RemoteStorageKind.MOCK_S3,
     )
 
@@ -629,7 +629,7 @@ def test_delete_timeline_client_hangup(neon_env_builder: NeonEnvBuilder):
 
     This tests cancel safety up to the given failpoint.
     """
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=RemoteStorageKind.MOCK_S3,
     )
 
@@ -698,7 +698,7 @@ def test_timeline_delete_works_for_remote_smoke(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 
@@ -773,7 +773,7 @@ def test_delete_orphaned_objects(
     pg_bin: PgBin,
 ):
     remote_storage_kind = RemoteStorageKind.LOCAL_FS
-    neon_env_builder.enable_remote_storage(remote_storage_kind)
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start(
         initial_tenant_conf={
@@ -837,7 +837,7 @@ def test_timeline_delete_resumed_on_attach(
     remote_storage_kind: RemoteStorageKind,
     pg_bin: PgBin,
 ):
-    neon_env_builder.enable_remote_storage(
+    neon_env_builder.enable_pageserver_remote_storage(
         remote_storage_kind=remote_storage_kind,
     )
 

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -346,9 +346,7 @@ def test_timeline_resurrection_on_attach(
     Original issue: https://github.com/neondatabase/neon/issues/3560
     """
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     ##### First start, insert data and upload it to the remote storage
     env = neon_env_builder.init_start()
@@ -433,9 +431,7 @@ def test_timeline_delete_fail_before_local_delete(neon_env_builder: NeonEnvBuild
     the deletion of the local state.
     """
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        RemoteStorageKind.MOCK_S3,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.MOCK_S3)
 
     env = neon_env_builder.init_start()
 
@@ -552,9 +548,7 @@ def test_concurrent_timeline_delete_stuck_on(
     signalling to console that it should retry later.
     """
 
-    neon_env_builder.enable_pageserver_remote_storage(
-        RemoteStorageKind.MOCK_S3,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.MOCK_S3)
 
     env = neon_env_builder.init_start()
 
@@ -629,9 +623,7 @@ def test_delete_timeline_client_hangup(neon_env_builder: NeonEnvBuilder):
 
     This tests cancel safety up to the given failpoint.
     """
-    neon_env_builder.enable_pageserver_remote_storage(
-        RemoteStorageKind.MOCK_S3,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.MOCK_S3)
 
     env = neon_env_builder.init_start()
 
@@ -698,9 +690,7 @@ def test_timeline_delete_works_for_remote_smoke(
     neon_env_builder: NeonEnvBuilder,
     remote_storage_kind: RemoteStorageKind,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 
@@ -837,9 +827,7 @@ def test_timeline_delete_resumed_on_attach(
     remote_storage_kind: RemoteStorageKind,
     pg_bin: PgBin,
 ):
-    neon_env_builder.enable_pageserver_remote_storage(
-        remote_storage_kind,
-    )
+    neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start(initial_tenant_conf=MANY_SMALL_LAYERS_TENANT_CONFIG)
 

--- a/test_runner/regress/test_timeline_size.py
+++ b/test_runner/regress/test_timeline_size.py
@@ -306,7 +306,7 @@ def test_timeline_physical_size_init(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: Optional[RemoteStorageKind]
 ):
     if remote_storage_kind is not None:
-        neon_env_builder.enable_remote_storage(remote_storage_kind)
+        neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 
@@ -347,7 +347,7 @@ def test_timeline_physical_size_post_checkpoint(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: Optional[RemoteStorageKind]
 ):
     if remote_storage_kind is not None:
-        neon_env_builder.enable_remote_storage(remote_storage_kind)
+        neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 
@@ -378,7 +378,7 @@ def test_timeline_physical_size_post_compaction(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: Optional[RemoteStorageKind]
 ):
     if remote_storage_kind is not None:
-        neon_env_builder.enable_remote_storage(remote_storage_kind)
+        neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     # Disable background compaction as we don't want it to happen after `get_physical_size` request
     # and before checking the expected size on disk, which makes the assertion failed
@@ -431,7 +431,7 @@ def test_timeline_physical_size_post_gc(
     neon_env_builder: NeonEnvBuilder, remote_storage_kind: Optional[RemoteStorageKind]
 ):
     if remote_storage_kind is not None:
-        neon_env_builder.enable_remote_storage(remote_storage_kind)
+        neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     # Disable background compaction and GC as we don't want it to happen after `get_physical_size` request
     # and before checking the expected size on disk, which makes the assertion failed
@@ -564,7 +564,7 @@ def test_tenant_physical_size(
     random.seed(100)
 
     if remote_storage_kind is not None:
-        neon_env_builder.enable_remote_storage(remote_storage_kind)
+        neon_env_builder.enable_pageserver_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -37,7 +37,6 @@ from fixtures.pg_version import PgVersion
 from fixtures.port_distributor import PortDistributor
 from fixtures.remote_storage import (
     RemoteStorageKind,
-    RemoteStorageUsers,
     available_remote_storages,
 )
 from fixtures.types import Lsn, TenantId, TimelineId
@@ -436,12 +435,7 @@ def is_wal_trimmed(sk: Safekeeper, tenant_id: TenantId, timeline_id: TimelineId,
 @pytest.mark.parametrize("remote_storage_kind", available_remote_storages())
 def test_wal_backup(neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind):
     neon_env_builder.num_safekeepers = 3
-
-    neon_env_builder.enable_remote_storage(
-        remote_storage_kind=remote_storage_kind,
-    )
-
-    neon_env_builder.remote_storage_users = RemoteStorageUsers.SAFEKEEPER
+    neon_env_builder.enable_safekeeper_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
 
@@ -488,11 +482,7 @@ def test_wal_backup(neon_env_builder: NeonEnvBuilder, remote_storage_kind: Remot
 def test_s3_wal_replay(neon_env_builder: NeonEnvBuilder, remote_storage_kind: RemoteStorageKind):
     neon_env_builder.num_safekeepers = 3
 
-    neon_env_builder.enable_remote_storage(
-        remote_storage_kind=remote_storage_kind,
-    )
-
-    neon_env_builder.remote_storage_users = RemoteStorageUsers.SAFEKEEPER
+    neon_env_builder.enable_safekeeper_remote_storage(remote_storage_kind)
 
     env = neon_env_builder.init_start()
     tenant_id = env.initial_tenant

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -266,7 +266,7 @@ def test_restarts(neon_env_builder: NeonEnvBuilder):
 # Test that safekeepers push their info to the broker and learn peer status from it
 def test_broker(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.num_safekeepers = 3
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     tenant_id = env.initial_tenant
@@ -312,7 +312,7 @@ def test_broker(neon_env_builder: NeonEnvBuilder):
 def test_wal_removal(neon_env_builder: NeonEnvBuilder, auth_enabled: bool):
     neon_env_builder.num_safekeepers = 2
     # to advance remote_consistent_lsn
-    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
+    neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
     neon_env_builder.auth_enabled = auth_enabled
     env = neon_env_builder.init_start()
 

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -266,7 +266,7 @@ def test_restarts(neon_env_builder: NeonEnvBuilder):
 # Test that safekeepers push their info to the broker and learn peer status from it
 def test_broker(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.num_safekeepers = 3
-    neon_env_builder.enable_local_fs_remote_storage()
+    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
     env = neon_env_builder.init_start()
 
     tenant_id = env.initial_tenant
@@ -312,7 +312,7 @@ def test_broker(neon_env_builder: NeonEnvBuilder):
 def test_wal_removal(neon_env_builder: NeonEnvBuilder, auth_enabled: bool):
     neon_env_builder.num_safekeepers = 2
     # to advance remote_consistent_lsn
-    neon_env_builder.enable_local_fs_remote_storage()
+    neon_env_builder.enable_remote_storage(RemoteStorageKind.LOCAL_FS)
     neon_env_builder.auth_enabled = auth_enabled
     env = neon_env_builder.init_start()
 


### PR DESCRIPTION
Remote storage cleanup split from #5198:
- pageserver, extensions, and safekeepers now have their separate remote storage
- RemoteStorageKind has the configuration code
- S3Storage has the cleanup code
- with MOCK_S3, pageserver, extensions, safekeepers use different buckets
- with LOCAL_FS, `repo_dir / "local_fs_remote_storage" / $user` is used as path, where $user is `pageserver`, `safekeeper`
- no more `NeonEnvBuilder.enable_xxx_remote_storage` but one `enable_{pageserver,extensions,safekeeper}_remote_storage`

Should not have any real changes. These will allow us to default to `LOCAL_FS` for pageserver on the next PR, remove `RemoteStorageKind.NOOP`, work towards #5172.

