### PR TITLE
[DO NOT MERGE] Allow compute to start when pageserver doesn't have prev_lsn.

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -459,11 +459,7 @@ where
         // add zenith.signal file
         let mut zenith_signal = String::new();
         if self.prev_record_lsn == Lsn(0) {
-            if self.lsn == self.timeline.get_ancestor_lsn() {
-                write!(zenith_signal, "PREV LSN: none")?;
-            } else {
-                write!(zenith_signal, "PREV LSN: invalid")?;
-            }
+            write!(zenith_signal, "PREV LSN: none")?;
         } else {
             write!(zenith_signal, "PREV LSN: {}", self.prev_record_lsn)?;
         }


### PR DESCRIPTION
I'm testing recovery scenario using only pageserver in case if sakekeeper data is not available. Looks like in the case of crash restart of pageserver we may not retain prev_lsn and compute will refuse to start with `cannot start in read-write mode from this base backup`. This PR is to build images to check that setting `PREV LSN: none` can help in that case. 