### PR TITLE
pg_embedding with Pg16 support

### DIFF
--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -552,7 +552,7 @@ COPY --from=pg-build /usr/local/pgsql/ /usr/local/pgsql/
 
 ENV PATH "/usr/local/pgsql/bin/:$PATH"
 RUN wget https://github.com/neondatabase/pg_embedding/archive/refs/tags/0.3.6.tar.gz -O pg_embedding.tar.gz && \
-    echo "4cde1cc643f40d3742b362b0052c17dca368fdc2ee74eb03c7ec415009209150 pg_embedding.tar.gz" | sha256sum --check && \
+    echo "b2e2b359335d26987778c7fae0c9bcc8ebc3530fc214113be1ddbc8a136e52ac pg_embedding.tar.gz" | sha256sum --check && \
     mkdir pg_embedding-src && cd pg_embedding-src && tar xvzf ../pg_embedding.tar.gz --strip-components=1 -C . && \
     make -j $(getconf _NPROCESSORS_ONLN) && \
     make -j $(getconf _NPROCESSORS_ONLN) install && \

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -551,8 +551,8 @@ FROM build-deps AS pg-embedding-pg-build
 COPY --from=pg-build /usr/local/pgsql/ /usr/local/pgsql/
 
 ENV PATH "/usr/local/pgsql/bin/:$PATH"
-RUN wget https://github.com/neondatabase/pg_embedding/archive/refs/tags/0.3.5.tar.gz -O pg_embedding.tar.gz && \
-    echo "0e95b27b8b6196e2cf0a0c9ec143fe2219b82e54c5bb4ee064e76398cbe69ae9 pg_embedding.tar.gz" | sha256sum --check && \
+RUN wget https://github.com/neondatabase/pg_embedding/archive/refs/tags/0.3.6.tar.gz -O pg_embedding.tar.gz && \
+    echo "4cde1cc643f40d3742b362b0052c17dca368fdc2ee74eb03c7ec415009209150 pg_embedding.tar.gz" | sha256sum --check && \
     mkdir pg_embedding-src && cd pg_embedding-src && tar xvzf ../pg_embedding.tar.gz --strip-components=1 -C . && \
     make -j $(getconf _NPROCESSORS_ONLN) && \
     make -j $(getconf _NPROCESSORS_ONLN) install && \


### PR DESCRIPTION
Update the pg_embedding to the newer version in order to support the upcoming release of Postgres16