### PR TITLE
pageserver: fix loading control plane JWT token

### DIFF
--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -228,6 +228,12 @@ impl SecretString {
     }
 }
 
+impl From<String> for SecretString {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
 impl std::fmt::Debug for SecretString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[SECRET]")

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -487,6 +487,10 @@ impl PageServerConfigBuilder {
         self.control_plane_api = BuilderValue::Set(api)
     }
 
+    pub fn control_plane_api_token(&mut self, token: Option<SecretString>) {
+        self.control_plane_api_token = BuilderValue::Set(token)
+    }
+
     pub fn build(self) -> anyhow::Result<PageServerConf> {
         let concurrent_tenant_size_logical_size_queries = self
             .concurrent_tenant_size_logical_size_queries
@@ -785,6 +789,14 @@ impl PageServerConf {
                         builder.control_plane_api(None)
                     } else {
                         builder.control_plane_api(Some(parsed.parse().context("failed to parse control plane URL")?))
+                    }
+                },
+                "control_plane_api_token" => {
+                    let parsed = parse_toml_string(key, item)?;
+                    if parsed.is_empty() {
+                        builder.control_plane_api_token(None)
+                    } else {
+                        builder.control_plane_api_token(Some(parsed.into()))
                     }
                 },
                 _ => bail!("unrecognized pageserver option '{key}'"),


### PR DESCRIPTION
## Problem

In #5383 this configuration was added, but it missed the parts of the Builder class that let it actually be used.

## Summary of changes

Add `control_plane_api_token` hooks to PageserverConfigBuilder