### PR TITLE
Use single WAL record for 0-extension of relations

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1970,6 +1970,14 @@ neon_read_at_lsn(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno,
 		XLogWaitForReplayOf(request_lsn);
 
 	/*
+	 * It is possible that previous modifications in this backend haven't been
+ 	 * flushed yet (e.g. in neon_zeroextend), so we do so right now to make sure
+  	 * future reads don't have to wait forever.
+	 */
+	if (!RecoveryInProgress())
+		XLogFlush(request_lsn);
+
+	/*
 	 * Try to find prefetched page in the list of received pages.
 	 */
 	entry = prfh_lookup(MyPState->prf_hash, (PrefetchRequest *) &buftag);


### PR DESCRIPTION
Bulk materialization of empty pages at logging of new last relation block is handled in the Pageserver already, so no need for us to log those pages.

I hope this will fix some of the issues in #5392 

## Problem

#5392 

## Summary of changes

Only emit one WAL record for every call to zeroextend, instead of one for every page extended using zeroextend.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
