### PR TITLE
page cache: metrics: add page content kind dimension

### DIFF
--- a/pageserver/src/context.rs
+++ b/pageserver/src/context.rs
@@ -94,6 +94,17 @@ pub struct RequestContext {
     task_kind: TaskKind,
     download_behavior: DownloadBehavior,
     access_stats_behavior: AccessStatsBehavior,
+    page_content_kind: PageContentKind,
+}
+
+/// The kind of access to the page cache.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, enum_map::Enum, strum_macros::IntoStaticStr)]
+pub enum PageContentKind {
+    Unknown,
+    DeltaLayerBtreeNode,
+    DeltaLayerValue,
+    ImageLayerBtreeNode,
+    ImageLayerValue,
 }
 
 /// Desired behavior if the operation requires an on-demand download
@@ -137,6 +148,7 @@ impl RequestContextBuilder {
                 task_kind,
                 download_behavior: DownloadBehavior::Download,
                 access_stats_behavior: AccessStatsBehavior::Update,
+                page_content_kind: PageContentKind::Unknown,
             },
         }
     }
@@ -149,6 +161,7 @@ impl RequestContextBuilder {
                 task_kind: original.task_kind,
                 download_behavior: original.download_behavior,
                 access_stats_behavior: original.access_stats_behavior,
+                page_content_kind: original.page_content_kind,
             },
         }
     }
@@ -164,6 +177,11 @@ impl RequestContextBuilder {
     /// accesses should update the access time of the layer.
     pub(crate) fn access_stats_behavior(mut self, b: AccessStatsBehavior) -> Self {
         self.inner.access_stats_behavior = b;
+        self
+    }
+
+    pub(crate) fn page_content_kind(mut self, k: PageContentKind) -> Self {
+        self.inner.page_content_kind = k;
         self
     }
 
@@ -262,5 +280,9 @@ impl RequestContext {
 
     pub(crate) fn access_stats_behavior(&self) -> AccessStatsBehavior {
         self.access_stats_behavior
+    }
+
+    pub(crate) fn page_content_kind(&self) -> PageContentKind {
+        self.page_content_kind
     }
 }

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -138,14 +138,14 @@ pub struct PageCacheMetricsForTaskKind {
 }
 
 pub struct PageCacheMetrics {
-    by_task_kind: EnumMap<TaskKind, PageCacheMetricsForTaskKind>,
+    map: EnumMap<TaskKind, EnumMap<PageContentKind, PageCacheMetricsForTaskKind>>,
 }
 
 static PAGE_CACHE_READ_HITS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "pageserver_page_cache_read_hits_total",
         "Number of read accesses to the page cache that hit",
-        &["task_kind", "key_kind", "hit_kind"]
+        &["task_kind", "key_kind", "content_kind", "hit_kind"]
     )
     .expect("failed to define a metric")
 });
@@ -154,52 +154,70 @@ static PAGE_CACHE_READ_ACCESSES: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "pageserver_page_cache_read_accesses_total",
         "Number of read accesses to the page cache",
-        &["task_kind", "key_kind"]
+        &["task_kind", "key_kind", "content_kind"]
     )
     .expect("failed to define a metric")
 });
 
 pub static PAGE_CACHE: Lazy<PageCacheMetrics> = Lazy::new(|| PageCacheMetrics {
-    by_task_kind: EnumMap::from_array(std::array::from_fn(|task_kind| {
+    map: EnumMap::from_array(std::array::from_fn(|task_kind| {
         let task_kind = <TaskKind as enum_map::Enum>::from_usize(task_kind);
         let task_kind: &'static str = task_kind.into();
-        PageCacheMetricsForTaskKind {
-            read_accesses_materialized_page: {
-                PAGE_CACHE_READ_ACCESSES
-                    .get_metric_with_label_values(&[task_kind, "materialized_page"])
-                    .unwrap()
-            },
+        EnumMap::from_array(std::array::from_fn(|content_kind| {
+            let content_kind = <PageContentKind as enum_map::Enum>::from_usize(content_kind);
+            let content_kind: &'static str = content_kind.into();
+            PageCacheMetricsForTaskKind {
+                read_accesses_materialized_page: {
+                    PAGE_CACHE_READ_ACCESSES
+                        .get_metric_with_label_values(&[
+                            task_kind,
+                            "materialized_page",
+                            &content_kind,
+                        ])
+                        .unwrap()
+                },
 
-            read_accesses_immutable: {
-                PAGE_CACHE_READ_ACCESSES
-                    .get_metric_with_label_values(&[task_kind, "immutable"])
-                    .unwrap()
-            },
+                read_accesses_immutable: {
+                    PAGE_CACHE_READ_ACCESSES
+                        .get_metric_with_label_values(&[task_kind, "immutable", &content_kind])
+                        .unwrap()
+                },
 
-            read_hits_immutable: {
-                PAGE_CACHE_READ_HITS
-                    .get_metric_with_label_values(&[task_kind, "immutable", "-"])
-                    .unwrap()
-            },
+                read_hits_immutable: {
+                    PAGE_CACHE_READ_HITS
+                        .get_metric_with_label_values(&[task_kind, "immutable", &content_kind, "-"])
+                        .unwrap()
+                },
 
-            read_hits_materialized_page_exact: {
-                PAGE_CACHE_READ_HITS
-                    .get_metric_with_label_values(&[task_kind, "materialized_page", "exact"])
-                    .unwrap()
-            },
+                read_hits_materialized_page_exact: {
+                    PAGE_CACHE_READ_HITS
+                        .get_metric_with_label_values(&[
+                            task_kind,
+                            "materialized_page",
+                            &content_kind,
+                            "exact",
+                        ])
+                        .unwrap()
+                },
 
-            read_hits_materialized_page_older_lsn: {
-                PAGE_CACHE_READ_HITS
-                    .get_metric_with_label_values(&[task_kind, "materialized_page", "older_lsn"])
-                    .unwrap()
-            },
-        }
+                read_hits_materialized_page_older_lsn: {
+                    PAGE_CACHE_READ_HITS
+                        .get_metric_with_label_values(&[
+                            task_kind,
+                            "materialized_page",
+                            &content_kind,
+                            "older_lsn",
+                        ])
+                        .unwrap()
+                },
+            }
+        }))
     })),
 });
 
 impl PageCacheMetrics {
-    pub(crate) fn for_task_kind(&self, task_kind: TaskKind) -> &PageCacheMetricsForTaskKind {
-        &self.by_task_kind[task_kind]
+    pub(crate) fn for_ctx(&self, ctx: &RequestContext) -> &PageCacheMetricsForTaskKind {
+        &self.map[ctx.task_kind()][ctx.page_content_kind()]
     }
 }
 
@@ -1283,6 +1301,7 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
+use crate::context::{PageContentKind, RequestContext};
 use crate::task_mgr::TaskKind;
 
 pub struct RemoteTimelineClientMetrics {

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -349,7 +349,7 @@ impl PageCache {
         ctx: &RequestContext,
     ) -> Option<(Lsn, PageReadGuard)> {
         crate::metrics::PAGE_CACHE
-            .for_task_kind(ctx.task_kind())
+            .for_ctx(ctx)
             .read_accesses_materialized_page
             .inc();
 
@@ -370,12 +370,12 @@ impl PageCache {
             {
                 if available_lsn == lsn {
                     crate::metrics::PAGE_CACHE
-                        .for_task_kind(ctx.task_kind())
+                        .for_ctx(ctx)
                         .read_hits_materialized_page_exact
                         .inc();
                 } else {
                     crate::metrics::PAGE_CACHE
-                        .for_task_kind(ctx.task_kind())
+                        .for_ctx(ctx)
                         .read_hits_materialized_page_older_lsn
                         .inc();
                 }
@@ -513,11 +513,9 @@ impl PageCache {
             }
             CacheKey::ImmutableFilePage { .. } => (
                 &crate::metrics::PAGE_CACHE
-                    .for_task_kind(ctx.task_kind())
+                    .for_ctx(ctx)
                     .read_accesses_immutable,
-                &crate::metrics::PAGE_CACHE
-                    .for_task_kind(ctx.task_kind())
-                    .read_hits_immutable,
+                &crate::metrics::PAGE_CACHE.for_ctx(ctx).read_hits_immutable,
             ),
         };
         read_access.inc();

--- a/pageserver/src/tenant/disk_btree.rs
+++ b/pageserver/src/tenant/disk_btree.rs
@@ -273,7 +273,7 @@ where
         while let Some((node_blknum, opt_iter)) = stack.pop() {
             // Locate the node.
             let node_buf = block_cursor
-                .read_blk(self.start_blk + node_blknum, ctx)
+                .read_blk(self.start_blk + node_blknum, &ctx)
                 .await?;
 
             let node = OnDiskNode::deparse(node_buf.as_ref())?;

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -28,7 +28,7 @@
 //! "values" part.
 //!
 use crate::config::PageServerConf;
-use crate::context::RequestContext;
+use crate::context::{PageContentKind, RequestContext, RequestContextBuilder};
 use crate::page_cache::PAGE_SZ;
 use crate::repository::{Key, Value, KEY_SIZE};
 use crate::tenant::blob_io::BlobWriter;
@@ -915,16 +915,22 @@ impl DeltaLayerInner {
 
                     !blob_ref.will_init()
                 },
-                ctx,
+                &RequestContextBuilder::extend(ctx)
+                    .page_content_kind(PageContentKind::DeltaLayerBtreeNode)
+                    .build(),
             )
             .await?;
+
+        let ctx = &RequestContextBuilder::extend(ctx)
+            .page_content_kind(PageContentKind::DeltaLayerValue)
+            .build();
 
         // Ok, 'offsets' now contains the offsets of all the entries we need to read
         let cursor = file.block_cursor();
         let mut buf = Vec::new();
         for (entry_lsn, pos) in offsets {
             cursor
-                .read_blob_into_buf(pos, &mut buf, ctx)
+                .read_blob_into_buf(pos, &mut buf, &ctx)
                 .await
                 .with_context(|| {
                     format!(
@@ -1005,7 +1011,9 @@ impl DeltaLayerInner {
                     all_keys.push(entry);
                     true
                 },
-                ctx,
+                &RequestContextBuilder::extend(ctx)
+                    .page_content_kind(PageContentKind::DeltaLayerBtreeNode)
+                    .build(),
             )
             .await?;
         if let Some(last) = all_keys.last_mut() {


### PR DESCRIPTION
The TaskKind dimension added in #5339 is insufficient to understand what
kind of data causes the cache hits.
