### PR TITLE
test_tenant_reattach: fix reattach mode names

### DIFF
--- a/test_runner/regress/test_tenant_detach.py
+++ b/test_runner/regress/test_tenant_detach.py
@@ -55,7 +55,7 @@ def do_gc_target(
 class ReattachMode(str, enum.Enum):
     REATTACH_EXPLICIT = "explicit"
     REATTACH_RESET = "reset"
-    REATTACH_RESET_DROP = "reset"
+    REATTACH_RESET_DROP = "reset_drop"
 
 
 # Basic detach and re-attach test


### PR DESCRIPTION
## Problem

Ref https://neondb.slack.com/archives/C033QLM5P7D/p1701987609146109?thread_ts=1701976393.757279&cid=C033QLM5P7D

## Summary of changes
- Make reattach mode names unique for `test_tenant_reattach`

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
