### PR TITLE
vm-monitor: Remove mem::forget of tokio::sync::mpsc::Sender

### DIFF
--- a/libs/vm_monitor/src/runner.rs
+++ b/libs/vm_monitor/src/runner.rs
@@ -4,9 +4,9 @@
 //! This is the "Monitor" part of the monitor binary and is the main entrypoint for
 //! all functionality.
 
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use std::{fmt::Debug, mem};
 
 use anyhow::{bail, Context};
 use axum::extract::ws::{Message, WebSocket};


### PR DESCRIPTION
## Problem

If the cgroup integration was not enabled, this would cause compute_ctl to leak memory.

Thankfully, we never use vm-monitor *without* the cgroup handling enabled, so this wasn't actually impacting us, but... it still looked suspicious, so figured it was worth changing.

ref https://github.com/neondatabase/neon/pull/5348#discussion_r1337401989

## Summary of changes

Remove the `mem::forget`, and instead use a `tokio::select!` precondition where the receiver is actually read from.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.~~
- [ ] ~~If it is a core feature, I have added thorough tests.~~
- [ ] ~~Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?~~
- [ ] ~~If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.~~

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
