### PR TITLE
Fix neon_extra_build.yml

### DIFF
--- a/.github/workflows/neon_extra_builds.yml
+++ b/.github/workflows/neon_extra_builds.yml
@@ -101,10 +101,10 @@ jobs:
         run: make postgres-v16 -j$(sysctl -n hw.ncpu)
 
       - name: Build neon extensions
-        run: make neon-pg-ext -j$(nproc)
+        run: make neon-pg-ext -j$(sysctl -n hw.ncpu)
 
       - name: Build walproposer-lib
-        run: make walproposer-lib -j$(nproc)
+        run: make walproposer-lib -j$(sysctl -n hw.ncpu)
 
       - name: Run cargo build
         run: cargo build --all --release
@@ -136,7 +136,10 @@ jobs:
 
       # Some of our rust modules use FFI and need those to be checked
       - name: Get postgres headers
-        run: make postgres-headers -j$(sysctl -n hw.ncpu)
+        run: make postgres-headers -j$(nproc)
+
+      - name: Build walproposer-lib
+        run: make walproposer-lib -j$(nproc)
 
       - name: Produce the build stats
         run: cargo build --all --release --timings

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ walproposer-lib: neon-pg-ext-v16
 		-f $(ROOT_PROJECT_DIR)/pgxn/neon/Makefile walproposer-lib
 	cp $(POSTGRES_INSTALL_DIR)/v16/lib/libpgport.a $(POSTGRES_INSTALL_DIR)/build/walproposer-lib
 	cp $(POSTGRES_INSTALL_DIR)/v16/lib/libpgcommon.a $(POSTGRES_INSTALL_DIR)/build/walproposer-lib
+ifeq ($(UNAME_S),Linux)
 	$(AR) d $(POSTGRES_INSTALL_DIR)/build/walproposer-lib/libpgport.a \
 		pg_strong_random.o
 	$(AR) d $(POSTGRES_INSTALL_DIR)/build/walproposer-lib/libpgcommon.a \
@@ -195,6 +196,7 @@ walproposer-lib: neon-pg-ext-v16
 		scram-common.o \
 		md5_common.o \
 		checksum_helper.o
+endif
 
 .PHONY: walproposer-lib-clean
 walproposer-lib-clean:


### PR DESCRIPTION
Build walproposer-lib in gather-rust-build-stats, fix nproc usage, fix walproposer-lib on macos.