### PR TITLE
tests: wait tenants to be loaded on NeonPageserver.start

### DIFF
--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -909,6 +909,16 @@ fn handle_pageserver(sub_match: &ArgMatches, env: &local_env::LocalEnv) -> Resul
             }
         }
 
+        Some(("tenants-loaded", subcommand_args)) => {
+            match get_pageserver(env, subcommand_args)?.check_tenants_loaded() {
+                Ok(_) => println!("Page server loaded the tenants"),
+                Err(err) => {
+                    eprintln!("pageserver tenants-loaded failed: {}", err);
+                    exit(1);
+                }
+            }
+        }
+
         Some((sub_name, _)) => bail!("Unexpected pageserver subcommand '{}'", sub_name),
         None => bail!("no pageserver subcommand provided"),
     }
@@ -1301,6 +1311,9 @@ fn cli() -> Command {
                 .subcommand(Command::new("restart")
                     .about("Restart local pageserver")
                     .arg(pageserver_config_args.clone())
+                )
+                .subcommand(Command::new("tenants-loaded")
+                    .about("Wait till pageserver loads tenants")
                 )
         )
         .subcommand(

--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -314,6 +314,16 @@ impl PageServerNode {
         Ok(())
     }
 
+    pub fn check_tenants_loaded(&self) -> Result<()> {
+        self.http_request(
+            Method::GET,
+            format!("{}/tenants_loaded", self.http_base_url),
+        )?
+        .send()?
+        .error_from_body()?;
+        Ok(())
+    }
+
     pub fn tenant_list(&self) -> Result<Vec<TenantInfo>> {
         Ok(self
             .http_request(Method::GET, format!("{}/tenant", self.http_base_url))?

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -382,7 +382,7 @@ fn start_pageserver(
     ))?;
 
     BACKGROUND_RUNTIME.spawn({
-        let init_done_rx = init_done_rx;
+        let init_done_rx = init_done_rx.clone();
         let shutdown_pageserver = shutdown_pageserver.clone();
         let drive_init = async move {
             // NOTE: unlike many futures in pageserver, this one is cancellation-safe
@@ -475,6 +475,7 @@ fn start_pageserver(
                 broker_client.clone(),
                 disk_usage_eviction_state,
                 deletion_queue.new_client(),
+                init_done_rx,
             )
             .context("Failed to initialize router state")?,
         );

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -78,7 +78,7 @@ impl State {
         broker_client: storage_broker::BrokerClientChannel,
         disk_usage_eviction_state: Arc<disk_usage_eviction_task::State>,
         deletion_queue_client: DeletionQueueClient,
-        init_done_rx: Barrier,
+        tenants_loaded: Barrier,
     ) -> anyhow::Result<Self> {
         let allowlist_routes = ["/v1/status", "/v1/doc", "/swagger.yml"]
             .iter()
@@ -92,7 +92,7 @@ impl State {
             broker_client,
             disk_usage_eviction_state,
             deletion_queue_client,
-            tenants_loaded: init_done_rx,
+            tenants_loaded,
         })
     }
 

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1640,7 +1640,7 @@ pub fn make_router(
         .get("/v1/status", |r| api_handler(r, status_handler))
         .get("/v1/tenants_loaded", |r| {
             testing_api_handler(
-                "block till pageserver loads tenants",
+                "wait till pageserver loads tenants",
                 r,
                 tenants_loaded_handler,
             )

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1630,6 +1630,7 @@ class NeonPageserver(PgProtocol):
         self,
         overrides: Tuple[str, ...] = (),
         extra_env_vars: Optional[Dict[str, str]] = None,
+        wait_tenants_loaded=True,
     ) -> "NeonPageserver":
         """
         Start the page server.
@@ -1642,7 +1643,8 @@ class NeonPageserver(PgProtocol):
             self.id, overrides=overrides, extra_env_vars=extra_env_vars
         )
         self.running = True
-        self.http_client().check_ready()
+        if wait_tenants_loaded:
+            self.http_client().wait_tenants_loaded()
         return self
 
     def stop(self, immediate: bool = False) -> "NeonPageserver":

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1336,6 +1336,15 @@ class NeonCli(AbstractNeonCli):
         log.info(f"Stopping pageserver with {cmd}")
         return self.raw_cli(cmd)
 
+    def pageserver_loaded_tenants(self, id: int) -> "subprocess.CompletedProcess[str]":
+        """
+        Wait till pageserver loads tenants
+        """
+        cmd = ["pageserver", "tenants-loaded", f"--id={id}"]
+
+        log.info(f"Waiting till pageserver loads tenants with {cmd}")
+        return self.raw_cli(cmd)
+
     def safekeeper_start(
         self, id: int, extra_opts: Optional[List[str]] = None
     ) -> "subprocess.CompletedProcess[str]":
@@ -1667,7 +1676,7 @@ class NeonPageserver(PgProtocol):
         )
         self.running = True
         if wait_tenants_loaded:
-            self.http_client().wait_tenants_loaded()
+            self.env.neon_cli.pageserver_loaded_tenants(self.id)
         return self
 
     def stop(self, immediate: bool = False) -> "NeonPageserver":

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1642,6 +1642,7 @@ class NeonPageserver(PgProtocol):
             self.id, overrides=overrides, extra_env_vars=extra_env_vars
         )
         self.running = True
+        self.http_client().check_ready()
         return self
 
     def stop(self, immediate: bool = False) -> "NeonPageserver":

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -169,11 +169,11 @@ class PageserverHttpClient(requests.Session):
     def check_status(self):
         self.get(f"http://localhost:{self.port}/v1/status").raise_for_status()
 
-    def check_ready(self):
+    def wait_tenants_loaded(self):
         """
-        Blocks till pageserver initialization is done
+        Wait till pageserver loads the tenants
         """
-        self.get(f"http://localhost:{self.port}/v1/ready").raise_for_status()
+        self.get(f"http://localhost:{self.port}/v1/tenants_loaded").raise_for_status()
 
     def configure_failpoints(self, config_strings: Tuple[str, str] | List[Tuple[str, str]]):
         self.is_testing_enabled_or_skip()

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -169,6 +169,12 @@ class PageserverHttpClient(requests.Session):
     def check_status(self):
         self.get(f"http://localhost:{self.port}/v1/status").raise_for_status()
 
+    def check_ready(self):
+        """
+        Blocks till pageserver initialization is done
+        """
+        self.get(f"http://localhost:{self.port}/v1/ready").raise_for_status()
+
     def configure_failpoints(self, config_strings: Tuple[str, str] | List[Tuple[str, str]]):
         self.is_testing_enabled_or_skip()
 

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -171,7 +171,7 @@ class PageserverHttpClient(requests.Session):
 
     def wait_tenants_loaded(self):
         """
-        Wait till pageserver loads the tenants
+        Wait till pageserver loads tenants
         """
         self.get(f"http://localhost:{self.port}/v1/tenants_loaded").raise_for_status()
 

--- a/test_runner/regress/test_pageserver_restart.py
+++ b/test_runner/regress/test_pageserver_restart.py
@@ -62,7 +62,8 @@ def test_pageserver_restart(neon_env_builder: NeonEnvBuilder, generations: bool)
     tenant_load_delay_ms = 5000
     env.pageserver.stop()
     env.pageserver.start(
-        extra_env_vars={"FAILPOINTS": f"before-loading-tenant=return({tenant_load_delay_ms})"}
+        extra_env_vars={"FAILPOINTS": f"before-loading-tenant=return({tenant_load_delay_ms})"},
+        wait_tenants_loaded=False,
     )
 
     # Check that it's in Loading state


### PR DESCRIPTION
## Problem
Tests sometimes start some operations immediately after calling `NeonPageserver.start` which leads to flakiness because sometimes pageserver startup sequence is not fully completed quick enough

Closes #4864

## Summary of changes
Add tenants_loaded api to pageserver which waits till pageserver loads the tenants
