### PR TITLE
Simplify PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,3 @@
 ## Problem
 
 ## Summary of changes
-
-## Checklist before requesting a review
-
-- [ ] I have performed a self-review of my code.
-- [ ] If it is a core feature, I have added thorough tests.
-- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
-- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.
-
-## Checklist before merging
-
-- [ ] Do not forget to reformat commit message to not include the above checklist


### PR DESCRIPTION
## Problem
Our PR template has a condescending checklist about adding tests, adding metrics, etc. But in reality, deciding when tests/metrics are important takes good engineering judgement and the checklist doesn't help. It's the job of the code reviewer to stop a PR that has an uncomfortably low amount of tests. Right now everyone ignores this checklist and leaves it blank, so it's just adding noise and reinforcing our habits of ignoring our own process. It's better not to have it.

There is one point in the checklist that actually contains useful information: `If this PR requires public announcement, mark it with /release-notes label`, but it's invisible because it's surrounded by useless words we've been trained to ignore. I have some doubts about removing this point, but at the same time I'm not sure how effective it is. This instruction is not very specific about what requires public announcement so it will be interpreted differently by anyone. I would not rely on it.

Announcements are a matter of devrel. The information that an engineer can provide is: is there a breaking change? is there a new user-visible feature? Is the change backwards-compatible (would rollback work)? Etc. And if we want these labels to be reliable, we should require the PR author to say either "breaking change" or "no breaking change". Otherwise people will forget and the label cannot be trusted. I'm not sure exactly what's the right move (someone with more knowledge of github tricks might know better (cc @bayandin ?)) but the checklist is not helping.

See also https://neondb.slack.com/archives/C033RQ5SPDH/p1698422366833229 Relying on the right person to be present during the rollback is an error-prone practice. Maybe it can be addressed.

Opinions are welcome.

## Summary of changes
Removed checklist from PR template.
