### PR TITLE
Make http timeout configurable

### DIFF
--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -81,8 +81,8 @@ struct ProxyCliArgs {
     #[clap(long, default_value_t = false, value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
     allow_self_signed_compute: bool,
     /// timeout for http connections
-    #[clap(long, default_value_t = 15)]
-    sql_over_http_timeout: u64,
+    #[clap(long, default_value = "15s", value_parser = humantime::parse_duration)]
+    sql_over_http_timeout: tokio::time::Duration,
 }
 
 #[tokio::main]

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -82,7 +82,7 @@ struct ProxyCliArgs {
     allow_self_signed_compute: bool,
     /// timeout for http connections
     #[clap(long, default_value_t = 15)]
-    connection_timeout_secs: u64,
+    sql_over_http_timeout: u64,
 }
 
 #[tokio::main]
@@ -225,7 +225,7 @@ fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
         }
     };
     let http_config = HttpConfig {
-        connection_timeout_secs: args.connection_timeout_secs,
+        sql_over_http_timeout: args.sql_over_http_timeout,
     };
     let config = Box::leak(Box::new(ProxyConfig {
         tls_config,

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -28,7 +28,7 @@ pub struct TlsConfig {
 }
 
 pub struct HttpConfig {
-    pub connection_timeout_secs: u64,
+    pub sql_over_http_timeout: u64,
 }
 
 impl TlsConfig {

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -13,6 +13,7 @@ pub struct ProxyConfig {
     pub auth_backend: auth::BackendType<'static, ()>,
     pub metric_collection: Option<MetricCollectionConfig>,
     pub allow_self_signed_compute: bool,
+    pub http_config: HttpConfig,
 }
 
 #[derive(Debug)]
@@ -24,6 +25,10 @@ pub struct MetricCollectionConfig {
 pub struct TlsConfig {
     pub config: Arc<rustls::ServerConfig>,
     pub common_names: Option<HashSet<String>>,
+}
+
+pub struct HttpConfig {
+    pub connection_timeout_secs: u64,
 }
 
 impl TlsConfig {

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -28,7 +28,7 @@ pub struct TlsConfig {
 }
 
 pub struct HttpConfig {
-    pub sql_over_http_timeout: u64,
+    pub sql_over_http_timeout: tokio::time::Duration,
 }
 
 impl TlsConfig {

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -193,9 +193,8 @@ pub async fn handle(
     session_id: uuid::Uuid,
     config: &'static HttpConfig,
 ) -> Result<Response<Body>, ApiError> {
-    let timeout = config.sql_over_http_timeout;
     let result = tokio::time::timeout(
-        tokio::time::Duration::from_secs(timeout),
+        config.sql_over_http_timeout,
         handle_inner(request, sni_hostname, conn_pool, session_id),
     )
     .await;
@@ -224,8 +223,10 @@ pub async fn handle(
             }
         },
         Err(_) => {
-            let message =
-                format!("HTTP-Connection timed out, execution time exeeded {timeout} seconds",);
+            let message = format!(
+                "HTTP-Connection timed out, execution time exeeded {} seconds",
+                config.sql_over_http_timeout.as_secs()
+            );
             error!(message);
             json_response(
                 StatusCode::GATEWAY_TIMEOUT,

--- a/proxy/src/http/sql_over_http.rs
+++ b/proxy/src/http/sql_over_http.rs
@@ -193,7 +193,7 @@ pub async fn handle(
     session_id: uuid::Uuid,
     config: &'static HttpConfig,
 ) -> Result<Response<Body>, ApiError> {
-    let timeout = config.connection_timeout_secs;
+    let timeout = config.sql_over_http_timeout;
     let result = tokio::time::timeout(
         tokio::time::Duration::from_secs(timeout),
         handle_inner(request, sni_hostname, conn_pool, session_id),

--- a/proxy/src/http/websocket.rs
+++ b/proxy/src/http/websocket.rs
@@ -205,7 +205,14 @@ async fn ws_handler(
     // TODO: that deserves a refactor as now this function also handles http json client besides websockets.
     // Right now I don't want to blow up sql-over-http patch with file renames and do that as a follow up instead.
     } else if request.uri().path() == "/sql" && request.method() == Method::POST {
-        sql_over_http::handle(request, sni_hostname, conn_pool, session_id).await
+        sql_over_http::handle(
+            request,
+            sni_hostname,
+            conn_pool,
+            session_id,
+            &config.http_config,
+        )
+        .await
     } else if request.uri().path() == "/sql" && request.method() == Method::OPTIONS {
         Response::builder()
             .header("Allow", "OPTIONS, POST")


### PR DESCRIPTION
## Problem

Currently http timeout is hardcoded to 15 seconds.

## Summary of changes

Added an option to configure it via cli args.

Context: https://neondb.slack.com/archives/C04DGM6SMTM/p1696941726151899

