### PR TITLE
Bump vm-builder v0.17.11 -> v0.17.12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -834,7 +834,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.17.11
+      VM_BUILDER_VERSION: v0.17.12
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Only relevant change is neondatabase/autoscaling#534 - refer there for more details.