### PR TITLE
rust-1.72.0 changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "compute_tools",
     "control_plane",

--- a/libs/pq_proto/src/lib.rs
+++ b/libs/pq_proto/src/lib.rs
@@ -959,7 +959,7 @@ mod tests {
         let make_params = |options| StartupMessageParams::new([("options", options)]);
 
         let params = StartupMessageParams::new([]);
-        assert!(matches!(params.options_escaped(), None));
+        assert!(params.options_escaped().is_none());
 
         let params = make_params("");
         assert!(split_options(&params).is_empty());

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -573,7 +573,7 @@ mod tests {
 
     #[test]
     fn relative_path() {
-        let all_paths = vec!["", "some/path", "some/path/"];
+        let all_paths = ["", "some/path", "some/path/"];
         let all_paths: Vec<RemotePath> = all_paths
             .iter()
             .map(|x| RemotePath::new(Path::new(x)).expect("bad path"))

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -73,7 +73,7 @@ pub mod defaults {
     /// Default built-in configuration file.
     ///
     pub const DEFAULT_CONFIG_FILE: &str = formatcp!(
-        r###"
+        r#"
 # Initial configuration file created by 'pageserver --init'
 #listen_pg_addr = '{DEFAULT_PG_LISTEN_ADDR}'
 #listen_http_addr = '{DEFAULT_HTTP_LISTEN_ADDR}'
@@ -118,7 +118,7 @@ pub mod defaults {
 
 [remote_storage]
 
-"###
+"#
     );
 }
 

--- a/s3_scrubber/src/checks.rs
+++ b/s3_scrubber/src/checks.rs
@@ -46,7 +46,10 @@ pub async fn validate_pageserver_active_tenant_and_timelines(
             .push(active_branch);
 
         let Some(active_project) = s3_active_projects.get(&active_project_id) else {
-            error!("Branch {:?} for project {:?} has no such project in the active projects", active_branch_id, active_project_id);
+            error!(
+                "Branch {:?} for project {:?} has no such project in the active projects",
+                active_branch_id, active_project_id
+            );
             continue;
         };
 


### PR DESCRIPTION
I like to use the current stable for better errors. `rustfmt` has learned to format `let irrefutable = $expr else { ... };` blocks, which causes an issue.

Also there's nagging on the root workspace resolver not being defined. Picking the later one should not be an issue, as far as I know, we don't use these features yet, nor should we. Later is most likely what people will expect.

With clippy there's currently an error which prohibits us from upgrading on most likely all places of `anyhow::bail!`... Which is a bit unfortunate. Will probably need to file a bug.