### PR TITLE
Add API description for safekeeper copy endpoint

### DIFF
--- a/safekeeper/src/http/openapi_spec.yaml
+++ b/safekeeper/src/http/openapi_spec.yaml
@@ -86,7 +86,7 @@ paths:
         default:
           $ref: "#/components/responses/GenericError"
 
-  /v1/tenant/{tenant_id}/timeline/{timeline_id}/copy_to:
+  /v1/tenant/{tenant_id}/timeline/{source_timeline_id}/copy:
     parameters:
       - name: tenant_id
         in: path
@@ -94,14 +94,8 @@ paths:
         schema:
           type: string
           format: hex
-      - name: timeline_id
+      - name: source_timeline_id
         in: path
-        required: true
-        schema:
-          type: string
-          format: hex
-      - name: target_timeline_id
-        in: query
         required: true
         schema:
           type: string
@@ -117,7 +111,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TimelineCreateRequest"
+              $ref: "#/components/schemas/TimelineCopyRequest"
       responses:
         "201":
           description: Timeline created
@@ -245,6 +239,24 @@ components:
         timeline_id:
           type: string
           format: hex
+        peer_ids:
+          type: array
+          items:
+            type: integer
+            minimum: 0
+
+    TimelineCopyRequest:
+      type: object
+      required:
+        - target_timeline_id
+        - until_lsn
+        - peer_ids
+      properties:
+        target_timeline_id:
+          type: string
+          format: hex
+        until_lsn:
+          type: string
         peer_ids:
           type: array
           items:

--- a/safekeeper/src/http/openapi_spec.yaml
+++ b/safekeeper/src/http/openapi_spec.yaml
@@ -86,6 +86,47 @@ paths:
         default:
           $ref: "#/components/responses/GenericError"
 
+  /v1/tenant/{tenant_id}/timeline/{timeline_id}/copy_to:
+    parameters:
+      - name: tenant_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: hex
+      - name: timeline_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: hex
+      - name: target_timeline_id
+        in: query
+        required: true
+        schema:
+          type: string
+          format: hex
+
+    post:
+      tags:
+      - "Timeline"
+      summary: Register new timeline as copy of existing timeline
+      description: ""
+      operationId: v1CopyTenantTimeline
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TimelineCreateRequest"
+      responses:
+        "201":
+          description: Timeline created
+          # TODO: return timeline info?
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        default:
+          $ref: "#/components/responses/GenericError"
+
 
   /v1/tenant/{tenant_id}/timeline/{timeline_id}:
     parameters:

--- a/safekeeper/src/http/openapi_spec.yaml
+++ b/safekeeper/src/http/openapi_spec.yaml
@@ -250,18 +250,12 @@ components:
       required:
         - target_timeline_id
         - until_lsn
-        - peer_ids
       properties:
         target_timeline_id:
           type: string
           format: hex
         until_lsn:
           type: string
-        peer_ids:
-          type: array
-          items:
-            type: integer
-            minimum: 0
 
     SkTimelineInfo:
       type: object


### PR DESCRIPTION
Adds a yaml API description for a new endpoint that allows creation of a new timeline as the copy of an existing one.
 
Part of #5282