### PR TITLE
build: use --features testing with cargo neon alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,4 +19,4 @@ rustdocflags = ["-Arustdoc::private_intra_doc_links"]
 
 [alias]
 build_testing = ["build", "--features", "testing"]
-neon = ["run", "--bin", "neon_local"]
+neon = ["run", "--bin", "neon_local", "--features", "testing"]

--- a/README.md
+++ b/README.md
@@ -98,8 +98,11 @@ cd neon
 # demonstrably slower build than a release build. For a release build,
 # use "BUILD_TYPE=release make -j`nproc` -s"
 # Remove -s for the verbose build log
+#
+# CARGO_BUILD_FLAGS="--features=testing" is suggested because it allows to
+# recompile less when compiling to run the tests or exploring locally.
 
-make -j`nproc` -s
+CARGO_BUILD_FLAGS="--features=testing" make -j`nproc` -s
 ```
 
 #### Building on OSX
@@ -115,8 +118,11 @@ cd neon
 # demonstrably slower build than a release build. For a release build,
 # use "BUILD_TYPE=release make -j`sysctl -n hw.logicalcpu` -s"
 # Remove -s for the verbose build log
+#
+# CARGO_BUILD_FLAGS="--features=testing" is suggested because it allows to
+# recompile less when compiling to run the tests or exploring locally.
 
-make -j`sysctl -n hw.logicalcpu` -s
+CARGO_BUILD_FLAGS="--features=testing" make -j`sysctl -n hw.logicalcpu` -s
 ```
 
 #### Dependency installation notes


### PR DESCRIPTION
Most often I compile with `cargo build_testing`. Doing a `cargo neon` after it will require linking.