### PR TITLE
test: python needs thread safety as well

### DIFF
--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -138,6 +138,7 @@ def subprocess_capture(
 
 
 _global_counter = 0
+_global_counter_lock = threading.Lock()
 
 
 def global_counter() -> int:
@@ -146,9 +147,13 @@ def global_counter() -> int:
     This is useful for giving output files a unique number, so if we run the
     same command multiple times we can keep their output separate.
     """
-    global _global_counter
-    _global_counter += 1
-    return _global_counter
+    global _global_counter, _global_counter_lock
+    _global_counter_lock.acquire()
+    try:
+        _global_counter += 1
+        return _global_counter
+    finally:
+        _global_counter_lock.release()
 
 
 def print_gc_result(row: Dict[str, Any]):

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -148,12 +148,9 @@ def global_counter() -> int:
     same command multiple times we can keep their output separate.
     """
     global _global_counter, _global_counter_lock
-    _global_counter_lock.acquire()
-    try:
+    with _global_counter_lock:
         _global_counter += 1
         return _global_counter
-    finally:
-        _global_counter_lock.release()
 
 
 def print_gc_result(row: Dict[str, Any]):

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -142,7 +142,7 @@ _global_counter_lock = threading.Lock()
 
 
 def global_counter() -> int:
-    """A really dumb global counter.
+    """A really dumb but thread-safe global counter.
 
     This is useful for giving output files a unique number, so if we run the
     same command multiple times we can keep their output separate.


### PR DESCRIPTION
we have test cases which launch processes from threads, and they capture output assuming this counter is thread-safe. at least according to my understanding this operation in python requires a lock to be thread-safe.