### PR TITLE
test: support validating allowed_errors against a logfile

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -42,7 +42,7 @@ from urllib3.util.retry import Retry
 from fixtures.broker import NeonBroker
 from fixtures.log_helper import log
 from fixtures.pageserver.allowed_errors import (
-    default_pageserver_allowed_errors,
+    DEFAULT_PAGESERVER_ALLOWED_ERRORS,
     scan_pageserver_log_for_errors,
 )
 from fixtures.pageserver.http import PageserverHttpClient
@@ -1626,7 +1626,7 @@ class NeonPageserver(PgProtocol):
         # env.pageserver.allowed_errors.append(".*could not open garage door.*")
         #
         # The entries in the list are regular experessions.
-        self.allowed_errors = default_pageserver_allowed_errors()
+        self.allowed_errors = list(DEFAULT_PAGESERVER_ALLOWED_ERRORS)
 
     def timeline_dir(self, tenant_id: TenantId, timeline_id: Optional[TimelineId] = None) -> Path:
         """Get a timeline directory's path based on the repo directory of the test environment"""

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -19,7 +19,7 @@ from functools import cached_property
 from itertools import chain, product
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Type, cast
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, cast
 from urllib.parse import urlparse
 
 import asyncpg
@@ -41,6 +41,10 @@ from urllib3.util.retry import Retry
 
 from fixtures.broker import NeonBroker
 from fixtures.log_helper import log
+from fixtures.pageserver.allowed_errors import (
+    default_pageserver_allowed_errors,
+    scan_pageserver_log_for_errors,
+)
 from fixtures.pageserver.http import PageserverHttpClient
 from fixtures.pageserver.utils import wait_for_last_record_lsn, wait_for_upload
 from fixtures.pg_version import PgVersion
@@ -1792,85 +1796,6 @@ class NeonPageserver(PgProtocol):
         return client.tenant_attach(tenant_id, config, config_null, generation=generation)
 
 
-def scan_pageserver_log_for_errors(
-    input: Iterable[str], allowed_errors: List[str]
-) -> List[Tuple[int, str]]:
-    error_or_warn = re.compile(r"\s(ERROR|WARN)")
-    errors = []
-    for lineno, line in enumerate(input, start=1):
-        if len(line) == 0:
-            continue
-
-        if error_or_warn.search(line):
-            # Is this a torn log line?  This happens when force-killing a process and restarting
-            # Example: "2023-10-25T09:38:31.752314Z  WARN deletion executo2023-10-25T09:38:31.875947Z  INFO version: git-env:0f9452f76e8ccdfc88291bccb3f53e3016f40192"
-            if re.match("\\d{4}-\\d{2}-\\d{2}T.+\\d{4}-\\d{2}-\\d{2}T.+INFO version.+", line):
-                continue
-
-            # It's an ERROR or WARN. Is it in the allow-list?
-            for a in allowed_errors:
-                if re.match(a, line):
-                    break
-            else:
-                errors.append((lineno, line))
-    return errors
-
-
-def default_pageserver_allowed_errors():
-    """Why as a function not a constant somewhere? These lists are modified, and this is the easiest way to create unique instances."""
-    return [
-        # All tests print these, when starting up or shutting down
-        ".*wal receiver task finished with an error: walreceiver connection handling failure.*",
-        ".*Shutdown task error: walreceiver connection handling failure.*",
-        ".*wal_connection_manager.*tcp connect error: Connection refused.*",
-        ".*query handler for .* failed: Socket IO error: Connection reset by peer.*",
-        ".*serving compute connection task.*exited with error: Postgres connection error.*",
-        ".*serving compute connection task.*exited with error: Connection reset by peer.*",
-        ".*serving compute connection task.*exited with error: Postgres query error.*",
-        ".*Connection aborted: error communicating with the server: Transport endpoint is not connected.*",
-        # FIXME: replication patch for tokio_postgres regards  any but CopyDone/CopyData message in CopyBoth stream as unexpected
-        ".*Connection aborted: unexpected message from server*",
-        ".*kill_and_wait_impl.*: wait successful.*",
-        ".*query handler for 'pagestream.*failed: Broken pipe.*",  # pageserver notices compute shut down
-        ".*query handler for 'pagestream.*failed: Connection reset by peer.*",  # pageserver notices compute shut down
-        # safekeeper connection can fail with this, in the window between timeline creation
-        # and streaming start
-        ".*Failed to process query for timeline .*: state uninitialized, no data to read.*",
-        # Tests related to authentication and authorization print these
-        ".*Error processing HTTP request: Forbidden",
-        # intentional failpoints
-        ".*failpoint ",
-        # FIXME: These need investigation
-        ".*manual_gc.*is_shutdown_requested\\(\\) called in an unexpected task or thread.*",
-        ".*tenant_list: timeline is not found in remote index while it is present in the tenants registry.*",
-        ".*Removing intermediate uninit mark file.*",
-        # Tenant::delete_timeline() can cause any of the four following errors.
-        # FIXME: we shouldn't be considering it an error: https://github.com/neondatabase/neon/issues/2946
-        ".*could not flush frozen layer.*queue is in state Stopped",  # when schedule layer upload fails because queued got closed before compaction got killed
-        ".*wait for layer upload ops to complete.*",  # .*Caused by:.*wait_completion aborted because upload queue was stopped
-        ".*gc_loop.*Gc failed, retrying in.*timeline is Stopping",  # When gc checks timeline state after acquiring layer_removal_cs
-        ".*gc_loop.*Gc failed, retrying in.*: Cannot run GC iteration on inactive tenant",  # Tenant::gc precondition
-        ".*compaction_loop.*Compaction failed.*, retrying in.*timeline or pageserver is shutting down",  # When compaction checks timeline state after acquiring layer_removal_cs
-        ".*query handler for 'pagestream.*failed: Timeline .* was not found",  # postgres reconnects while timeline_delete doesn't hold the tenant's timelines.lock()
-        ".*query handler for 'pagestream.*failed: Timeline .* is not active",  # timeline delete in progress
-        ".*task iteration took longer than the configured period.*",
-        # this is until #3501
-        ".*Compaction failed.*, retrying in [^:]+: Cannot run compaction iteration on inactive tenant",
-        # these can happen anytime we do compactions from background task and shutdown pageserver
-        r".*ERROR.*ancestor timeline \S+ is being stopped",
-        # this is expected given our collaborative shutdown approach for the UploadQueue
-        ".*Compaction failed.*, retrying in .*: Other\\(queue is in state Stopped.*",
-        # Pageserver timeline deletion should be polled until it gets 404, so ignore it globally
-        ".*Error processing HTTP request: NotFound: Timeline .* was not found",
-        ".*took more than expected to complete.*",
-        # these can happen during shutdown, but it should not be a reason to fail a test
-        ".*completed, took longer than expected.*",
-        # AWS S3 may emit 500 errors for keys in a DeleteObjects response: we retry these
-        # and it is not a failure of our code when it happens.
-        ".*DeleteObjects.*We encountered an internal error. Please try again.*",
-    ]
-
-
 def append_pageserver_param_overrides(
     params_to_update: List[str],
     remote_storage: Optional[RemoteStorage],
@@ -3383,35 +3308,3 @@ def parse_project_git_version_output(s: str) -> str:
         return commit
 
     raise ValueError(f"unable to parse --version output: '{s}'")
-
-
-if __name__ == "__main__":
-    import argparse
-
-    def check_allowed_errors_impl():
-        import sys
-
-        allowed_errors = default_pageserver_allowed_errors()
-
-        # add any test specifics here
-
-        errors = scan_pageserver_log_for_errors(sys.stdin, allowed_errors)
-
-        for lineno, error in errors:
-            print(f"-:{lineno}: {error}", file=sys.stderr)
-
-        if len(errors) > 0:
-            print(f"\n{len(errors)} errors", file=sys.stderr)
-            sys.exit(1)
-
-        sys.exit(0)
-
-    parser = argparse.ArgumentParser(
-        "neon_fixtures", description="do some checks done in test suite on demand"
-    )
-    subparsers = parser.add_subparsers()
-
-    check_allowed_errors = subparsers.add_parser(
-        "check_allowed_errors", help="check stdin against pageserver global allowed_errors"
-    )
-    check_allowed_errors.set_defaults(func=check_allowed_errors_impl)

--- a/test_runner/fixtures/pageserver/allowed_errors.py
+++ b/test_runner/fixtures/pageserver/allowed_errors.py
@@ -1,0 +1,118 @@
+import re
+from typing import Iterable, List, Tuple
+
+
+def scan_pageserver_log_for_errors(
+    input: Iterable[str], allowed_errors: List[str]
+) -> List[Tuple[int, str]]:
+    error_or_warn = re.compile(r"\s(ERROR|WARN)")
+    errors = []
+    for lineno, line in enumerate(input, start=1):
+        if len(line) == 0:
+            continue
+
+        if error_or_warn.search(line):
+            # Is this a torn log line?  This happens when force-killing a process and restarting
+            # Example: "2023-10-25T09:38:31.752314Z  WARN deletion executo2023-10-25T09:38:31.875947Z  INFO version: git-env:0f9452f76e8ccdfc88291bccb3f53e3016f40192"
+            if re.match("\\d{4}-\\d{2}-\\d{2}T.+\\d{4}-\\d{2}-\\d{2}T.+INFO version.+", line):
+                continue
+
+            # It's an ERROR or WARN. Is it in the allow-list?
+            for a in allowed_errors:
+                if re.match(a, line):
+                    break
+            else:
+                errors.append((lineno, line))
+    return errors
+
+
+def default_pageserver_allowed_errors():
+    """Why as a function not a constant somewhere? These lists are modified, and this is the easiest way to create unique instances."""
+    return [
+        # All tests print these, when starting up or shutting down
+        ".*wal receiver task finished with an error: walreceiver connection handling failure.*",
+        ".*Shutdown task error: walreceiver connection handling failure.*",
+        ".*wal_connection_manager.*tcp connect error: Connection refused.*",
+        ".*query handler for .* failed: Socket IO error: Connection reset by peer.*",
+        ".*serving compute connection task.*exited with error: Postgres connection error.*",
+        ".*serving compute connection task.*exited with error: Connection reset by peer.*",
+        ".*serving compute connection task.*exited with error: Postgres query error.*",
+        ".*Connection aborted: error communicating with the server: Transport endpoint is not connected.*",
+        # FIXME: replication patch for tokio_postgres regards  any but CopyDone/CopyData message in CopyBoth stream as unexpected
+        ".*Connection aborted: unexpected message from server*",
+        ".*kill_and_wait_impl.*: wait successful.*",
+        ".*query handler for 'pagestream.*failed: Broken pipe.*",  # pageserver notices compute shut down
+        ".*query handler for 'pagestream.*failed: Connection reset by peer.*",  # pageserver notices compute shut down
+        # safekeeper connection can fail with this, in the window between timeline creation
+        # and streaming start
+        ".*Failed to process query for timeline .*: state uninitialized, no data to read.*",
+        # Tests related to authentication and authorization print these
+        ".*Error processing HTTP request: Forbidden",
+        # intentional failpoints
+        ".*failpoint ",
+        # FIXME: These need investigation
+        ".*manual_gc.*is_shutdown_requested\\(\\) called in an unexpected task or thread.*",
+        ".*tenant_list: timeline is not found in remote index while it is present in the tenants registry.*",
+        ".*Removing intermediate uninit mark file.*",
+        # Tenant::delete_timeline() can cause any of the four following errors.
+        # FIXME: we shouldn't be considering it an error: https://github.com/neondatabase/neon/issues/2946
+        ".*could not flush frozen layer.*queue is in state Stopped",  # when schedule layer upload fails because queued got closed before compaction got killed
+        ".*wait for layer upload ops to complete.*",  # .*Caused by:.*wait_completion aborted because upload queue was stopped
+        ".*gc_loop.*Gc failed, retrying in.*timeline is Stopping",  # When gc checks timeline state after acquiring layer_removal_cs
+        ".*gc_loop.*Gc failed, retrying in.*: Cannot run GC iteration on inactive tenant",  # Tenant::gc precondition
+        ".*compaction_loop.*Compaction failed.*, retrying in.*timeline or pageserver is shutting down",  # When compaction checks timeline state after acquiring layer_removal_cs
+        ".*query handler for 'pagestream.*failed: Timeline .* was not found",  # postgres reconnects while timeline_delete doesn't hold the tenant's timelines.lock()
+        ".*query handler for 'pagestream.*failed: Timeline .* is not active",  # timeline delete in progress
+        ".*task iteration took longer than the configured period.*",
+        # this is until #3501
+        ".*Compaction failed.*, retrying in [^:]+: Cannot run compaction iteration on inactive tenant",
+        # these can happen anytime we do compactions from background task and shutdown pageserver
+        r".*ERROR.*ancestor timeline \S+ is being stopped",
+        # this is expected given our collaborative shutdown approach for the UploadQueue
+        ".*Compaction failed.*, retrying in .*: Other\\(queue is in state Stopped.*",
+        # Pageserver timeline deletion should be polled until it gets 404, so ignore it globally
+        ".*Error processing HTTP request: NotFound: Timeline .* was not found",
+        ".*took more than expected to complete.*",
+        # these can happen during shutdown, but it should not be a reason to fail a test
+        ".*completed, took longer than expected.*",
+        # AWS S3 may emit 500 errors for keys in a DeleteObjects response: we retry these
+        # and it is not a failure of our code when it happens.
+        ".*DeleteObjects.*We encountered an internal error. Please try again.*",
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    def check_allowed_errors_impl(_args):
+        import sys
+
+        allowed_errors = default_pageserver_allowed_errors()
+
+        # add any test specifics here; cli parsing is not provided for the
+        # difficulty of copypasting regexes as arguments without any quoting
+        # errors.
+
+        errors = scan_pageserver_log_for_errors(sys.stdin, allowed_errors)
+
+        for lineno, error in errors:
+            print(f"-:{lineno}: {error.strip()}", file=sys.stderr)
+
+        print(f"\n{len(errors)} not allowed errors", file=sys.stderr)
+
+        if len(errors) > 0:
+            sys.exit(1)
+        sys.exit(0)
+
+    parser = argparse.ArgumentParser(
+        "neon_fixtures", description="do some checks done in test suite on demand"
+    )
+    subparsers = parser.add_subparsers()
+
+    check_allowed_errors = subparsers.add_parser(
+        "check_allowed_errors", help="check stdin against pageserver global allowed_errors"
+    )
+    check_allowed_errors.set_defaults(func=check_allowed_errors_impl)
+
+    args = parser.parse_args()
+    args.func(args)

--- a/test_runner/fixtures/pageserver/allowed_errors.py
+++ b/test_runner/fixtures/pageserver/allowed_errors.py
@@ -25,6 +25,7 @@ def scan_pageserver_log_for_errors(
                 errors.append((lineno, line))
     return errors
 
+
 DEFAULT_PAGESERVER_ALLOWED_ERRORS = (
     # All tests print these, when starting up or shutting down
     ".*wal receiver task finished with an error: walreceiver connection handling failure.*",
@@ -77,6 +78,7 @@ DEFAULT_PAGESERVER_ALLOWED_ERRORS = (
     ".*DeleteObjects.*We encountered an internal error. Please try again.*",
 )
 
+
 def check_allowed_errors():
     import sys
 
@@ -96,6 +98,7 @@ def check_allowed_errors():
     if len(errors) > 0:
         sys.exit(1)
     sys.exit(0)
+
 
 if __name__ == "__main__":
     import argparse

--- a/test_runner/fixtures/pageserver/allowed_errors.py
+++ b/test_runner/fixtures/pageserver/allowed_errors.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 import argparse
 import re
 import sys
@@ -81,7 +83,7 @@ DEFAULT_PAGESERVER_ALLOWED_ERRORS = (
 )
 
 
-def check_allowed_errors(input):
+def _check_allowed_errors(input):
     allowed_errors: List[str] = list(DEFAULT_PAGESERVER_ALLOWED_ERRORS)
 
     # add any test specifics here; cli parsing is not provided for the
@@ -95,9 +97,7 @@ def check_allowed_errors(input):
 
     print(f"\n{len(errors)} not allowed errors", file=sys.stderr)
 
-    if len(errors) > 0:
-        sys.exit(1)
-    sys.exit(0)
+    return errors
 
 
 if __name__ == "__main__":
@@ -112,4 +112,6 @@ if __name__ == "__main__":
         help="Pageserver logs file. Reads from stdin if no file is provided.",
     )
     args = parser.parse_args()
-    check_allowed_errors(args.input)
+    errors = _check_allowed_errors(args.input)
+
+    sys.exit(len(errors) > 0)

--- a/test_runner/fixtures/pageserver/allowed_errors.py
+++ b/test_runner/fixtures/pageserver/allowed_errors.py
@@ -25,94 +25,84 @@ def scan_pageserver_log_for_errors(
                 errors.append((lineno, line))
     return errors
 
+DEFAULT_PAGESERVER_ALLOWED_ERRORS = (
+    # All tests print these, when starting up or shutting down
+    ".*wal receiver task finished with an error: walreceiver connection handling failure.*",
+    ".*Shutdown task error: walreceiver connection handling failure.*",
+    ".*wal_connection_manager.*tcp connect error: Connection refused.*",
+    ".*query handler for .* failed: Socket IO error: Connection reset by peer.*",
+    ".*serving compute connection task.*exited with error: Postgres connection error.*",
+    ".*serving compute connection task.*exited with error: Connection reset by peer.*",
+    ".*serving compute connection task.*exited with error: Postgres query error.*",
+    ".*Connection aborted: error communicating with the server: Transport endpoint is not connected.*",
+    # FIXME: replication patch for tokio_postgres regards  any but CopyDone/CopyData message in CopyBoth stream as unexpected
+    ".*Connection aborted: unexpected message from server*",
+    ".*kill_and_wait_impl.*: wait successful.*",
+    ".*query handler for 'pagestream.*failed: Broken pipe.*",  # pageserver notices compute shut down
+    ".*query handler for 'pagestream.*failed: Connection reset by peer.*",  # pageserver notices compute shut down
+    # safekeeper connection can fail with this, in the window between timeline creation
+    # and streaming start
+    ".*Failed to process query for timeline .*: state uninitialized, no data to read.*",
+    # Tests related to authentication and authorization print these
+    ".*Error processing HTTP request: Forbidden",
+    # intentional failpoints
+    ".*failpoint ",
+    # FIXME: These need investigation
+    ".*manual_gc.*is_shutdown_requested\\(\\) called in an unexpected task or thread.*",
+    ".*tenant_list: timeline is not found in remote index while it is present in the tenants registry.*",
+    ".*Removing intermediate uninit mark file.*",
+    # Tenant::delete_timeline() can cause any of the four following errors.
+    # FIXME: we shouldn't be considering it an error: https://github.com/neondatabase/neon/issues/2946
+    ".*could not flush frozen layer.*queue is in state Stopped",  # when schedule layer upload fails because queued got closed before compaction got killed
+    ".*wait for layer upload ops to complete.*",  # .*Caused by:.*wait_completion aborted because upload queue was stopped
+    ".*gc_loop.*Gc failed, retrying in.*timeline is Stopping",  # When gc checks timeline state after acquiring layer_removal_cs
+    ".*gc_loop.*Gc failed, retrying in.*: Cannot run GC iteration on inactive tenant",  # Tenant::gc precondition
+    ".*compaction_loop.*Compaction failed.*, retrying in.*timeline or pageserver is shutting down",  # When compaction checks timeline state after acquiring layer_removal_cs
+    ".*query handler for 'pagestream.*failed: Timeline .* was not found",  # postgres reconnects while timeline_delete doesn't hold the tenant's timelines.lock()
+    ".*query handler for 'pagestream.*failed: Timeline .* is not active",  # timeline delete in progress
+    ".*task iteration took longer than the configured period.*",
+    # this is until #3501
+    ".*Compaction failed.*, retrying in [^:]+: Cannot run compaction iteration on inactive tenant",
+    # these can happen anytime we do compactions from background task and shutdown pageserver
+    r".*ERROR.*ancestor timeline \S+ is being stopped",
+    # this is expected given our collaborative shutdown approach for the UploadQueue
+    ".*Compaction failed.*, retrying in .*: Other\\(queue is in state Stopped.*",
+    # Pageserver timeline deletion should be polled until it gets 404, so ignore it globally
+    ".*Error processing HTTP request: NotFound: Timeline .* was not found",
+    ".*took more than expected to complete.*",
+    # these can happen during shutdown, but it should not be a reason to fail a test
+    ".*completed, took longer than expected.*",
+    # AWS S3 may emit 500 errors for keys in a DeleteObjects response: we retry these
+    # and it is not a failure of our code when it happens.
+    ".*DeleteObjects.*We encountered an internal error. Please try again.*",
+)
 
-def default_pageserver_allowed_errors():
-    """Why as a function not a constant somewhere? These lists are modified, and this is the easiest way to create unique instances."""
-    return [
-        # All tests print these, when starting up or shutting down
-        ".*wal receiver task finished with an error: walreceiver connection handling failure.*",
-        ".*Shutdown task error: walreceiver connection handling failure.*",
-        ".*wal_connection_manager.*tcp connect error: Connection refused.*",
-        ".*query handler for .* failed: Socket IO error: Connection reset by peer.*",
-        ".*serving compute connection task.*exited with error: Postgres connection error.*",
-        ".*serving compute connection task.*exited with error: Connection reset by peer.*",
-        ".*serving compute connection task.*exited with error: Postgres query error.*",
-        ".*Connection aborted: error communicating with the server: Transport endpoint is not connected.*",
-        # FIXME: replication patch for tokio_postgres regards  any but CopyDone/CopyData message in CopyBoth stream as unexpected
-        ".*Connection aborted: unexpected message from server*",
-        ".*kill_and_wait_impl.*: wait successful.*",
-        ".*query handler for 'pagestream.*failed: Broken pipe.*",  # pageserver notices compute shut down
-        ".*query handler for 'pagestream.*failed: Connection reset by peer.*",  # pageserver notices compute shut down
-        # safekeeper connection can fail with this, in the window between timeline creation
-        # and streaming start
-        ".*Failed to process query for timeline .*: state uninitialized, no data to read.*",
-        # Tests related to authentication and authorization print these
-        ".*Error processing HTTP request: Forbidden",
-        # intentional failpoints
-        ".*failpoint ",
-        # FIXME: These need investigation
-        ".*manual_gc.*is_shutdown_requested\\(\\) called in an unexpected task or thread.*",
-        ".*tenant_list: timeline is not found in remote index while it is present in the tenants registry.*",
-        ".*Removing intermediate uninit mark file.*",
-        # Tenant::delete_timeline() can cause any of the four following errors.
-        # FIXME: we shouldn't be considering it an error: https://github.com/neondatabase/neon/issues/2946
-        ".*could not flush frozen layer.*queue is in state Stopped",  # when schedule layer upload fails because queued got closed before compaction got killed
-        ".*wait for layer upload ops to complete.*",  # .*Caused by:.*wait_completion aborted because upload queue was stopped
-        ".*gc_loop.*Gc failed, retrying in.*timeline is Stopping",  # When gc checks timeline state after acquiring layer_removal_cs
-        ".*gc_loop.*Gc failed, retrying in.*: Cannot run GC iteration on inactive tenant",  # Tenant::gc precondition
-        ".*compaction_loop.*Compaction failed.*, retrying in.*timeline or pageserver is shutting down",  # When compaction checks timeline state after acquiring layer_removal_cs
-        ".*query handler for 'pagestream.*failed: Timeline .* was not found",  # postgres reconnects while timeline_delete doesn't hold the tenant's timelines.lock()
-        ".*query handler for 'pagestream.*failed: Timeline .* is not active",  # timeline delete in progress
-        ".*task iteration took longer than the configured period.*",
-        # this is until #3501
-        ".*Compaction failed.*, retrying in [^:]+: Cannot run compaction iteration on inactive tenant",
-        # these can happen anytime we do compactions from background task and shutdown pageserver
-        r".*ERROR.*ancestor timeline \S+ is being stopped",
-        # this is expected given our collaborative shutdown approach for the UploadQueue
-        ".*Compaction failed.*, retrying in .*: Other\\(queue is in state Stopped.*",
-        # Pageserver timeline deletion should be polled until it gets 404, so ignore it globally
-        ".*Error processing HTTP request: NotFound: Timeline .* was not found",
-        ".*took more than expected to complete.*",
-        # these can happen during shutdown, but it should not be a reason to fail a test
-        ".*completed, took longer than expected.*",
-        # AWS S3 may emit 500 errors for keys in a DeleteObjects response: we retry these
-        # and it is not a failure of our code when it happens.
-        ".*DeleteObjects.*We encountered an internal error. Please try again.*",
-    ]
+def check_allowed_errors():
+    import sys
 
+    allowed_errors: List[str] = list(DEFAULT_PAGESERVER_ALLOWED_ERRORS)
+
+    # add any test specifics here; cli parsing is not provided for the
+    # difficulty of copypasting regexes as arguments without any quoting
+    # errors.
+
+    errors = scan_pageserver_log_for_errors(sys.stdin, allowed_errors)
+
+    for lineno, error in errors:
+        print(f"-:{lineno}: {error.strip()}", file=sys.stderr)
+
+    print(f"\n{len(errors)} not allowed errors", file=sys.stderr)
+
+    if len(errors) > 0:
+        sys.exit(1)
+    sys.exit(0)
 
 if __name__ == "__main__":
     import argparse
 
-    def check_allowed_errors_impl(_args):
-        import sys
-
-        allowed_errors = default_pageserver_allowed_errors()
-
-        # add any test specifics here; cli parsing is not provided for the
-        # difficulty of copypasting regexes as arguments without any quoting
-        # errors.
-
-        errors = scan_pageserver_log_for_errors(sys.stdin, allowed_errors)
-
-        for lineno, error in errors:
-            print(f"-:{lineno}: {error.strip()}", file=sys.stderr)
-
-        print(f"\n{len(errors)} not allowed errors", file=sys.stderr)
-
-        if len(errors) > 0:
-            sys.exit(1)
-        sys.exit(0)
-
     parser = argparse.ArgumentParser(
-        "neon_fixtures", description="do some checks done in test suite on demand"
+        description="check stdin against pageserver global allowed_errors"
     )
-    subparsers = parser.add_subparsers()
-
-    check_allowed_errors = subparsers.add_parser(
-        "check_allowed_errors", help="check stdin against pageserver global allowed_errors"
-    )
-    check_allowed_errors.set_defaults(func=check_allowed_errors_impl)
-
+    parser.set_defaults(func=check_allowed_errors)
     args = parser.parse_args()
-    args.func(args)
+    args.func()

--- a/test_runner/fixtures/pageserver/allowed_errors.py
+++ b/test_runner/fixtures/pageserver/allowed_errors.py
@@ -1,4 +1,6 @@
+import argparse
 import re
+import sys
 from typing import Iterable, List, Tuple
 
 
@@ -79,16 +81,14 @@ DEFAULT_PAGESERVER_ALLOWED_ERRORS = (
 )
 
 
-def check_allowed_errors():
-    import sys
-
+def check_allowed_errors(input):
     allowed_errors: List[str] = list(DEFAULT_PAGESERVER_ALLOWED_ERRORS)
 
     # add any test specifics here; cli parsing is not provided for the
     # difficulty of copypasting regexes as arguments without any quoting
     # errors.
 
-    errors = scan_pageserver_log_for_errors(sys.stdin, allowed_errors)
+    errors = scan_pageserver_log_for_errors(input, allowed_errors)
 
     for lineno, error in errors:
         print(f"-:{lineno}: {error.strip()}", file=sys.stderr)
@@ -101,11 +101,15 @@ def check_allowed_errors():
 
 
 if __name__ == "__main__":
-    import argparse
-
     parser = argparse.ArgumentParser(
-        description="check stdin against pageserver global allowed_errors"
+        description="check input against pageserver global allowed_errors"
     )
-    parser.set_defaults(func=check_allowed_errors)
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=argparse.FileType("r"),
+        default=sys.stdin,
+        help="Pageserver logs file. Reads from stdin if no file is provided.",
+    )
     args = parser.parse_args()
-    args.func()
+    check_allowed_errors(args.input)


### PR DESCRIPTION
this will make it easier to test if an added allowed_error does in fact match for example against a log file from an allure report.

```
$ python3 test_runner/fixtures/pageserver/allowed_errors.py --help
usage: allowed_errors.py [-h] [-i INPUT]

check input against pageserver global allowed_errors

optional arguments:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        Pageserver logs file. Reads from stdin if no file is provided.
```