### PR TITLE
Fix blob_io test

### DIFF
--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -327,7 +327,7 @@ mod tests {
                 let mut sz: u16 = rng.gen();
                 // Make 50% of the arrays small
                 if rng.gen() {
-                    sz |= 63;
+                    sz &= 63;
                 }
                 random_array(sz.into())
             })


### PR DESCRIPTION
The comment says `Make 50% of the arrays small`, but the code does `sz |= 63;`, which makes the value large, not small.
