### PR TITLE
proxy: start work on jwt auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
- "ring",
+ "ring 0.16.20",
  "time",
  "tokio",
  "tower",
@@ -703,7 +703,7 @@ dependencies = [
  "bytes",
  "dyn-clone",
  "futures",
- "getrandom 0.2.9",
+ "getrandom 0.2.11",
  "http-types",
  "log",
  "paste",
@@ -864,6 +864,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "biscuit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e28fc7c56c61743a01d0d1b73e4fed68b8a4f032ea3a2d4bb8c6520a33fc05a"
+dependencies = [
+ "chrono",
+ "data-encoding",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "ring 0.17.5",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,11 +961,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -1846,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2342,7 +2359,7 @@ checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.1",
  "pem 1.1.1",
- "ring",
+ "ring 0.16.20",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -2382,9 +2399,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -2691,7 +2708,7 @@ checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
 dependencies = [
  "base64 0.13.1",
  "chrono",
- "getrandom 0.2.9",
+ "getrandom 0.2.11",
  "http",
  "rand 0.8.5",
  "serde",
@@ -3474,6 +3491,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
+ "biscuit",
  "bstr",
  "bytes",
  "chrono",
@@ -3619,7 +3637,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -3660,7 +3678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4954fbc00dcd4d8282c987710e50ba513d351400dbdd00e803a05172a90d8976"
 dependencies = [
  "pem 2.0.1",
- "ring",
+ "ring 0.16.20",
  "time",
  "yasna",
 ]
@@ -3830,7 +3848,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "getrandom 0.2.9",
+ "getrandom 0.2.11",
  "http",
  "hyper",
  "parking_lot 0.11.2",
@@ -3851,7 +3869,7 @@ checksum = "1b97ad83c2fc18113346b7158d79732242002427c30f620fa817c1f32901e0a8"
 dependencies = [
  "anyhow",
  "async-trait",
- "getrandom 0.2.9",
+ "getrandom 0.2.11",
  "matchit",
  "opentelemetry",
  "reqwest",
@@ -3882,9 +3900,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom 0.2.11",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4003,7 +4035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "rustls-webpki 0.101.4",
  "sct",
 ]
@@ -4035,8 +4067,8 @@ version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4045,8 +4077,8 @@ version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4191,8 +4223,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4311,7 +4343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99dc599bd6646884fc403d593cdcb9816dd67c50cff3271c01ff123617908dcd"
 dependencies = [
  "debugid",
- "getrandom 0.2.9",
+ "getrandom 0.2.11",
  "hex",
  "serde",
  "serde_json",
@@ -4357,6 +4389,7 @@ version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4960,7 +4993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5831152cb0d3f79ef5523b357319ba154795d64c7078b2daa95a803b54057f"
 dependencies = [
  "futures",
- "ring",
+ "ring 0.16.20",
  "rustls",
  "tokio",
  "tokio-postgres",
@@ -5417,6 +5450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "ureq"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5517,7 +5556,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.11",
  "serde",
 ]
 
@@ -6010,7 +6049,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.7.2",
  "reqwest",
- "ring",
+ "ring 0.16.20",
  "rustls",
  "scopeguard",
  "serde",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -68,7 +68,7 @@ webpki-roots.workspace = true
 x509-parser.workspace = true
 native-tls.workspace = true
 postgres-native-tls.workspace = true
-
+biscuit = { version = "0.7",features = [] }
 workspace_hack.workspace = true
 tokio-util.workspace = true
 

--- a/proxy/src/auth/backend.rs
+++ b/proxy/src/auth/backend.rs
@@ -6,6 +6,7 @@ pub use link::LinkAuthError;
 use serde::{Deserialize, Serialize};
 use tokio_postgres::config::AuthKeys;
 
+use crate::console::provider::neon::UserRowLevel;
 use crate::proxy::{handle_try_wake, retry_after, LatencyTimer};
 use crate::{
     auth::{self, ClientCredentials},
@@ -328,7 +329,7 @@ impl BackendType<'_, ClientCredentials<'_>> {
         dbname: String,
         username: String,
         policies: Vec<Policy>,
-    ) -> anyhow::Result<String> {
+    ) -> anyhow::Result<UserRowLevel> {
         use BackendType::*;
 
         match self {

--- a/proxy/src/auth/backend.rs
+++ b/proxy/src/auth/backend.rs
@@ -350,8 +350,8 @@ impl BackendType<'_, ClientCredentials<'_>> {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Policy {
-    table: String,
-    column: String,
+    pub table: String,
+    pub column: String,
 }
 
 // enum PolicyType {

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -1,6 +1,8 @@
 pub mod mock;
 pub mod neon;
 
+use self::neon::UserRowLevel;
+
 use super::messages::MetricsAuxInfo;
 use crate::{
     auth::{backend::Policy, ClientCredentials},
@@ -257,7 +259,7 @@ pub trait Api {
         dbname: String,
         username: String,
         policies: Vec<Policy>,
-    ) -> anyhow::Result<String>;
+    ) -> anyhow::Result<UserRowLevel>;
 }
 
 /// Various caches for [`console`](super).

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -3,7 +3,7 @@ pub mod neon;
 
 use super::messages::MetricsAuxInfo;
 use crate::{
-    auth::ClientCredentials,
+    auth::{ClientCredentials, backend::Policy},
     cache::{timed_lru, TimedLru},
     compute, scram,
 };
@@ -248,6 +248,16 @@ pub trait Api {
         extra: &ConsoleReqExtra<'_>,
         creds: &ClientCredentials,
     ) -> Result<CachedNodeInfo, errors::WakeComputeError>;
+
+    /// Get the password for the RLS user
+    async fn ensure_row_level(
+        &self,
+        extra: &ConsoleReqExtra<'_>,
+        creds: &ClientCredentials,
+        dbname: String,
+        username: String,
+        policies: Vec<Policy>
+    ) -> anyhow::Result<String>;
 }
 
 /// Various caches for [`console`](super).

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -3,7 +3,7 @@ pub mod neon;
 
 use super::messages::MetricsAuxInfo;
 use crate::{
-    auth::{ClientCredentials, backend::Policy},
+    auth::{backend::Policy, ClientCredentials},
     cache::{timed_lru, TimedLru},
     compute, scram,
 };
@@ -256,7 +256,7 @@ pub trait Api {
         creds: &ClientCredentials,
         dbname: String,
         username: String,
-        policies: Vec<Policy>
+        policies: Vec<Policy>,
     ) -> anyhow::Result<String>;
 }
 

--- a/proxy/src/console/provider/mock.rs
+++ b/proxy/src/console/provider/mock.rs
@@ -4,7 +4,13 @@ use super::{
     errors::{ApiError, GetAuthInfoError, WakeComputeError},
     AuthInfo, CachedNodeInfo, ConsoleReqExtra, NodeInfo,
 };
-use crate::{auth::ClientCredentials, compute, error::io_error, scram, url::ApiUrl};
+use crate::{
+    auth::{backend::Policy, ClientCredentials},
+    compute,
+    error::io_error,
+    scram,
+    url::ApiUrl,
+};
 use async_trait::async_trait;
 use futures::TryFutureExt;
 use thiserror::Error;
@@ -120,6 +126,18 @@ impl super::Api for Api {
         self.do_wake_compute()
             .map_ok(CachedNodeInfo::new_uncached)
             .await
+    }
+
+    /// Get the password for the RLS user
+    async fn ensure_row_level(
+        &self,
+        _extra: &ConsoleReqExtra<'_>,
+        _creds: &ClientCredentials,
+        _dbname: String,
+        _username: String,
+        _policies: Vec<Policy>,
+    ) -> anyhow::Result<String> {
+        Err(anyhow::anyhow!("unimplemented"))
     }
 }
 

--- a/proxy/src/console/provider/mock.rs
+++ b/proxy/src/console/provider/mock.rs
@@ -2,6 +2,7 @@
 
 use super::{
     errors::{ApiError, GetAuthInfoError, WakeComputeError},
+    neon::UserRowLevel,
     AuthInfo, CachedNodeInfo, ConsoleReqExtra, NodeInfo,
 };
 use crate::{
@@ -136,7 +137,7 @@ impl super::Api for Api {
         _dbname: String,
         _username: String,
         _policies: Vec<Policy>,
-    ) -> anyhow::Result<String> {
+    ) -> anyhow::Result<UserRowLevel> {
         Err(anyhow::anyhow!("unimplemented"))
     }
 }

--- a/proxy/src/console/provider/neon.rs
+++ b/proxy/src/console/provider/neon.rs
@@ -266,6 +266,7 @@ impl super::Api for Api {
     }
 
     /// Get the password for the RLS user
+    #[tracing::instrument(skip_all)]
     async fn ensure_row_level(
         &self,
         extra: &ConsoleReqExtra<'_>,

--- a/proxy/src/console/provider/neon.rs
+++ b/proxy/src/console/provider/neon.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::time::Instant;
 use tokio_postgres::config::SslMode;
-use tracing::{debug, error, info, info_span, warn, Instrument};
+use tracing::{error, info, info_span, warn, Instrument};
 
 #[derive(Clone)]
 pub struct Api {

--- a/proxy/src/console/provider/neon.rs
+++ b/proxy/src/console/provider/neon.rs
@@ -187,9 +187,12 @@ impl Api {
             let start = Instant::now();
             let response = self.endpoint.execute(request).await?;
             info!(duration = ?start.elapsed(), "received http response");
-            let body = parse_body::<UserRowLevel>(response).await?;
+            let mut body = parse_body::<UserRowLevel>(response).await?;
 
-            debug!(user = %body.username, pw=%body.password, "please don't merge this in production");
+            // hack
+            body.username = body.username.to_lowercase();
+
+            // info!(user = %body.username, pw=%body.password, "please don't merge this in production");
 
             Ok(body)
         }

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -88,6 +88,14 @@ impl Endpoint {
         self.client.get(url.into_inner())
     }
 
+    /// Return a [builder](RequestBuilder) for a `POST` request,
+    /// appending a single `path` segment to the base endpoint URL.
+    pub fn post(&self, path: &str) -> RequestBuilder {
+        let mut url = self.endpoint.clone();
+        url.path_segments_mut().push(path);
+        self.client.post(url.into_inner())
+    }
+
     /// Execute a [request](reqwest::Request).
     pub async fn execute(&self, request: Request) -> Result<Response, Error> {
         self.client.execute(request).await

--- a/proxy/src/serverless/jwt_auth.rs
+++ b/proxy/src/serverless/jwt_auth.rs
@@ -1,0 +1,98 @@
+// https://adapted-gorilla-88.clerk.accounts.dev/.well-known/jwks.json
+
+use std::sync::Arc;
+
+use anyhow::{bail, Context};
+use biscuit::{
+    jwk::{JWKSet, JWK},
+    jws, CompactPart,
+};
+use dashmap::DashMap;
+use reqwest::{IntoUrl, Url};
+use serde::{de::DeserializeOwned, Serialize};
+use tokio::sync::RwLock;
+
+pub struct JWKSetCaches {
+    pub map: DashMap<Url, Arc<JWKSetCache>>,
+}
+
+impl JWKSetCaches {
+    pub async fn get_cache(&self, url: impl IntoUrl) -> anyhow::Result<Arc<JWKSetCache>> {
+        let url = url.into_url()?;
+        if let Some(x) = self.map.get(&url) {
+            return Ok(x.clone());
+        }
+        let cache = JWKSetCache::new(url.clone()).await?;
+        let cache = Arc::new(cache);
+        self.map.insert(url, cache.clone());
+        Ok(cache)
+    }
+}
+
+pub struct JWKSetCache {
+    url: Url,
+    current: RwLock<biscuit::jwk::JWKSet<()>>,
+}
+
+impl JWKSetCache {
+    pub async fn new(url: impl IntoUrl) -> anyhow::Result<Self> {
+        let url = url.into_url()?;
+        let current = reqwest::get(url.clone()).await?.json().await?;
+        Ok(Self {
+            url,
+            current: RwLock::new(current),
+        })
+    }
+
+    pub async fn get(&self, kid: &str) -> anyhow::Result<JWK<()>> {
+        let current = self.current.read().await.clone();
+        if let Some(key) = current.find(kid) {
+            return Ok(key.clone());
+        }
+        let new = reqwest::get(self.url.clone()).await?.json().await?;
+        if new == current {
+            bail!("not found")
+        }
+        *self.current.write().await = new;
+        current.find(kid).cloned().context("not found")
+    }
+
+    pub async fn decode<T, H>(
+        &self,
+        token: &jws::Compact<T, H>,
+    ) -> anyhow::Result<jws::Compact<T, H>>
+    where
+        T: CompactPart,
+        H: Serialize + DeserializeOwned,
+    {
+        let current = self.current.read().await.clone();
+        match token.decode_with_jwks(&current, None) {
+            Ok(t) => Ok(t),
+            Err(biscuit::errors::Error::ValidationError(
+                biscuit::errors::ValidationError::KeyNotFound,
+            )) => {
+                let new: JWKSet<()> = reqwest::get(self.url.clone()).await?.json().await?;
+                if new == current {
+                    bail!("not found")
+                }
+                *self.current.write().await = new.clone();
+                token.decode_with_jwks(&new, None).context("error")
+                // current.find(kid).cloned().context("not found")
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JWKSetCache;
+    #[tokio::test]
+    async fn jwkset() {
+        let cache =
+            JWKSetCache::new("https://adapted-gorilla-88.clerk.accounts.dev/.well-known/jwks.json")
+                .await
+                .unwrap();
+        dbg!(cache.get("ins_2YFechxysnwZcZN6TDHEz6u6w6v").await.unwrap());
+    }
+}

--- a/proxy/src/serverless/sql_over_http.rs
+++ b/proxy/src/serverless/sql_over_http.rs
@@ -158,8 +158,10 @@ async fn get_conn_info(
     let username = if let Some(auth) = authorization {
         // TODO: introduce control plane API to fetch this
         let jwks_url = match sni_hostname {
-            "foo" => "https://adapted-gorilla-88.clerk.accounts.dev/.well-known/jwks.json",
-            _ => anyhow::bail!("invalid sni name"),
+            "ep-winter-pond-71436068.cloud.krypton.aws.neon.build" => {
+                "https://adapted-gorilla-88.clerk.accounts.dev/.well-known/jwks.json"
+            }
+            _ => anyhow::bail!("jwt auth not supported"),
         };
         let jwk_cache = jwk_cache_pool.get_cache(jwks_url).await?;
 

--- a/proxy/src/serverless/sql_over_http.rs
+++ b/proxy/src/serverless/sql_over_http.rs
@@ -158,7 +158,7 @@ async fn get_conn_info(
     let username = if let Some(auth) = authorization {
         // TODO: introduce control plane API to fetch this
         let jwks_url = match sni_hostname {
-            "ep-winter-pond-71436068.cloud.krypton.aws.neon.build" => {
+            "ep-flat-night-23370355.cloud.krypton.aws.neon.build" => {
                 "https://adapted-gorilla-88.clerk.accounts.dev/.well-known/jwks.json"
             }
             _ => anyhow::bail!("jwt auth not supported"),

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -54,7 +54,7 @@ ring = { version = "0.16", features = ["std"] }
 rustls = { version = "0.21", features = ["dangerous_configuration"] }
 scopeguard = { version = "1" }
 serde = { version = "1", features = ["alloc", "derive"] }
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 smallvec = { version = "1", default-features = false, features = ["write"] }
 time = { version = "0.3", features = ["local-offset", "macros", "serde-well-known"] }
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "test-util"] }


### PR DESCRIPTION
## Problem

🤐 

## Summary of changes

1. Add Authorization header to CORS
2. If Authorization header is provided in POST /sql, get the JWKs URL from the console setting for the endpoint ID
3. Validate the JWT in the Authorization Bearer token with the given JWKs
4. Take the polices and user_id (`sub`ject) from the JWT and give it to control-plane (`/proxy_ensure_row_level`)
5. Take the returned password from control-plane and connect to the database as normal

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
