### PR TITLE
approved-for-ci-run.yml: fix ci-run/pr-* branch deletion

### DIFF
--- a/.github/workflows/approved-for-ci-run.yml
+++ b/.github/workflows/approved-for-ci-run.yml
@@ -96,6 +96,6 @@ jobs:
     steps:
       - run: |
           CLOSED="$(gh pr --repo ${GITHUB_REPOSITORY} list --head ${HEAD} --json 'closed' --jq '.[].closed')"
-          if [ "${CLOSED}" != "false" ]; then
+          if [ "${CLOSED}" == "false" ]; then
             gh pr --repo "${GITHUB_REPOSITORY}" close "${BRANCH}" --delete-branch
           fi

--- a/.github/workflows/approved-for-ci-run.yml
+++ b/.github/workflows/approved-for-ci-run.yml
@@ -19,6 +19,7 @@ on:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
+  BRANCH: "ci-run/pr-${{ github.event.pull_request.number }}"
 
 permissions: write-all
 
@@ -58,15 +59,14 @@ jobs:
 
       - run: gh pr checkout "${PR_NUMBER}"
 
-      - run: git checkout -b "ci-run/pr-${PR_NUMBER}"
+      - run: git checkout -b "${BRANCH}"
 
-      - run: git push --force origin "ci-run/pr-${PR_NUMBER}"
+      - run: git push --force origin "${BRANCH}"
 
       - name: Create a Pull Request for CI run (if required)
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          HEAD="ci-run/pr-${PR_NUMBER}"
           cat << EOF > body.md
             This Pull Request is created automatically to run the CI pipeline for #${PR_NUMBER}
 
@@ -79,7 +79,7 @@ jobs:
           if [ -z "${ALREADY_CREATED}" ]; then
             gh pr --repo "${GITHUB_REPOSITORY}" create --title "CI run for PR #${PR_NUMBER}" \
                                                        --body-file "body.md" \
-                                                       --head "${HEAD}" \
+                                                       --head "${BRANCH}" \
                                                        --base "main" \
                                                        --draft
           fi
@@ -95,9 +95,7 @@ jobs:
 
     steps:
       - run: |
-          HEAD="ci-run/pr-${PR_NUMBER}"
-
           CLOSED="$(gh pr --repo ${GITHUB_REPOSITORY} list --head ${HEAD} --json 'closed' --jq '.[].closed')"
           if [ "${CLOSED}" != "false" ]; then
-            gh pr --repo "${GITHUB_REPOSITORY}" close "ci-run/pr-${{ github.event.pull_request.number }}" --delete-branch
+            gh pr --repo "${GITHUB_REPOSITORY}" close "${BRANCH}" --delete-branch
           fi


### PR DESCRIPTION
## Problem

`ci-run/pr-*` branches (and attached PRs) should be deleted automatically when their parent PRs get closed.
But there are not

## Summary of changes
- Fix condition

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
