### PR TITLE
Fix baseline commit and branch for code coverage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -587,8 +587,8 @@ jobs:
           BUCKET: neon-github-public-dev
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          BASELINE="$(git merge-base HEAD origin/main)"
           CURRENT="${COMMIT_SHA}"
+          BASELINE="$(git merge-base $CURRENT origin/main)"
 
           cp /tmp/coverage/report/lcov.info ./${CURRENT}.info
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -585,13 +585,13 @@ jobs:
         id: upload-coverage-report-new
         env:
           BUCKET: neon-github-public-dev
+          # A differential coverage report is available only for PRs.
+          # (i.e. for pushes into main/release branches we have a regular coverage report)
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          # Use `ref` for PRs and `ref_name` for pushes, both returns branch name as is.
-          # `ref` for pushes returns `refs/heads/<branch-name>` so it won't work for us.
-          REF_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
         run: |
           CURRENT="${COMMIT_SHA}"
-          BASELINE="$(git merge-base origin/$REF_NAME $CURRENT)"
+          BASELINE="$(git merge-base $BASE_SHA $CURRENT)"
 
           cp /tmp/coverage/report/lcov.info ./${CURRENT}.info
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -586,9 +586,10 @@ jobs:
         env:
           BUCKET: neon-github-public-dev
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          REF: ${{ github.event.pull_request.base.ref || github.ref }}
         run: |
           CURRENT="${COMMIT_SHA}"
-          BASELINE="$(git merge-base $CURRENT origin/main)"
+          BASELINE="$(git merge-base $CURRENT $REF)"
 
           cp /tmp/coverage/report/lcov.info ./${CURRENT}.info
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -586,10 +586,12 @@ jobs:
         env:
           BUCKET: neon-github-public-dev
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          REF: ${{ github.event.pull_request.base.ref || github.ref }}
+          # Use `ref` for PRs and `ref_name` for pushes, both returns branch name as is.
+          # `ref` for pushes returns `refs/heads/<branch-name>` so it won't work for us.
+          REF_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }}
         run: |
           CURRENT="${COMMIT_SHA}"
-          BASELINE="$(git merge-base $CURRENT $REF)"
+          BASELINE="$(git merge-base origin/$REF_NAME $CURRENT)"
 
           cp /tmp/coverage/report/lcov.info ./${CURRENT}.info
 


### PR DESCRIPTION
## Problem

`HEAD` commit for a PR is a phantom merge commit, which skews baseline commit for coverage reports.

See https://github.com/neondatabase/neon/pull/5751#issuecomment-1790717867

## Summary of changes
- Use commit hash instead of `HEAD` for finding baseline commits for code coverage
- Use the base branch for PRs or the current branch for pushes 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
