### PR TITLE
metrics: distinguish page reconstruction success & failure

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -94,14 +94,39 @@ pub(crate) static READ_NUM_FS_LAYERS: Lazy<Histogram> = Lazy::new(|| {
 });
 
 // Metrics collected on operations on the storage repository.
-pub(crate) static RECONSTRUCT_TIME: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
+static RECONSTRUCT_TIME_IMPL: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
         "pageserver_getpage_reconstruct_seconds",
         "Time spent in reconstruct_value (reconstruct a page from deltas)",
+        &["result"],
         CRITICAL_OP_BUCKETS.into(),
     )
     .expect("failed to define a metric")
 });
+
+pub(crate) struct ReconstructTimeMetrics {
+    ok: Histogram,
+    err: Histogram,
+}
+
+pub(crate) static RECONSTRUCT_TIME: Lazy<ReconstructTimeMetrics> =
+    Lazy::new(|| ReconstructTimeMetrics {
+        ok: RECONSTRUCT_TIME_IMPL
+            .get_metric_with_label_values(&["ok"])
+            .unwrap(),
+        err: RECONSTRUCT_TIME_IMPL
+            .get_metric_with_label_values(&["err"])
+            .unwrap(),
+    });
+
+impl ReconstructTimeMetrics {
+    pub(crate) fn for_result<T, E>(&self, result: &Result<T, E>) -> &Histogram {
+        match result {
+            Ok(_) => &self.ok,
+            Err(_) => &self.err,
+        }
+    }
+}
 
 pub(crate) static MATERIALIZED_PAGE_CACHE_HIT_DIRECT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
@@ -1856,7 +1881,6 @@ pub fn preinitialize_metrics() {
     // histograms
     [
         &READ_NUM_FS_LAYERS,
-        &RECONSTRUCT_TIME,
         &WAIT_LSN_TIME,
         &WAL_REDO_TIME,
         &WAL_REDO_WAIT_TIME,
@@ -1867,4 +1891,7 @@ pub fn preinitialize_metrics() {
     .for_each(|h| {
         Lazy::force(h);
     });
+
+    // Custom
+    Lazy::force(&RECONSTRUCT_TIME);
 }

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -101,18 +101,16 @@ pub(crate) struct ReconstructTimeMetrics {
 }
 
 pub(crate) static RECONSTRUCT_TIME: Lazy<ReconstructTimeMetrics> = Lazy::new(|| {
-    static IMPL: Lazy<HistogramVec> = Lazy::new(|| {
-        register_histogram_vec!(
-            "pageserver_getpage_reconstruct_seconds",
-            "Time spent in reconstruct_value (reconstruct a page from deltas)",
-            &["result"],
-            CRITICAL_OP_BUCKETS.into(),
-        )
-        .expect("failed to define a metric")
-    });
+    let inner = register_histogram_vec!(
+        "pageserver_getpage_reconstruct_seconds",
+        "Time spent in reconstruct_value (reconstruct a page from deltas)",
+        &["result"],
+        CRITICAL_OP_BUCKETS.into(),
+    )
+    .expect("failed to define a metric");
     ReconstructTimeMetrics {
-        ok: IMPL.get_metric_with_label_values(&["ok"]).unwrap(),
-        err: IMPL.get_metric_with_label_values(&["err"]).unwrap(),
+        ok: inner.get_metric_with_label_values(&["ok"]).unwrap(),
+        err: inner.get_metric_with_label_values(&["err"]).unwrap(),
     }
 });
 


### PR DESCRIPTION
Here's the existing dashboards that use the metric:

https://github.com/search?q=repo%3Aneondatabase%2Fgrafana-dashboard-export%20pageserver_getpage_reconstruct_seconds&type=code

Looks like only `_count` and `_sum` values are used currently.
We can fix them up easily post merge.

I think the histogram is worth keeping, though.

follow-up to https://github.com/neondatabase/neon/pull/5459#pullrequestreview-1657072882
