### PR TITLE
remove confusing no-op .take() of init_tenant_load_remote

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -733,7 +733,7 @@ impl Tenant {
     ///
     async fn attach(
         self: &Arc<Tenant>,
-        mut init_order: Option<InitializationOrder>,
+        init_order: Option<InitializationOrder>,
         preload: Option<TenantPreload>,
         ctx: &RequestContext,
     ) -> anyhow::Result<()> {
@@ -749,11 +749,6 @@ impl Tenant {
                 return self.load_local(init_order, ctx).await;
             }
         };
-
-        // Signal that we have completed remote phase
-        init_order
-            .as_mut()
-            .and_then(|x| x.initial_tenant_load_remote.take());
 
         let mut timelines_to_resume_deletions = vec![];
 


### PR DESCRIPTION
The `Tenant::spawn()` method already `.take()`s it.

I think this was an oversight in https://github.com/neondatabase/neon/pull/5580 .
