### PR TITLE
Bump vm-builder v0.17.10 -> v0.17.11

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -834,7 +834,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.17.10
+      VM_BUILDER_VERSION: v0.17.11
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This only includes the changes from neondatabase/autoscaling#525, which improves graceful VM shutdown.