### PR TITLE
Support changing pageserver dynamically

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -156,6 +156,7 @@ fn main() -> Result<()> {
                 let path = Path::new(sp);
                 let file = File::open(path)?;
                 spec = Some(serde_json::from_reader(file)?);
+                live_config_allowed = true;
             } else if let Some(id) = compute_id {
                 if let Some(cp_base) = control_plane_uri {
                     live_config_allowed = true;

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -41,6 +41,11 @@ pub fn write_postgres_conf(
     // File::create() destroys the file content if it exists.
     let mut file = File::create(path)?;
 
+    // Write the postgresql.conf content from the spec file as is.
+    if let Some(conf) = &spec.cluster.postgresql_conf {
+        writeln!(file, "{}", conf)?;
+    }
+
     // Add options for connecting to storage
     writeln!(file, "# Neon storage settings")?;
     if let Some(s) = &spec.pageserver_connstring {
@@ -86,11 +91,6 @@ pub fn write_postgres_conf(
 
     if let Some(port) = extension_server_port {
         writeln!(file, "neon.extension_server_port={}", port)?;
-    }
-
-    // Write the postgresql.conf content from the spec file as is.
-    if let Some(conf) = &spec.cluster.postgresql_conf {
-        writeln!(file, "{}", conf)?;
     }
 
     Ok(())

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -41,11 +41,6 @@ pub fn write_postgres_conf(
     // File::create() destroys the file content if it exists.
     let mut file = File::create(path)?;
 
-    // Write the postgresql.conf content from the spec file as is.
-    if let Some(conf) = &spec.cluster.postgresql_conf {
-        writeln!(file, "{}", conf)?;
-    }
-
     // Add options for connecting to storage
     writeln!(file, "# Neon storage settings")?;
     if let Some(s) = &spec.pageserver_connstring {
@@ -91,6 +86,11 @@ pub fn write_postgres_conf(
 
     if let Some(port) = extension_server_port {
         writeln!(file, "neon.extension_server_port={}", port)?;
+    }
+
+    // Write the postgresql.conf content from the spec file as is.
+    if let Some(conf) = &spec.cluster.postgresql_conf {
+        writeln!(file, "{}", conf)?;
     }
 
     Ok(())

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -798,7 +798,7 @@ fn handle_endpoint(ep_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<(
                 ep.start(&auth_token, safekeepers, remote_ext_config)?;
             }
         }
-        "sighup" => {
+        "reconfigure" => {
             let endpoint_id = sub_args
                 .get_one::<String>("endpoint_id")
                 .ok_or_else(|| anyhow!("No endpoint ID provided to sighup"))?;
@@ -806,7 +806,7 @@ fn handle_endpoint(ep_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<(
                 .endpoints
                 .get(endpoint_id.as_str())
                 .with_context(|| format!("postgres endpoint {endpoint_id} is not found"))?;
-            endpoint.sighup()?;
+            endpoint.reconfigure()?;
         }
         "stop" => {
             let endpoint_id = sub_args
@@ -1379,8 +1379,8 @@ fn cli() -> Command {
                     .arg(safekeepers_arg)
                     .arg(remote_ext_config_args)
                 )
-                .subcommand(Command::new("sighup")
-                            .about("Send SIGHUP to the endpoint's postmaster")
+                .subcommand(Command::new("reconfigure")
+                            .about("Reconfigure the endpoint")
                             .arg(endpoint_id_arg.clone())
                             .arg(tenant_id_arg.clone())
                 )

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -801,7 +801,7 @@ fn handle_endpoint(ep_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<(
         "reconfigure" => {
             let endpoint_id = sub_args
                 .get_one::<String>("endpoint_id")
-                .ok_or_else(|| anyhow!("No endpoint ID provided to sighup"))?;
+                .ok_or_else(|| anyhow!("No endpoint ID provided to reconfigure"))?;
             let endpoint = cplane
                 .endpoints
                 .get(endpoint_id.as_str())

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -798,6 +798,16 @@ fn handle_endpoint(ep_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<(
                 ep.start(&auth_token, safekeepers, remote_ext_config)?;
             }
         }
+        "sighup" => {
+            let endpoint_id = sub_args
+                .get_one::<String>("endpoint_id")
+                .ok_or_else(|| anyhow!("No endpoint ID provided to sighup"))?;
+            let endpoint = cplane
+                .endpoints
+                .get(endpoint_id.as_str())
+                .with_context(|| format!("postgres endpoint {endpoint_id} is not found"))?;
+            endpoint.sighup()?;
+        }
         "stop" => {
             let endpoint_id = sub_args
                 .get_one::<String>("endpoint_id")
@@ -1368,6 +1378,11 @@ fn cli() -> Command {
                     .arg(hot_standby_arg)
                     .arg(safekeepers_arg)
                     .arg(remote_ext_config_args)
+                )
+                .subcommand(Command::new("sighup")
+                            .about("Send SIGHUP to the endpoint's postmaster")
+                            .arg(endpoint_id_arg.clone())
+                            .arg(tenant_id_arg.clone())
                 )
                 .subcommand(
                     Command::new("stop")

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -806,7 +806,15 @@ fn handle_endpoint(ep_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<(
                 .endpoints
                 .get(endpoint_id.as_str())
                 .with_context(|| format!("postgres endpoint {endpoint_id} is not found"))?;
-            endpoint.reconfigure()?;
+            let pageserver_id =
+                if let Some(id_str) = sub_args.get_one::<String>("endpoint-pageserver-id") {
+                    Some(NodeId(
+                        id_str.parse().context("while parsing pageserver id")?,
+                    ))
+                } else {
+                    None
+                };
+            endpoint.reconfigure(pageserver_id)?;
         }
         "stop" => {
             let endpoint_id = sub_args
@@ -1381,6 +1389,7 @@ fn cli() -> Command {
                 )
                 .subcommand(Command::new("reconfigure")
                             .about("Reconfigure the endpoint")
+                            .arg(endpoint_pageserver_id_arg)
                             .arg(endpoint_id_arg.clone())
                             .arg(tenant_id_arg.clone())
                 )

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -435,12 +435,10 @@ impl Endpoint {
         match std::fs::read(&postgresql_conf_path) {
             Ok(content) => Ok(String::from_utf8(content)?),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok("".to_string()),
-            Err(e) => {
-                return Err(anyhow::Error::new(e).context(format!(
-                    "failed to read config file in {}",
-                    postgresql_conf_path.to_str().unwrap()
-                )))
-            }
+            Err(e) => Err(anyhow::Error::new(e).context(format!(
+                "failed to read config file in {}",
+                postgresql_conf_path.to_str().unwrap()
+            ))),
         }
     }
 

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -19,6 +19,7 @@
 #include "access/xlog.h"
 #include "access/xlogutils.h"
 #include "storage/buf_internals.h"
+#include "c.h"
 
 #include "libpq-fe.h"
 #include "libpq/pqformat.h"
@@ -63,6 +64,14 @@ int			max_reconnect_attempts = 60;
 bool	(*old_redo_read_buffer_filter) (XLogReaderState *record, uint8 block_id) = NULL;
 
 static bool pageserver_flush(void);
+
+static void
+pageserver_sighup_handler(SIGNAL_ARGS)
+{
+    neon_log(LOG, "Received SIGHUP, flushing existing pageserver");
+    pageserver_flush();
+    neon_log(LOG, "Flush complete");
+}
 
 static bool
 pageserver_connect(int elevel)
@@ -400,7 +409,7 @@ pg_init_libpagestore(void)
 							   NULL,
 							   &page_server_connstring,
 							   "",
-							   PGC_POSTMASTER,
+							   PGC_SIGHUP,
 							   0,	/* no flags required */
 							   NULL, NULL, NULL);
 
@@ -482,5 +491,8 @@ pg_init_libpagestore(void)
 		old_redo_read_buffer_filter = redo_read_buffer_filter;
 		redo_read_buffer_filter = neon_redo_read_buffer_filter;
 	}
+
+        pqsignal(SIGHUP, pageserver_sighup_handler);
+
 	lfc_init();
 }

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -64,6 +64,8 @@ int			max_reconnect_attempts = 60;
 bool	(*old_redo_read_buffer_filter) (XLogReaderState *record, uint8 block_id) = NULL;
 
 static bool pageserver_flush(void);
+static void pageserver_disconnect(void);
+
 
 static pqsigfunc	 prev_signal_handler;
 
@@ -74,9 +76,8 @@ pageserver_sighup_handler(SIGNAL_ARGS)
 	{
         	prev_signal_handler(postgres_signal_arg);
 	}
-	neon_log(LOG, "Received SIGHUP, flushing existing pageserver. New pageserver connstring is %s", page_server_connstring);
-	pageserver_flush();
-	neon_log(LOG, "Flush complete");
+	neon_log(LOG, "Received SIGHUP, disconnecting pageserver. New pageserver connstring is %s", page_server_connstring);
+	pageserver_disconnect();
 }
 
 static bool

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1445,12 +1445,12 @@ class NeonCli(AbstractNeonCli):
         res.check_returncode()
         return res
 
-    def endpoint_sighup(
+    def endpoint_reconfigure(
         self,
         endpoint_id: str,
         check_return_code=True,
     ) -> "subprocess.CompletedProcess[str]":
-        args = ["endpoint", "sighup", endpoint_id]
+        args = ["endpoint", "reconfigure", endpoint_id]
         return self.raw_cli(args, check_return_code=check_return_code)
 
     def endpoint_stop(
@@ -2542,9 +2542,9 @@ class Endpoint(PgProtocol):
 
         return self
 
-    def sighup(self):
+    def reconfigure(self):
         assert self.endpoint_id is not None
-        self.env.neon_cli.endpoint_sighup(self.endpoint_id, self.tenant_id)
+        self.env.neon_cli.endpoint_reconfigure(self.endpoint_id, self.tenant_id)
 
     def respec(self, **kwargs):
         """Update the endpoint.json file used by control_plane."""

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1445,6 +1445,14 @@ class NeonCli(AbstractNeonCli):
         res.check_returncode()
         return res
 
+    def endpoint_sighup(
+        self,
+        endpoint_id: str,
+        check_return_code=True,
+    ) -> "subprocess.CompletedProcess[str]":
+        args = ["endpoint", "sighup", endpoint_id]
+        return self.raw_cli(args, check_return_code=check_return_code)
+
     def endpoint_stop(
         self,
         endpoint_id: str,
@@ -2533,6 +2541,10 @@ class Endpoint(PgProtocol):
                 conf.write("\n")
 
         return self
+
+    def sighup(self):
+        assert self.endpoint_id is not None
+        self.env.neon_cli.endpoint_sighup(self.endpoint_id, self.tenant_id)
 
     def respec(self, **kwargs):
         """Update the endpoint.json file used by control_plane."""

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1448,9 +1448,15 @@ class NeonCli(AbstractNeonCli):
     def endpoint_reconfigure(
         self,
         endpoint_id: str,
+        tenant_id: Optional[TenantId]] = None,
+        pageserver_id: Optional[str] = None,
         check_return_code=True,
     ) -> "subprocess.CompletedProcess[str]":
         args = ["endpoint", "reconfigure", endpoint_id]
+        if tenant_id is not None:
+            args.extend(["--tenant-id", str(tenant_id)])
+        if pageserver_id is not None:
+            args.extend(["--pageserver-id", str(pageserver_id)])
         return self.raw_cli(args, check_return_code=check_return_code)
 
     def endpoint_stop(
@@ -2542,9 +2548,9 @@ class Endpoint(PgProtocol):
 
         return self
 
-    def reconfigure(self):
+    def reconfigure(self, pageserver_id: Optional[str] = None):
         assert self.endpoint_id is not None
-        self.env.neon_cli.endpoint_reconfigure(self.endpoint_id, self.tenant_id)
+        self.env.neon_cli.endpoint_reconfigure(self.endpoint_id, self.tenant_id, pageserver_id)
 
     def respec(self, **kwargs):
         """Update the endpoint.json file used by control_plane."""

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1449,7 +1449,7 @@ class NeonCli(AbstractNeonCli):
         self,
         endpoint_id: str,
         tenant_id: Optional[TenantId] = None,
-        pageserver_id: Optional[str] = None,
+        pageserver_id: Optional[int] = None,
         check_return_code=True,
     ) -> "subprocess.CompletedProcess[str]":
         args = ["endpoint", "reconfigure", endpoint_id]
@@ -2548,7 +2548,7 @@ class Endpoint(PgProtocol):
 
         return self
 
-    def reconfigure(self, pageserver_id: Optional[str] = None):
+    def reconfigure(self, pageserver_id: Optional[int] = None):
         assert self.endpoint_id is not None
         self.env.neon_cli.endpoint_reconfigure(self.endpoint_id, self.tenant_id, pageserver_id)
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1448,7 +1448,7 @@ class NeonCli(AbstractNeonCli):
     def endpoint_reconfigure(
         self,
         endpoint_id: str,
-        tenant_id: Optional[TenantId]] = None,
+        tenant_id: Optional[TenantId] = None,
         pageserver_id: Optional[str] = None,
         check_return_code=True,
     ) -> "subprocess.CompletedProcess[str]":

--- a/test_runner/regress/test_change_pageserver.py
+++ b/test_runner/regress/test_change_pageserver.py
@@ -13,8 +13,8 @@ def test_change_pageserver(neon_env_builder: NeonEnvBuilder):
     env.neon_cli.create_branch("test_change_pageserver")
     endpoint = env.endpoints.create_start("test_change_pageserver")
 
+    alt_pageserver_id = env.pageservers[1].id
     env.pageservers[1].tenant_attach(env.initial_tenant)
-    new_pageserver_pg_port = env.pageservers[1].service_port.pg
 
     pg_conn = endpoint.connect()
     cur = pg_conn.cursor()
@@ -47,10 +47,7 @@ def test_change_pageserver(neon_env_builder: NeonEnvBuilder):
     cur.execute("SELECT count(*) FROM foo")
     assert cur.fetchone() == (100000,)
 
-    endpoint.config(
-        [f"neon.pageserver_connstring='postgresql://no_user:@localhost:{new_pageserver_pg_port}'"]
-    )
-    endpoint.reconfigure()
+    endpoint.reconfigure(pageserver_id=alt_pageserver_id)
     env.pageservers[
         0
     ].stop()  # Stop the old pageserver just to make sure we're reading from the new one

--- a/test_runner/regress/test_change_pageserver.py
+++ b/test_runner/regress/test_change_pageserver.py
@@ -48,6 +48,14 @@ def test_change_pageserver(neon_env_builder: NeonEnvBuilder):
     assert cur.fetchone() == (100000,)
 
     endpoint.reconfigure(pageserver_id=alt_pageserver_id)
+
+    # Verify that the neon.pageserver_connstring GUC is set to the correct thing
+    cur.execute("SELECT setting FROM pg_settings WHERE name='neon.pageserver_connstring'")
+    connstring = cur.fetchone()
+    assert connstring is not None
+    expected_connstring = f"postgresql://no_user:@localhost:{env.pageservers[1].service_port.pg}"
+    assert expected_connstring == expected_connstring
+
     env.pageservers[
         0
     ].stop()  # Stop the old pageserver just to make sure we're reading from the new one

--- a/test_runner/regress/test_change_pageserver.py
+++ b/test_runner/regress/test_change_pageserver.py
@@ -1,0 +1,49 @@
+from fixtures.log_helper import log
+from fixtures.neon_fixtures import NeonEnvBuilder
+
+
+def test_change_pageserver(neon_env_builder: NeonEnvBuilder):
+    neon_env_builder.num_pageservers = 2
+    env = neon_env_builder.init_start()
+
+    env.neon_cli.create_branch("test_change_pageserver")
+    endpoint = env.endpoints.create_start("test_change_pageserver")
+    env.pageservers[0].http_client()
+    new_pageserver_http = env.pageservers[1].http_client()
+
+    pg_conn = endpoint.connect()
+    cur = pg_conn.cursor()
+
+    # Create table, and insert some rows. Make it big enough that it doesn't fit in
+    # shared_buffers, otherwise the SELECT after restart will just return answer
+    # from shared_buffers without hitting the page server, which defeats the point
+    # of this test.
+    cur.execute("CREATE TABLE foo (t text)")
+    cur.execute(
+        """
+        INSERT INTO foo
+            SELECT 'long string to consume some space' || g
+            FROM generate_series(1, 100000) g
+        """
+    )
+
+    # Verify that the table is larger than shared_buffers
+    cur.execute(
+        """
+        select setting::int * pg_size_bytes(unit) as shared_buffers, pg_relation_size('foo') as tbl_size
+        from pg_settings where name = 'shared_buffers'
+        """
+    )
+    row = cur.fetchone()
+    assert row is not None
+    log.info(f"shared_buffers is {row[0]}, table size {row[1]}")
+    assert int(row[0]) < int(row[1])
+
+    cur.execute("SELECT count(*) FROM foo")
+    assert cur.fetchone() == (100000,)
+
+    endpoint.config([f"neon.pageserver_connstring = {new_pageserver_http}"])
+    endpoint.sighup()
+
+    cur.execute("SELECT count(*) FROM foo")
+    assert cur.fetchone() == (100000,)


### PR DESCRIPTION
## Problem
We currently require full restart of compute if we change the pageserver url
## Summary of changes
Makes it so that we don't have to do a full restart, but can just send SIGHUP
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
