### PR TITLE
pageserver: fix deletion/creation race

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1709,10 +1709,7 @@ impl Timeline {
         guard.initialize_local_layers(loaded_layers, disk_consistent_lsn + 1);
 
         if let Some(rtc) = self.remote_client.as_ref() {
-            rtc.schedule_layer_file_deletion(&needs_cleanup)?;
-            rtc.schedule_index_upload_for_file_changes()?;
-            // Tenant::create_timeline will wait for these uploads to happen before returning, or
-            // on retry.
+            rtc.flushing_delete_layers(&needs_cleanup).await?;
         }
 
         info!(


### PR DESCRIPTION
Closes: https://github.com/neondatabase/neon/issues/5878

## Problem

- #5878 

## Summary of changes

When deleting future layers on startup, wait for completion of the remote timeline client and do a flush-execute on the deletion queue.  This enforces ordering of the deletions vs. any later uploads.

This workaround will become unnecessary when we enable generations, as that will avoid all classes of bugs where keys collide across restarts, since the keys of an upload after restart will always have a new generation in them.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
