### PR TITLE
fix(layer): reinit on access before eviction happens 

### DIFF
--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -692,12 +692,10 @@ impl LayerInner {
 
                     return Ok(strong);
                 } else {
-                    // path to here:
-                    // 1. the on_downloaded_layer_drop is stuck on spawn_blocking queue
-                    // 2. is there something else?
+                    // path to here: the evict_blocking is stuck on spawn_blocking queue.
                     //
                     // reset the contents, deactivating the eviction and causing a
-                    // EvictionCancelled::LostToDownload.
+                    // EvictionCancelled::LostToDownload or EvictionCancelled::VersionCheckFailed.
                     locked.take_and_deinit()
                 }
             };
@@ -707,7 +705,7 @@ impl LayerInner {
 
             assert!(
                 matches!(weak, ResidentOrWantedEvicted::WantedEvicted(..)),
-                "unexpected {weak:?}, ResidentOrWantedEvicted::get has a bug"
+                "unexpected {weak:?}, ResidentOrWantedEvicted::get_and_upgrade has a bug"
             );
 
             permit = Some(_permit);

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -569,10 +569,11 @@ impl LayerInner {
 
         let mut rx = self.status.subscribe();
 
-        self.wanted_evicted.store(true, Ordering::Relaxed);
-
         let was_first = match self.inner.get() {
-            Some(mut either) => either.downgrade(),
+            Some(mut either) => {
+                self.wanted_evicted.store(true, Ordering::Relaxed);
+                either.downgrade()
+            }
             None => return Err(EvictionError::NotFound),
         };
 

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -863,6 +863,8 @@ impl LayerInner {
     fn info(&self, reset: LayerAccessStatsReset) -> HistoricLayerInfo {
         let layer_file_name = self.desc.filename().file_name();
 
+        // this is not accurate: we could have the file locally but there was a cancellation
+        // and now we are not in sync, or we are currently downloading it.
         let remote = self.inner.get().is_none();
 
         let access_stats = self.access_stats.as_api_model(reset);

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -622,6 +622,8 @@ impl LayerInner {
 
                 // check if we really need to be downloaded; could have been already downloaded by a
                 // cancelled previous attempt.
+                //
+                // FIXME: what if it's a directory? that is currently needs_download == true
                 let needs_download = self
                     .needs_download()
                     .await

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -587,6 +587,7 @@ impl LayerInner {
                 //
                 // use however late (compared to the initial expressing of wanted) as the
                 // "outcome" now
+                LAYER_IMPL_METRICS.inc_broadcast_lagged();
                 match self.inner.get() {
                     Some(_) => Err(EvictionError::Downloaded),
                     None => Ok(()),
@@ -1443,6 +1444,13 @@ impl LayerImplMetrics {
     fn inc_permanent_loading_failures(&self) {
         self.rare_counters
             .get_metric_with_label_values(&["permanent_loading_failure"])
+            .unwrap()
+            .inc();
+    }
+
+    fn inc_broadcast_lagged(&self) {
+        self.rare_counters
+            .get_metric_with_label_values(&["broadcast_lagged"])
             .unwrap()
             .inc();
     }


### PR DESCRIPTION
Right before merging, I added a loop to `fn LayerInner::get_or_maybe_download`, which was always supposed to be there. However I had forgotten to restart initialization instead of waiting for the eviction to happen to support original design goal of "eviction should always lose to redownload (or init)". This was wrong. After this fix, if `spawn_blocking` queue is blocked on something, nothing bad will happen.

Part of #5737.

Included is a bonus FIXME to be discussed or be left there.