### PR TITLE
pageserver: shut down idle walredo processes

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1710,11 +1710,6 @@ impl Tenant {
                 .await?;
         }
 
-        // Perhaps we did no work and the walredo process has been idle for some time:
-        // give it a chance to shut down to avoid leaving walredo process running indefinitely.
-        self.walredo_mgr
-            .maybe_quiesce(self.get_compaction_period() * 10);
-
         Ok(())
     }
 

--- a/pageserver/src/tenant/tasks.rs
+++ b/pageserver/src/tenant/tasks.rs
@@ -198,6 +198,10 @@ async fn compaction_loop(tenant: Arc<Tenant>, cancel: CancellationToken) {
 
             warn_when_period_overrun(started_at.elapsed(), period, BackgroundLoopKind::Compaction);
 
+            // Perhaps we did no work and the walredo process has been idle for some time:
+            // give it a chance to shut down to avoid leaving walredo process running indefinitely.
+            tenant.walredo_mgr.maybe_quiesce(period * 10);
+
             // Sleep
             if tokio::time::timeout(sleep_duration, cancel.cancelled())
                 .await


### PR DESCRIPTION
The longer a pageserver runs, the more walredo processes it accumulates from tenants that are touched intermittently (e.g. by availability checks).  This can lead to getting OOM killed.

Changes:
- Add an Instant recording the last use of the walredo process for a tenant
- After compaction iteration in the background task, check for idleness and stop the walredo process if idle for more than 10x compaction period.

Cc: #3620