### PR TITLE
pageserver: fix eviction across generations

### DIFF
--- a/pageserver/src/disk_usage_eviction_task.rs
+++ b/pageserver/src/disk_usage_eviction_task.rs
@@ -411,6 +411,11 @@ pub async fn disk_usage_eviction_task_iteration_impl<U: Usage>(
                                 evictions_failed.file_sizes += file_size;
                                 evictions_failed.count += 1;
                             }
+                            Some(Err(EvictionError::MetadataInconsistency(detail))) => {
+                                warn!(%layer, "failed to evict layer: {detail}");
+                                evictions_failed.file_sizes += file_size;
+                                evictions_failed.count += 1;
+                            }
                             None => {
                                 assert!(cancel.is_cancelled());
                                 return;

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1419,6 +1419,13 @@ impl RemoteTimelineClient {
             }
         }
     }
+
+    pub(crate) fn get_layer_metadata(
+        &self,
+        name: &LayerFileName,
+    ) -> anyhow::Result<Option<LayerFileMetadata>> {
+        self.upload_queue.lock().unwrap().get_layer_metadata(name)
+    }
 }
 
 pub fn remote_timelines_path(tenant_id: &TenantId) -> RemotePath {

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -501,20 +501,14 @@ impl RemoteTimelineClient {
 
     /// Download a (layer) file from `path`, into local filesystem.
     ///
+    /// 'layer_metadata' is the metadata from the remote index file.
+    ///
     /// On success, returns the size of the downloaded file.
     pub async fn download_layer_file(
         &self,
         layer_file_name: &LayerFileName,
+        layer_metadata: &LayerFileMetadata,
     ) -> anyhow::Result<u64> {
-        let layer_metadata = {
-            let q = self.upload_queue.lock().unwrap();
-            q.get_layer_metadata(layer_file_name)?.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Tried to download layer file that does not exist in remote metadata"
-                )
-            })?
-        };
-
         let downloaded_size = {
             let _unfinished_gauge_guard = self.metrics.call_begin(
                 &RemoteOpFileKind::Layer,
@@ -529,7 +523,7 @@ impl RemoteTimelineClient {
                 self.tenant_id,
                 self.timeline_id,
                 layer_file_name,
-                &layer_metadata,
+                layer_metadata,
             )
             .measure_remote_op(
                 self.tenant_id,

--- a/pageserver/src/tenant/storage_layer/remote_layer.rs
+++ b/pageserver/src/tenant/storage_layer/remote_layer.rs
@@ -4,7 +4,6 @@
 use crate::config::PageServerConf;
 use crate::context::RequestContext;
 use crate::repository::Key;
-use crate::tenant::remote_timeline_client::index::LayerFileMetadata;
 use crate::tenant::storage_layer::{Layer, ValueReconstructResult, ValueReconstructState};
 use crate::tenant::timeline::layer_manager::LayerManager;
 use anyhow::{bail, Result};
@@ -35,8 +34,6 @@ use super::{
 pub struct RemoteLayer {
     pub desc: PersistentLayerDesc,
 
-    pub layer_metadata: LayerFileMetadata,
-
     access_stats: LayerAccessStats,
 
     pub(crate) ongoing_download: Arc<tokio::sync::Semaphore>,
@@ -59,7 +56,6 @@ impl std::fmt::Debug for RemoteLayer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RemoteLayer")
             .field("file_name", &self.desc.filename())
-            .field("layer_metadata", &self.layer_metadata)
             .field("is_incremental", &self.desc.is_incremental())
             .finish()
     }
@@ -115,7 +111,7 @@ impl PersistentLayer for RemoteLayer {
         if self.desc.is_delta {
             HistoricLayerInfo::Delta {
                 layer_file_name,
-                layer_file_size: self.layer_metadata.file_size(),
+                layer_file_size: self.desc.file_size,
                 lsn_start: lsn_range.start,
                 lsn_end: lsn_range.end,
                 remote: true,
@@ -124,7 +120,7 @@ impl PersistentLayer for RemoteLayer {
         } else {
             HistoricLayerInfo::Image {
                 layer_file_name,
-                layer_file_size: self.layer_metadata.file_size(),
+                layer_file_size: self.desc.file_size,
                 lsn_start: lsn_range.start,
                 remote: true,
                 access_stats: self.access_stats.as_api_model(reset),
@@ -142,7 +138,7 @@ impl RemoteLayer {
         tenantid: TenantId,
         timelineid: TimelineId,
         fname: &ImageFileName,
-        layer_metadata: &LayerFileMetadata,
+        file_size: u64,
         access_stats: LayerAccessStats,
     ) -> RemoteLayer {
         RemoteLayer {
@@ -151,9 +147,8 @@ impl RemoteLayer {
                 timelineid,
                 fname.key_range.clone(),
                 fname.lsn,
-                layer_metadata.file_size(),
+                file_size,
             ),
-            layer_metadata: layer_metadata.clone(),
             ongoing_download: Arc::new(tokio::sync::Semaphore::new(1)),
             download_replacement_failure: std::sync::atomic::AtomicBool::default(),
             access_stats,
@@ -164,7 +159,7 @@ impl RemoteLayer {
         tenantid: TenantId,
         timelineid: TimelineId,
         fname: &DeltaFileName,
-        layer_metadata: &LayerFileMetadata,
+        file_size: u64,
         access_stats: LayerAccessStats,
     ) -> RemoteLayer {
         RemoteLayer {
@@ -173,9 +168,8 @@ impl RemoteLayer {
                 timelineid,
                 fname.key_range.clone(),
                 fname.lsn_range.clone(),
-                layer_metadata.file_size(),
+                file_size,
             ),
-            layer_metadata: layer_metadata.clone(),
             ongoing_download: Arc::new(tokio::sync::Semaphore::new(1)),
             download_replacement_failure: std::sync::atomic::AtomicBool::default(),
             access_stats,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1294,14 +1294,12 @@ impl Timeline {
                 Ok(delta) => Some(delta),
             };
 
-        let layer_metadata = LayerFileMetadata::new(layer_file_size, self.generation);
-
         let new_remote_layer = Arc::new(match local_layer.filename() {
             LayerFileName::Image(image_name) => RemoteLayer::new_img(
                 self.tenant_id,
                 self.timeline_id,
                 &image_name,
-                &layer_metadata,
+                layer_file_size,
                 local_layer
                     .access_stats()
                     .clone_for_residence_change(LayerResidenceStatus::Evicted),
@@ -1310,7 +1308,7 @@ impl Timeline {
                 self.tenant_id,
                 self.timeline_id,
                 &delta_name,
-                &layer_metadata,
+                layer_file_size,
                 local_layer
                     .access_stats()
                     .clone_for_residence_change(LayerResidenceStatus::Evicted),
@@ -1831,12 +1829,24 @@ impl Timeline {
                                 stats,
                             ))
                         }
-                        (Delta(d), Evicted(remote) | UseRemote { remote, .. }) => Arc::new(
-                            RemoteLayer::new_delta(tenant_id, timeline_id, &d, remote, stats),
-                        ),
-                        (Image(i), Evicted(remote) | UseRemote { remote, .. }) => Arc::new(
-                            RemoteLayer::new_img(tenant_id, timeline_id, &i, remote, stats),
-                        ),
+                        (Delta(d), Evicted(remote) | UseRemote { remote, .. }) => {
+                            Arc::new(RemoteLayer::new_delta(
+                                tenant_id,
+                                timeline_id,
+                                &d,
+                                remote.file_size(),
+                                stats,
+                            ))
+                        }
+                        (Image(i), Evicted(remote) | UseRemote { remote, .. }) => {
+                            Arc::new(RemoteLayer::new_img(
+                                tenant_id,
+                                timeline_id,
+                                &i,
+                                remote.file_size(),
+                                stats,
+                            ))
+                        }
                     };
 
                     if let NeedsUpload(m) = decision {
@@ -4420,7 +4430,7 @@ impl Timeline {
                 // Does retries + exponential back-off internally.
                 // When this fails, don't layer further retry attempts here.
                 let result = remote_client
-                    .download_layer_file(&remote_layer.filename(), &remote_layer.layer_metadata)
+                    .download_layer_file(&remote_layer.filename())
                     .await;
 
                 if let Ok(size) = &result {

--- a/pageserver/src/tenant/timeline/eviction_task.rs
+++ b/pageserver/src/tenant/timeline/eviction_task.rs
@@ -285,6 +285,10 @@ impl Timeline {
                     warn!(layer = %l, "failed to evict layer: {e}");
                     stats.not_evictable += 1;
                 }
+                Some(Err(EvictionError::MetadataInconsistency(detail))) => {
+                    warn!(layer = %l, "failed to evict layer: {detail}");
+                    stats.not_evictable += 1;
+                }
             }
         }
         if stats.candidates == stats.not_evictable {

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -203,6 +203,18 @@ impl UploadQueue {
             UploadQueue::Stopped(stopped) => Ok(stopped),
         }
     }
+
+    pub(crate) fn get_layer_metadata(
+        &self,
+        name: &LayerFileName,
+    ) -> anyhow::Result<Option<LayerFileMetadata>> {
+        match self {
+            UploadQueue::Stopped(_) | UploadQueue::Uninitialized => {
+                anyhow::bail!("queue is in state {}", self.as_str())
+            }
+            UploadQueue::Initialized(inner) => Ok(inner.latest_files.get(name).cloned()),
+        }
+    }
 }
 
 /// An in-progress upload or delete task.

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -203,18 +203,6 @@ impl UploadQueue {
             UploadQueue::Stopped(stopped) => Ok(stopped),
         }
     }
-
-    pub(crate) fn get_layer_metadata(
-        &self,
-        name: &LayerFileName,
-    ) -> anyhow::Result<Option<LayerFileMetadata>> {
-        match self {
-            UploadQueue::Stopped(_) | UploadQueue::Uninitialized => {
-                anyhow::bail!("queue is in state {}", self.as_str())
-            }
-            UploadQueue::Initialized(inner) => Ok(inner.latest_files.get(name).cloned()),
-        }
-    }
 }
 
 /// An in-progress upload or delete task.

--- a/test_runner/regress/test_pageserver_generations.py
+++ b/test_runner/regress/test_pageserver_generations.py
@@ -104,6 +104,22 @@ def generate_uploads_and_deletions(
         assert gc_result["layers_removed"] > 0
 
 
+def read_all(
+    env: NeonEnv, tenant_id: Optional[TenantId] = None, timeline_id: Optional[TimelineId] = None
+):
+    if tenant_id is None:
+        tenant_id = env.initial_tenant
+    assert tenant_id is not None
+
+    if timeline_id is None:
+        timeline_id = env.initial_timeline
+    assert timeline_id is not None
+
+    env.pageserver.http_client()
+    with env.endpoints.create_start("main", tenant_id=tenant_id) as endpoint:
+        endpoint.safe_psql("SELECT SUM(LENGTH(val)) FROM foo;")
+
+
 def get_metric_or_0(ps_http, metric: str) -> int:
     v = ps_http.get_metric_value(metric)
     return 0 if v is None else int(v)
@@ -467,3 +483,48 @@ def test_emergency_mode(neon_env_builder: NeonEnvBuilder, pg_bin: PgBin):
     assert get_deletion_queue_depth(ps_http) == 0
     assert get_deletion_queue_validated(ps_http) > 0
     assert get_deletion_queue_executed(ps_http) > 0
+
+
+def evict_all_layers(env: NeonEnv, tenant_id: TenantId, timeline_id: TimelineId):
+    timeline_path = env.pageserver.timeline_dir(tenant_id, timeline_id)
+    initial_local_layers = sorted(
+        list(filter(lambda path: path.name != "metadata", timeline_path.glob("*")))
+    )
+    client = env.pageserver.http_client()
+    for layer in initial_local_layers:
+        if "ephemeral" in layer.name:
+            continue
+        log.info(f"Evicting layer {tenant_id}/{timeline_id} {layer.name}")
+        client.evict_layer(tenant_id=tenant_id, timeline_id=timeline_id, layer_name=layer.name)
+
+
+def test_eviction_across_generations(neon_env_builder: NeonEnvBuilder):
+    """
+    Eviction and on-demand downloads exercise a particular code path where RemoteLayer is constructed
+    and must be constructed using the proper generation for the layer, which may not be the same generation
+    that the tenant is running in.
+    """
+    neon_env_builder.enable_generations = True
+    neon_env_builder.enable_pageserver_remote_storage(
+        RemoteStorageKind.MOCK_S3,
+    )
+    env = neon_env_builder.init_start(initial_tenant_conf=TENANT_CONF)
+    env.pageserver.http_client()
+    tenant_id = env.initial_tenant
+    timeline_id = env.initial_timeline
+
+    generate_uploads_and_deletions(env)
+
+    read_all(env, tenant_id, timeline_id)
+    evict_all_layers(env, tenant_id, timeline_id)
+    read_all(env, tenant_id, timeline_id)
+
+    # This will cause the generation to increment
+    env.pageserver.stop()
+    env.pageserver.start()
+
+    # Now we are running as generation 2, but must still correctly remember that the layers
+    # we are evicting and downloading are from generation 1.
+    read_all(env, tenant_id, timeline_id)
+    evict_all_layers(env, tenant_id, timeline_id)
+    read_all(env, tenant_id, timeline_id)


### PR DESCRIPTION
## Problem

Bug was introduced by me in 83ae2bd82c

When eviction constructs a RemoteLayer to replace the layer it just evicted, it is building a LayerFileMetadata using its _current_ generation, rather than the generation of the layer.

## Summary of changes

- Retrieve Generation from RemoteTimelineClient when evicting.  This will no longer be necessary when #4938 lands.
- Add a test for the scenario in question (this fails without the fix).