### PR TITLE
fix(pageserver): update the `STORAGE_IO_TIME` metrics to avoid expensive operations

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -537,7 +537,15 @@ const STORAGE_IO_TIME_BUCKETS: &[f64] = &[
     30.000,   // 30000 ms
 ];
 
-#[derive(Debug)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    IntoStaticStr,
+    strum_macros::EnumCount,
+    strum_macros::EnumIter,
+    strum_macros::FromRepr,
+)]
 pub enum StorageIoOperation {
     Open,
     Close,

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -593,6 +593,24 @@ pub(crate) static STORAGE_IO_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     .expect("failed to define a metric")
 });
 
+#[derive(Debug)]
+pub struct StorageIoTime {
+    metrics: [Histogram; StorageIoOperation::COUNT],
+}
+
+impl StorageIoTime {
+    fn new() -> Self {
+        let metrics = std::array::from_fn(|i| {
+            let op = StorageIoOperation::from_repr(i).unwrap();
+            let metric = STORAGE_IO_TIME
+                .get_metric_with_label_values(&[op.as_str()])
+                .unwrap();
+            metric
+        });
+        Self { metrics }
+    }
+}
+
 const STORAGE_IO_SIZE_OPERATIONS: &[&str] = &["read", "write"];
 
 // Needed for the https://neonprod.grafana.net/d/5uK9tHL4k/picking-tenant-for-relocation?orgId=1

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -610,7 +610,7 @@ impl StorageIoTime {
     }
 }
 
-pub(crate) const STORAGE_IO_TIME_METRIC: StorageIoTime = StorageIoTime::new();
+pub(crate) static STORAGE_IO_TIME_METRIC: Lazy<StorageIoTime> = Lazy::new(|| StorageIoTime::new());
 
 const STORAGE_IO_SIZE_OPERATIONS: &[&str] = &["read", "write"];
 

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -589,7 +589,7 @@ static STORAGE_IO_TIME: Lazy<HistogramVec> = Lazy::new(|| {
 });
 
 #[derive(Debug)]
-struct StorageIoTime {
+pub(crate) struct StorageIoTime {
     metrics: [Histogram; StorageIoOperation::COUNT],
 }
 
@@ -605,8 +605,8 @@ impl StorageIoTime {
         Self { metrics }
     }
 
-    pub(crate) fn get(&self, op: StorageIoOperation) -> Histogram {
-        self.metrics[op as usize]
+    pub(crate) fn get(&self, op: StorageIoOperation) -> &Histogram {
+        &self.metrics[op as usize]
     }
 }
 

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -577,22 +577,6 @@ impl StorageIoOperation {
     }
 }
 
-impl From<&str> for StorageIoOperation {
-    fn from(v: &str) -> Self {
-        match v {
-            "open" => StorageIoOperation::Open,
-            "close" => StorageIoOperation::Close,
-            "close-by-replace" => StorageIoOperation::CloseByReplace,
-            "read" => StorageIoOperation::Read,
-            "write" => StorageIoOperation::Write,
-            "seek" => StorageIoOperation::Seek,
-            "fsync" => StorageIoOperation::Fsync,
-            "metadata" => StorageIoOperation::Metadata,
-            _ => unreachable!(),
-        }
-    }
-}
-
 /// Tracks time taken by fs operations near VirtualFile.
 static STORAGE_IO_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -537,6 +537,33 @@ const STORAGE_IO_TIME_BUCKETS: &[f64] = &[
     30.000,   // 30000 ms
 ];
 
+#[derive(Debug)]
+pub enum StorageIoOperation {
+    Open,
+    Close,
+    CloseByReplace,
+    Read,
+    Write,
+    Seek,
+    Fsync,
+    Metadata,
+}
+
+impl StorageIoOperation {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StorageIoOperation::Open => "open",
+            StorageIoOperation::Close => "close",
+            StorageIoOperation::CloseByReplace => "close-by-replace",
+            StorageIoOperation::Read => "read",
+            StorageIoOperation::Write => "write",
+            StorageIoOperation::Seek => "seek",
+            StorageIoOperation::Fsync => "fsync",
+            StorageIoOperation::Metadata => "metadata",
+        }
+    }
+}
+
 /// Tracks time taken by fs operations near VirtualFile.
 ///
 /// Operations:

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -537,7 +537,7 @@ const STORAGE_IO_TIME_BUCKETS: &[f64] = &[
     30.000,   // 30000 ms
 ];
 
-/// Tracks time taken by fs operations near VirtualFile.
+/// VirtualFile fs operation variants.
 ///
 /// Operations:
 /// - open ([`std::fs::OpenOptions::open`])
@@ -593,6 +593,7 @@ impl From<&str> for StorageIoOperation {
     }
 }
 
+/// Tracks time taken by fs operations near VirtualFile.
 static STORAGE_IO_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "pageserver_io_operations_seconds",

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -607,7 +607,7 @@ impl StorageIoTime {
     }
 }
 
-pub(crate) static STORAGE_IO_TIME_METRIC: Lazy<StorageIoTime> = Lazy::new(|| StorageIoTime::new());
+pub(crate) static STORAGE_IO_TIME_METRIC: Lazy<StorageIoTime> = Lazy::new(StorageIoTime::new);
 
 const STORAGE_IO_SIZE_OPERATIONS: &[&str] = &["read", "write"];
 


### PR DESCRIPTION
Introduce the `StorageIoOperation` enum, `StorageIoTime` struct, and `STORAGE_IO_TIME_METRIC` static which provides lockless access to histograms consumed by `VirtualFile`.

Closes #5131