### PR TITLE
tokio-epoll-uring: fix cfg(test) and provide again VirtualFile::read_at, used only in cfg(test)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5158,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "tokio-epoll-uring"
 version = "0.1.0"
-source = "git+https://github.com/neondatabase/tokio-epoll-uring.git?branch=main#53c832d322244f704c7612125496df5ac117ac39"
+source = "git+https://github.com/neondatabase/tokio-epoll-uring.git?branch=main#2ae71cebd8f032ebfa987b713a77bc3d23aac57c"
 dependencies = [
  "futures",
  "once_cell",
@@ -5714,7 +5714,7 @@ dependencies = [
 [[package]]
 name = "uring-common"
 version = "0.1.0"
-source = "git+https://github.com/neondatabase/tokio-epoll-uring.git?branch=main#53c832d322244f704c7612125496df5ac117ac39"
+source = "git+https://github.com/neondatabase/tokio-epoll-uring.git?branch=main#2ae71cebd8f032ebfa987b713a77bc3d23aac57c"
 dependencies = [
  "io-uring",
  "libc",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -83,7 +83,6 @@ enum-map.workspace = true
 enumset.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
-# WIP PR: https://github.com/neondatabase/tokio-epoll-uring/pull/25
 #tokio-epoll-uring = { path = "../../tokio-epoll-uring/tokio-epoll-uring" }
 tokio-epoll-uring = { git = "https://github.com/neondatabase/tokio-epoll-uring.git" , branch = "main" }
 

--- a/pageserver/src/tenant/ephemeral_file.rs
+++ b/pageserver/src/tenant/ephemeral_file.rs
@@ -91,7 +91,7 @@ impl EphemeralFile {
                 page_cache::ReadBufResult::NotFound(write_guard) => {
                     let write_guard = self
                         .file
-                        .read_exact_at(write_guard, blknum as u64 * PAGE_SZ as u64)
+                        .read_exact_at_page(write_guard, blknum as u64 * PAGE_SZ as u64)
                         .await?;
                     let read_guard = write_guard.mark_valid();
                     return Ok(BlockLease::PageReadGuard(read_guard));


### PR DESCRIPTION
With this PR, the tests pass on my machine.

I'm working on making the tokio-epoll-uring.git repo public so that the neon.git CI passes.

I'll rebase https://github.com/neondatabase/neon/pull/6101 onto this one.

