### PR TITLE
Clean up local state if index_part.json request gives 404

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3095,6 +3095,8 @@ impl Tenant {
             anyhow::bail!("failpoint before-checkpoint-new-timeline");
         });
 
+        pausable_failpoint!("before-checkpoint-new-timeline-pausable");
+
         unfinished_timeline
             .freeze_and_flush()
             .await

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3095,8 +3095,6 @@ impl Tenant {
             anyhow::bail!("failpoint before-checkpoint-new-timeline");
         });
 
-        pausable_failpoint!("before-checkpoint-new-timeline-pausable");
-
         unfinished_timeline
             .freeze_and_flush()
             .await

--- a/test_runner/regress/test_broken_timeline.py
+++ b/test_runner/regress/test_broken_timeline.py
@@ -148,7 +148,8 @@ def test_timeline_init_break_before_checkpoint(neon_env_builder: NeonEnvBuilder)
 def test_timeline_init_break_before_checkpoint_recreate(
     neon_env_builder: NeonEnvBuilder, pause_or_return: str
 ):
-    env = neon_env_builder.init_start()
+    env = neon_env_builder.init_configs()
+    env.start()
     pageserver_http = env.pageserver.http_client()
 
     env.pageserver.allowed_errors.extend(
@@ -163,6 +164,7 @@ def test_timeline_init_break_before_checkpoint_recreate(
             ".*method=POST path=.*/timeline .*request was dropped before completing.*"
         )
 
+    pageserver_http.tenant_create(env.initial_tenant)
     tenant_id = env.initial_tenant
 
     timelines_dir = env.pageserver.timeline_dir(tenant_id)

--- a/test_runner/regress/test_tenant_delete.py
+++ b/test_runner/regress/test_tenant_delete.py
@@ -197,7 +197,6 @@ def test_delete_tenant_exercise_crash_safety_failpoints(
             # So by ignoring these instead of waiting for empty upload queue
             # we execute more distinct code paths.
             '.*stopping left-over name="remote upload".*',
-            ".*Failed to load index_part from remote storage, failed creation?.*",
         ]
     )
 

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -293,7 +293,6 @@ def test_pageserver_with_empty_tenants(
     env.pageserver.allowed_errors.extend(
         [
             ".*marking .* as locally complete, while it doesnt exist in remote index.*",
-            ".*Failed to load index_part from remote storage, failed creation?.*",
             ".*load failed.*list timelines directory.*",
         ]
     )

--- a/test_runner/regress/test_timeline_delete.py
+++ b/test_runner/regress/test_timeline_delete.py
@@ -230,9 +230,6 @@ def test_delete_timeline_exercise_crash_safety_failpoints(
     env.pageserver.allowed_errors.append(".*Timeline dir entry become invalid.*")
     # In one of the branches we poll for tenant to become active. Polls can generate this log message:
     env.pageserver.allowed_errors.append(f".*Tenant {env.initial_tenant} is not active*")
-    env.pageserver.allowed_errors.append(
-        ".*Failed to load index_part from remote storage, failed creation?.*"
-    )
 
     ps_http.configure_failpoints((failpoint, "return"))
 
@@ -311,9 +308,10 @@ def test_delete_timeline_exercise_crash_safety_failpoints(
         )
 
     timeline_dir = env.pageserver.timeline_dir(env.initial_tenant, timeline_id)
-    if failpoint != "timeline-delete-after-index-delete":
-        # Check local is empty
-        assert (not timeline_dir.exists()) or len(os.listdir(timeline_dir)) == 0
+
+    # Check local is empty
+    assert (not timeline_dir.exists()) or len(os.listdir(timeline_dir)) == 0
+
     # Check no delete mark present
     assert not (timeline_dir.parent / f"{timeline_id}.___deleted").exists()
 


### PR DESCRIPTION
If `index_part.json` is (verifiably) not present on remote storage, we should regard the timeline as inexistent. This lets `clean_up_timelines` purge the partial local disk state, which is important in the case of incomplete creations leaving behind state that hinders retries. For incomplete deletions, we also want the timeline's local disk content be gone completely.

The PR removes the allowed warnings added by #5390 and #5912, as we now are only supposed to issue info level messages. It also adds a reproducer for #6007, by parametrizing the `test_timeline_init_break_before_checkpoint_recreate` test added by #5390. If one reverts the .rs changes, the "cannot create its uninit mark file" log line occurs once one comments out the failing checks for the local disk state being actually empty.

Closes #6007