### PR TITLE
fix: time the reconstruction, not future creation

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -501,9 +501,9 @@ impl Timeline {
             .await?;
         timer.stop_and_record();
 
-        let res = RECONSTRUCT_TIME
-            .observe_closure_duration(|| self.reconstruct_value(key, lsn, reconstruct_state))
-            .await;
+        let timer = RECONSTRUCT_TIME.start_timer();
+        let res = self.reconstruct_value(key, lsn, reconstruct_state).await;
+        timer.stop_and_record();
 
         if cfg!(feature = "testing") && res.is_err() {
             // it can only be walredo issue


### PR DESCRIPTION
`pageserver_getpage_reconstruct_seconds` histogram had been only recording the time it takes to create a future, not await on it. Since: https://github.com/neondatabase/neon/commit/eb0a698adcb94ece00c21a7689145b47956c0588.