### PR TITLE
failure during timeline creation: always clean up timeline dir

### DIFF
--- a/pageserver/src/tenant/timeline/uninit.rs
+++ b/pageserver/src/tenant/timeline/uninit.rs
@@ -168,7 +168,7 @@ impl TimelineUninitMark {
             .write(true)
             .open(&uninit_mark_path)
             .context("create uninit mark file")?;
-        crashsafe::fsync_file_and_parent(&common_parent).context("fsync uninit mark file")?;
+        crashsafe::fsync_file_and_parent(common_parent).context("fsync uninit mark file")?;
 
         Ok(Self {
             uninit_mark_deleted: false,


### PR DESCRIPTION
Context: https://app.incident.io/neondb/incidents/103

Problem
=======

Before this change, there's the following race condition if the tenant
gets deleted during timeline creation:

TBD, copy from https://neondb.slack.com/archives/C066ZFAJU85/p1700751858049319

The root of the problem is that we bail out of timeline creation without
cleaning up the uninit marker or timeline directory.

Solution
========

This PR changes the code to do that, and with our new policy for
infallible local IO, it also takes the opportunity to clean stuff up
around `TimelineUninitMark` & `UninitializedTimeline`.

I also added a missing fsync of the common parent directory between
timelines_dir removal and uninit marker removal.

We could probably get rid of the entire uninit mark idea, as
we no longer treat local FS state as the source of truth, and we only
upload to remote storage after successful creation (right?).
