### PR TITLE
pageserver: fix race between deletion completion and incoming requests

### DIFF
--- a/pageserver/src/tenant/delete.rs
+++ b/pageserver/src/tenant/delete.rs
@@ -287,6 +287,8 @@ impl DeleteTenantFlow {
     ) -> Result<(), DeleteTenantError> {
         span::debug_assert_current_span_has_tenant_id();
 
+        pausable_failpoint!("tenant-delete-before-run");
+
         let mut guard = Self::prepare(&tenant).await?;
 
         if let Err(e) = Self::run_inner(&mut guard, conf, remote_storage.as_ref(), &tenant).await {
@@ -538,6 +540,7 @@ impl DeleteTenantFlow {
             .context("cleanup_remaining_fs_traces")?;
 
         {
+            pausable_failpoint!("tenant-delete-before-map-remove");
             let mut locked = tenants.write().unwrap();
             if locked.remove(&tenant.tenant_id).is_none() {
                 warn!("Tenant got removed from tenants map during deletion");

--- a/pageserver/src/tenant/delete.rs
+++ b/pageserver/src/tenant/delete.rs
@@ -583,8 +583,7 @@ impl DeleteTenantFlow {
                                     }
                                 },
                                 TenantSlot::InProgress(_) => {
-                                    // TenantsMap::remove handles InProgress separately, should never return it here
-                                    unreachable!();
+                                    unreachable!("TenantsMap::remove handles InProgress separately, should never return it here");
                                 }
                             };
                             break;

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -122,6 +122,12 @@ fn exactly_one_or_none<'a>(
     }
 }
 
+pub(crate) enum TenantsMapRemoveResult {
+    Occupied(TenantSlot),
+    Vacant,
+    InProgress(utils::completion::Barrier),
+}
+
 impl TenantsMap {
     /// Convenience function for typical usage, where we want to get a `Tenant` object, for
     /// working with attached tenants.  If the TenantId is in the map but in Secondary state,
@@ -136,25 +142,27 @@ impl TenantsMap {
         }
     }
 
-    /// Only for use from DeleteTenantFlow
-    pub(crate) fn remove(&mut self, tenant_id: &TenantId) -> Option<utils::completion::Barrier> {
+    /// Only for use from DeleteTenantFlow.  This method directly removes a TenantSlot from the map.
+    ///
+    /// The normal way to remove a tenant is using a SlotGuard, which will gracefully remove the guarded
+    /// slot if the enclosed tenant is shutdown.
+    pub(crate) fn remove(&mut self, tenant_id: &TenantId) -> TenantsMapRemoveResult {
         use std::collections::btree_map::Entry;
         match self {
-            TenantsMap::Initializing => None,
+            TenantsMap::Initializing => TenantsMapRemoveResult::Vacant,
             TenantsMap::Open(m) | TenantsMap::ShuttingDown(m) => {
                 let key = exactly_one_or_none(m, tenant_id).map(|(k, _)| *k);
                 match key {
                     Some(key) => match m.entry(key) {
                         Entry::Occupied(entry) => match entry.get() {
-                            TenantSlot::InProgress(barrier) => Some(barrier.clone()),
-                            _ => {
-                                entry.remove();
-                                None
+                            TenantSlot::InProgress(barrier) => {
+                                TenantsMapRemoveResult::InProgress(barrier.clone())
                             }
+                            _ => TenantsMapRemoveResult::Occupied(entry.remove()),
                         },
-                        Entry::Vacant(_entry) => None,
+                        Entry::Vacant(_entry) => TenantsMapRemoveResult::Vacant,
                     },
-                    None => None,
+                    None => TenantsMapRemoveResult::Vacant,
                 }
             }
         }

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -254,6 +254,7 @@ class PageserverHttpClient(requests.Session):
     def tenant_delete(self, tenant_id: TenantId):
         res = self.delete(f"http://localhost:{self.port}/v1/tenant/{tenant_id}")
         self.verbose_error(res)
+        return res
 
     def tenant_load(self, tenant_id: TenantId):
         res = self.post(f"http://localhost:{self.port}/v1/tenant/{tenant_id}/load")


### PR DESCRIPTION
## Problem

This is a narrow race that can leave a stuck Stopping tenant behind, while emitting a log error "Missing InProgress marker during tenant upsert, this is a bug"

- Deletion request 1 puts tenant into Stopping state, and fires off background part of DeleteTenantFlow
- Deletion request 2 acquires a SlotGuard for the same tenant ID, leaves a TenantSlot::InProgress in place while it checks if the tenant's state is accept able.
- DeleteTenantFlow finishes, calls TenantsMap::remove, which removes the InProgress marker.
- Deletion request 2 calls SlotGuard::revert, which upserts the old value (the Tenant in Stopping state), and emits the telltale log message.

Closes: #5936 

## Summary of changes

- Add a regression test which uses pausable failpoints to reproduce this scenario.
- TenantsMap::remove is only called by DeleteTenantFlow.  Its behavior is tweaked to express the different possible states, especially `InProgress` which carriers a barrier.
- In DeleteTenantFlow, if we see such a barrier result from remove(), wait for the barrier and then try removing again.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
