### PR TITLE
vm-monitor: Refactor scaling logic into CgroupWatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5190,6 +5190,7 @@ dependencies = [
  "clap",
  "futures",
  "inotify 0.10.2",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "sysinfo",

--- a/libs/vm_monitor/Cargo.toml
+++ b/libs/vm_monitor/Cargo.toml
@@ -29,3 +29,4 @@ workspace_hack = { version = "0.1", path = "../../workspace_hack" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3.3"
+pin-project-lite.workspace = true


### PR DESCRIPTION
The general idea of this PR is to move the on-downscale and on-upscale cgroup handling logic into into the CgroupWatcher itself via message passing of commands, rather than directly acting on the cgroup from the thread handling the websocket message.

This change is the large pre-requisite to a handful of smaller changes that should be much easier with this, all part of the Epic about fixing memory.high throttling (#5444):

1. Fix a potential race condition wherein the logic that increases memory.high in response to memory.high events could overwrite newer (more permissive) values set by actual upscaling
    - **Handled by this change already!**
3. Fix a bug where due to already increased memory.high to avoid throttling, upscaling actually decreases memory.high and leads to unrecoverable throttling.
4. If memory.high has been increased to avoid throttling but no upscaling has happened, periodically try to decrease back to the desired memory.high.

For more general context, refer to #5444.

---

Remaining items before merging:

- [ ] Self-review
- [ ] Add (basic, at the very least) doc comments to added functions from this change
- [ ] Run some manual tests using the autoscaling repo's setup