### PR TITLE
proxy: limit concurrent wake_compute requests per endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6476,6 +6476,7 @@ dependencies = [
  "clap",
  "clap_builder",
  "crossbeam-utils",
+ "dashmap",
  "either",
  "fail",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ comfy-table = "6.1"
 const_format = "0.2"
 crc32c = "0.6"
 crossbeam-utils = "0.8.5"
-dashmap = "5.5.0"
+dashmap = { version = "5.5.0", features = ["raw-api"] }
 either = "1.8"
 enum-map = "2.4.2"
 enumset = "1.0.12"

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -227,10 +227,12 @@ fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
                 shards,
                 permits,
                 epoch,
+                timeout,
             } = args.wake_compute_lock.parse()?;
             info!(permits, shards, ?epoch, "Using NodeLocks (wake_compute)");
             let locks = Box::leak(Box::new(
-                console::locks::ApiLocks::new("wake_compute_lock", permits, shards).unwrap(),
+                console::locks::ApiLocks::new("wake_compute_lock", permits, shards, timeout)
+                    .unwrap(),
             ));
             tokio::spawn(locks.garbage_collect_worker(epoch));
 

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -1,3 +1,4 @@
+use dashmap::DashMap;
 use futures::future::Either;
 use proxy::auth;
 use proxy::config::AuthenticationConfig;
@@ -80,6 +81,9 @@ struct ProxyCliArgs {
     /// cache for `wake_compute` api method (use `size=0` to disable)
     #[clap(long, default_value = config::CacheOptions::DEFAULT_OPTIONS_NODE_INFO)]
     wake_compute_cache: String,
+    /// lock for `wake_compute` api method (use `permits=0` to disable)
+    #[clap(long, default_value = config::WakeComputeLockOptions::DEFAULT_OPTIONS_WAKE_COMPUTE_LOCK)]
+    wake_compute_lock: String,
     /// Allow self-signed certificates for compute nodes (for testing)
     #[clap(long, default_value_t = false, value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
     allow_self_signed_compute: bool,
@@ -220,10 +224,22 @@ fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
                 node_info: console::caches::NodeInfoCache::new("node_info_cache", size, ttl),
             }));
 
+            let config::WakeComputeLockOptions {
+                shards,
+                permits,
+                epoch,
+            } = args.wake_compute_lock.parse()?;
+            info!(permits, shards, ?epoch, "Using NodeLocks (wake_compute)");
+            let locks = Box::leak(Box::new(console::locks::ApiLocks {
+                node_locks: DashMap::with_shard_amount(shards),
+                permits,
+            }));
+            tokio::spawn(locks.garbage_collect_worker(epoch));
+
             let url = args.auth_endpoint.parse()?;
             let endpoint = http::Endpoint::new(url, http::new_client());
 
-            let api = console::provider::neon::Api::new(endpoint, caches);
+            let api = console::provider::neon::Api::new(endpoint, caches, locks);
             auth::BackendType::Console(Cow::Owned(api), ())
         }
         AuthBackend::Postgres => {

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -1,4 +1,3 @@
-use dashmap::DashMap;
 use futures::future::Either;
 use proxy::auth;
 use proxy::config::AuthenticationConfig;
@@ -230,10 +229,9 @@ fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
                 epoch,
             } = args.wake_compute_lock.parse()?;
             info!(permits, shards, ?epoch, "Using NodeLocks (wake_compute)");
-            let locks = Box::leak(Box::new(console::locks::ApiLocks {
-                node_locks: DashMap::with_shard_amount(shards),
-                permits,
-            }));
+            let locks = Box::leak(Box::new(
+                console::locks::ApiLocks::new("wake_compute_lock", permits, shards).unwrap(),
+            ));
             tokio::spawn(locks.garbage_collect_worker(epoch));
 
             let url = args.auth_endpoint.parse()?;

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -80,7 +80,7 @@ struct ProxyCliArgs {
     /// cache for `wake_compute` api method (use `size=0` to disable)
     #[clap(long, default_value = config::CacheOptions::DEFAULT_OPTIONS_NODE_INFO)]
     wake_compute_cache: String,
-    /// lock for `wake_compute` api method (use `permits=0` to disable)
+    /// lock for `wake_compute` api method. example: "shards=32,permits=4,epoch=10m,timeout=1s". (use `permits=0` to disable).
     #[clap(long, default_value = config::WakeComputeLockOptions::DEFAULT_OPTIONS_WAKE_COMPUTE_LOCK)]
     wake_compute_lock: String,
     /// Allow self-signed certificates for compute nodes (for testing)

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -354,17 +354,29 @@ mod tests {
 
     #[test]
     fn test_parse_lock_options() -> anyhow::Result<()> {
-        let WakeComputeLockOptions { epoch, permits, shards } = "shards=32,permits=4,epoch=10m".parse()?;
-        assert_eq!(epoch, Duration::from_secs(10*60));
+        let WakeComputeLockOptions {
+            epoch,
+            permits,
+            shards,
+        } = "shards=32,permits=4,epoch=10m".parse()?;
+        assert_eq!(epoch, Duration::from_secs(10 * 60));
         assert_eq!(shards, 32);
         assert_eq!(permits, 4);
 
-        let WakeComputeLockOptions { epoch, permits, shards } = "epoch=60s,shards=16,permits=8".parse()?;
+        let WakeComputeLockOptions {
+            epoch,
+            permits,
+            shards,
+        } = "epoch=60s,shards=16,permits=8".parse()?;
         assert_eq!(epoch, Duration::from_secs(60));
         assert_eq!(shards, 16);
         assert_eq!(permits, 8);
 
-        let WakeComputeLockOptions { epoch, permits, shards } = "permits=0".parse()?;
+        let WakeComputeLockOptions {
+            epoch,
+            permits,
+            shards,
+        } = "permits=0".parse()?;
         assert_eq!(epoch, Duration::ZERO);
         assert_eq!(shards, 1);
         assert_eq!(permits, 0);

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -382,7 +382,7 @@ mod tests {
             shards,
         } = "permits=0".parse()?;
         assert_eq!(epoch, Duration::ZERO);
-        assert_eq!(shards, 1);
+        assert_eq!(shards, 2);
         assert_eq!(permits, 0);
 
         Ok(())

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -264,6 +264,69 @@ impl FromStr for CacheOptions {
     }
 }
 
+/// Helper for cmdline cache options parsing.
+pub struct WakeComputeLockOptions {
+    /// The number of shards the lock map should have
+    pub shards: usize,
+    /// The number of allowed concurrent requests for each endpoitn
+    pub permits: usize,
+    /// Gargage collection epoch
+    pub epoch: Duration,
+}
+
+impl WakeComputeLockOptions {
+    /// Default options for [`crate::console::provider::ApiLocks`].
+    pub const DEFAULT_OPTIONS_WAKE_COMPUTE_LOCK: &'static str = "permits=0";
+
+    // pub const DEFAULT_OPTIONS_WAKE_COMPUTE_LOCK: &'static str = "shards=32,permits=4,epoch=10m";
+
+    /// Parse lock options passed via cmdline.
+    /// Example: [`Self::DEFAULT_OPTIONS_WAKE_COMPUTE_LOCK`].
+    fn parse(options: &str) -> anyhow::Result<Self> {
+        let mut shards = None;
+        let mut permits = None;
+        let mut epoch = None;
+
+        for option in options.split(',') {
+            let (key, value) = option
+                .split_once('=')
+                .with_context(|| format!("bad key-value pair: {option}"))?;
+
+            match key {
+                "shards" => shards = Some(value.parse()?),
+                "permits" => permits = Some(value.parse()?),
+                "epoch" => epoch = Some(humantime::parse_duration(value)?),
+                unknown => bail!("unknown key: {unknown}"),
+            }
+        }
+
+        // these dont matter if lock is disabled
+        if let Some(0) = permits {
+            epoch = Some(Duration::default());
+            shards = Some(1);
+        }
+
+        let out = Self {
+            shards: shards.context("missing `shards`")?,
+            permits: permits.context("missing `permits`")?,
+            epoch: epoch.context("missing `epoch`")?,
+        };
+
+        ensure!(out.shards > 0, "shard count must be > 0");
+
+        Ok(out)
+    }
+}
+
+impl FromStr for WakeComputeLockOptions {
+    type Err = anyhow::Error;
+
+    fn from_str(options: &str) -> Result<Self, Self::Err> {
+        let error = || format!("failed to parse cache lock options '{options}'");
+        Self::parse(options).with_context(error)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,6 +348,26 @@ mod tests {
         let CacheOptions { size, ttl } = "size=0".parse()?;
         assert_eq!(size, 0);
         assert_eq!(ttl, Duration::default());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_lock_options() -> anyhow::Result<()> {
+        let WakeComputeLockOptions { epoch, permits, shards } = "shards=32,permits=4,epoch=10m".parse()?;
+        assert_eq!(epoch, Duration::from_secs(10*60));
+        assert_eq!(shards, 32);
+        assert_eq!(permits, 4);
+
+        let WakeComputeLockOptions { epoch, permits, shards } = "epoch=60s,shards=16,permits=8".parse()?;
+        assert_eq!(epoch, Duration::from_secs(60));
+        assert_eq!(shards, 16);
+        assert_eq!(permits, 8);
+
+        let WakeComputeLockOptions { epoch, permits, shards } = "permits=0".parse()?;
+        assert_eq!(epoch, Duration::ZERO);
+        assert_eq!(shards, 1);
+        assert_eq!(permits, 0);
 
         Ok(())
     }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -287,13 +287,10 @@ impl WakeComputeLockOptions {
         let mut permits = None;
         let mut epoch = None;
 
-        dbg!(options);
-
         for option in options.split(',') {
             let (key, value) = option
                 .split_once('=')
                 .with_context(|| format!("bad key-value pair: {option}"))?;
-            dbg!(key, value);
 
             match key {
                 "shards" => shards = Some(value.parse()?),
@@ -316,7 +313,10 @@ impl WakeComputeLockOptions {
         };
 
         ensure!(out.shards > 1, "shard count must be > 1");
-        ensure!(out.shards.is_power_of_two(), "shard count must be a power of two");
+        ensure!(
+            out.shards.is_power_of_two(),
+            "shard count must be a power of two"
+        );
 
         Ok(out)
     }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -287,10 +287,13 @@ impl WakeComputeLockOptions {
         let mut permits = None;
         let mut epoch = None;
 
+        dbg!(options);
+
         for option in options.split(',') {
             let (key, value) = option
                 .split_once('=')
                 .with_context(|| format!("bad key-value pair: {option}"))?;
+            dbg!(key, value);
 
             match key {
                 "shards" => shards = Some(value.parse()?),
@@ -303,7 +306,7 @@ impl WakeComputeLockOptions {
         // these dont matter if lock is disabled
         if let Some(0) = permits {
             epoch = Some(Duration::default());
-            shards = Some(1);
+            shards = Some(2);
         }
 
         let out = Self {
@@ -312,7 +315,8 @@ impl WakeComputeLockOptions {
             epoch: epoch.context("missing `epoch`")?,
         };
 
-        ensure!(out.shards > 0, "shard count must be > 0");
+        ensure!(out.shards > 1, "shard count must be > 1");
+        ensure!(out.shards.is_power_of_two(), "shard count must be a power of two");
 
         Ok(out)
     }

--- a/proxy/src/console.rs
+++ b/proxy/src/console.rs
@@ -13,5 +13,10 @@ pub mod caches {
     pub use super::provider::{ApiCaches, NodeInfoCache};
 }
 
+/// Various cache-related types.
+pub mod locks {
+    pub use super::provider::ApiLocks;
+}
+
 /// Console's management API.
 pub mod mgmt;

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use dashmap::DashMap;
-use std::{sync::Arc};
+use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::info;
 

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use dashmap::DashMap;
-use std::{sync::Arc, time::Duration};
+use std::{sync::Arc};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::info;
 

--- a/proxy/src/console/provider/neon.rs
+++ b/proxy/src/console/provider/neon.rs
@@ -3,12 +3,12 @@
 use super::{
     super::messages::{ConsoleError, GetRoleSecret, WakeCompute},
     errors::{ApiError, GetAuthInfoError, WakeComputeError},
-    ApiCaches, AuthInfo, CachedNodeInfo, ConsoleReqExtra, NodeInfo,
+    ApiCaches, ApiLocks, AuthInfo, CachedNodeInfo, ConsoleReqExtra, NodeInfo,
 };
 use crate::{auth::ClientCredentials, compute, http, scram};
 use async_trait::async_trait;
 use futures::TryFutureExt;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 use tokio::time::Instant;
 use tokio_postgres::config::SslMode;
 use tracing::{error, info, info_span, warn, Instrument};
@@ -17,12 +17,17 @@ use tracing::{error, info, info_span, warn, Instrument};
 pub struct Api {
     endpoint: http::Endpoint,
     caches: &'static ApiCaches,
+    locks: &'static ApiLocks,
     jwt: String,
 }
 
 impl Api {
     /// Construct an API object containing the auth parameters.
-    pub fn new(endpoint: http::Endpoint, caches: &'static ApiCaches) -> Self {
+    pub fn new(
+        endpoint: http::Endpoint,
+        caches: &'static ApiCaches,
+        locks: &'static ApiLocks,
+    ) -> Self {
         let jwt: String = match std::env::var("NEON_PROXY_TO_CONTROLPLANE_TOKEN") {
             Ok(v) => v,
             Err(_) => "".to_string(),
@@ -30,6 +35,7 @@ impl Api {
         Self {
             endpoint,
             caches,
+            locks,
             jwt,
         }
     }
@@ -162,9 +168,22 @@ impl super::Api for Api {
             return Ok(cached);
         }
 
+        let key: Arc<str> = key.into();
+
+        let permit = self.locks.get_wake_compute_permit(&key).await;
+
+        // after getting back a permit - it's possible the cache was filled
+        // double check
+        if permit.should_check_cache() {
+            if let Some(cached) = self.caches.node_info.get(&key) {
+                info!(key = &*key, "found cached compute node info");
+                return Ok(cached);
+            }
+        }
+
         let node = self.do_wake_compute(extra, creds).await?;
-        let (_, cached) = self.caches.node_info.insert(key.into(), node);
-        info!(key = key, "created a cache entry for compute node info");
+        let (_, cached) = self.caches.node_info.insert(key.clone(), node);
+        info!(key = &*key, "created a cache entry for compute node info");
 
         Ok(cached)
     }

--- a/proxy/src/console/provider/neon.rs
+++ b/proxy/src/console/provider/neon.rs
@@ -170,7 +170,7 @@ impl super::Api for Api {
 
         let key: Arc<str> = key.into();
 
-        let permit = self.locks.get_wake_compute_permit(&key).await;
+        let permit = self.locks.get_wake_compute_permit(&key).await?;
 
         // after getting back a permit - it's possible the cache was filled
         // double check

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -568,6 +568,7 @@ fn report_error(e: &WakeComputeError, retry: bool) {
             "api_console_other_server_error"
         }
         WakeComputeError::ApiError(ApiError::Console { .. }) => "api_console_other_error",
+        WakeComputeError::TimeoutError => "timeout_error",
     };
     NUM_WAKEUP_FAILURES.with_label_values(&[retry, kind]).inc();
 }

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -25,6 +25,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 clap = { version = "4", features = ["derive", "string"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "help", "std", "string", "suggestions", "usage"] }
 crossbeam-utils = { version = "0.8" }
+dashmap = { version = "5", default-features = false, features = ["raw-api"] }
 either = { version = "1" }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 futures = { version = "0.3" }


### PR DESCRIPTION
## Problem

A user can perform many database connections at the same instant of time - these will all cache miss and materialise as requests to the control plane. #5705

## Summary of changes

I am using a `DashMap` (a sharded `RwLock<HashMap>`) of endpoints -> semaphores to apply a limiter. If the limiter is enabled (permits > 0), the semaphore will be retrieved per endpoint and a permit will be awaited before continuing to call the wake_compute endpoint.

### Important details

This dashmap would grow uncontrollably without maintenance. It's not a cache so I don't think an LRU-based reclamation makes sense. Instead, I've made use of the sharding functionality of DashMap to lock a single shard and clear out unused semaphores periodically.

I ran a test in release, using 128 tokio tasks among 12 threads each pushing 1000 entries into the map per second, clearing a shard every 2 seconds (64 second epoch with 32 shards). The endpoint names were sampled from a gamma distribution to make sure some overlap would occur, and each permit was held for 1ms. The histogram for time to clear each shard settled between 256-512us without any variance in my testing.

Holding a lock for under a millisecond for 1 of the shards does not concern me as blocking

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
