### PR TITLE
Bump vm-builder v0.18.2 -> v0.18.5

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -847,7 +847,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.18.4
+      VM_BUILDER_VERSION: v0.18.5
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -847,7 +847,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.18.2
+      VM_BUILDER_VERSION: v0.18.4
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Applicable changes are:
- neondatabase/autoscaling#584, setting pgbouncer auth_dbname=postgres in order to fix superuser connections from preventing dropping databases.
- neondatabase/autoscaling#589, disabling pgbouncer prepared statements support by setting `max_prepared_statements=0`