### PR TITLE
Optionally return json from get_lsn_by_timestamp

### DIFF
--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -1401,6 +1401,7 @@ components:
           format: hex
         kind:
           type: string
+          enum: [past, present, future, nodata]
 
     Error:
       type: object

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -398,6 +398,11 @@ paths:
           content:
             application/json:
               schema:
+                $ref: "#/components/schemas/LsnByTimestampResponse"
+              schema:
+                type: string
+            application/json:
+              schema:
                 type: string
         "400":
           description: Error when no tenant id found in path, no timeline id or invalid timestamp
@@ -1383,6 +1388,18 @@ components:
         timeline_id:
           type: string
           format: hex
+
+    LsnByTimestampResponse:
+      type: object
+      required:
+        - lsn
+        - type
+      properties:
+        lsn:
+          type: string
+          format: hex
+        type:
+          type: string
 
     Error:
       type: object

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -396,12 +396,9 @@ paths:
         "200":
           description: OK
           content:
-            application/vnd.neon-v2+json:
-              schema:
-                $ref: "#/components/schemas/LsnByTimestampResponse"
             application/json:
               schema:
-                type: string
+                $ref: "#/components/schemas/LsnByTimestampResponse"
         "400":
           description: Error when no tenant id found in path, no timeline id or invalid timestamp
           content:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -396,7 +396,7 @@ paths:
         "200":
           description: OK
           content:
-            application/json:
+            application/vnd.neon-v2+json:
               schema:
                 $ref: "#/components/schemas/LsnByTimestampResponse"
             application/json:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -399,8 +399,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/LsnByTimestampResponse"
-              schema:
-                type: string
             application/json:
               schema:
                 type: string

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -392,6 +392,12 @@ paths:
             type: string
             format: date-time
           description: A timestamp to get the LSN
+        - name: version
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: The version of the endpoint to use
       responses:
         "200":
           description: OK

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -1393,12 +1393,12 @@ components:
       type: object
       required:
         - lsn
-        - type
+        - kind
       properties:
         lsn:
           type: string
           format: hex
-        type:
+        kind:
           type: string
 
     Error:

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -516,7 +516,7 @@ async fn get_lsn_by_timestamp_handler(
             StatusCode::OK,
             Result {
                 lsn: lsn.to_string(),
-                kind: kind,
+                kind,
             },
         )
     } else {

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -504,9 +504,9 @@ async fn get_lsn_by_timestamp_handler(
         #[derive(serde::Serialize)]
         struct Result {
             lsn: String,
-            r#type: &'static str,
+            kind: &'static str,
         }
-        let (lsn, type_) = match result {
+        let (lsn, kind) = match result {
             LsnForTimestamp::Present(lsn) => (lsn, "present"),
             LsnForTimestamp::Future(lsn) => (lsn, "future"),
             LsnForTimestamp::Past(lsn) => (lsn, "past"),
@@ -516,7 +516,7 @@ async fn get_lsn_by_timestamp_handler(
             StatusCode::OK,
             Result {
                 lsn: lsn.to_string(),
-                r#type: type_,
+                kind: kind,
             },
         )
     } else {

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -514,6 +514,8 @@ async fn get_lsn_by_timestamp_handler(
         };
         json_response(StatusCode::OK, Result { lsn, kind })
     } else {
+        // FIXME: this is a temporary crutch not to break backwards compatibility
+        // See https://github.com/neondatabase/neon/pull/5608
         let result = match result {
             LsnForTimestamp::Present(lsn) => format!("{lsn}"),
             LsnForTimestamp::Future(_lsn) => "future".into(),

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -499,7 +499,7 @@ async fn get_lsn_by_timestamp_handler(
     if request
         .headers()
         .get(header::ACCEPT)
-        .map(|v| v == "application/json")
+        .map(|v| v == "application/vnd.neon-v2+json")
         .unwrap_or_default()
     {
         #[serde_as]

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -441,13 +441,13 @@ class PageserverHttpClient(requests.Session):
         assert res_json is None
 
     def timeline_get_lsn_by_timestamp(
-        self, tenant_id: TenantId, timeline_id: TimelineId, timestamp
+        self, tenant_id: TenantId, timeline_id: TimelineId, timestamp, version: int
     ):
         log.info(
             f"Requesting lsn by timestamp {timestamp}, tenant {tenant_id}, timeline {timeline_id}"
         )
         res = self.get(
-            f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/get_lsn_by_timestamp?timestamp={timestamp}",
+            f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/get_lsn_by_timestamp?timestamp={timestamp}&version={version}",
         )
         self.verbose_error(res)
         res_json = res.json()

--- a/test_runner/regress/test_lsn_mapping.py
+++ b/test_runner/regress/test_lsn_mapping.py
@@ -11,6 +11,71 @@ from fixtures.utils import query_scalar
 #
 # Test pageserver get_lsn_by_timestamp API
 #
+def test_lsn_mapping_old(neon_env_builder: NeonEnvBuilder):
+    env = neon_env_builder.init_start()
+
+    new_timeline_id = env.neon_cli.create_branch("test_lsn_mapping")
+    endpoint_main = env.endpoints.create_start("test_lsn_mapping")
+    log.info("postgres is running on 'test_lsn_mapping' branch")
+
+    cur = endpoint_main.connect().cursor()
+    # Create table, and insert rows, each in a separate transaction
+    # Disable synchronous_commit to make this initialization go faster.
+    #
+    # Each row contains current insert LSN and the current timestamp, when
+    # the row was inserted.
+    cur.execute("SET synchronous_commit=off")
+    cur.execute("CREATE TABLE foo (x integer)")
+    tbl = []
+    for i in range(1000):
+        cur.execute("INSERT INTO foo VALUES(%s)", (i,))
+        # Get the timestamp at UTC
+        after_timestamp = query_scalar(cur, "SELECT clock_timestamp()").replace(tzinfo=None)
+        tbl.append([i, after_timestamp])
+
+    # Execute one more transaction with synchronous_commit enabled, to flush
+    # all the previous transactions
+    cur.execute("SET synchronous_commit=on")
+    cur.execute("INSERT INTO foo VALUES (-1)")
+
+    # Wait until WAL is received by pageserver
+    wait_for_last_flush_lsn(env, endpoint_main, env.initial_tenant, new_timeline_id)
+
+    with env.pageserver.http_client() as client:
+        # Check edge cases: timestamp in the future
+        probe_timestamp = tbl[-1][1] + timedelta(hours=1)
+        result = client.timeline_get_lsn_by_timestamp(
+            env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z", 1
+        )
+        assert result == "future"
+
+        # timestamp too the far history
+        probe_timestamp = tbl[0][1] - timedelta(hours=10)
+        result = client.timeline_get_lsn_by_timestamp(
+            env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z", 1
+        )
+        assert result == "past"
+
+        # Probe a bunch of timestamps in the valid range
+        for i in range(1, len(tbl), 100):
+            probe_timestamp = tbl[i][1]
+            lsn = client.timeline_get_lsn_by_timestamp(
+                env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z", 1
+            )
+            # Call get_lsn_by_timestamp to get the LSN
+            # Launch a new read-only node at that LSN, and check that only the rows
+            # that were supposed to be committed at that point in time are visible.
+            endpoint_here = env.endpoints.create_start(
+                branch_name="test_lsn_mapping", endpoint_id="ep-lsn_mapping_read", lsn=lsn
+            )
+            assert endpoint_here.safe_psql("SELECT max(x) FROM foo")[0][0] == i
+
+            endpoint_here.stop_and_destroy()
+
+
+#
+# Test pageserver get_lsn_by_timestamp API
+#
 def test_lsn_mapping(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_start()
 
@@ -45,23 +110,24 @@ def test_lsn_mapping(neon_env_builder: NeonEnvBuilder):
         # Check edge cases: timestamp in the future
         probe_timestamp = tbl[-1][1] + timedelta(hours=1)
         result = client.timeline_get_lsn_by_timestamp(
-            env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z"
+            env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z", 2
         )
-        assert result == "future"
+        assert result["kind"] == "future"
 
         # timestamp too the far history
         probe_timestamp = tbl[0][1] - timedelta(hours=10)
         result = client.timeline_get_lsn_by_timestamp(
-            env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z"
+            env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z", 2
         )
-        assert result == "past"
+        assert result["kind"] == "past"
 
         # Probe a bunch of timestamps in the valid range
         for i in range(1, len(tbl), 100):
             probe_timestamp = tbl[i][1]
-            lsn = client.timeline_get_lsn_by_timestamp(
-                env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z"
+            result = client.timeline_get_lsn_by_timestamp(
+                env.initial_tenant, new_timeline_id, f"{probe_timestamp.isoformat()}Z", 2
             )
+            lsn = result["lsn"]
             # Call get_lsn_by_timestamp to get the LSN
             # Launch a new read-only node at that LSN, and check that only the rows
             # that were supposed to be committed at that point in time are visible.


### PR DESCRIPTION
This PR does two things: first a minor refactor to not use HTTP/1.x style header names and also to not panic if some certain requests had no "Accept" header. As a second thing, it addresses the third bullet point from #3689:

> Change `get_lsn_by_timestamp` API method to return LSN even if we only found commit before the specified timestamp.

This is done by adding a version parameter to the `get_lsn_by_timestamp` API call and making its behaviour depend on the version number.

Part of #3414 (but doesn't address it in its entirety).