### PR TITLE
page cache metrics: remove unused read_accesses_ephemeral & read_hits_ephemeral

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -129,10 +129,8 @@ pub(crate) static MATERIALIZED_PAGE_CACHE_HIT: Lazy<IntCounter> = Lazy::new(|| {
 
 pub struct PageCacheMetrics {
     pub read_accesses_materialized_page: IntCounter,
-    pub read_accesses_ephemeral: IntCounter,
     pub read_accesses_immutable: IntCounter,
 
-    pub read_hits_ephemeral: IntCounter,
     pub read_hits_immutable: IntCounter,
     pub read_hits_materialized_page_exact: IntCounter,
     pub read_hits_materialized_page_older_lsn: IntCounter,
@@ -163,25 +161,13 @@ pub static PAGE_CACHE: Lazy<PageCacheMetrics> = Lazy::new(|| PageCacheMetrics {
             .unwrap()
     },
 
-    read_accesses_ephemeral: {
-        PAGE_CACHE_READ_ACCESSES
-            .get_metric_with_label_values(&["ephemeral"])
-            .unwrap()
-    },
-
     read_accesses_immutable: {
         PAGE_CACHE_READ_ACCESSES
             .get_metric_with_label_values(&["immutable"])
             .unwrap()
     },
 
-    read_hits_ephemeral: {
-        PAGE_CACHE_READ_HITS
-            .get_metric_with_label_values(&["ephemeral", "-"])
-            .unwrap()
-    },
-
-    read_hits_immutable: {
+   read_hits_immutable: {
         PAGE_CACHE_READ_HITS
             .get_metric_with_label_values(&["immutable", "-"])
             .unwrap()


### PR DESCRIPTION
We removed the user of this in #4994 .

But the metrics field was `pub`, so, didn't cause an unused-warning in #4994.