### PR TITLE
proxy: fix memory leak

### DIFF
--- a/proxy/src/bin/pg_sni_router.rs
+++ b/proxy/src/bin/pg_sni_router.rs
@@ -168,7 +168,7 @@ async fn task_main(
                     .instrument(tracing::info_span!("handle_client", ?session_id))
                 );
             }
-            Some(Err(e)) = connections.join_next() => {
+            Some(Err(e)) = connections.join_next(), if !connections.is_empty() => {
                 if !e.is_panic() && !e.is_cancelled() {
                     warn!("unexpected error from joined connection task: {e:?}");
                 }

--- a/proxy/src/bin/pg_sni_router.rs
+++ b/proxy/src/bin/pg_sni_router.rs
@@ -168,6 +168,11 @@ async fn task_main(
                     .instrument(tracing::info_span!("handle_client", ?session_id))
                 );
             }
+            Some(Err(e)) = connections.join_next() => {
+                if !e.is_panic() && !e.is_cancelled() {
+                    warn!("unexpected error from joined connection task: {e:?}");
+                }
+            }
             _ = cancellation_token.cancelled() => {
                 drop(listener);
                 break;

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -130,6 +130,11 @@ pub async fn task_main(
                     }),
                 );
             }
+            Some(Err(e)) = connections.join_next() => {
+                if !e.is_panic() && !e.is_cancelled() {
+                    warn!("unexpected error from joined connection task: {e:?}");
+                }
+            }
             _ = cancellation_token.cancelled() => {
                 drop(listener);
                 break;

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -130,7 +130,7 @@ pub async fn task_main(
                     }),
                 );
             }
-            Some(Err(e)) = connections.join_next() => {
+            Some(Err(e)) = connections.join_next(), if !connections.is_empty() => {
                 if !e.is_panic() && !e.is_cancelled() {
                     warn!("unexpected error from joined connection task: {e:?}");
                 }


### PR DESCRIPTION
## Problem

these JoinSets live for the duration of the process. they might have many millions of connections spawned on them and they never get cleared.

Fixes #4672 

## Summary of changes

Drain the connections as we go

## Proof

Running proxy with 50000 connections over 100 seconds

### Before
![Screenshot 2023-10-04 at 19 29 25](https://github.com/neondatabase/neon/assets/6625462/76b7fcba-b8c7-4112-bb29-ce4b45c72b9e)
### After
![Screenshot 2023-10-04 at 19 29 45](https://github.com/neondatabase/neon/assets/6625462/653beae3-b4de-4d61-94c2-8fefb5fc72e9)

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
