### PR TITLE
pageserver: terminate on local I/O errors

### DIFF
--- a/pageserver/src/deletion_queue/list_writer.rs
+++ b/pageserver/src/deletion_queue/list_writer.rs
@@ -198,7 +198,6 @@ impl ListWriter {
                     Ok(None)
                 } else {
                     on_fatal_io_error(&e);
-                    unreachable!();
                 }
             }
         }
@@ -227,8 +226,6 @@ impl ListWriter {
                 // This is fatal: any failure to read this local directory indicates a
                 // storage problem or configuration problem of the node.
                 virtual_file::on_fatal_io_error(&e);
-
-                return Err(e.into());
             }
         };
 
@@ -300,7 +297,6 @@ impl ListWriter {
                 Ok(b) => b,
                 Err(e) => {
                     virtual_file::on_fatal_io_error(&e);
-                    unreachable!();
                 }
             };
 

--- a/pageserver/src/deletion_queue/list_writer.rs
+++ b/pageserver/src/deletion_queue/list_writer.rs
@@ -243,11 +243,7 @@ impl ListWriter {
             let file_name = dentry.file_name();
             let dentry_str = file_name.to_string_lossy();
 
-            if Some(file_name.as_os_str()) == header_path.file_name() {
-                // Don't try and parse the header's name like a list
-                continue;
-            }
-
+            // Temporary files might be left behind from `crashsafe_overwrite`
             if dentry_str.ends_with(TEMP_SUFFIX) {
                 info!("Cleaning up temporary file {dentry_str}");
                 let absolute_path = deletion_directory.join(dentry.file_name());
@@ -260,6 +256,11 @@ impl ListWriter {
                     );
                 }
 
+                continue;
+            }
+
+            if Some(file_name.as_os_str()) == header_path.file_name() {
+                // Don't try and parse the header's name like a list
                 continue;
             }
 

--- a/pageserver/src/deletion_queue/validator.rs
+++ b/pageserver/src/deletion_queue/validator.rs
@@ -306,8 +306,6 @@ where
                 metrics::DELETION_QUEUE.unexpected_errors.inc();
 
                 on_fatal_io_error(&e);
-
-                break;
             }
         }
     }

--- a/pageserver/src/deletion_queue/validator.rs
+++ b/pageserver/src/deletion_queue/validator.rs
@@ -28,6 +28,7 @@ use crate::config::PageServerConf;
 use crate::control_plane_client::ControlPlaneGenerationsApi;
 use crate::control_plane_client::RetryForeverError;
 use crate::metrics;
+use crate::virtual_file::on_fatal_io_error;
 
 use super::deleter::DeleterMessage;
 use super::DeletionHeader;
@@ -303,6 +304,9 @@ where
                 // issue (probably permissions) has been fixed by then.
                 tracing::error!("Failed to delete {}: {e:#}", list_path.display());
                 metrics::DELETION_QUEUE.unexpected_errors.inc();
+
+                on_fatal_io_error(&e);
+
                 break;
             }
         }

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -234,7 +234,10 @@ impl BlobWriter<false> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{context::DownloadBehavior, task_mgr::TaskKind, tenant::block_io::BlockReaderRef};
+    use crate::{
+        context::DownloadBehavior, task_mgr::TaskKind, tenant::block_io::BlockReaderRef,
+        virtual_file::Error,
+    };
     use rand::{Rng, SeedableRng};
 
     async fn round_trip_test<const BUFFERED: bool>(blobs: &[Vec<u8>]) -> Result<(), Error> {

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -275,7 +275,6 @@ impl Error {
         // having to apply the same "terminate on errors" behavior.
         if is_fatal_io_error(&instance.inner) {
             on_fatal_io_error(&instance.inner);
-            unreachable!();
         }
 
         instance

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -180,7 +180,7 @@ const EBADF: i32 = 9;
 /// cause: this includes EIO, EROFS, and EACCESS: all these indicate either
 /// bad storage or bad configuration, and we can't fix that from inside
 /// a running process.
-pub(crate) fn on_fatal_io_error(e: &std::io::Error) {
+pub(crate) fn on_fatal_io_error(e: &std::io::Error) -> ! {
     tracing::error!("Fatal I/O error: {}", &e);
     std::process::abort();
 }

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -208,6 +208,15 @@ impl CrashsafeOverwriteError {
     }
 }
 
+/// Call this when the local filesystem gives us an error with an external
+/// cause: this includes EIO, EROFS, and EACCESS: all these indicate either
+/// bad storage or bad configuration, and we can't fix that from inside
+/// a running process.
+pub(crate) fn on_fatal_io_error(e: &std::io::Error) {
+    tracing::error!("Fatal I/O error: {}", &e);
+    std::process::abort();
+}
+
 impl VirtualFile {
     /// Open a file in read-only mode. Like File::open.
     pub async fn open(path: &Path) -> Result<VirtualFile, std::io::Error> {


### PR DESCRIPTION
## Problem

In general, failures to read or write to local disk are fatal: only a few cases are retryable (notably ENOSPC), whereas EIO, EROFS, EACCESS etc indicate either a configuration issue of the node, or unhealthy hardware that we shouldn't continue to use.

## Summary of changes

- Add `is_fatal_io_error` and `on_fatal_io_error` functions, to decide if a particular std::io::Error should terminate the process, and to terminate the process respectively.
- Add `virtual_file::Error` with a built-in behaviour to terminate the process on fatal errors.  By using this return type, functions can reliably ensure that they will encounter the check on all `?` points, without having to carefully remember to call a function to maybe-terminate.  All users of VirtualFile inherit the terminate-on-fatal-errors behavior.
- Add explicit calls into `on_fatal_io_error` in deletion queue locations that use `tokio::fs` I/O.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
