### PR TITLE
remote_storage: Use streaming upload for azure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time 0.3.21",
+ "tokio",
  "url",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ license = "Apache-2.0"
 [workspace.dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
 async-compression = { version = "0.4.0", features = ["tokio", "gzip"] }
-azure_core = "0.16"
+azure_core = { version = "0.16", features = ["tokio"] }
 azure_identity = "0.16"
 azure_storage = "0.16"
 azure_storage_blobs = "0.16"

--- a/libs/remote_storage/src/simulate_failures.rs
+++ b/libs/remote_storage/src/simulate_failures.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 
 use crate::{
     Download, DownloadError, Listing, ListingMode, RemotePath, RemoteStorage, StorageMetadata,
+    UploadSource,
 };
 
 pub struct UnreliableWrapper {
@@ -108,7 +109,7 @@ impl RemoteStorage for UnreliableWrapper {
 
     async fn upload(
         &self,
-        data: impl tokio::io::AsyncRead + Unpin + Send + Sync + 'static,
+        data: UploadSource,
         // S3 PUT request requires the content length to be specified,
         // otherwise it starts to fail with the concurrent connection count increasing.
         data_size_bytes: usize,

--- a/pageserver/src/tenant/delete.rs
+++ b/pageserver/src/tenant/delete.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
 use pageserver_api::models::TenantState;
-use remote_storage::{GenericRemoteStorage, RemotePath};
+use remote_storage::{GenericRemoteStorage, RemotePath, UploadSource};
 use tokio::sync::OwnedMutexGuard;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, instrument, warn, Instrument, Span};
@@ -68,11 +68,15 @@ async fn create_remote_delete_mark(
 ) -> Result<(), DeleteTenantError> {
     let remote_mark_path = remote_tenant_delete_mark_path(conf, tenant_id)?;
 
-    let data: &[u8] = &[];
     backoff::retry(
         || async {
             remote_storage
-                .upload(data, 0, &remote_mark_path, None)
+                .upload(
+                    UploadSource::Bytes(bytes::Bytes::new()),
+                    0,
+                    &remote_mark_path,
+                    None,
+                )
                 .await
         },
         |_e| false,

--- a/safekeeper/src/wal_backup.rs
+++ b/safekeeper/src/wal_backup.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use postgres_ffi::v14::xlog_utils::XLogSegNoOffsetToRecPtr;
 use postgres_ffi::XLogFileName;
 use postgres_ffi::{XLogSegNo, PG_TLI};
-use remote_storage::{GenericRemoteStorage, RemotePath};
+use remote_storage::{GenericRemoteStorage, RemotePath, UploadSource};
 use tokio::fs::File;
 
 use tokio::select;
@@ -494,14 +494,12 @@ async fn backup_object(
         .as_ref()
         .unwrap();
 
-    let file = tokio::io::BufReader::new(
-        File::open(&source_file)
-            .await
-            .with_context(|| format!("Failed to open file {} for wal backup", source_file))?,
-    );
+    let file = File::open(&source_file)
+        .await
+        .with_context(|| format!("Failed to open file {} for wal backup", source_file))?;
 
     storage
-        .upload_storage_object(Box::new(file), size, target_file)
+        .upload_storage_object(UploadSource::File(file), size, target_file)
         .await
 }
 


### PR DESCRIPTION
ref #5563, and
https://neondb.slack.com/archives/C033RQ5SPDH/p1697685786098139?thread_ts=1697569498.435379&cid=C033RQ5SPDH

General idea is that it's too much hassle to get the generic bundle of traits to work for all cloud providers' SDKs, and really we only care about uploading from `File`s and `Bytes`, so we can just directly pass those to `upload()` and let it do the right thing.

Specifically, this PR changes upload() from taking
```
from: impl io::AsyncRead + Unpin + Send + Sync + 'static,
```
to
```
from: UploadSource,
```
where `UploadSource` is an enum that's either a `File` or `Bytes`.

This change conflicts with #5446.