### PR TITLE
fix: schedule_compaction_update must only unlink

### DIFF
--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -725,9 +725,9 @@ impl RemoteTimelineClient {
         for (name, gen) in &with_generations {
             if let Some(unexpected) = upload_queue.dangling_files.insert(name.to_owned(), *gen) {
                 if &unexpected == gen {
-                    panic!("{name} was unlinked twicew with same generation");
+                    tracing::error!("{name} was unlinked twice with same generation");
                 } else {
-                    panic!("{name} was unlinked twice with different generations {gen:?} and {unexpected:?}");
+                    tracing::error!("{name} was unlinked twice with different generations {gen:?} and {unexpected:?}");
                 }
             }
         }
@@ -767,22 +767,18 @@ impl RemoteTimelineClient {
 
         #[cfg(feature = "testing")]
         {
-            let mut errors = Vec::new();
             for (name, gen) in &with_generations {
                 match upload_queue.dangling_files.remove(name) {
                     Some(same) if &same == gen => { /* expected */ }
                     Some(other) => {
-                        errors.push(format!(
+                        tracing::error!(
                             "{name} was unlinked with {other:?} but deleted with {gen:?}"
-                        ));
+                        );
                     }
                     None => {
-                        errors.push(format!("{name} was unlinked but was not dangling"));
+                        tracing::error!("{name} was unlinked but was not dangling");
                     }
                 }
-            }
-            if !errors.is_empty() {
-                panic!("surprising deletions: {errors:?}");
             }
         }
 

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -766,18 +766,14 @@ impl RemoteTimelineClient {
         }
 
         #[cfg(feature = "testing")]
-        {
-            for (name, gen) in &with_generations {
-                match upload_queue.dangling_files.remove(name) {
-                    Some(same) if &same == gen => { /* expected */ }
-                    Some(other) => {
-                        tracing::error!(
-                            "{name} was unlinked with {other:?} but deleted with {gen:?}"
-                        );
-                    }
-                    None => {
-                        tracing::error!("{name} was unlinked but was not dangling");
-                    }
+        for (name, gen) in &with_generations {
+            match upload_queue.dangling_files.remove(name) {
+                Some(same) if &same == gen => { /* expected */ }
+                Some(other) => {
+                    tracing::error!("{name} was unlinked with {other:?} but deleted with {gen:?}");
+                }
+                None => {
+                    tracing::error!("{name} was unlinked but was not dangling");
                 }
             }
         }

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -807,9 +807,7 @@ impl RemoteTimelineClient {
 
         let names = compacted_from.iter().map(|x| x.layer_desc().filename());
 
-        let with_generations =
-            self.schedule_unlinking_of_layers_from_index_part0(upload_queue, names);
-        self.schedule_deletion_of_unlinked0(upload_queue, with_generations);
+        self.schedule_unlinking_of_layers_from_index_part0(upload_queue, names);
         self.launch_queued_tasks(upload_queue);
 
         Ok(())

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -80,6 +80,11 @@ pub(crate) struct UploadQueueInitialized {
     /// tasks to finish. For example, metadata upload cannot be performed before all
     /// preceding layer file uploads have completed.
     pub(crate) queued_operations: VecDeque<UploadOp>,
+
+    /// Files which have been unlinked but not yet had scheduled a deletion for. Only kept around
+    /// for asserting.
+    #[cfg(feature = "testing")]
+    pub(crate) dangling_files: HashMap<LayerFileName, Generation>,
 }
 
 impl UploadQueueInitialized {
@@ -136,6 +141,8 @@ impl UploadQueue {
             num_inprogress_deletions: 0,
             inprogress_tasks: HashMap::new(),
             queued_operations: VecDeque::new(),
+            #[cfg(feature = "testing")]
+            dangling_files: HashMap::new(),
         };
 
         *self = UploadQueue::Initialized(state);
@@ -181,6 +188,8 @@ impl UploadQueue {
             num_inprogress_deletions: 0,
             inprogress_tasks: HashMap::new(),
             queued_operations: VecDeque::new(),
+            #[cfg(feature = "testing")]
+            dangling_files: HashMap::new(),
         };
 
         *self = UploadQueue::Initialized(state);

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -82,7 +82,10 @@ pub(crate) struct UploadQueueInitialized {
     pub(crate) queued_operations: VecDeque<UploadOp>,
 
     /// Files which have been unlinked but not yet had scheduled a deletion for. Only kept around
-    /// for asserting.
+    /// for error logging.
+    ///
+    /// Putting this behind a testing feature to catch problems in tests, but assuming we could have a
+    /// bug causing leaks, then it's better to not leave this enabled for production builds.
     #[cfg(feature = "testing")]
     pub(crate) dangling_files: HashMap<LayerFileName, Generation>,
 }


### PR DESCRIPTION
#5649 added the concept of dangling layers which #4938 uses but only partially. I forgot to change `schedule_compaction_update` to not schedule deletions to uphold the "have a layer, you can read it".

With the now remembered fix, I don't think these checks should ever fail except for a mistake I already did. These changes might be useful for protecting future changes, even though the Layer carrying the generation AND the `schedule_(gc|compaction)_update` require strong arcs.

Rationale for keeping the `#[cfg(feature = "testing")]` is worsening any leak situation which might come up.