### PR TITLE
Forbid installation of `pg_embedding` extension

### DIFF
--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -589,8 +589,7 @@ RUN case "${PG_VERSION}" in \
     echo "${PG_EMBEDDING_CHECKSUM} pg_embedding.tar.gz" | sha256sum --check && \
     mkdir pg_embedding-src && cd pg_embedding-src && tar xvzf ../pg_embedding.tar.gz --strip-components=1 -C . && \
     make -j $(getconf _NPROCESSORS_ONLN) && \
-    make -j $(getconf _NPROCESSORS_ONLN) install && \
-    echo 'trusted = true' >> /usr/local/pgsql/share/extension/embedding.control
+    make -j $(getconf _NPROCESSORS_ONLN) install
 
 #########################################################################################
 #


### PR DESCRIPTION
## Problem

The idea is to disable new installation of this extension.

## Summary of changes

I just removed the `trusted` option which shouldn't break already installed extensions

