### PR TITLE
pageserver: fixes to `/location_config` API

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1039,9 +1039,17 @@ async fn put_tenant_location_config_handler(
     // The `Detached` state is special, it doesn't upsert a tenant, it removes
     // its local disk content and drops it from memory.
     if let LocationConfigMode::Detached = request_data.config.mode {
-        mgr::detach_tenant(conf, tenant_id, true, &state.deletion_queue_client)
+        if let Err(e) = mgr::detach_tenant(conf, tenant_id, true, &state.deletion_queue_client)
             .instrument(info_span!("tenant_detach", %tenant_id))
-            .await?;
+            .await
+        {
+            match e {
+                TenantStateError::NotFound(_) => {
+                    // This API is idempotent: a NotFound on a detach is fine.
+                }
+                _ => return Err(e.into()),
+            }
+        }
         return json_response(StatusCode::OK, ());
     }
 

--- a/pageserver/src/tenant/delete.rs
+++ b/pageserver/src/tenant/delete.rs
@@ -458,7 +458,7 @@ impl DeleteTenantFlow {
             .await
             .expect("cant be stopping or broken");
 
-        tenant.attach(ctx).await.context("attach")?;
+        tenant.attach(ctx, true).await.context("attach")?;
 
         Self::background(
             guard,


### PR DESCRIPTION
## Problem

I found some issues with the `/location_config` API when writing new tests.

## Summary of changes

- Calling the API with the "Detached" state is now idempotent.
- `Tenant::spawn_attach` now takes a boolean to indicate whether to expect a marker file.  Marker files are used in the old attach path, but not in the new location conf API.  They aren't needed because in the New World, we will do away with the distinction between spawn_attach and spawn_load (this is not done in the PR, but that's okay because this API is not used in the wild yet).
- Instead of using `schedule_local_tenant_processing`, the location conf API handler does its own directory creation and calls `spawn_attach` directly.
- A new `unsafe_create_dir_all` is added.  This differs from crashsafe::create_dir_all in two ways:
   - It is intentionally not crashsafe, because in the location conf API we are no longer using directory or config existence as the signal for any important business logic.
   - It is async and uses `tokio::fs`.
