### PR TITLE
add tokio metrics collector

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,7 +16,6 @@ opt-level = 1
 # This is only present for local builds, as it will be overridden
 # by the RUSTDOCFLAGS env var in CI.
 rustdocflags = ["-Arustdoc::private_intra_doc_links"]
-rustflags = ["--cfg=tokio_unstable"]
 
 [alias]
 build_testing = ["build", "--features", "testing"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,6 +16,7 @@ opt-level = 1
 # This is only present for local builds, as it will be overridden
 # by the RUSTDOCFLAGS env var in CI.
 rustdocflags = ["-Arustdoc::private_intra_doc_links"]
+rustflags = ["--cfg=tokio_unstable"]
 
 [alias]
 build_testing = ["build", "--features", "testing"]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -184,9 +184,14 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ debug, release ]
+        # add tokio_unstable on debug
+        include:
+          - build_type: debug
+            rustflags: "--cfg=tokio_unstable"
     env:
       BUILD_TYPE: ${{ matrix.build_type }}
       GIT_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
+      RUSTFLAGS: ${{ matrix.rustflags }}
 
     steps:
       - name: Fix git ownership

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,9 +2676,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -2790,6 +2790,7 @@ dependencies = [
  "libc",
  "once_cell",
  "prometheus",
+ "tokio",
  "workspace_hack",
 ]
 
@@ -5357,18 +5358,18 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ tar = "0.4"
 test-context = "0.1"
 thiserror = "1.0"
 tls-listener = { version = "0.7", features = ["rustls", "hyper-h1"] }
-tokio = { version = "1.17", features = ["macros"] }
+tokio = { version = "1.29", features = ["macros"] }
 tokio-io-timeout = "1.2.0"
 tokio-postgres-rustls = "0.10.0"
 tokio-rustls = "0.24"

--- a/libs/metrics/Cargo.toml
+++ b/libs/metrics/Cargo.toml
@@ -9,5 +9,6 @@ prometheus.workspace = true
 libc.workspace = true
 once_cell.workspace = true
 chrono.workspace = true
+tokio.workspace = true
 
 workspace_hack.workspace = true

--- a/libs/metrics/src/lib.rs
+++ b/libs/metrics/src/lib.rs
@@ -21,6 +21,9 @@ pub use prometheus::{register_int_gauge_vec, IntGaugeVec};
 pub use prometheus::{Encoder, TextEncoder};
 use prometheus::{Registry, Result};
 
+#[cfg(tokio_unstable)]
+pub mod tokio_metrics;
+
 pub mod launch_timestamp;
 mod wrappers;
 pub use wrappers::{CountedReader, CountedWriter};

--- a/libs/metrics/src/lib.rs
+++ b/libs/metrics/src/lib.rs
@@ -21,7 +21,6 @@ pub use prometheus::{register_int_gauge_vec, IntGaugeVec};
 pub use prometheus::{Encoder, TextEncoder};
 use prometheus::{Registry, Result};
 
-#[cfg(tokio_unstable)]
 pub mod tokio_metrics;
 
 pub mod launch_timestamp;

--- a/libs/metrics/src/tokio_metrics.rs
+++ b/libs/metrics/src/tokio_metrics.rs
@@ -1,0 +1,307 @@
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+use prometheus::{
+    core::Desc,
+    proto::{self, LabelPair},
+};
+
+#[derive(Default)]
+pub struct TokioCollector {
+    handles: Vec<tokio::runtime::Handle>,
+}
+
+impl TokioCollector {
+    pub fn add_runtime(&mut self, handle: tokio::runtime::Handle) {
+        self.handles.push(handle);
+    }
+
+    fn guage(
+        &self,
+        desc: &Desc,
+        f: impl Fn(&tokio::runtime::RuntimeMetrics) -> f64,
+    ) -> proto::MetricFamily {
+        self.metric(desc, proto::MetricType::GAUGE, |rt| {
+            let mut g = proto::Gauge::default();
+            g.set_value(f(rt));
+            let mut m = proto::Metric::default();
+            m.set_gauge(g);
+            m
+        })
+    }
+
+    fn metric(
+        &self,
+        desc: &Desc,
+        typ: proto::MetricType,
+        f: impl Fn(&tokio::runtime::RuntimeMetrics) -> proto::Metric,
+    ) -> proto::MetricFamily {
+        let mut m = proto::MetricFamily::default();
+        m.set_name(desc.fq_name.clone());
+        m.set_help(desc.help.clone());
+        m.set_field_type(typ);
+        let mut metrics = vec![];
+        for rt in &self.handles {
+            let rt_metrics = rt.metrics();
+            let mut m = f(&rt_metrics);
+
+            let mut label_id = LabelPair::default();
+            label_id.set_name("id".to_owned());
+            label_id.set_value(rt.id().to_string());
+
+            m.set_label(vec![label_id]);
+            metrics.push(m);
+        }
+
+        m.set_metric(metrics);
+        m
+    }
+
+    // fn guage_per_worker(
+    //     &self,
+    //     desc: &Desc,
+    //     f: impl Fn(&tokio::runtime::RuntimeMetrics, usize) -> f64,
+    // ) -> proto::MetricFamily {
+    //     self.metric_per_worker(desc, proto::MetricType::GAUGE, |m, i| {
+    //         let mut g = proto::Gauge::default();
+    //         g.set_value(f(m, i));
+    //         let mut m = proto::Metric::default();
+    //         m.set_gauge(g);
+    //         m
+    //     })
+    // }
+
+    fn counter_per_worker(
+        &self,
+        desc: &Desc,
+        f: impl Fn(&tokio::runtime::RuntimeMetrics, usize) -> f64,
+    ) -> proto::MetricFamily {
+        self.metric_per_worker(desc, proto::MetricType::COUNTER, |m, i| {
+            let mut g = proto::Counter::default();
+            g.set_value(f(m, i));
+            let mut m = proto::Metric::default();
+            m.set_counter(g);
+            m
+        })
+    }
+
+    fn metric_per_worker(
+        &self,
+        desc: &Desc,
+        typ: proto::MetricType,
+        f: impl Fn(&tokio::runtime::RuntimeMetrics, usize) -> proto::Metric,
+    ) -> proto::MetricFamily {
+        let mut m = proto::MetricFamily::default();
+        m.set_name(desc.fq_name.clone());
+        m.set_help(desc.help.clone());
+        m.set_field_type(typ);
+        let mut metrics = vec![];
+        for rt in &self.handles {
+            let rt_metrics = rt.metrics();
+            let workers = rt_metrics.num_workers();
+
+            for i in 0..workers {
+                let mut m = f(&rt_metrics, i);
+
+                let mut label_id = LabelPair::default();
+                label_id.set_name("id".to_owned());
+                label_id.set_value(rt.id().to_string());
+
+                let mut label_worker = LabelPair::default();
+                label_worker.set_name("worker".to_owned());
+                label_worker.set_value(i.to_string());
+
+                m.set_label(vec![label_id, label_worker]);
+                metrics.push(m);
+            }
+        }
+
+        m.set_metric(metrics);
+        m
+    }
+}
+
+static ACTIVE_TASK_COUNT: Lazy<Desc> = Lazy::new(|| {
+    Desc::new(
+        "tokio_active_task_count_total".to_owned(),
+        "the number of active tasks in the runtime".to_owned(),
+        vec!["id".to_owned()],
+        HashMap::default(),
+    )
+    .expect("should be a valid description")
+});
+static WORKER_STEAL_COUNT: Lazy<Desc> = Lazy::new(|| {
+    Desc::new(
+        "tokio_worker_steal_count_total".to_owned(),
+        "the number of tasks the given worker thread stole from another worker thread".to_owned(),
+        vec!["id".to_owned(), "worker".to_owned()],
+        HashMap::default(),
+    )
+    .expect("should be a valid description")
+});
+
+impl prometheus::core::Collector for TokioCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&ACTIVE_TASK_COUNT, &WORKER_STEAL_COUNT]
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        vec![
+            self.guage(&ACTIVE_TASK_COUNT, |m| m.active_tasks_count() as f64),
+            self.counter_per_worker(&WORKER_STEAL_COUNT, |m, i| m.worker_steal_count(i) as f64),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use prometheus::{Registry, TextEncoder};
+    use tokio::{runtime, sync::Mutex, task::JoinSet};
+
+    use crate::tokio_metrics::TokioCollector;
+
+    #[tokio::test]
+    async fn gather() {
+        let registry = Registry::new();
+        let mut collector = TokioCollector::default();
+        collector.add_runtime(tokio::runtime::Handle::current());
+        registry.register(Box::new(collector)).unwrap();
+
+        let lock = Arc::new(Mutex::new(0));
+        let guard = lock.lock().await;
+        let mut joinset = JoinSet::new();
+        for _ in 0..10 {
+            let lock = lock.clone();
+            joinset.spawn(async move {
+                let mut _guard = lock.lock().await;
+            });
+        }
+
+        let text = TextEncoder.encode_to_string(&registry.gather()).unwrap();
+        assert_eq!(
+            text,
+            r#"# HELP tokio_active_task_count_total the number of active tasks in the runtime
+# TYPE tokio_active_task_count_total gauge
+tokio_active_task_count_total{id="1"} 10
+# HELP tokio_worker_steal_count_total the number of tasks the given worker thread stole from another worker thread
+# TYPE tokio_worker_steal_count_total counter
+tokio_worker_steal_count_total{id="1",worker="0"} 0
+"#
+        );
+
+        drop(guard);
+        while let Some(_x) = joinset.join_next().await {}
+
+        let text = TextEncoder.encode_to_string(&registry.gather()).unwrap();
+        assert_eq!(
+            text,
+            r#"# HELP tokio_active_task_count_total the number of active tasks in the runtime
+# TYPE tokio_active_task_count_total gauge
+tokio_active_task_count_total{id="1"} 0
+# HELP tokio_worker_steal_count_total the number of tasks the given worker thread stole from another worker thread
+# TYPE tokio_worker_steal_count_total counter
+tokio_worker_steal_count_total{id="1",worker="0"} 0
+"#
+        );
+    }
+
+    #[test]
+    fn gather_multiple_runtimes() {
+        let registry = Registry::new();
+        let mut collector = TokioCollector::default();
+
+        let runtime1 = runtime::Builder::new_current_thread().build().unwrap();
+        let runtime2 = runtime::Builder::new_current_thread().build().unwrap();
+
+        collector.add_runtime(runtime1.handle().clone());
+        collector.add_runtime(runtime2.handle().clone());
+
+        registry.register(Box::new(collector)).unwrap();
+
+        std::thread::scope(|s| {
+            let lock1 = Arc::new(Mutex::new(0));
+            let lock2 = Arc::new(Mutex::new(0));
+
+            let guard1 = lock1.clone().try_lock_owned().unwrap();
+            let guard2 = lock2.clone().try_lock_owned().unwrap();
+
+            s.spawn(move || {
+                runtime1.block_on(async {
+                    let mut joinset = JoinSet::new();
+                    for _ in 0..5 {
+                        let lock = lock1.clone();
+                        joinset.spawn(async move {
+                            let mut _guard = lock.lock().await;
+                        });
+                    }
+                    while let Some(_x) = joinset.join_next().await {}
+                })
+            });
+
+            s.spawn(move || {
+                runtime2.block_on(async {
+                    let mut joinset = JoinSet::new();
+                    for _ in 0..5 {
+                        let lock = lock2.clone();
+                        joinset.spawn(async move {
+                            let mut _guard = lock.lock().await;
+                        });
+                    }
+                    while let Some(_x) = joinset.join_next().await {}
+                })
+            });
+
+            std::thread::sleep(Duration::from_millis(10));
+
+            let text = TextEncoder.encode_to_string(&registry.gather()).unwrap();
+            assert_eq!(
+                text,
+                r#"# HELP tokio_active_task_count_total the number of active tasks in the runtime
+# TYPE tokio_active_task_count_total gauge
+tokio_active_task_count_total{id="1"} 5
+tokio_active_task_count_total{id="2"} 5
+# HELP tokio_worker_steal_count_total the number of tasks the given worker thread stole from another worker thread
+# TYPE tokio_worker_steal_count_total counter
+tokio_worker_steal_count_total{id="1",worker="0"} 0
+tokio_worker_steal_count_total{id="2",worker="0"} 0
+"#
+            );
+
+            drop(guard1);
+            std::thread::sleep(Duration::from_millis(10));
+
+            let text = TextEncoder.encode_to_string(&registry.gather()).unwrap();
+            assert_eq!(
+                text,
+                r#"# HELP tokio_active_task_count_total the number of active tasks in the runtime
+# TYPE tokio_active_task_count_total gauge
+tokio_active_task_count_total{id="1"} 0
+tokio_active_task_count_total{id="2"} 5
+# HELP tokio_worker_steal_count_total the number of tasks the given worker thread stole from another worker thread
+# TYPE tokio_worker_steal_count_total counter
+tokio_worker_steal_count_total{id="1",worker="0"} 0
+tokio_worker_steal_count_total{id="2",worker="0"} 0
+"#
+            );
+
+            drop(guard2);
+            std::thread::sleep(Duration::from_millis(10));
+
+            let text = TextEncoder.encode_to_string(&registry.gather()).unwrap();
+            assert_eq!(
+                text,
+                r#"# HELP tokio_active_task_count_total the number of active tasks in the runtime
+# TYPE tokio_active_task_count_total gauge
+tokio_active_task_count_total{id="1"} 0
+tokio_active_task_count_total{id="2"} 0
+# HELP tokio_worker_steal_count_total the number of tasks the given worker thread stole from another worker thread
+# TYPE tokio_worker_steal_count_total counter
+tokio_worker_steal_count_total{id="1",worker="0"} 0
+tokio_worker_steal_count_total{id="2",worker="0"} 0
+"#
+            );
+        });
+    }
+}

--- a/libs/metrics/src/tokio_metrics.rs
+++ b/libs/metrics/src/tokio_metrics.rs
@@ -158,6 +158,7 @@ impl prometheus::core::Collector for TokioCollector {
 }
 
 #[cfg(test)]
+#[cfg(tokio_unstable)]
 mod tests {
     use std::{sync::Arc, time::Duration};
 
@@ -166,7 +167,6 @@ mod tests {
 
     use crate::tokio_metrics::TokioCollector;
 
-    // this will get flaky if we have other tokio tests in this crate...
     #[test]
     fn gather_multiple_runtimes() {
         let registry = Registry::new();

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1639,6 +1639,9 @@ pub fn make_router(
     launch_ts: &'static LaunchTimestamp,
     auth: Option<Arc<JwtAuth>>,
 ) -> anyhow::Result<RouterBuilder<hyper::Body, ApiError>> {
+    // for the /metrics endpoint
+    crate::task_mgr::runtime_collector().register()?;
+
     let spec = include_bytes!("openapi_spec.yml");
     let mut router = attach_openapi_ui(endpoint::make_router(), spec, "/swagger.yml", "/v1/doc");
     if auth.is_some() {

--- a/pageserver/src/task_mgr.rs
+++ b/pageserver/src/task_mgr.rs
@@ -151,8 +151,7 @@ pub(crate) static BACKGROUND_RUNTIME_WORKER_THREADS: Lazy<usize> = Lazy::new(|| 
 });
 
 pub fn runtime_collector() -> TokioCollector {
-    let mut collector = TokioCollector::default();
-    collector
+    TokioCollector::default()
         .add_runtime(
             COMPUTE_REQUEST_RUNTIME.handle().clone(),
             "compute".to_owned(),
@@ -162,8 +161,7 @@ pub fn runtime_collector() -> TokioCollector {
             WALRECEIVER_RUNTIME.handle().clone(),
             "walreceiver".to_owned(),
         )
-        .add_runtime(BACKGROUND_RUNTIME.handle().clone(), "background".to_owned());
-    collector
+        .add_runtime(BACKGROUND_RUNTIME.handle().clone(), "background".to_owned())
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -1,3 +1,4 @@
+use ::metrics::tokio_metrics::TokioCollector;
 use futures::future::Either;
 use proxy::auth;
 use proxy::config::AuthenticationConfig;
@@ -97,6 +98,10 @@ async fn main() -> anyhow::Result<()> {
     let _logging_guard = proxy::logging::init().await?;
     let _panic_hook_guard = utils::logging::replace_panic_hook_with_tracing_panic_hook();
     let _sentry_guard = init_sentry(Some(GIT_VERSION.into()), &[]);
+
+    TokioCollector::default()
+        .add_runtime(tokio::runtime::Handle::current(), "main".to_owned())
+        .register()?;
 
     info!("Version: {GIT_VERSION}");
     ::metrics::set_build_info_metric(GIT_VERSION);

--- a/safekeeper/src/bin/safekeeper.rs
+++ b/safekeeper/src/bin/safekeeper.rs
@@ -29,13 +29,13 @@ use safekeeper::defaults::{
     DEFAULT_HEARTBEAT_TIMEOUT, DEFAULT_HTTP_LISTEN_ADDR, DEFAULT_MAX_OFFLOADER_LAG_BYTES,
     DEFAULT_PG_LISTEN_ADDR,
 };
-use safekeeper::wal_service;
 use safekeeper::GlobalTimelines;
 use safekeeper::SafeKeeperConf;
 use safekeeper::{broker, WAL_SERVICE_RUNTIME};
 use safekeeper::{control_file, BROKER_RUNTIME};
 use safekeeper::{http, WAL_REMOVER_RUNTIME};
 use safekeeper::{remove_wal, WAL_BACKUP_RUNTIME};
+use safekeeper::{runtime_collector, wal_service};
 use safekeeper::{wal_backup, HTTP_RUNTIME};
 use storage_broker::DEFAULT_ENDPOINT;
 use utils::auth::{JwtAuth, Scope};
@@ -339,6 +339,10 @@ async fn start_safekeeper(conf: SafeKeeperConf) -> Result<()> {
     // after daemonizing, otherwise process collector will be upset.
     let timeline_collector = safekeeper::metrics::TimelineCollector::new();
     metrics::register_internal(Box::new(timeline_collector))?;
+
+    runtime_collector()
+        .add_runtime(Handle::current(), "main".to_owned())
+        .register()?;
 
     let (wal_backup_launcher_tx, wal_backup_launcher_rx) = mpsc::channel(100);
 

--- a/safekeeper/src/lib.rs
+++ b/safekeeper/src/lib.rs
@@ -1,3 +1,4 @@
+use ::metrics::tokio_metrics::TokioCollector;
 use camino::Utf8PathBuf;
 use once_cell::sync::Lazy;
 use remote_storage::RemoteStorageConfig;
@@ -165,3 +166,22 @@ pub static METRICS_SHIFTER_RUNTIME: Lazy<Runtime> = Lazy::new(|| {
         .build()
         .expect("Failed to create broker runtime")
 });
+
+pub fn runtime_collector() -> TokioCollector {
+    TokioCollector::default()
+        .add_runtime(
+            WAL_SERVICE_RUNTIME.handle().clone(),
+            "wal service".to_owned(),
+        )
+        .add_runtime(HTTP_RUNTIME.handle().clone(), "http".to_owned())
+        .add_runtime(BROKER_RUNTIME.handle().clone(), "broker".to_owned())
+        .add_runtime(
+            WAL_REMOVER_RUNTIME.handle().clone(),
+            "wal remover".to_owned(),
+        )
+        .add_runtime(WAL_BACKUP_RUNTIME.handle().clone(), "wal backup".to_owned())
+        .add_runtime(
+            METRICS_SHIFTER_RUNTIME.handle().clone(),
+            "metric shifter".to_owned(),
+        )
+}


### PR DESCRIPTION
## Problem

It would be interesting to see runtime stats over time

## Summary of changes

Adds a prometheus collector for tokio runtime metrics.

TODO:

- [ ] Add more of the counters
- [ ] Try and get tokio to use counters instead of gauges
- [ ] Verify that it doesn't impact performance
- [ ] Confirm that 15 seconds prometheus scrape is enough to get interesting stats - otherwise perform eager aggregations

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
