### PR TITLE
fix: LocalFs starting from PosixPath('...')

### DIFF
--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -325,9 +325,9 @@ def prepare_snapshot(
 
     # For each pageserver config, edit it and rewrite
     for config_path, pageserver_config in path_to_config.items():
-        pageserver_config["remote_storage"]["local_path"] = LocalFsStorage.component_path(
+        pageserver_config["remote_storage"]["local_path"] = str(LocalFsStorage.component_path(
             repo_dir, RemoteStorageUser.PAGESERVER
-        )
+        ))
 
         for param in ("listen_http_addr", "listen_pg_addr", "broker_endpoint"):
             pageserver_config[param] = port_distributor.replace_with_new_port(


### PR DESCRIPTION
I forgot a `str(...)` conversion. This lead to log lines such as:

```
Using fs root 'PosixPath('/tmp/test_output/test_backward_compatibility[debug-pg14]/compatibility_snapshot/repo/local_fs_remote_storage/pageserver')' as a remote storage
```

This surprisingly works, creating hierarchy of under current working directory:
- `PosixPath('`
  - `tmp` .. up until .. `local_fs_remote_storage`
    - `pageserver')`

It should not work, nor after #5198 where remote storage is required will it work.