### PR TITLE
Less noisy pausable_failpoint

### DIFF
--- a/pageserver/src/tenant/delete.rs
+++ b/pageserver/src/tenant/delete.rs
@@ -286,7 +286,7 @@ impl DeleteTenantFlow {
     ) -> Result<(), DeleteTenantError> {
         span::debug_assert_current_span_has_tenant_id();
 
-        pausable_failpoint!("tenant-delete-before-run");
+        crate::failpoint_support::pausable_failpoint!("tenant-delete-before-run");
 
         let mut guard = Self::prepare(&tenant).await?;
 
@@ -538,7 +538,7 @@ impl DeleteTenantFlow {
             .context("cleanup_remaining_fs_traces")?;
 
         {
-            pausable_failpoint!("tenant-delete-before-map-remove");
+            crate::failpoint_support::pausable_failpoint!("tenant-delete-before-map-remove");
 
             // This block is simply removing the TenantSlot for this tenant.  It requires a loop because
             // we might conflict with a TenantSlot::InProgress marker and need to wait for it.

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -961,7 +961,7 @@ impl RemoteTimelineClient {
             stopped.deleted_at = SetDeletedFlagProgress::NotRunning;
         });
 
-        pausable_failpoint!("persist_deleted_index_part");
+        crate::failpoint_support::pausable_failpoint!("persist_deleted_index_part");
 
         backoff::retry(
             || {
@@ -1326,7 +1326,7 @@ impl RemoteTimelineClient {
                     res
                 }
                 UploadOp::Delete(delete) => {
-                    pausable_failpoint!("before-delete-layer-pausable");
+                    crate::failpoint_support::pausable_failpoint!("before-delete-layer-pausable");
                     self.deletion_queue_client
                         .push_layers(
                             self.tenant_shard_id,

--- a/pageserver/src/tenant/remote_timeline_client/upload.rs
+++ b/pageserver/src/tenant/remote_timeline_client/upload.rs
@@ -34,7 +34,7 @@ pub(super) async fn upload_index_part<'a>(
     fail_point!("before-upload-index", |_| {
         bail!("failpoint before-upload-index")
     });
-    pausable_failpoint!("before-upload-index-pausable");
+    crate::failpoint_support::pausable_failpoint!("before-upload-index-pausable");
 
     let index_part_bytes = index_part
         .to_s3_bytes()
@@ -68,7 +68,7 @@ pub(super) async fn upload_timeline_layer<'a>(
         bail!("failpoint before-upload-layer")
     });
 
-    pausable_failpoint!("before-upload-layer-pausable");
+    crate::failpoint_support::pausable_failpoint!("before-upload-layer-pausable");
 
     let storage_path = remote_path(conf, source_path, generation)?;
     let source_file_res = fs::File::open(&source_path).await;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2736,7 +2736,9 @@ impl Timeline {
                 )
             };
 
-        pausable_failpoint!("flush-layer-cancel-after-writing-layer-out-pausable");
+        crate::failpoint_support::pausable_failpoint!(
+            "flush-layer-cancel-after-writing-layer-out-pausable"
+        );
 
         if self.cancel.is_cancelled() {
             return Err(FlushLayerError::Cancelled);
@@ -2774,7 +2776,7 @@ impl Timeline {
         // We still schedule the upload, resulting in an error, but ideally we'd somehow avoid this
         // race situation.
         // See https://github.com/neondatabase/neon/issues/4526
-        pausable_failpoint!("flush-frozen-pausable");
+        crate::failpoint_support::pausable_failpoint!("flush-frozen-pausable");
 
         // This failpoint is used by another test case `test_pageserver_recovery`.
         fail_point!("flush-frozen-exit");

--- a/pageserver/src/tenant/timeline/delete.rs
+++ b/pageserver/src/tenant/timeline/delete.rs
@@ -558,7 +558,7 @@ impl DeleteTimelineFlow {
 
         delete_remote_layers_and_index(timeline).await?;
 
-        pausable_failpoint!("in_progress_delete");
+        crate::failpoint_support::pausable_failpoint!("in_progress_delete");
 
         cleanup_remaining_timeline_fs_traces(conf, tenant.tenant_shard_id, timeline.timeline_id)
             .await?;


### PR DESCRIPTION
`pausable_failpoint!` is a macro which supports `pause` action from `fail`, which we need to do in a `spawn_blocking` task so that we don't block an executor thread. We also wish to synchronize with the failpoint being hit from python tests, so we scan the log until we hit see that we might now be paused at the failpoint[^1].

This PR introduces more synchronization and a timeout to "knowing" if we are paused. The suggested 100ms might be too much or too little. Let's see a few rounds of test runs to determine that. It might be this is not usable on runners but it is definitely usable when debugging a test run.

[^1]: or have previously printed the message because we cannot know if the action will be taken or not.