### PR TITLE
Remove outdated and flaky perf test

### DIFF
--- a/test_runner/performance/test_startup.py
+++ b/test_runner/performance/test_startup.py
@@ -1,6 +1,4 @@
-from contextlib import closing
 
-import pytest
 import requests
 from fixtures.benchmark_fixture import MetricReport, NeonBenchmarker
 from fixtures.neon_fixtures import NeonEnvBuilder
@@ -81,49 +79,3 @@ def test_startup_simple(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenc
 
         # Imitate optimizations that console would do for the second start
         endpoint.respec(skip_pg_catalog_updates=True)
-
-
-# This test sometimes runs for longer than the global 5 minute timeout.
-@pytest.mark.timeout(900)
-def test_startup(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenchmarker):
-    neon_env_builder.num_safekeepers = 3
-    env = neon_env_builder.init_start()
-
-    # Start
-    env.neon_cli.create_branch("test_startup")
-    with zenbenchmark.record_duration("startup_time"):
-        endpoint = env.endpoints.create_start("test_startup")
-        endpoint.safe_psql("select 1;")
-
-    # Restart
-    endpoint.stop_and_destroy()
-    with zenbenchmark.record_duration("restart_time"):
-        endpoint.create_start("test_startup")
-        endpoint.safe_psql("select 1;")
-
-    # Fill up
-    num_rows = 1000000  # 30 MB
-    num_tables = 100
-    with closing(endpoint.connect()) as conn:
-        with conn.cursor() as cur:
-            for i in range(num_tables):
-                cur.execute(f"create table t_{i} (i integer);")
-                cur.execute(f"insert into t_{i} values (generate_series(1,{num_rows}));")
-
-    # Read
-    with zenbenchmark.record_duration("read_time"):
-        endpoint.safe_psql("select * from t_0;")
-
-    # Read again
-    with zenbenchmark.record_duration("second_read_time"):
-        endpoint.safe_psql("select * from t_0;")
-
-    # Restart
-    endpoint.stop_and_destroy()
-    with zenbenchmark.record_duration("restart_with_data"):
-        endpoint.create_start("test_startup")
-        endpoint.safe_psql("select 1;")
-
-    # Read
-    with zenbenchmark.record_duration("read_after_restart"):
-        endpoint.safe_psql("select * from t_0;")


### PR DESCRIPTION
see: https://neondb.slack.com/archives/C04BLQ4LW7K/p1698873117635749?thread_ts=1698868751.726789&cid=C04BLQ4LW7K

tldr: this test is too slow (because it writes lots of data), mostly exercises sync_safekeepers, but that's no longer on the critical path. The `test_startup_simple` test should be enough to cover what we need