### PR TITLE
fix: deny branching, starting compute from not yet uploaded timelines

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -396,6 +396,9 @@ async fn timeline_create_handler(
                     format!("{err:#}")
                 ))
             }
+            Err(e @ tenant::CreateTimelineError::AncestorNotActive) => {
+                json_response(StatusCode::INTERNAL_SERVER_ERROR, HttpErrorBody::from_msg(e.to_string()))
+            }
             Err(tenant::CreateTimelineError::Other(err)) => Err(ApiError::InternalServerError(err)),
         }
     }

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -397,7 +397,7 @@ async fn timeline_create_handler(
                 ))
             }
             Err(e @ tenant::CreateTimelineError::AncestorNotActive) => {
-                json_response(StatusCode::INTERNAL_SERVER_ERROR, HttpErrorBody::from_msg(e.to_string()))
+                json_response(StatusCode::SERVICE_UNAVAILABLE, HttpErrorBody::from_msg(e.to_string()))
             }
             Err(tenant::CreateTimelineError::Other(err)) => Err(ApiError::InternalServerError(err)),
         }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -406,6 +406,8 @@ pub enum CreateTimelineError {
     AlreadyExists,
     #[error(transparent)]
     AncestorLsn(anyhow::Error),
+    #[error("ancestor timeline is not active")]
+    AncestorNotActive,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -1587,6 +1589,12 @@ impl Tenant {
                     .get_timeline(ancestor_timeline_id, false)
                     .context("Cannot branch off the timeline that's not present in pageserver")?;
 
+                // instead of waiting around, just deny the request because ancestor is not yet
+                // ready for other purposes either.
+                if !ancestor_timeline.is_active() {
+                    return Err(CreateTimelineError::AncestorNotActive);
+                }
+
                 if let Some(lsn) = ancestor_start_lsn.as_mut() {
                     *lsn = lsn.align();
 
@@ -1619,8 +1627,6 @@ impl Tenant {
             }
         };
 
-        loaded_timeline.activate(broker_client, None, ctx);
-
         if let Some(remote_client) = loaded_timeline.remote_client.as_ref() {
             // Wait for the upload of the 'index_part.json` file to finish, so that when we return
             // Ok, the timeline is durable in remote storage.
@@ -1631,6 +1637,8 @@ impl Tenant {
                 format!("wait for {} timeline initial uploads to complete", kind)
             })?;
         }
+
+        loaded_timeline.activate(broker_client, None, ctx);
 
         Ok(loaded_timeline)
     }

--- a/pageserver/src/tenant/remote_timeline_client/upload.rs
+++ b/pageserver/src/tenant/remote_timeline_client/upload.rs
@@ -31,6 +31,7 @@ pub(super) async fn upload_index_part<'a>(
     fail_point!("before-upload-index", |_| {
         bail!("failpoint before-upload-index")
     });
+    pausable_failpoint!("before-upload-index-pausable");
 
     let index_part_bytes =
         serde_json::to_vec(&index_part).context("serialize index part file into bytes")?;

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1464,6 +1464,29 @@ class NeonCli(AbstractNeonCli):
 
         return self.raw_cli(args, check_return_code=check_return_code)
 
+    def map_branch(
+        self, name: str, tenant_id: TenantId, timeline_id: TimelineId
+    ) -> "subprocess.CompletedProcess[str]":
+        """
+        Map tenant id and timeline id to a neon_local branch name. They do not have to exist.
+        Usually needed when creating branches via PageserverHttpClient and not neon_local.
+
+        After creating a name mapping, you can use EndpointFactory.create_start
+        with this registered branch name.
+        """
+        args = [
+            "mappings",
+            "map",
+            "--branch-name",
+            name,
+            "--tenant-id",
+            str(tenant_id),
+            "--timeline-id",
+            str(timeline_id),
+        ]
+
+        return self.raw_cli(args, check_return_code=True)
+
     def start(self, check_return_code=True) -> "subprocess.CompletedProcess[str]":
         return self.raw_cli(["start"], check_return_code=check_return_code)
 

--- a/test_runner/fixtures/pageserver/utils.py
+++ b/test_runner/fixtures/pageserver/utils.py
@@ -72,13 +72,11 @@ def wait_until_tenant_state(
     Does not use `wait_until` for debugging purposes
     """
     for _ in range(iterations):
-        tenant = None
         try:
             tenant = pageserver_http.tenant_status(tenant_id=tenant_id)
         except Exception as e:
             log.debug(f"Tenant {tenant_id} state retrieval failure: {e}")
-
-        if tenant is not None:
+        else:
             log.debug(f"Tenant {tenant_id} data: {tenant}")
             if tenant["state"]["slug"] == expected_state:
                 return tenant

--- a/test_runner/fixtures/pageserver/utils.py
+++ b/test_runner/fixtures/pageserver/utils.py
@@ -72,13 +72,18 @@ def wait_until_tenant_state(
     Does not use `wait_until` for debugging purposes
     """
     for _ in range(iterations):
+        tenant = None
         try:
             tenant = pageserver_http.tenant_status(tenant_id=tenant_id)
+        except Exception as e:
+            log.debug(f"Tenant {tenant_id} state retrieval failure: {e}")
+
+        if tenant is not None:
             log.debug(f"Tenant {tenant_id} data: {tenant}")
             if tenant["state"]["slug"] == expected_state:
                 return tenant
-        except Exception as e:
-            log.debug(f"Tenant {tenant_id} state retrieval failure: {e}")
+            if tenant["state"]["slug"] == "Broken":
+                raise RuntimeError(f"tenant became Broken, not {expected_state}")
 
         time.sleep(period)
 

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -5,10 +5,17 @@ from typing import List
 
 import pytest
 from fixtures.log_helper import log
-from fixtures.neon_fixtures import Endpoint, NeonEnv, PgBin
-from fixtures.types import Lsn
+from fixtures.neon_fixtures import (
+    Endpoint,
+    NeonEnv,
+    NeonEnvBuilder,
+    PgBin,
+)
+from fixtures.pageserver.utils import wait_until_tenant_active
+from fixtures.types import Lsn, TimelineId
 from fixtures.utils import query_scalar
 from performance.test_perf_pgbench import get_scales_matrix
+from requests import ReadTimeout
 
 
 # Test branch creation
@@ -128,3 +135,149 @@ def test_branching_unnormalized_start_lsn(neon_simple_env: NeonEnv, pg_bin: PgBi
     endpoint1 = env.endpoints.create_start("b1")
 
     pg_bin.run_capture(["pgbench", "-i", endpoint1.connstr()])
+
+
+def test_cannot_create_endpoint_on_non_uploaded_timeline(neon_env_builder: NeonEnvBuilder):
+    """
+    Endpoint should not be possible to create because branch has not been uploaded.
+    """
+
+    env = neon_env_builder.init_configs()
+    env.start()
+
+    env.pageserver.allowed_errors.append(
+        ".*request{method=POST path=/v1/tenant/.*/timeline request_id=.*}: request was dropped before completing.*"
+    )
+    ps_http = env.pageserver.http_client()
+
+    # pause all uploads
+    ps_http.configure_failpoints(("before-upload-index-pausable", "pause"))
+    ps_http.tenant_create(env.initial_tenant)
+
+    initial_branch = "initial_branch"
+
+    with pytest.raises(ReadTimeout):
+        ps_http.timeline_create(env.pg_version, env.initial_tenant, env.initial_timeline, timeout=2)
+
+    env.neon_cli.map_branch(initial_branch, env.initial_tenant, env.initial_timeline)
+
+    env.endpoints.create_start(initial_branch, tenant_id=env.initial_tenant)
+
+    # FIXME: uploads bother shutdown
+    env.pageserver.stop(immediate=True)
+
+    raise RuntimeError(
+        "above should had thrown, but of course did not because this is unimplemented"
+    )
+
+
+def test_cannot_branch_from_non_uploaded_branch(neon_env_builder: NeonEnvBuilder):
+    """
+    Branch should not be possible to create because ancestor has not been uploaded.
+    """
+
+    env = neon_env_builder.init_configs()
+    env.start()
+
+    env.pageserver.allowed_errors.append(
+        ".*request{method=POST path=/v1/tenant/.*/timeline request_id=.*}: request was dropped before completing.*"
+    )
+    ps_http = env.pageserver.http_client()
+
+    # pause all uploads
+    ps_http.configure_failpoints(("before-upload-index-pausable", "pause"))
+    ps_http.tenant_create(env.initial_tenant)
+
+    with pytest.raises(ReadTimeout):
+        ps_http.timeline_create(env.pg_version, env.initial_tenant, env.initial_timeline, timeout=2)
+
+    branch_id = TimelineId.generate()
+
+    with pytest.raises(ReadTimeout):
+        # FIXME: this should be rejected somehow
+        ps_http.timeline_create(
+            env.pg_version,
+            env.initial_tenant,
+            branch_id,
+            ancestor_timeline_id=env.initial_timeline,
+            timeout=2
+        )
+
+    env.pageserver.stop(immediate=True)
+
+    raise RuntimeError("was able to branch before ancestor has been uploaded")
+
+
+def test_non_uploaded_branch_availability_after_restart(neon_env_builder: NeonEnvBuilder):
+    """
+    Currently before RFC#27 we keep and continue uploading branches which were not successfully uploaded before shutdown.
+
+    This test likely duplicates some other test, but it's easier to write one than to make sure there will be a failing test when the rfc is implemented.
+    """
+
+    env = neon_env_builder.init_configs()
+    env.start()
+
+    env.pageserver.allowed_errors.append(
+        ".*request{method=POST path=/v1/tenant/.*/timeline request_id=.*}: request was dropped before completing.*"
+    )
+    ps_http = env.pageserver.http_client()
+
+    # pause all uploads
+    ps_http.configure_failpoints(("before-upload-index-pausable", "pause"))
+    ps_http.tenant_create(env.initial_tenant)
+
+    with pytest.raises(ReadTimeout):
+        ps_http.timeline_create(env.pg_version, env.initial_tenant, env.initial_timeline, timeout=2)
+
+    env.pageserver.stop(immediate=True)
+
+    # now without a failpoint
+    env.pageserver.start()
+
+    wait_until_tenant_active(ps_http, env.initial_tenant)
+
+    # currently it lives on and will get eventually uploaded, but this will change
+    detail = ps_http.timeline_detail(env.initial_tenant, env.initial_timeline)
+    assert detail is not None
+
+
+def test_non_uploaded_branch_chain_availability_after_restart(neon_env_builder: NeonEnvBuilder):
+    """
+    Similar to test_non_uploaded_branch_availability_after_restart but create a chain of branches.
+    """
+
+    env = neon_env_builder.init_configs()
+    env.start()
+
+    env.pageserver.allowed_errors.append(
+        ".*request{method=POST path=/v1/tenant/.*/timeline request_id=.*}: request was dropped before completing.*"
+    )
+    ps_http = env.pageserver.http_client()
+
+    # pause all uploads
+    ps_http.configure_failpoints(("before-upload-index-pausable", "pause"))
+    ps_http.tenant_create(env.initial_tenant)
+
+    with pytest.raises(ReadTimeout):
+        ps_http.timeline_create(env.pg_version, env.initial_tenant, env.initial_timeline, timeout=2)
+
+    second_id = TimelineId.generate()
+
+    with pytest.raises(ReadTimeout):
+        ps_http.timeline_create(env.pg_version, env.initial_tenant, second_id, ancestor_timeline_id=env.initial_timeline, timeout=2)
+
+    # make sure it's readable now, the create just hangs
+    detail = ps_http.timeline_detail(env.initial_tenant, second_id)
+
+    env.pageserver.stop(immediate=True)
+
+    # now without a failpoint
+    env.pageserver.start()
+
+    wait_until_tenant_active(ps_http, env.initial_tenant)
+
+    # currently it lives on and will get eventually uploaded, but this will change to both returning 404
+    for id in [second_id, env.initial_timeline]:
+        detail = ps_http.timeline_detail(env.initial_tenant, id)
+        assert detail is not None

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -195,14 +195,12 @@ def test_cannot_branch_from_non_uploaded_branch(neon_env_builder: NeonEnvBuilder
 
     branch_id = TimelineId.generate()
 
-    with pytest.raises(ReadTimeout):
-        # FIXME: this should be rejected somehow
+    with pytest.raises(PageserverApiException, match = "ancestor timeline is not active"):
         ps_http.timeline_create(
             env.pg_version,
             env.initial_tenant,
             branch_id,
             ancestor_timeline_id=env.initial_timeline,
-            timeout=2
         )
 
     with pytest.raises(PageserverApiException, match = f"NotFound: Timeline {env.initial_tenant}/{branch_id} was not found"):

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -12,7 +12,7 @@ from fixtures.neon_fixtures import (
     NeonEnvBuilder,
     PgBin,
 )
-from fixtures.pageserver.http import PageserverApiException, TimelineCreate409
+from fixtures.pageserver.http import PageserverApiException
 from fixtures.pageserver.utils import wait_until_tenant_active
 from fixtures.types import Lsn, TimelineId
 from fixtures.utils import query_scalar
@@ -216,7 +216,7 @@ def test_cannot_branch_from_non_uploaded_branch(neon_env_builder: NeonEnvBuilder
     env.pageserver.stop(immediate=True)
 
 
-def test_competing_branchings_from_loading_race_to_ok_or_409(neon_env_builder: NeonEnvBuilder):
+def test_competing_branchings_from_loading_race_to_ok_or_err(neon_env_builder: NeonEnvBuilder):
     """
     If the activate only after upload is used, then retries could become competing.
     """
@@ -278,8 +278,10 @@ def test_competing_branchings_from_loading_race_to_ok_or_409(neon_env_builder: N
     log.info(failed)
     log.info(succeeded)
 
-    # FIXME: there's probably multiple valid status codes
-    assert isinstance(failed, TimelineCreate409)
+    # FIXME: there's probably multiple valid status codes:
+    # - Timeline 62505b9a9f6b1d29117b1b74eaf07b12/56cd19d3b2dbcc65e9d53ec6ca304f24 already exists
+    # - whatever 409 response says, but that is a subclass of PageserverApiException
+    assert isinstance(failed, PageserverApiException)
     assert succeeded["state"] == "Active"
 
 

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -354,10 +354,6 @@ def test_non_uploaded_branch_chain_availability_after_restart(neon_env_builder: 
 
     wait_until_tenant_active(ps_http, env.initial_tenant)
 
-    # missing test case:
-    # first timeline is successfully created and uploaded
-    # second timeline only exists on disk but not uploaded
-
     with pytest.raises(PageserverApiException, match=f"Timeline {env.initial_tenant}/{branch_id} was not found"):
         ps_http.timeline_detail(env.initial_tenant, branch_id)
 

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -18,6 +18,7 @@ from fixtures.types import Lsn, TimelineId
 from fixtures.utils import query_scalar
 from performance.test_perf_pgbench import get_scales_matrix
 from requests import RequestException
+from requests.exceptions import RetryError
 
 
 # Test branch creation
@@ -215,7 +216,7 @@ def test_cannot_branch_from_non_uploaded_branch(neon_env_builder: NeonEnvBuilder
 
         branch_id = TimelineId.generate()
 
-        with pytest.raises(PageserverApiException, match="ancestor timeline is not active"):
+        with pytest.raises(RetryError, match="too many 503 error responses"):
             ps_http.timeline_create(
                 env.pg_version,
                 env.initial_tenant,

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -367,7 +367,7 @@ def test_non_uploaded_branch_availability_after_restart(neon_env_builder: NeonEn
 
     # currently it lives on and will get eventually uploaded, but this will change
     detail = ps_http.timeline_detail(env.initial_tenant, env.initial_timeline)
-    assert detail is not None
+    assert detail["state"] == "Active"
 
 
 def test_non_uploaded_branch_chain_availability_after_restart(neon_env_builder: NeonEnvBuilder):

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -169,7 +169,7 @@ def test_cannot_create_endpoint_on_non_uploaded_timeline(neon_env_builder: NeonE
     with pytest.raises(RuntimeError, match="is not active, state: Loading"):
         env.endpoints.create_start(initial_branch, tenant_id=env.initial_tenant)
 
-    # FIXME: stuck uploads bother shutdown
+    # FIXME: paused uploads bother shutdown
     env.pageserver.stop(immediate=True)
 
 
@@ -211,6 +211,7 @@ def test_cannot_branch_from_non_uploaded_branch(neon_env_builder: NeonEnvBuilder
         # the work, but will never get to that because we have the pause
         # failpoint
 
+    # FIXME: paused uploads bother shutdown
     env.pageserver.stop(immediate=True)
 
 
@@ -306,6 +307,7 @@ def test_non_uploaded_branch_availability_after_restart(neon_env_builder: NeonEn
     with pytest.raises(ReadTimeout):
         ps_http.timeline_create(env.pg_version, env.initial_tenant, env.initial_timeline, timeout=2)
 
+    # FIXME: paused uploads bother shutdown
     env.pageserver.stop(immediate=True)
 
     # now without a failpoint
@@ -349,6 +351,7 @@ def test_non_uploaded_branch_chain_availability_after_restart(neon_env_builder: 
 
     ps_http.timeline_detail(env.initial_tenant, branch_id)
 
+    # FIXME: paused uploads bother shutdown
     env.pageserver.stop(immediate=True)
 
     # now without a failpoint

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -435,9 +435,10 @@ def test_non_uploaded_branch_chain_availability_after_restart(neon_env_builder: 
 
 def wait_until_paused(env: NeonEnv, failpoint: str):
     found = False
+    msg = f"at failpoint {failpoint}"
     for _ in range(20):
         time.sleep(1)
-        found = env.pageserver.log_contains("msg") is not None
+        found = env.pageserver.log_contains(msg) is not None
         if found:
             break
-    assert found is not None
+    assert found

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -271,12 +271,12 @@ def test_competing_branchings_from_loading_race_to_ok_or_err(neon_env_builder: N
     first = queue.get()
     second = queue.get()
 
+    log.info(first)
+    log.info(second)
+
     (succeeded, failed) = (first, second) if isinstance(second, Exception) else (second, first)
     assert isinstance(failed, Exception)
     assert isinstance(succeeded, Dict)
-
-    log.info(failed)
-    log.info(succeeded)
 
     # FIXME: there's probably multiple valid status codes:
     # - Timeline 62505b9a9f6b1d29117b1b74eaf07b12/56cd19d3b2dbcc65e9d53ec6ca304f24 already exists

--- a/test_runner/regress/test_branching.py
+++ b/test_runner/regress/test_branching.py
@@ -340,14 +340,11 @@ def test_non_uploaded_branch_chain_availability_after_restart(neon_env_builder: 
 
     branch_id = TimelineId.generate()
 
-    with pytest.raises(ReadTimeout):
-        ps_http.timeline_create(env.pg_version, env.initial_tenant, branch_id, ancestor_timeline_id=env.initial_timeline, timeout=2)
+    with pytest.raises(PageserverApiException, match = "ancestor timeline is not active"):
+        ps_http.timeline_create(env.pg_version, env.initial_tenant, branch_id, ancestor_timeline_id=env.initial_timeline)
 
-    ## this did not work:
-    # ps_http.configure_failpoints(("before-upload-index-pausable", "off->pause"))
-    # time.sleep(1)
-
-    ps_http.timeline_detail(env.initial_tenant, branch_id)
+    with pytest.raises(PageserverApiException, match=f"Timeline {env.initial_tenant}/{branch_id} was not found"):
+        ps_http.timeline_detail(env.initial_tenant, branch_id)
 
     # FIXME: paused uploads bother shutdown
     env.pageserver.stop(immediate=True)


### PR DESCRIPTION
Part of #5172. First commits show that we used to allow starting up a compute or creating a branch off a not yet uploaded timeline. This PR moves activation of a timeline to happen **after** initial layer file(s) (if any) and `index_part.json` have been uploaded. Simply moving activation to be *after* downloads have finished works because we now spawn a task per http request handler.

Current behaviour of uploading on the timelines on next startup is kept, to be removed later as part of #5172.

Adds:
- `NeonCli.map_branch` and corresponding `neon_local` implementation: allow creating computes for timelines managed via pageserver http client/api
- possibly duplicate tests (I did not want to search for, will cleanup in a follow-up if these duplicated)

Changes:
- make `wait_until_tenant_state` return immediatedly on `Broken` and not wait more