### PR TITLE
s3_scrubber: prepare for scrubbing buckets with generation-aware content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4430,6 +4430,7 @@ dependencies = [
  "itertools",
  "pageserver",
  "rand 0.8.5",
+ "remote_storage",
  "reqwest",
  "serde",
  "serde_json",

--- a/libs/utils/src/generation.rs
+++ b/libs/utils/src/generation.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// See docs/rfcs/025-generation-numbers.md for detail on how generation
 /// numbers are used.
-#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub enum Generation {
     // Generations with this magic value will not add a suffix to S3 keys, and will not
     // be included in persisted index_part.json.  This value is only to be used

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1542,7 +1542,7 @@ pub fn remote_index_path(
 }
 
 /// Given the key of an index, parse out the generation part of the name
-pub(crate) fn parse_remote_index_path(path: RemotePath) -> Option<Generation> {
+pub fn parse_remote_index_path(path: RemotePath) -> Option<Generation> {
     let file_name = match path.get_path().file_name() {
         Some(f) => f,
         None => {

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -155,7 +155,7 @@ pub struct IndexLayerMetadata {
 
     #[serde(default = "Generation::none")]
     #[serde(skip_serializing_if = "Generation::is_none")]
-    pub(super) generation: Generation,
+    pub generation: Generation,
 }
 
 impl From<LayerFileMetadata> for IndexLayerMetadata {

--- a/s3_scrubber/Cargo.toml
+++ b/s3_scrubber/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { workspace = true, default-features = false, features = ["rustls-tls"
 aws-config = { workspace = true, default-features = false, features = ["rustls", "credentials-sso"] }
 
 pageserver = { path = "../pageserver" }
+remote_storage = { path = "../libs/remote_storage" }
 
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/s3_scrubber/src/checks.rs
+++ b/s3_scrubber/src/checks.rs
@@ -222,10 +222,10 @@ pub(crate) enum BlobDataParseResult {
 fn parse_layer_object_name(name: &str) -> Result<(LayerFileName, Generation), String> {
     match name.rsplit_once('-') {
         // FIXME: this is gross, just use a regex?
-        Some(gen) if gen.1.len() == 8 => {
-            let layer = gen.0.parse::<LayerFileName>()?;
+        Some((layer_filename, gen)) if gen.len() == 8 => {
+            let layer = layer_filename.parse::<LayerFileName>()?;
             let gen =
-                Generation::parse_suffix(gen.1).ok_or("Malformed generation suffix".to_string())?;
+                Generation::parse_suffix(gen).ok_or("Malformed generation suffix".to_string())?;
             Ok((layer, gen))
         }
         _ => Ok((name.parse::<LayerFileName>()?, Generation::none())),

--- a/s3_scrubber/src/checks.rs
+++ b/s3_scrubber/src/checks.rs
@@ -259,7 +259,7 @@ pub(crate) async fn list_timeline_blobs(
         let blob_name = key.strip_prefix(&timeline_dir_target.prefix_in_bucket);
         match blob_name {
             Some(name) if name.starts_with("index_part.json") => {
-                tracing::info!("Index key {}", key);
+                tracing::info!("Index key {key}");
                 index_parts.push(obj)
             }
             Some(maybe_layer_name) => match parse_layer_object_name(maybe_layer_name) {
@@ -268,7 +268,7 @@ pub(crate) async fn list_timeline_blobs(
                     s3_layers.insert((new_layer, gen));
                 }
                 Err(e) => {
-                    tracing::info!("Error parsing key {}", maybe_layer_name);
+                    tracing::info!("Error parsing key {maybe_layer_name}");
                     errors.push(
                         format!("S3 list response got an object with key {key} that is not a layer name: {e}"),
                     );

--- a/s3_scrubber/src/checks.rs
+++ b/s3_scrubber/src/checks.rs
@@ -120,7 +120,7 @@ pub(crate) async fn branch_cleanup_and_check_errors(
                             // correct, we need to try sending a HEAD request for the
                             // layer we think is missing.
                             result.errors.push(format!(
-                                "index_part.json contains a layer {}{} that is not present in S3",
+                                "index_part.json contains a layer {}{} that is not present in remote storage",
                                 layer_map_key.0.file_name(),
                                 layer_map_key.1.get_suffix()
                             ))

--- a/s3_scrubber/src/metadata_stream.rs
+++ b/s3_scrubber/src/metadata_stream.rs
@@ -13,10 +13,10 @@ pub fn stream_tenants<'a>(
 ) -> impl Stream<Item = anyhow::Result<TenantId>> + 'a {
     try_stream! {
         let mut continuation_token = None;
+        let tenants_target = target.tenants_root();
         loop {
-            let tenants_target = target.tenants_root();
             let fetch_response =
-                list_objects_with_retries(s3_client, tenants_target, continuation_token.clone()).await?;
+                list_objects_with_retries(s3_client, &tenants_target, continuation_token.clone()).await?;
 
             let new_entry_ids = fetch_response
                 .common_prefixes()

--- a/s3_scrubber/src/scan_metadata.rs
+++ b/s3_scrubber/src/scan_metadata.rs
@@ -10,8 +10,10 @@ use aws_sdk_s3::Client;
 use futures_util::{pin_mut, StreamExt, TryStreamExt};
 use histogram::Histogram;
 use pageserver::tenant::IndexPart;
+use serde::Serialize;
 use utils::id::TenantTimelineId;
 
+#[derive(Serialize)]
 pub struct MetadataSummary {
     count: usize,
     with_errors: HashSet<TenantTimelineId>,
@@ -25,7 +27,9 @@ pub struct MetadataSummary {
 }
 
 /// A histogram plus minimum and maximum tracking
+#[derive(Serialize)]
 struct MinMaxHisto {
+    #[serde(skip)]
     histo: Histogram,
     min: u64,
     max: u64,

--- a/s3_scrubber/src/scan_metadata.rs
+++ b/s3_scrubber/src/scan_metadata.rs
@@ -113,6 +113,7 @@ impl MetadataSummary {
         self.count += 1;
         if let BlobDataParseResult::Parsed {
             index_part,
+            index_part_generation: _,
             s3_layers: _,
         } = &data.blob_data
         {

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -35,6 +35,7 @@ def subprocess_capture(
     echo_stderr=False,
     echo_stdout=False,
     capture_stdout=False,
+    timeout=None,
     **kwargs: Any,
 ) -> Tuple[str, Optional[str], int]:
     """Run a process and bifurcate its output to files and the `log` logger
@@ -104,7 +105,7 @@ def subprocess_capture(
                 stderr_handler = OutputHandler(p.stderr, stderr_f, echo=echo_stderr, capture=False)
                 stderr_handler.start()
 
-                r = p.wait()
+                r = p.wait(timeout=timeout)
 
                 stdout_handler.join()
                 stderr_handler.join()


### PR DESCRIPTION
## Problem

The scrubber didn't know how to find the latest index_part when generations were in use.

## Summary of changes

- Teach the scrubber to do the same dance that pageserver does when finding the latest index_part.json
- Teach the scrubber how to understand layer files with generation suffixes.
- General improvement to testability: scan_metadata has a machine readable output that the testing `S3Scrubber` wrapper can read.
- Existing test coverage of scrubber was false-passing because it just didn't see any data due to prefixing of data in the bucket.  Fix that.

This is incremental improvement: the more confidence we can have in the scrubber, the more we can use it in integration tests to validate the state of remote storage.