### PR TITLE
Use TEST_OUTPUT envvar in pageserver

### DIFF
--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -960,7 +960,8 @@ impl PageServerConf {
 
     #[cfg(test)]
     pub fn test_repo_dir(test_name: &str) -> Utf8PathBuf {
-        Utf8PathBuf::from(format!("../tmp_check/test_{test_name}"))
+        let test_output_dir = std::env::var("TEST_OUTPUT").unwrap_or("../tmp_check".into());
+        Utf8PathBuf::from(format!("{test_output_dir}/test_{test_name}"))
     }
 
     pub fn dummy_conf(repo_dir: Utf8PathBuf) -> Self {


### PR DESCRIPTION
In python tests we can use TEST_OUTPUT envvar to overwrite the default dir. It's useful for perf tests where you want to write to a dir inside the mounted ssd (the neon repo itself might not be). I'm sure there are other workarounds but this seems generally useful anyway.