### PR TITLE
vm-monitor: Replace filter_map with filter

### DIFF
--- a/libs/vm_monitor/src/cgroup.rs
+++ b/libs/vm_monitor/src/cgroup.rs
@@ -264,13 +264,8 @@ impl CgroupWatcher {
                 }
             })
             // Only report the event if the memory.high count increased
-            .filter_map(|high| {
-                if MEMORY_EVENT_COUNT.fetch_max(high, Ordering::AcqRel) < high {
-                    Some(high)
-                } else {
-                    None
-                }
-            })
+            // NB: fetch_max sets the atomic to the max, but *returns* the previous value.
+            .filter(|&high| MEMORY_EVENT_COUNT.fetch_max(high, Ordering::AcqRel) < high)
             .map(Sequenced::new);
 
         let initial_count = get_event_count(


### PR DESCRIPTION
I think there's a clippy lint for this? Not sure if we're not using that, or something.

In any case, I was confused reading this code previously, and I think this change should make what's going on a bit clearer (because `high` wasn't changing anyways!).