### PR TITLE
Optimize storing of null page in WAL

### DIFF
--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,5 +1,5 @@
 {
-    "postgres-v16": "a6e38861ffd6255beee9ff53f868d4289c68234b",
+    "postgres-v16": "5214da6a2c5b9f0bc0c0f1912a505394bfe71547",
     "postgres-v15": "bc88f539312fcc4bb292ce94ae9db09ab6656e8a",
     "postgres-v14": "dd067cf656f6810a25aca6025633d32d02c5085a"
 }

--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,5 +1,5 @@
 {
-    "postgres-v16": "5214da6a2c5b9f0bc0c0f1912a505394bfe71547",
+    "postgres-v16": "e3a22b72922055f9212eca12700190f118578362",
     "postgres-v15": "bc88f539312fcc4bb292ce94ae9db09ab6656e8a",
     "postgres-v14": "dd067cf656f6810a25aca6025633d32d02c5085a"
 }

--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,5 +1,5 @@
 {
-    "postgres-v16": "763000f1d0873b827829c41f2f6f799ffc0de55c",
+    "postgres-v16": "a6e38861ffd6255beee9ff53f868d4289c68234b",
     "postgres-v15": "bc88f539312fcc4bb292ce94ae9db09ab6656e8a",
     "postgres-v14": "dd067cf656f6810a25aca6025633d32d02c5085a"
 }


### PR DESCRIPTION
## Problem

PG16 (https://github.com/neondatabase/postgres/pull/327) adds new function to SMGR: zeroextend
It's implementation in Neon actually wal-log zero pages of extended relation.
This zero page is wal-logged using XLOG_FPI.
As far as page is zero, the hole optimization (excluding from the image everything between pg_upper and pd_lower) doesn't work.

## Summary of changes

In case of zero page (`PageIsNull()` returns true) assume `hole_size=BLCKSZ`

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
