### PR TITLE
pageserver: clean up page service Result handling for shutdown/disconnect

### DIFF
--- a/libs/pq_proto/src/lib.rs
+++ b/libs/pq_proto/src/lib.rs
@@ -670,6 +670,7 @@ pub fn read_cstr(buf: &mut Bytes) -> Result<Bytes, ProtocolError> {
 }
 
 pub const SQLSTATE_INTERNAL_ERROR: &[u8; 5] = b"XX000";
+pub const SQLSTATE_ADMIN_SHUTDOWN: &[u8; 5] = b"57P01";
 pub const SQLSTATE_SUCCESSFUL_COMPLETION: &[u8; 5] = b"00000";
 
 impl<'a> BeMessage<'a> {

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -574,6 +574,7 @@ fn start_pageserver(
                     pageserver_listener,
                     conf.pg_auth_type,
                     libpq_ctx,
+                    task_mgr::shutdown_token(),
                 )
                 .await
             },

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -321,7 +321,7 @@ impl PageServerHandler {
                         // We were requested to shut down.
                         let msg = "pageserver is shutting down";
                         let _ = pgb.write_message_noflush(&BeMessage::ErrorResponse(msg, None));
-                        Err(QueryError::Other(anyhow::anyhow!(msg)))
+                        Err(QueryError::Shutdown)
                     }
 
                     msg = pgb.read_message() => { msg.map_err(QueryError::from)}
@@ -418,7 +418,7 @@ impl PageServerHandler {
                 _ = self.cancel.cancelled() => {
                     // We were requested to shut down.
                     info!("shutdown request received in page handler");
-                    break;
+                    return Err(QueryError::Shutdown)
                 }
 
                 msg = pgb.read_message() => { msg }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -299,7 +299,7 @@ impl PageServerHandler {
                 Ok(flush_r?)
             },
             _ = self.cancel.cancelled() => {
-                Err(QueryError::Other(anyhow::anyhow!("Shutting down")))
+                Err(QueryError::Shutdown)
             }
         )
     }

--- a/test_runner/regress/test_pageserver_restarts_under_workload.py
+++ b/test_runner/regress/test_pageserver_restarts_under_workload.py
@@ -17,8 +17,6 @@ def test_pageserver_restarts_under_worload(neon_simple_env: NeonEnv, pg_bin: PgB
     n_restarts = 10
     scale = 10
 
-    env.pageserver.allowed_errors.append(".*query handler.*failed.*Shutting down")
-
     def run_pgbench(connstr: str):
         log.info(f"Start a pgbench workload on pg {connstr}")
         pg_bin.run_capture(["pgbench", "-i", f"-s{scale}", connstr])

--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -752,9 +752,6 @@ def test_ignore_while_attaching(
     env.pageserver.allowed_errors.append(
         f".*Tenant {tenant_id} will not become active\\. Current state: Stopping.*"
     )
-    # An endpoint is starting up concurrently with our detach, it can
-    # experience RPC failure due to shutdown.
-    env.pageserver.allowed_errors.append(".*query handler.*failed.*Shutting down")
 
     data_id = 1
     data_secret = "very secret secret"


### PR DESCRIPTION
## Problem

- QueryError always logged at error severity, even though disconnections are not true errors.
- QueryError type is not expressive enough to distinguish actual errors from shutdowns.
- In some functions we're returning Ok(()) on shutdown, in others we're returning an error

## Summary of changes

- Add QueryError::Shutdown and use it in places we check for cancellation
- Adopt consistent Result behavior: disconnects and shutdowns are always QueryError, not ok
- Transform shutdown+disconnect errors to Ok(()) at the very top of the task that runs query handler
- Use the postgres protocol error code for "admin shutdown" in responses to clients when we are shutting down.

Closes: #5517 