### PR TITLE
make `read_exact_at` cancel-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5158,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "tokio-epoll-uring"
 version = "0.1.0"
-source = "git+https://github.com/neondatabase/tokio-epoll-uring.git?branch=main#2ae71cebd8f032ebfa987b713a77bc3d23aac57c"
+source = "git+https://github.com/neondatabase/tokio-epoll-uring.git?branch=main#82d74064c5019b0e9a8ae1bcdc75b0345d41bba9"
 dependencies = [
  "futures",
  "once_cell",
@@ -5714,7 +5714,7 @@ dependencies = [
 [[package]]
 name = "uring-common"
 version = "0.1.0"
-source = "git+https://github.com/neondatabase/tokio-epoll-uring.git?branch=main#2ae71cebd8f032ebfa987b713a77bc3d23aac57c"
+source = "git+https://github.com/neondatabase/tokio-epoll-uring.git?branch=main#82d74064c5019b0e9a8ae1bcdc75b0345d41bba9"
 dependencies = [
  "io-uring",
  "libc",


### PR DESCRIPTION
Before this PR, we didn't move ownership of the `FileGuard` to the read future.

This meant the `read_exact_at` future wasn't cancel-safe, because dropping it while the `read` future was live could lead to use-after-`close` of the file descriptor.
We protected against that through a scopeguard.

This PR builds on top of https://github.com/neondatabase/tokio-epoll-uring/pull/27
, passing `FileGuard` ownership to the tokio-epoll-uring read() operation.

This makes the `read_exact_at` cancel-safe.