### PR TITLE
feat(layer): cancellable get_or_maybe_download

### DIFF
--- a/libs/utils/src/sync/heavier_once_cell.rs
+++ b/libs/utils/src/sync/heavier_once_cell.rs
@@ -262,10 +262,7 @@ mod tests {
             let cell = cell.clone();
             let deinitialization_started = deinitialization_started.clone();
             async move {
-                let (answer, _permit) = cell
-                    .get()
-                    .expect("initialized to value")
-                    .take_and_deinit();
+                let (answer, _permit) = cell.get().expect("initialized to value").take_and_deinit();
                 assert_eq!(answer, initial);
 
                 deinitialization_started.wait().await;

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -695,7 +695,7 @@ impl LayerInner {
                 let (value, init_permit) = download(init_permit).await?;
                 let guard = self.inner.set(value, init_permit);
                 let strong = guard
-                    .get()
+                    .get_and_upgrade()
                     .expect("init creates strong reference, we held the init permit");
                 return Ok(strong);
             }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -693,7 +693,7 @@ impl LayerInner {
                 // use the already held initialization permit because it is impossible to hit the
                 // below paths anymore essentially limiting the max loop iterations to 2.
                 let (value, init_permit) = download(init_permit).await?;
-                let guard = self.inner.set(value, init_permit);
+                let mut guard = self.inner.set(value, init_permit);
                 let strong = guard
                     .get_and_upgrade()
                     .expect("init creates strong reference, we held the init permit");


### PR DESCRIPTION
With the layer implementation as was done in #4938, it is possible via cancellation to cause two concurrent downloads on the same path, due to how `RemoteTimelineClient::download_remote_layer` does tempfiles. Thread the init semaphore through the spawned task of downloading to make this impossible to happen.