### PR TITLE
create-test-report: use ec2 github runner

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -478,7 +478,7 @@ jobs:
     needs: [ check-permissions, regress-tests, coverage-report, benchmarks ]
     if: ${{ !cancelled() && contains(fromJSON('["skipped", "success"]'), needs.check-permissions.result) }}
 
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: [ self-hosted, dev, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/rust:pinned
       options: --init


### PR DESCRIPTION
## Problem

`create-test-report` job usually takes ~3 minutes. I've taken [a random run](https://github.com/neondatabase/neon/actions/runs/7045887080/job/19178390469) of this job, from it:
- Total time reported by GitHub 3m 45s
- `allure generate ...` — report generation itself
```
real	0m6.079s
user	0m39.064s
sys	0m4.425s
```
- `aws s3 cp ...`  — uploading report to S3
```
real	1m58.877s
user	1m10.332s
sys	0m8.049s
```

Let's try to speed it up by using a GitHub Runner on ec2 instance in the same region as S3 

## Summary of changes
- Switch from gen3 small runner to ec2 runner in the same region as the bucket is

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
