### PR TITLE
Add test functions to neon_test_utils to consume CPU, memory, or local disk.

### DIFF
--- a/pgxn/neon_test_utils/neon_test_utils--1.0.sql
+++ b/pgxn/neon_test_utils/neon_test_utils--1.0.sql
@@ -7,6 +7,36 @@ AS 'MODULE_PATHNAME', 'test_consume_xids'
 LANGUAGE C STRICT
 PARALLEL UNSAFE;
 
+CREATE FUNCTION test_consume_cpu(seconds int)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'test_consume_cpu'
+LANGUAGE C STRICT
+PARALLEL UNSAFE;
+
+CREATE FUNCTION test_consume_memory(megabytes int)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'test_consume_memory'
+LANGUAGE C STRICT
+PARALLEL UNSAFE;
+
+CREATE FUNCTION test_release_memory(megabytes int DEFAULT NULL)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'test_release_memory'
+LANGUAGE C
+PARALLEL UNSAFE;
+
+CREATE FUNCTION test_consume_disk_space(megabytes int)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'test_consume_disk_space'
+LANGUAGE C STRICT
+PARALLEL UNSAFE;
+
+CREATE FUNCTION test_release_disk_space(megabytes int DEFAULT NULL)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'test_release_disk_space'
+LANGUAGE C
+PARALLEL UNSAFE;
+
 CREATE FUNCTION clear_buffer_cache()
 RETURNS VOID
 AS 'MODULE_PATHNAME', 'clear_buffer_cache'

--- a/test_runner/sql_regress/expected/neon-test-utils.out
+++ b/test_runner/sql_regress/expected/neon-test-utils.out
@@ -1,0 +1,46 @@
+-- Test the test utils in pgxn/neon_test_utils. We don't test that
+-- these actually consume resources like they should - that would be
+-- tricky - but at least we check that they don't crash.
+CREATE EXTENSION neon_test_utils;
+select test_consume_cpu(1);
+ test_consume_cpu 
+------------------
+ 
+(1 row)
+
+select test_consume_memory(20); -- Allocate 20 MB
+ test_consume_memory 
+---------------------
+ 
+(1 row)
+
+select test_release_memory(5);  -- Release 5 MB
+ test_release_memory 
+---------------------
+ 
+(1 row)
+
+select test_release_memory();   -- Release the remaining 15 MB
+ test_release_memory 
+---------------------
+ 
+(1 row)
+
+select test_consume_disk_space(20); -- Allocate 20 MB of disk space
+ test_consume_disk_space 
+-------------------------
+ 
+(1 row)
+
+select test_release_disk_space(5);  -- Release 5 MB
+ test_release_disk_space 
+-------------------------
+ 
+(1 row)
+
+select test_release_disk_space();   -- Release the remaining 15 MB
+ test_release_disk_space 
+-------------------------
+ 
+(1 row)
+

--- a/test_runner/sql_regress/parallel_schedule
+++ b/test_runner/sql_regress/parallel_schedule
@@ -7,4 +7,5 @@
 test: neon-cid
 test: neon-rel-truncate
 test: neon-clog
+test: neon-test-utils
 test: neon-vacuum-full

--- a/test_runner/sql_regress/sql/neon-test-utils.sql
+++ b/test_runner/sql_regress/sql/neon-test-utils.sql
@@ -1,0 +1,15 @@
+-- Test the test utils in pgxn/neon_test_utils. We don't test that
+-- these actually consume resources like they should - that would be
+-- tricky - but at least we check that they don't crash.
+
+CREATE EXTENSION neon_test_utils;
+
+select test_consume_cpu(1);
+
+select test_consume_memory(20); -- Allocate 20 MB
+select test_release_memory(5);  -- Release 5 MB
+select test_release_memory();   -- Release the remaining 15 MB
+
+select test_consume_disk_space(20); -- Allocate 20 MB of disk space
+select test_release_disk_space(5);  -- Release 5 MB
+select test_release_disk_space();   -- Release the remaining 15 MB


### PR DESCRIPTION
This is handy for testing VM autoscaling.
