### PR TITLE
test: disable removed future layers

### DIFF
--- a/pageserver/src/control_plane_client.rs
+++ b/pageserver/src/control_plane_client.rs
@@ -173,6 +173,7 @@ impl ControlPlaneGenerationsApi for ControlPlaneClient {
         };
 
         fail::fail_point!("control-plane-client-validate");
+        crate::pausable_failpoint!("control-plane-client-validate-pausable");
 
         let response: ValidateResponse = self.retry_http_forever(&re_attach_path, request).await?;
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -111,6 +111,7 @@ use utils::{
 
 /// Declare a failpoint that can use the `pause` failpoint action.
 /// We don't want to block the executor thread, hence, spawn_blocking + await.
+#[macro_export]
 macro_rules! pausable_failpoint {
     ($name:literal) => {
         if cfg!(feature = "testing") {

--- a/test_runner/regress/test_pageserver_generations.py
+++ b/test_runner/regress/test_pageserver_generations.py
@@ -343,20 +343,15 @@ def test_deletion_queue_recovery(
 
     ps_http = env.pageserver.http_client()
 
-    failpoints = [
-        # Prevent deletion lists from being executed, to build up some backlog of deletions
-        ("deletion-queue-before-execute", "return"),
-    ]
-
     if validate_before == ValidateBefore.NO_VALIDATE:
-        failpoints.append(
-            # Prevent deletion lists from being validated, we will test that they are
-            # dropped properly during recovery.  'pause' is okay here because we kill
-            # the pageserver with immediate=true
-            ("control-plane-client-validate", "pause")
-        )
+        # Prevent deletion lists from being validated, we will test that they are
+        # dropped properly during recovery.  'pause' is okay here because we kill
+        # the pageserver with immediate=true
+        ps_http.configure_failpoints(("control-plane-client-validate-pausable", "pause"))
+    else:
+        # Prevent deletion lists from being executed, to build up some backlog of deletions
+        ps_http.configure_failpoints(("deletion-queue-before-execute", "return"))
 
-    ps_http.configure_failpoints(failpoints)
     tenant_id = env.initial_tenant
     timeline_id = env.initial_timeline
 


### PR DESCRIPTION
Use `wait_for_upload_queue_empty` to make it more likely to not have future layers. Fix failpoint `pause` usage without `pausable_failpoint`.

Fixes: #6092