### PR TITLE
Check if walredo pipe was recreated by some other backend before killling walredo process

### DIFF
--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -267,13 +267,13 @@ impl PostgresRedoManager {
         let mut n_attempts = 0u32;
         loop {
             let mut proc = self.stdin.lock().unwrap();
-            let stdin_fd = proc.as_mut().unwrap().stdin.as_raw_fd();
             let lock_time = Instant::now();
 
             // launch the WAL redo process on first use
             if proc.is_none() {
                 self.launch(&mut proc, pg_version)?;
             }
+            let stdin_fd = proc.as_mut().unwrap().stdin.as_raw_fd();
             WAL_REDO_WAIT_TIME.observe(lock_time.duration_since(start_time).as_secs_f64());
 
             // Relational WAL records are applied using wal-redo-postgres


### PR DESCRIPTION
## Problem

@MMeent  discovered the following race condition:

1. T1 calls apply_batch_postgres(), which in turn calls apply_wal_records()
1. T1 appy_wal_records() returns with an error. As part of it return, it drops the MutexGuard on stdin.
2. T2 calls apply_bach_postgres(), which in turn calls apply_wal_records()
3. T2 sends a request to the still-living walredo process stdin
4. T2 drops the stdin lock, moves on to polling stdout
5. T1 acquires stdin lock
6. T1 calls kill_and_shutdown on the walredo process

See https://neondb.slack.com/archives/C06011NCEMR/p1697106833842969?thread_ts=1697100323.377499&cid=C06011NCEMR

The symptom that can be seen in the logs is that T1 logs the error from apply_wal_records(), then we see in arbitrary order the logs from T1's kill_and_shutdown and the logs from T2 observing closed pipe write end pipe, i.e., POLLHUP, i.e., `"WAL redo process closed its stderr unexpectedly"`.

## Summary of changes

Check if stdin is changed before killing walredo process.