### PR TITLE
Move run_initdb to be async and guarded by max of 8 running tasks. Fixes #5895. Use tenant.cancel for cancellation

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -420,7 +420,7 @@ async fn reload_auth_validation_keys_handler(
 
 async fn timeline_create_handler(
     mut request: Request<Body>,
-    _cancel: CancellationToken,
+    cancel: CancellationToken,
 ) -> Result<Response<Body>, ApiError> {
     let tenant_shard_id: TenantShardId = parse_request_param(&request, "tenant_shard_id")?;
     let request_data: TimelineCreateRequest = json_request(&mut request).await?;
@@ -440,6 +440,7 @@ async fn timeline_create_handler(
             request_data.ancestor_start_lsn,
             request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
             state.broker_client.clone(),
+            &cancel,
             &ctx,
         )
         .await {

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -420,7 +420,7 @@ async fn reload_auth_validation_keys_handler(
 
 async fn timeline_create_handler(
     mut request: Request<Body>,
-    cancel: CancellationToken,
+    _cancel: CancellationToken,
 ) -> Result<Response<Body>, ApiError> {
     let tenant_shard_id: TenantShardId = parse_request_param(&request, "tenant_shard_id")?;
     let request_data: TimelineCreateRequest = json_request(&mut request).await?;
@@ -440,7 +440,6 @@ async fn timeline_create_handler(
             request_data.ancestor_start_lsn,
             request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
             state.broker_client.clone(),
-            &cancel,
             &ctx,
         )
         .await {

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3421,8 +3421,8 @@ async fn run_initdb(
         .env_clear()
         .env("LD_LIBRARY_PATH", &initdb_lib_dir)
         .env("DYLD_LIBRARY_PATH", &initdb_lib_dir)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
         .with_context(|| {

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3448,6 +3448,12 @@ async fn run_initdb(
         .env("DYLD_LIBRARY_PATH", &initdb_lib_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        // If the `select!` below doesn't finish the `wait_with_output`,
+        // let the task get `wait()`ed for asynchronously by tokio.
+        // This means there is a slim chance we can go over the INIT_DB_SEMAPHORE.
+        // TODO: fix for this is non-trivial, see
+        // https://github.com/neondatabase/neon/pull/5921#pullrequestreview-1750858021
+        //
         .kill_on_drop(true)
         .spawn()?;
 


### PR DESCRIPTION
## Problem
https://github.com/neondatabase/neon/issues/5895
