### PR TITLE
proxy: more connection metrics

### DIFF
--- a/proxy/src/bin/pg_sni_router.rs
+++ b/proxy/src/bin/pg_sni_router.rs
@@ -254,11 +254,5 @@ async fn handle_client(
     let client = tokio::net::TcpStream::connect(destination).await?;
 
     let metrics_aux: MetricsAuxInfo = Default::default();
-    proxy::proxy::proxy_pass(
-        tls_stream,
-        client,
-        &metrics_aux,
-        proxy::proxy::ClientMode::Tcp,
-    )
-    .await
+    proxy::proxy::proxy_pass(tls_stream, client, &metrics_aux).await
 }

--- a/proxy/src/bin/pg_sni_router.rs
+++ b/proxy/src/bin/pg_sni_router.rs
@@ -254,5 +254,11 @@ async fn handle_client(
     let client = tokio::net::TcpStream::connect(destination).await?;
 
     let metrics_aux: MetricsAuxInfo = Default::default();
-    proxy::proxy::proxy_pass(tls_stream, client, &metrics_aux).await
+    proxy::proxy::proxy_pass(
+        tls_stream,
+        client,
+        &metrics_aux,
+        proxy::proxy::ClientMode::Tcp,
+    )
+    .await
 }

--- a/proxy/src/http/conn_pool.rs
+++ b/proxy/src/http/conn_pool.rs
@@ -20,6 +20,7 @@ use tokio_postgres::AsyncMessage;
 use crate::{
     auth, console,
     metrics::{Ids, MetricCounter, USAGE_METRICS},
+    proxy::NUM_DB_CONNECTIONS_GAUGE,
 };
 use crate::{compute, config};
 
@@ -418,36 +419,42 @@ async fn connect_to_compute_once(
     };
 
     tokio::spawn(
-        poll_fn(move |cx| {
-            if matches!(rx.has_changed(), Ok(true)) {
-                session = *rx.borrow_and_update();
-                info!(%session, "changed session");
+        async move {
+            NUM_DB_CONNECTIONS_GAUGE.with_label_values(&["http"]).inc();
+            scopeguard::defer! {
+                NUM_DB_CONNECTIONS_GAUGE.with_label_values(&["http"]).dec();
             }
+            poll_fn(move |cx| {
+                if matches!(rx.has_changed(), Ok(true)) {
+                    session = *rx.borrow_and_update();
+                    info!(%session, "changed session");
+                }
 
-            loop {
-                let message = ready!(connection.poll_message(cx));
+                loop {
+                    let message = ready!(connection.poll_message(cx));
 
-                match message {
-                    Some(Ok(AsyncMessage::Notice(notice))) => {
-                        info!(%session, "notice: {}", notice);
-                    }
-                    Some(Ok(AsyncMessage::Notification(notif))) => {
-                        warn!(%session, pid = notif.process_id(), channel = notif.channel(), "notification received");
-                    }
-                    Some(Ok(_)) => {
-                        warn!(%session, "unknown message");
-                    }
-                    Some(Err(e)) => {
-                        error!(%session, "connection error: {}", e);
-                        return Poll::Ready(())
-                    }
-                    None => {
-                        info!("connection closed");
-                        return Poll::Ready(())
+                    match message {
+                        Some(Ok(AsyncMessage::Notice(notice))) => {
+                            info!(%session, "notice: {}", notice);
+                        }
+                        Some(Ok(AsyncMessage::Notification(notif))) => {
+                            warn!(%session, pid = notif.process_id(), channel = notif.channel(), "notification received");
+                        }
+                        Some(Ok(_)) => {
+                            warn!(%session, "unknown message");
+                        }
+                        Some(Err(e)) => {
+                            error!(%session, "connection error: {}", e);
+                            return Poll::Ready(())
+                        }
+                        None => {
+                            info!("connection closed");
+                            return Poll::Ready(())
+                        }
                     }
                 }
-            }
-        })
+            }).await
+        }
         .instrument(span)
     );
 

--- a/proxy/src/http/conn_pool.rs
+++ b/proxy/src/http/conn_pool.rs
@@ -20,7 +20,7 @@ use tokio_postgres::AsyncMessage;
 use crate::{
     auth, console,
     metrics::{Ids, MetricCounter, USAGE_METRICS},
-    proxy::NUM_DB_CONNECTIONS_GAUGE,
+    proxy::{NUM_DB_CONNECTIONS_CLOSED_COUNTER, NUM_DB_CONNECTIONS_OPENED_COUNTER},
 };
 use crate::{compute, config};
 
@@ -420,9 +420,9 @@ async fn connect_to_compute_once(
 
     tokio::spawn(
         async move {
-            NUM_DB_CONNECTIONS_GAUGE.with_label_values(&["http"]).inc();
+            NUM_DB_CONNECTIONS_OPENED_COUNTER.with_label_values(&["http"]).inc();
             scopeguard::defer! {
-                NUM_DB_CONNECTIONS_GAUGE.with_label_values(&["http"]).dec();
+                NUM_DB_CONNECTIONS_CLOSED_COUNTER.with_label_values(&["http"]).inc();
             }
             poll_fn(move |cx| {
                 if matches!(rx.has_changed(), Ok(true)) {

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -24,9 +24,7 @@ use url::Url;
 use utils::http::error::ApiError;
 use utils::http::json::json_response;
 
-use crate::proxy::NUM_CLIENT_REQUEST_GAUGE;
-use crate::proxy::NUM_CONNECTIONS_ACCEPTED_COUNTER;
-use crate::proxy::NUM_CONNECTIONS_CLOSED_COUNTER;
+use crate::proxy::{NUM_CONNECTIONS_ACCEPTED_COUNTER, NUM_CONNECTIONS_CLOSED_COUNTER};
 
 use super::conn_pool::ConnInfo;
 use super::conn_pool::GlobalConnPool;
@@ -233,10 +231,8 @@ async fn handle_inner(
     NUM_CONNECTIONS_ACCEPTED_COUNTER
         .with_label_values(&["http"])
         .inc();
-    NUM_CLIENT_REQUEST_GAUGE.with_label_values(&["http"]).inc();
     scopeguard::defer! {
         NUM_CONNECTIONS_CLOSED_COUNTER.with_label_values(&["http"]).inc();
-        NUM_CLIENT_REQUEST_GAUGE.with_label_values(&["http"]).dec();
     }
 
     //

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -24,6 +24,10 @@ use url::Url;
 use utils::http::error::ApiError;
 use utils::http::json::json_response;
 
+use crate::proxy::NUM_CLIENT_REQUEST_GAUGE;
+use crate::proxy::NUM_CONNECTIONS_ACCEPTED_COUNTER;
+use crate::proxy::NUM_CONNECTIONS_CLOSED_COUNTER;
+
 use super::conn_pool::ConnInfo;
 use super::conn_pool::GlobalConnPool;
 
@@ -226,6 +230,15 @@ async fn handle_inner(
     conn_pool: Arc<GlobalConnPool>,
     session_id: uuid::Uuid,
 ) -> anyhow::Result<Response<Body>> {
+    NUM_CONNECTIONS_ACCEPTED_COUNTER
+        .with_label_values(&["http"])
+        .inc();
+    NUM_CLIENT_REQUEST_GAUGE.with_label_values(&["http"]).inc();
+    scopeguard::defer! {
+        NUM_CONNECTIONS_CLOSED_COUNTER.with_label_values(&["http"]).inc();
+        NUM_CLIENT_REQUEST_GAUGE.with_label_values(&["http"]).dec();
+    }
+
     //
     // Determine the destination and connection params
     //

--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -3,7 +3,10 @@ use crate::{
     config::ProxyConfig,
     error::io_error,
     protocol2::{ProxyProtocolAccept, WithClientIp},
-    proxy::{handle_client, ClientMode, NUM_CLIENT_CONNECTION_GAUGE},
+    proxy::{
+        handle_client, ClientMode, NUM_CLIENT_CONNECTION_CLOSED_COUNTER,
+        NUM_CLIENT_CONNECTION_OPENED_COUNTER,
+    },
 };
 use bytes::{Buf, Bytes};
 use futures::{Sink, Stream, StreamExt};
@@ -312,7 +315,7 @@ struct MetricService<S> {
 
 impl<S> MetricService<S> {
     fn new(inner: S) -> MetricService<S> {
-        NUM_CLIENT_CONNECTION_GAUGE
+        NUM_CLIENT_CONNECTION_OPENED_COUNTER
             .with_label_values(&["http"])
             .inc();
         MetricService { inner }
@@ -321,9 +324,9 @@ impl<S> MetricService<S> {
 
 impl<S> Drop for MetricService<S> {
     fn drop(&mut self) {
-        NUM_CLIENT_CONNECTION_GAUGE
+        NUM_CLIENT_CONNECTION_CLOSED_COUNTER
             .with_label_values(&["http"])
-            .dec();
+            .inc();
     }
 }
 

--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -3,7 +3,7 @@ use crate::{
     config::ProxyConfig,
     error::io_error,
     protocol2::{ProxyProtocolAccept, WithClientIp},
-    proxy::{handle_client, ClientMode},
+    proxy::{handle_client, ClientMode, NUM_CLIENT_CONNECTION_GAUGE},
 };
 use bytes::{Buf, Bytes};
 use futures::{Sink, Stream, StreamExt};
@@ -275,23 +275,25 @@ pub async fn task_main(
             let conn_pool = conn_pool.clone();
 
             async move {
-                Ok::<_, Infallible>(hyper::service::service_fn(move |req: Request<Body>| {
-                    let sni_name = sni_name.clone();
-                    let conn_pool = conn_pool.clone();
+                Ok::<_, Infallible>(MetricService::new(hyper::service::service_fn(
+                    move |req: Request<Body>| {
+                        let sni_name = sni_name.clone();
+                        let conn_pool = conn_pool.clone();
 
-                    async move {
-                        let cancel_map = Arc::new(CancelMap::default());
-                        let session_id = uuid::Uuid::new_v4();
+                        async move {
+                            let cancel_map = Arc::new(CancelMap::default());
+                            let session_id = uuid::Uuid::new_v4();
 
-                        ws_handler(req, config, conn_pool, cancel_map, session_id, sni_name)
-                            .instrument(info_span!(
-                                "ws-client",
-                                session = %session_id,
-                                %peer_addr,
-                            ))
-                            .await
-                    }
-                }))
+                            ws_handler(req, config, conn_pool, cancel_map, session_id, sni_name)
+                                .instrument(info_span!(
+                                    "ws-client",
+                                    session = %session_id,
+                                    %peer_addr,
+                                ))
+                                .await
+                        }
+                    },
+                )))
             }
         },
     );
@@ -302,4 +304,42 @@ pub async fn task_main(
         .await?;
 
     Ok(())
+}
+
+struct MetricService<S> {
+    inner: S,
+}
+
+impl<S> MetricService<S> {
+    fn new(inner: S) -> MetricService<S> {
+        NUM_CLIENT_CONNECTION_GAUGE
+            .with_label_values(&["http"])
+            .inc();
+        MetricService { inner }
+    }
+}
+
+impl<S> Drop for MetricService<S> {
+    fn drop(&mut self) {
+        NUM_CLIENT_CONNECTION_GAUGE
+            .with_label_values(&["http"])
+            .dec();
+    }
+}
+
+impl<S, ReqBody> hyper::service::Service<Request<ReqBody>> for MetricService<S>
+where
+    S: hyper::service::Service<Request<ReqBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        self.inner.call(req)
+    }
 }

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -40,7 +40,7 @@ const ERR_PROTO_VIOLATION: &str = "protocol violation";
 
 pub static NUM_DB_CONNECTIONS_OPENED_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "proxy_db_connections_opened_total",
+        "proxy_opened_db_connections_total",
         "Number of opened connections to a database.",
         &["protocol"],
     )
@@ -49,7 +49,7 @@ pub static NUM_DB_CONNECTIONS_OPENED_COUNTER: Lazy<IntCounterVec> = Lazy::new(||
 
 pub static NUM_DB_CONNECTIONS_CLOSED_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "proxy_db_connections_closed_total",
+        "proxy_closed_db_connections_total",
         "Number of closed connections to a database.",
         &["protocol"],
     )
@@ -58,7 +58,7 @@ pub static NUM_DB_CONNECTIONS_CLOSED_COUNTER: Lazy<IntCounterVec> = Lazy::new(||
 
 pub static NUM_CLIENT_CONNECTION_OPENED_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "proxy_client_connections_opened_total",
+        "proxy_opened_client_connections_total",
         "Number of opened connections from a client.",
         &["protocol"],
     )
@@ -67,7 +67,7 @@ pub static NUM_CLIENT_CONNECTION_OPENED_COUNTER: Lazy<IntCounterVec> = Lazy::new
 
 pub static NUM_CLIENT_CONNECTION_CLOSED_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "proxy_client_connections_closed_total",
+        "proxy_closed_client_connections_total",
         "Number of closed connections from a client.",
         &["protocol"],
     )

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -41,7 +41,7 @@ const ERR_PROTO_VIOLATION: &str = "protocol violation";
 
 pub static NUM_DB_CONNECTIONS_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
-        "proxy_connections_total",
+        "proxy_db_connections_total",
         "Number of active connections to a database.",
         &["protocol"],
     )
@@ -50,7 +50,7 @@ pub static NUM_DB_CONNECTIONS_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
 
 pub static NUM_CLIENT_REQUEST_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
-        "proxy_client_connections_total",
+        "proxy_client_requests_total",
         "Number of active requests from a client.",
         &["protocol"],
     )


### PR DESCRIPTION
## Problem

Hard to tell 
1. How many clients are connected to proxy
2. How many requests clients are making
3. How many connections are made to a database

1 and 2 are different because of the properties of HTTP.

We have 2 already tracked through `proxy_accepted_connections_total` and `proxy_closed_connections_total`, but nothing for 1 and 3

## Summary of changes

Adds 2 new counter gauges.

* `proxy_opened_client_connections_total`,`proxy_closed_client_connections_total` - how many client connections are open to proxy
* `proxy_opened_db_connections_total`,`proxy_closed_db_connections_total` - how many active connections are made through to a database.

For TCP and Websockets, we expect all 3 of these quantities to be roughly the same, barring users connecting but with invalid details.

For HTTP:
* client_connections/connections can differ because the client connections can be reused.
* connections/db_connections can differ because of connection pooling.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
