### PR TITLE
Collect number of connections by sni type

### DIFF
--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -1,7 +1,9 @@
 //! User credentials used in authentication.
 
 use crate::{
-    auth::password_hack::parse_endpoint_param, error::UserFacingError, proxy::{neon_options, NUM_CONNECTION_BY_SNI},
+    auth::password_hack::parse_endpoint_param,
+    error::UserFacingError,
+    proxy::{neon_options, NUM_CONNECTION_BY_SNI},
 };
 use itertools::Itertools;
 use pq_proto::StartupMessageParams;
@@ -131,7 +133,9 @@ impl<'a> ClientCredentials<'a> {
             NUM_CONNECTION_BY_SNI.with_label_values(&["no_sni"]).inc();
             info!("Connection without sni");
         } else {
-            NUM_CONNECTION_BY_SNI.with_label_values(&["password_hack"]).inc();
+            NUM_CONNECTION_BY_SNI
+                .with_label_values(&["password_hack"])
+                .inc();
             info!("Connection with password hack");
         }
 

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -3,7 +3,7 @@
 use crate::{
     auth::password_hack::parse_endpoint_param,
     error::UserFacingError,
-    proxy::{neon_options, NUM_CONNECTION_BY_SNI},
+    proxy::{neon_options, NUM_CONNECTION_ACCEPTED_BY_SNI},
 };
 use itertools::Itertools;
 use pq_proto::StartupMessageParams;
@@ -128,12 +128,12 @@ impl<'a> ClientCredentials<'a> {
         info!(user, project = project.as_deref(), "credentials");
         if sni.is_some() {
             info!("Connection with sni");
-            NUM_CONNECTION_BY_SNI.with_label_values(&["sni"]).inc();
+            NUM_CONNECTION_ACCEPTED_BY_SNI.with_label_values(&["sni"]).inc();
         } else if project.is_some() {
-            NUM_CONNECTION_BY_SNI.with_label_values(&["no_sni"]).inc();
+            NUM_CONNECTION_ACCEPTED_BY_SNI.with_label_values(&["no_sni"]).inc();
             info!("Connection without sni");
         } else {
-            NUM_CONNECTION_BY_SNI
+            NUM_CONNECTION_ACCEPTED_BY_SNI
                 .with_label_values(&["password_hack"])
                 .inc();
             info!("Connection with password hack");

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -128,9 +128,13 @@ impl<'a> ClientCredentials<'a> {
         info!(user, project = project.as_deref(), "credentials");
         if sni.is_some() {
             info!("Connection with sni");
-            NUM_CONNECTION_ACCEPTED_BY_SNI.with_label_values(&["sni"]).inc();
+            NUM_CONNECTION_ACCEPTED_BY_SNI
+                .with_label_values(&["sni"])
+                .inc();
         } else if project.is_some() {
-            NUM_CONNECTION_ACCEPTED_BY_SNI.with_label_values(&["no_sni"]).inc();
+            NUM_CONNECTION_ACCEPTED_BY_SNI
+                .with_label_values(&["no_sni"])
+                .inc();
             info!("Connection without sni");
         } else {
             NUM_CONNECTION_ACCEPTED_BY_SNI

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -1,7 +1,7 @@
 //! User credentials used in authentication.
 
 use crate::{
-    auth::password_hack::parse_endpoint_param, error::UserFacingError, proxy::neon_options,
+    auth::password_hack::parse_endpoint_param, error::UserFacingError, proxy::{neon_options, NUM_CONNECTION_BY_SNI},
 };
 use itertools::Itertools;
 use pq_proto::StartupMessageParams;
@@ -124,6 +124,16 @@ impl<'a> ClientCredentials<'a> {
         .transpose()?;
 
         info!(user, project = project.as_deref(), "credentials");
+        if sni.is_some() {
+            info!("Connection with sni");
+            NUM_CONNECTION_BY_SNI.with_label_values(&["sni"]).inc();
+        } else if project.is_some() {
+            NUM_CONNECTION_BY_SNI.with_label_values(&["no_sni"]).inc();
+            info!("Connection without sni");
+        } else {
+            NUM_CONNECTION_BY_SNI.with_label_values(&["password_hack"]).inc();
+            info!("Connection with password hack");
+        }
 
         let cache_key = format!(
             "{}{}",

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -129,6 +129,15 @@ pub static RATE_LIMITER_LIMIT: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static NUM_CONNECTION_BY_SNI: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "proxy_connections_by_sni",
+        "Number of connections (per sni).",
+        &["kind"],
+    )
+    .unwrap()
+});
+
 pub struct LatencyTimer {
     // time since the stopwatch was started
     start: Option<Instant>,

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -129,9 +129,9 @@ pub static RATE_LIMITER_LIMIT: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static NUM_CONNECTION_BY_SNI: Lazy<IntCounterVec> = Lazy::new(|| {
+pub static NUM_CONNECTION_ACCEPTED_BY_SNI: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "proxy_connections_by_sni",
+        "proxy_accepted_connections_by_sni",
         "Number of connections (per sni).",
         &["kind"],
     )


### PR DESCRIPTION
## Problem

We don't know the number of users with the different kind of authentication: ["sni", "endpoint in options" (A and B from [here](https://neon.tech/docs/connect/connection-errors)), "password_hack"]

## Summary of changes

Collect metrics by sni kind.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
