### PR TITLE
build: deny async-std and friends

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -172,7 +172,7 @@ jobs:
       # https://github.com/EmbarkStudios/cargo-deny
       - name: Check rust licenses/bans/advisories/sources
         if: ${{ !cancelled() }}
-        run: cargo deny check
+        run: cargo deny check --hide-inclusion-graph
 
   build-neon:
     needs: [ check-permissions, tag ]

--- a/deny.toml
+++ b/deny.toml
@@ -96,15 +96,6 @@ name = "async-global-executor"
 name = "async-executor"
 
 [[bans.deny]]
-# please use tokio channels or flume for mpmc channel
-# please use tokio-stream if you really must get channels wrapped as streams
-name = "async-channel"
-
-[[bans.deny]]
-# use tokio locking primitives
-name = "async-lock"
-
-[[bans.deny]]
 name = "smol"
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -74,9 +74,38 @@ highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"
 allow = []
-deny = []
+
 skip = []
 skip-tree = []
+
+[[bans.deny]]
+# we use tokio, the same rationale applies for async-{io,waker,global-executor,executor,channel,lock}, smol
+# if you find yourself here while adding a dependency, try "default-features = false", ask around on #rust
+name = "async-std"
+
+[[bans.deny]]
+name = "async-io"
+
+[[bans.deny]]
+name = "async-waker"
+
+[[bans.deny]]
+name = "async-global-executor"
+
+[[bans.deny]]
+name = "async-executor"
+
+[[bans.deny]]
+# please use tokio channels or flume for mpmc channel
+# please use tokio-stream if you really must get channels wrapped as streams
+name = "async-channel"
+
+[[bans.deny]]
+# use tokio locking primitives
+name = "async-lock"
+
+[[bans.deny]]
+name = "smol"
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:


### PR DESCRIPTION
rationale: some crates pull these in as default; hopefully these hints will require less cleanup-after and Cargo.lock file watching.

follow-up to #5848.