### PR TITLE
tests: allow-lists for occasional failures

### DIFF
--- a/test_runner/regress/test_tenant_conf.py
+++ b/test_runner/regress/test_tenant_conf.py
@@ -314,6 +314,10 @@ def test_creating_tenant_conf_after_attach(neon_env_builder: NeonEnvBuilder):
 
     assert not config_path.exists(), "detach did not remove config file"
 
+    # The re-attach's increment of the generation number may invalidate deletion queue
+    # updates in flight from the previous attachment.
+    env.pageserver.allowed_errors.append(".*Dropped remote consistent LSN updates.*")
+
     env.pageserver.tenant_attach(tenant_id)
     wait_until(
         number_of_iterations=5,


### PR DESCRIPTION
test_creating_tenant_conf_after...
- Test detaches a tenant and then re-attaches immediatel: this causes a race between pending remote LSN update and the generation bump in the attachment.

test_gc_cutoff:
- Test rapidly restarts a pageserver before one generation has had the chance to process deletions from the previous generation
