### PR TITLE
Proxy introduce allowed ips

### DIFF
--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -119,7 +119,7 @@ async fn main() -> anyhow::Result<()> {
     let mgmt_listener = TcpListener::bind(mgmt_address).await?;
 
     let proxy_address: SocketAddr = args.proxy.parse()?;
-    info!("Starting PROXY on {proxy_address}");
+    info!("Starting proxy on {proxy_address}");
     let proxy_listener = TcpListener::bind(proxy_address).await?;
     let cancellation_token = CancellationToken::new();
 

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -119,7 +119,7 @@ async fn main() -> anyhow::Result<()> {
     let mgmt_listener = TcpListener::bind(mgmt_address).await?;
 
     let proxy_address: SocketAddr = args.proxy.parse()?;
-    info!("Starting proxy on {proxy_address}");
+    info!("Starting PROXY on {proxy_address}");
     let proxy_listener = TcpListener::bind(proxy_address).await?;
     let cancellation_token = CancellationToken::new();
 

--- a/proxy/src/console/messages.rs
+++ b/proxy/src/console/messages.rs
@@ -13,6 +13,7 @@ pub struct ConsoleError {
 #[derive(Deserialize)]
 pub struct GetRoleSecret {
     pub role_secret: Box<str>,
+    pub allowed_ips: Option<Vec<Box<str>>>,
 }
 
 // Manually implement debug to omit sensitive info.
@@ -28,7 +29,6 @@ impl fmt::Debug for GetRoleSecret {
 pub struct WakeCompute {
     pub address: Box<str>,
     pub aux: MetricsAuxInfo,
-    pub allowed_ips: Option<Vec<Box<str>>>,
 }
 
 /// Async response which concludes the link auth flow.
@@ -191,19 +191,27 @@ mod tests {
 
     #[test]
     fn parse_wake_compute() -> anyhow::Result<()> {
-        // Empty `allowed_ips` field.
         let json = json!({
             "address": "0.0.0.0",
             "aux": dummy_aux(),
         });
         let _: WakeCompute = serde_json::from_str(&json.to_string())?;
+        Ok(())
+    }
+
+    #[test]
+    fn parse_get_role_secret() -> anyhow::Result<()> {
         // Empty `allowed_ips` field.
         let json = json!({
-            "address": "0.0.0.0",
-            "aux": dummy_aux(),
+            "role_secret": "secret",
+        });
+        let _: GetRoleSecret = serde_json::from_str(&json.to_string())?;
+        // Empty `allowed_ips` field.
+        let json = json!({
+            "role_secret": "secret",
             "allowed_ips": ["8.8.8.8"],
         });
-        let _: WakeCompute = serde_json::from_str(&json.to_string())?;
+        let _: GetRoleSecret = serde_json::from_str(&json.to_string())?;
 
         Ok(())
     }

--- a/proxy/src/console/messages.rs
+++ b/proxy/src/console/messages.rs
@@ -28,6 +28,7 @@ impl fmt::Debug for GetRoleSecret {
 pub struct WakeCompute {
     pub address: Box<str>,
     pub aux: MetricsAuxInfo,
+    pub allowed_ips: Option<Vec<Box<str>>>,
 }
 
 /// Async response which concludes the link auth flow.
@@ -184,6 +185,25 @@ mod tests {
             "N.E.W": "forward compatibility check",
             "aux": dummy_aux(),
         }))?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_wake_compute() -> anyhow::Result<()> {
+        // Empty `allowed_ips` field.
+        let json = json!({
+            "address": "0.0.0.0",
+            "aux": dummy_aux(),
+        });
+        let _: WakeCompute = serde_json::from_str(&json.to_string())?;
+        // Empty `allowed_ips` field.
+        let json = json!({
+            "address": "0.0.0.0",
+            "aux": dummy_aux(),
+            "allowed_ips": ["8.8.8.8"],
+        });
+        let _: WakeCompute = serde_json::from_str(&json.to_string())?;
 
         Ok(())
     }


### PR DESCRIPTION
## Problem

Proxy doesn't accept wake_compute responses with the allowed IPs.

## Summary of changes

Extend wake_compute api to be able to return allowed_ips.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
