### PR TITLE
tests: use tenant_create() helper in test_bulk_insert

### DIFF
--- a/test_runner/performance/test_bulk_insert.py
+++ b/test_runner/performance/test_bulk_insert.py
@@ -57,7 +57,7 @@ def measure_recovery_time(env: NeonCompare):
     # when we "create" the Tenant again, we will replay the WAL from the beginning.
     client.tenant_delete(env.tenant)
     wait_tenant_status_404(client, env.tenant, iterations=60, interval=0.5)
-    client.tenant_create(new_tenant_id=env.tenant)
+    env.env.pageserver.tenant_create(tenant_id=env.tenant)
 
     # Measure recovery time
     with env.record_duration("wal_recovery"):


### PR DESCRIPTION
## Problem

Since #5449 we enable generations in tests by default.  Running benchmarks was missed while merging that PR, and there was one that needed updating.

## Summary of changes

Make test_bulk_insert use the proper generation-aware helper for tenant creation.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
