### PR TITLE
tests: fix missing comma  in test_timeline_deletion_with_files_stuck_…

### DIFF
--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -585,9 +585,11 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
     # checkpoint operations. Hence, checkpoint is allowed to fail now.
     log.info("sending delete request")
     checkpoint_allowed_to_fail.set()
-    env.pageserver.allowed_errors.append(
-        ".* ERROR .*Error processing HTTP request: InternalServerError\\(The timeline or pageserver is shutting down"
-        ".* ERROR .*[Cc]ould not flush frozen layer.*"
+    env.pageserver.allowed_errors.extend(
+        [
+            ".* ERROR .*Error processing HTTP request: InternalServerError\\(The timeline or pageserver is shutting down",
+            ".* ERROR .*[Cc]ould not flush frozen layer.*",
+        ]
     )
 
     # Generous timeout, because currently deletions can get blocked waiting for compaction


### PR DESCRIPTION
…in_upload_queue

This was a syntax mistake in https://github.com/neondatabase/neon/pull/5149

We didn't notice because the situation the log allow list covers is a relative rare race.