### PR TITLE
Improve CrashsafeOverwriteError source printing

### DIFF
--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -177,19 +177,19 @@ impl OpenFiles {
 pub enum CrashsafeOverwriteError {
     #[error("final path has no parent dir")]
     FinalPathHasNoParentDir,
-    #[error("remove tempfile: {0}")]
+    #[error("remove tempfile")]
     RemovePreviousTempfile(#[source] std::io::Error),
-    #[error("create tempfile: {0}")]
+    #[error("create tempfile")]
     CreateTempfile(#[source] std::io::Error),
-    #[error("write tempfile: {0}")]
+    #[error("write tempfile")]
     WriteContents(#[source] std::io::Error),
-    #[error("sync tempfile: {0}")]
+    #[error("sync tempfile")]
     SyncTempfile(#[source] std::io::Error),
-    #[error("rename tempfile to final path: {0}")]
+    #[error("rename tempfile to final path")]
     RenameTempfileToFinalPath(#[source] std::io::Error),
-    #[error("open final path parent dir: {0}")]
+    #[error("open final path parent dir")]
     OpenFinalPathParentDir(#[source] std::io::Error),
-    #[error("sync final path parent dir: {0}")]
+    #[error("sync final path parent dir")]
     SyncFinalPathParentDir(#[source] std::io::Error),
 }
 impl CrashsafeOverwriteError {


### PR DESCRIPTION
## Problem
Duplication of error in log

#5366 
## Summary of changes
Removed `{0}` from error description above each enum due to presence of `#[source]` to avoid duplication

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
