### PR TITLE
Fix GitHub Autocomment for `ci-run/pr`s

### DIFF
--- a/scripts/comment-test-report.js
+++ b/scripts/comment-test-report.js
@@ -210,7 +210,7 @@ module.exports = async ({ github, context, fetch, report, coverage }) => {
     // Which PR to comment (for ci-run/pr-* it will comment the parent PR, not the ci-run/pr-* PR)
     let prToComment
     if (isPullRequest) {
-        const branchName = context.payload.pull_request.base.ref.replace(/^refs\/heads\//, "")
+        const branchName = context.payload.pull_request.head.ref.replace(/^refs\/heads\//, "")
         const match = branchName.match(/ci-run\/pr-(?<prNumber>\d+)/)?.groups
         if (match) {
             ({ prNumber } = match)


### PR DESCRIPTION
## Problem

When PR `ci-run/pr-*` is created the GitHub Autocomment with test results is supposed to be posted to the original PR, currently, this doesn't work.

I created this PR from a personal fork to debug and fix the issue. 

## Summary of changes
- `scripts/comment-test-report.js`: use `pull_request.head` instead of `pull_request.base` 🤦 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
