### PR TITLE
Fix safekeeper log spans

### DIFF
--- a/safekeeper/src/wal_service.rs
+++ b/safekeeper/src/wal_service.rs
@@ -36,14 +36,14 @@ pub async fn task_main(
         let conf = conf.clone();
         let conn_id = issue_connection_id(&mut connection_count);
 
-        tokio::spawn(async move {
-            if let Err(err) = handle_socket(socket, conf, conn_id, allowed_auth_scope)
-                .instrument(info_span!("", cid = %conn_id))
-                .await
-            {
-                error!("connection handler exited: {}", err);
+        tokio::spawn(
+            async move {
+                if let Err(err) = handle_socket(socket, conf, conn_id, allowed_auth_scope).await {
+                    error!("connection handler exited: {}", err);
+                }
             }
-        });
+            .instrument(info_span!("", cid = %conn_id, ttid = field::Empty)),
+        );
     }
 }
 


### PR DESCRIPTION
We were missing spans with ttid in "WAL backup" and several other places, this commit should fix it.

Here are the examples of logs before and after: https://gist.github.com/petuhovskiy/711a4a4e7ddde3cab3fa6419b2f70fb9