### PR TITLE
asyncify-simple_rcu: minor fixes

### DIFF
--- a/libs/utils/src/simple_rcu.rs
+++ b/libs/utils/src/simple_rcu.rs
@@ -142,8 +142,8 @@ impl<V> Deref for RcuReadGuard<V> {
 ///
 /// Write guard returned by `write`
 ///
-/// NB: Holding this guard blocks all concurrent `read` and `write` calls, so
-/// it should only be held for a short duration!
+/// NB: Holding this guard blocks all concurrent `read` and `write` calls, so it should only be
+/// held for a short duration!
 ///
 /// Calling [`Self::store_and_unlock`] consumes the guard, making new reads and new writes possible
 /// again.

--- a/libs/utils/src/simple_rcu.rs
+++ b/libs/utils/src/simple_rcu.rs
@@ -145,7 +145,7 @@ impl<V> Deref for RcuReadGuard<V> {
 /// NB: Holding this guard blocks all concurrent `read` and `write` calls, so
 /// it should only be held for a short duration!
 ///
-/// Calling `store` consumes the guard, making new reads and new writes possible
+/// Calling [`Self::store_and_unlock`] consumes the guard, making new reads and new writes possible
 /// again.
 ///
 pub struct RcuWriteGuard<'a, V> {


### PR DESCRIPTION
- remove the mutex
- documentation

See: #6046.