### PR TITLE
Release 2023-09-28: Fix (lack of) restart on neonvm postmaster SIGKILL

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -834,7 +834,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.17.11
+      VM_BUILDER_VERSION: v0.17.12
 
     steps:
       - name: Checkout


### PR DESCRIPTION
release plan: https://neondb.slack.com/archives/C03H1K0PGKH/p1695918254769329?thread_ts=1695712529.096689&cid=C03H1K0PGKH

> So, proposed release steps: build images, update pinned compute image in cloud helm chart [+ deploy that], and then (on Monday) we update ps/sk versions in the DB and unpin the compute image?

ref:

- https://neondb.slack.com/archives/C03H1K0PGKH/p1695917439818059?thread_ts=1695712529.096689&cid=C03H1K0PGKH
- https://github.com/neondatabase/neon/pull/5407
- https://github.com/neondatabase/autoscaling/pull/534
- https://github.com/neondatabase/neon/issues/5405

---

Also includes https://github.com/neondatabase/neon/pull/5387, ref https://neondb.slack.com/archives/C03H1K0PGKH/p1695918864294109?thread_ts=1695712529.096689&cid=C03H1K0PGKH