### PR TITLE
Support custom types in broker

### DIFF
--- a/storage_broker/benches/rps.rs
+++ b/storage_broker/benches/rps.rs
@@ -3,9 +3,12 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use storage_broker::proto::subscribe_safekeeper_info_request::SubscriptionKey;
-use storage_broker::proto::TenantTimelineId as ProtoTenantTimelineId;
-use storage_broker::proto::{SafekeeperTimelineInfo, SubscribeSafekeeperInfoRequest};
+
+use storage_broker::proto::{
+    filter_tenant_timeline_id, FilterTenantTimelineId, MessageType, SubscribeByFilterRequest,
+    TenantTimelineId as ProtoTenantTimelineId, TypedMessage,
+};
+use storage_broker::proto::{SafekeeperTimelineInfo};
 
 use storage_broker::{BrokerClientChannel, DEFAULT_ENDPOINT};
 use tokio::time;
@@ -91,15 +94,21 @@ async fn subscribe(client: Option<BrokerClientChannel>, counter: Arc<AtomicU64>,
         None => storage_broker::connect(DEFAULT_ENDPOINT, Duration::from_secs(5)).unwrap(),
     };
 
-    let key = SubscriptionKey::TenantTimelineId(ProtoTenantTimelineId {
+    let ttid = ProtoTenantTimelineId {
         tenant_id: vec![0xFF; 16],
         timeline_id: tli_from_u64(i),
-    });
-    let request = SubscribeSafekeeperInfoRequest {
-        subscription_key: Some(key),
     };
-    let mut stream = client
-        .subscribe_safekeeper_info(request)
+
+    let request = SubscribeByFilterRequest {
+        types: vec![MessageType::SafekeeperTimelineInfo.into()],
+        tenant_timeline_id: Some(FilterTenantTimelineId {
+            mode: filter_tenant_timeline_id::Mode::SpecificTimeline.into(),
+            tenant_timeline_id: Some(ttid),
+        }),
+    };
+
+    let mut stream: tonic::Streaming<TypedMessage> = client
+        .subscribe_by_filter(request)
         .await
         .unwrap()
         .into_inner();

--- a/storage_broker/benches/rps.rs
+++ b/storage_broker/benches/rps.rs
@@ -4,11 +4,11 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 
+use storage_broker::proto::SafekeeperTimelineInfo;
 use storage_broker::proto::{
     filter_tenant_timeline_id, FilterTenantTimelineId, MessageType, SubscribeByFilterRequest,
     TenantTimelineId as ProtoTenantTimelineId, TypedMessage,
 };
-use storage_broker::proto::{SafekeeperTimelineInfo};
 
 use storage_broker::{BrokerClientChannel, DEFAULT_ENDPOINT};
 use tokio::time;

--- a/storage_broker/benches/rps.rs
+++ b/storage_broker/benches/rps.rs
@@ -6,8 +6,8 @@ use clap::Parser;
 
 use storage_broker::proto::SafekeeperTimelineInfo;
 use storage_broker::proto::{
-    filter_tenant_timeline_id, FilterTenantTimelineId, MessageType, SubscribeByFilterRequest,
-    TenantTimelineId as ProtoTenantTimelineId, TypedMessage,
+    FilterTenantTimelineId, MessageType, SubscribeByFilterRequest,
+    TenantTimelineId as ProtoTenantTimelineId, TypeSubscription, TypedMessage,
 };
 
 use storage_broker::{BrokerClientChannel, DEFAULT_ENDPOINT};
@@ -100,9 +100,11 @@ async fn subscribe(client: Option<BrokerClientChannel>, counter: Arc<AtomicU64>,
     };
 
     let request = SubscribeByFilterRequest {
-        types: vec![MessageType::SafekeeperTimelineInfo.into()],
+        types: vec![TypeSubscription {
+            r#type: MessageType::SafekeeperTimelineInfo.into(),
+        }],
         tenant_timeline_id: Some(FilterTenantTimelineId {
-            mode: filter_tenant_timeline_id::Mode::SpecificTimeline.into(),
+            enabled: true,
             tenant_timeline_id: Some(ttid),
         }),
     };

--- a/storage_broker/proto/broker.proto
+++ b/storage_broker/proto/broker.proto
@@ -84,6 +84,8 @@ message SubscribeByFilterRequest {
 enum MessageType {
     UNKNOWN = 0;
     SAFEKEEPER_TIMELINE_INFO = 2;
+    SAFEKEEPER_DISCOVERY_REQUEST = 3;
+    SAFEKEEPER_DISCOVERY_RESPONSE = 4;
 }
 
 // A message with a type.
@@ -91,4 +93,22 @@ message TypedMessage {
     MessageType type = 1;
 
     optional SafekeeperTimelineInfo safekeeper_timeline_info = 2;
+    optional SafekeeperDiscoveryRequest safekeeper_discovery_request = 3;
+    optional SafekeeperDiscoveryResponse safekeeper_discovery_response = 4;
+}
+
+message SafekeeperDiscoveryRequest {
+    TenantTimelineId tenant_timeline_id = 1;
+}
+
+// Shorter version of SafekeeperTimelineInfo, contains only necessary fields.
+message SafekeeperDiscoveryResponse {
+    uint64 safekeeper_id = 1;
+    TenantTimelineId tenant_timeline_id = 2;
+    // WAL available to download.
+    uint64 commit_lsn = 3;
+    // A connection string to use for WAL downloading.
+    string safekeeper_connstr = 4;
+    // Availability zone of a safekeeper.
+    optional string availability_zone = 5;
 }

--- a/storage_broker/proto/broker.proto
+++ b/storage_broker/proto/broker.proto
@@ -10,6 +10,12 @@ service BrokerService {
 
     // Publish safekeeper updates.
     rpc PublishSafekeeperInfo(stream SafekeeperTimelineInfo) returns (google.protobuf.Empty) {};
+
+    // Subscribe to all messages, limited by a filter.
+    rpc SubscribeByFilter(SubscribeByFilterRequest) returns (stream TypedMessage) {};
+
+    // Publish one message.
+    rpc PublishOne(TypedMessage) returns (google.protobuf.Empty) {};
 }
 
 message SubscribeSafekeeperInfoRequest {
@@ -47,4 +53,42 @@ message SafekeeperTimelineInfo {
 message TenantTimelineId {
     bytes tenant_id = 1;
     bytes timeline_id = 2;
+}
+
+message FilterTenantTimelineId {
+    enum Mode {
+        // Invalid mode.
+        INVALID = 0;
+
+        // Subscribe to all timelines.
+        ALL_TIMELINES = 1;
+
+        // Subscribe to a specific timeline.
+        SPECIFIC_TIMELINE = 2;
+    }
+
+    Mode mode = 1;
+
+    // Valid only if mode == SPECIFIC_TIMELINE.
+    optional TenantTimelineId tenant_timeline_id = 2;
+}
+
+message SubscribeByFilterRequest {
+    // Subscription will emit messages only of the specified types.
+    repeated MessageType types = 1;
+
+    // Subscription will emit messages only for the specified tenant/timeline.
+    FilterTenantTimelineId tenant_timeline_id = 2;
+}
+
+enum MessageType {
+    UNKNOWN = 0;
+    SAFEKEEPER_TIMELINE_INFO = 2;
+}
+
+// A message with a type.
+message TypedMessage {
+    MessageType type = 1;
+
+    optional SafekeeperTimelineInfo safekeeper_timeline_info = 2;
 }

--- a/storage_broker/proto/broker.proto
+++ b/storage_broker/proto/broker.proto
@@ -56,29 +56,23 @@ message TenantTimelineId {
 }
 
 message FilterTenantTimelineId {
-    enum Mode {
-        // Invalid mode.
-        INVALID = 0;
+    // If true, only messages related to `tenant_timeline_id` will be emitted.
+    // Otherwise, messages for all timelines will be emitted.
+    bool enabled = 1;
+    TenantTimelineId tenant_timeline_id = 2;
+}
 
-        // Subscribe to all timelines.
-        ALL_TIMELINES = 1;
-
-        // Subscribe to a specific timeline.
-        SPECIFIC_TIMELINE = 2;
-    }
-
-    Mode mode = 1;
-
-    // Valid only if mode == SPECIFIC_TIMELINE.
-    optional TenantTimelineId tenant_timeline_id = 2;
+message TypeSubscription {
+    MessageType type = 1;
 }
 
 message SubscribeByFilterRequest {
-    // Subscription will emit messages only of the specified types.
-    repeated MessageType types = 1;
+    // Subscription will emit messages only of the specified types. You need to specify
+    // at least one type to receive any messages.
+    repeated TypeSubscription types = 1;
 
-    // Subscription will emit messages only for the specified tenant/timeline.
-    FilterTenantTimelineId tenant_timeline_id = 2;
+    // If set and enabled, subscription will emit messages only for the specified tenant/timeline.
+    optional FilterTenantTimelineId tenant_timeline_id = 2;
 }
 
 enum MessageType {

--- a/storage_broker/src/metrics.rs
+++ b/storage_broker/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Broker metrics.
 
-use metrics::{register_int_gauge, IntGauge};
+use metrics::{register_int_counter, register_int_gauge, IntCounter, IntGauge};
 use once_cell::sync::Lazy;
 
 pub static NUM_PUBS: Lazy<IntGauge> = Lazy::new(|| {
@@ -20,6 +20,38 @@ pub static NUM_SUBS_ALL: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "storage_broker_all_keys_active_subscribers",
         "Number of subsciptions to all keys"
+    )
+    .expect("Failed to register metric")
+});
+
+pub static PROCESSED_MESSAGES_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "storage_broker_processed_messages_total",
+        "Number of messages received by storage broker, before routing and broadcasting"
+    )
+    .expect("Failed to register metric")
+});
+
+pub static BROADCASTED_MESSAGES_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "storage_broker_broadcasted_messages_total",
+        "Number of messages broadcasted (sent over network) to subscribers"
+    )
+    .expect("Failed to register metric")
+});
+
+pub static BROADCAST_DROPPED_MESSAGES_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "storage_broker_broadcast_dropped_messages_total",
+        "Number of messages dropped due to channel capacity overflow"
+    )
+    .expect("Failed to register metric")
+});
+
+pub static PUBLISHED_ONEOFF_MESSAGES_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "storage_broker_published_oneoff_messages_total",
+        "Number of one-off messages sent via PublishOne method"
     )
     .expect("Failed to register metric")
 });


### PR DESCRIPTION
Old methods are unchanged for backwards compatibility. Added `SafekeeperDiscoveryRequest` and `SafekeeperDiscoveryResponse` types to serve as example, and also as a prerequisite for https://github.com/neondatabase/neon/issues/5471