### PR TITLE
fix: accidential return Ok

### DIFF
--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -313,7 +313,7 @@ async fn calculate_synthetic_size_worker(
 
         let res = tokio::time::timeout_at(
             started_at + synthetic_size_calculation_interval,
-            task_mgr::shutdown_token().cancelled(),
+            cancel.cancelled(),
         )
         .await;
         if res.is_ok() {

--- a/pageserver/src/consumption_metrics.rs
+++ b/pageserver/src/consumption_metrics.rs
@@ -290,11 +290,12 @@ async fn calculate_synthetic_size_worker(
                     if let Some(PageReconstructError::Cancelled) =
                         e.downcast_ref::<PageReconstructError>()
                     {
-                        return Ok(());
-                    }
-                    error!(
+                        // it is being shutdown, be quiet
+                    } else {
+                        error!(
                         "failed to calculate synthetic size for tenant {tenant_shard_id}: {e:#}"
                     );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Error indicating request cancellation OR timeline shutdown was deemed as a reason to exit the background worker that calculated synthetic size. Fix it to only be considered for avoiding logging such of such errors.