### PR TITLE
Fix invalid database resulting from failed DROP DB

### DIFF
--- a/pgxn/neon/control_plane_connector.c
+++ b/pgxn/neon/control_plane_connector.c
@@ -742,11 +742,11 @@ NeonProcessUtility(
 		case T_DropdbStmt:
 			HandleDropDb(castNode(DropdbStmt, parseTree));
 			/*
-			* We do this here to hack around the fact that Postgres performs the drop
-			* INSIDE of standard_ProcessUtility, which means that if we try to
-			* abort the drop normally it'll be too late. DROP DATABASE can't be inside
-			* of a transaction block anyway, so this should be fine to do.
-			*/
+			 * We do this here to hack around the fact that Postgres performs the drop
+			 * INSIDE of standard_ProcessUtility, which means that if we try to
+			 * abort the drop normally it'll be too late. DROP DATABASE can't be inside
+			 * of a transaction block anyway, so this should be fine to do.
+			 */
 			NeonXactCallback(XACT_EVENT_PRE_COMMIT, NULL);
 			break;
 		case T_CreateRoleStmt:

--- a/pgxn/neon/control_plane_connector.c
+++ b/pgxn/neon/control_plane_connector.c
@@ -741,6 +741,13 @@ NeonProcessUtility(
 			break;
 		case T_DropdbStmt:
 			HandleDropDb(castNode(DropdbStmt, parseTree));
+                        /*
+                         * We do this here to hack around the fact that Postgres performs the drop
+                         * INSIDE of standard_ProcessUtility, which means that if we try to
+                         * abort the drop normally it'll be too late. DROP DATABASE can't be inside
+                         * of a transaction block anyway, so this should be fine to do.
+                         */
+                        NeonXactCallback(XACT_EVENT_PRE_COMMIT, NULL);
 			break;
 		case T_CreateRoleStmt:
 			HandleCreateRole(castNode(CreateRoleStmt, parseTree));

--- a/pgxn/neon/control_plane_connector.c
+++ b/pgxn/neon/control_plane_connector.c
@@ -741,13 +741,13 @@ NeonProcessUtility(
 			break;
 		case T_DropdbStmt:
 			HandleDropDb(castNode(DropdbStmt, parseTree));
-                        /*
-                         * We do this here to hack around the fact that Postgres performs the drop
-                         * INSIDE of standard_ProcessUtility, which means that if we try to
-                         * abort the drop normally it'll be too late. DROP DATABASE can't be inside
-                         * of a transaction block anyway, so this should be fine to do.
-                         */
-                        NeonXactCallback(XACT_EVENT_PRE_COMMIT, NULL);
+			/*
+			* We do this here to hack around the fact that Postgres performs the drop
+			* INSIDE of standard_ProcessUtility, which means that if we try to
+			* abort the drop normally it'll be too late. DROP DATABASE can't be inside
+			* of a transaction block anyway, so this should be fine to do.
+			*/
+			NeonXactCallback(XACT_EVENT_PRE_COMMIT, NULL);
 			break;
 		case T_CreateRoleStmt:
 			HandleCreateRole(castNode(CreateRoleStmt, parseTree));

--- a/test_runner/regress/test_ddl_forwarding.py
+++ b/test_runner/regress/test_ddl_forwarding.py
@@ -210,12 +210,13 @@ def test_ddl_forwarding(ddl: DdlForwardingContext):
         cur.execute("CREATE DATABASE failure WITH OWNER=cork")
         ddl.wait()
 
+    ddl.failures(False)
+    cur.execute("CREATE DATABASE failure WITH OWNER=cork")
+    ddl.wait()
     with pytest.raises(psycopg2.InternalError):
-        ddl.failures(False)
-        cur.execute("CREATE DATABASE failure WITH OWNER=cork")
-        ddl.wait()
         ddl.failures(True)
         cur.execute("DROP DATABASE failure")
         ddl.wait()
+    ddl.pg.connect(dbname="failure")  # Ensure we can connect after a failed drop
 
     conn.close()

--- a/test_runner/regress/test_ddl_forwarding.py
+++ b/test_runner/regress/test_ddl_forwarding.py
@@ -210,5 +210,12 @@ def test_ddl_forwarding(ddl: DdlForwardingContext):
         cur.execute("CREATE DATABASE failure WITH OWNER=cork")
         ddl.wait()
 
-    ddl.failures(False)
+    with pytest.raises(psycopg2.InternalError):
+        ddl.failures(False)
+        cur.execute("CREATE DATABASE failure WITH OWNER=cork")
+        ddl.wait()
+        ddl.failures(True)
+        cur.execute("DROP DATABASE failure")
+        ddl.wait()
+
     conn.close()


### PR DESCRIPTION
## Problem
If the control plane happened to respond to a DROP DATABASE request with a non-200 response, we'd abort the DROP DATABASE transaction in the usual spot. However, Postgres for some reason actually performs the drop inside of `standard_ProcessUtility`. As such, the database was left in a weird state after aborting the transaction. We had test coverage of a failed CREATE DATABASE but not a failed DROP DATABASE.
 
## Summary of changes
Since DROP DATABASE can't be inside of a transaction block, we can just forward the DDL changes to the control plane inside of `ProcessUtility_hook`, and if we respond with 500 bail out of `ProcessUtility` before we perform the drop. This change also adds a test, which reproduced the invalid database issue before the fix was applied. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
