### PR TITLE
fixed the storage node docker image build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ ARG TAG=pinned
 
 # Build Postgres
 FROM $REPOSITORY/$IMAGE:$TAG AS pg-build
+
+# Install necessary dependencies
+USER root
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev build-essential
+
+USER nonroot
 WORKDIR /home/nonroot
 
 COPY --chown=nonroot vendor/postgres-v14 vendor/postgres-v14


### PR DESCRIPTION
## Problem
git clone --recursive https://github.com/neondatabase/neon.git
cd neon
git checkout releases/2023-11-10
git submodule update
docker build -t neon/storage-node -f Dockerfile --build-arg REPOSITORY=neondatabase --progress=plain .

then error below 
...
140.1 Compiling amcheck v16
------
Dockerfile:21
--------------------
  20 |     ENV BUILD_TYPE release
  21 | >>> RUN set -e \
  22 | >>>     && mold -run make -j $(nproc) -s neon-pg-ext \
  23 | >>>     && rm -rf pg_install/build \
  24 | >>>     && tar -C pg_install -czf /home/nonroot/postgres_install.tar.gz .
  25 |     
--------------------
ERROR: failed to solve: process "/bin/bash -c set -e     && mold -run make -j $(nproc) -s neon-pg-ext     && rm -rf pg_install/build     && tar -C pg_install -czf /home/nonroot/postgres_install.tar.gz ." did not complete successfully: exit code: 2

## Summary of changes
added necessary dependencies, i.e.  libcurl4-openssl-dev build-essential to Dockerfile,

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
