### PR TITLE
layer: fix livelock with no spawn_blocking

### DIFF
--- a/libs/utils/src/sync/heavier_once_cell.rs
+++ b/libs/utils/src/sync/heavier_once_cell.rs
@@ -95,6 +95,8 @@ impl<T> OnceCell<T> {
     }
 
     /// Returns a guard to an existing initialized value, if any.
+    ///
+    /// FIXME: this should be called "get_mut"
     pub fn get(&self) -> Option<Guard<'_, T>> {
         let guard = self.inner.lock().unwrap();
         if guard.value.is_some() {

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -863,6 +863,8 @@ impl LayerInner {
     fn info(&self, reset: LayerAccessStatsReset) -> HistoricLayerInfo {
         let layer_file_name = self.desc.filename().file_name();
 
+        // this is not accurate: we could have the file locally but there was a cancellation
+        // and now we are not in sync, or we are currently downloading it.
         let remote = self.inner.get().is_none();
 
         let access_stats = self.access_stats.as_api_model(reset);

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -651,6 +651,18 @@ impl LayerInner {
                         return Err(DownloadError::DownloadRequired);
                     }
 
+                    // FIXME: in this case it will not work -- we might even do a short download:
+                    // T1: get_or_maybe_download
+                    // T2: get_or_maybe_download -- locked behind semaphore
+                    // T1: spawn_download_and_wait spawns T3
+                    // T3: do some downloading
+                    // T1: gets cancelled
+                    // T2: acquire semaphore
+                    // T2: spawn_download_and_wait spawns T4
+                    // T3 and T4 are misbehaving because they download over the same tempfile
+                    //
+                    // this probably needs some API using which we can move the semaphore permit to
+                    // a spawned task?
                     self.spawn_download_and_wait(timeline).await?;
                 } else {
                     // the file is present locally, probably by a previous but cancelled call to
@@ -740,6 +752,12 @@ impl LayerInner {
         let (tx, rx) = tokio::sync::oneshot::channel();
         // this is sadly needed because of task_mgr::shutdown_tasks, otherwise we cannot
         // block tenant::mgr::remove_tenant_from_memory.
+        //
+        // also the localfs remote storage is not cancellation safe, and the download_layer_file
+        // uses a colliding file name for two or more concurrent invocations.
+        //
+        // FIXME: this needs to carry the initialization semaphore from heavier_once_cell::OnceCell
+        // into the task, and then out of it to avoid two concurrent downloads.
 
         let this: Arc<Self> = self.clone();
         crate::task_mgr::spawn(

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -622,6 +622,8 @@ impl LayerInner {
 
                 // check if we really need to be downloaded; could have been already downloaded by a
                 // cancelled previous attempt.
+                //
+                // FIXME: what if it's a directory? that is currently needs_download == true
                 let needs_download = self
                     .needs_download()
                     .await

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -587,6 +587,7 @@ impl LayerInner {
                 //
                 // use however late (compared to the initial expressing of wanted) as the
                 // "outcome" now
+                LAYER_IMPL_METRICS.inc_broadcast_lagged();
                 match self.inner.get() {
                     Some(_) => Err(EvictionError::Downloaded),
                     None => Ok(()),
@@ -1443,6 +1444,13 @@ impl LayerImplMetrics {
     fn inc_permanent_loading_failures(&self) {
         self.rare_counters
             .get_metric_with_label_values(&["permanent_loading_failure"])
+            .unwrap()
+            .inc();
+    }
+
+    fn inc_broadcast_lagged(&self) {
+        self.rare_counters
+            .get_metric_with_label_values(&["broadcast_lagged"])
             .unwrap()
             .inc();
     }


### PR DESCRIPTION
Fixes a livelock if there are layer downloading accesses while spawn_blocking queue is blocked, completing the original design of eviction "downloads always win." This was simply an omission of me rushing the original PR #4938.

Why are there no tests?

There are plenty of FIXME's I'll try to handle in follow-ups while tests run.

- [ ] use the token from deinit instead of reshuffling scheduling
- [ ] thread the init permit through layer download to avoid multiple at the same time
- [ ] remove download failed backoff, download_layer_file already has it
- [ ] restore on-demand download logging
- [ ] propagate cancellation to spawned download task at least