### PR TITLE
Fix python list_segments of sk.

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2945,7 +2945,7 @@ class Safekeeper:
         tli_dir = self.timeline_dir(tenant_id, timeline_id)
         segments = []
         for _, _, filenames in os.walk(tli_dir):
-            segments.extend([f for f in filenames if f != "safekeeper.control"])
+            segments.extend([f for f in filenames if not f.startswith("safekeeper.control")])
         segments.sort()
         return segments
 


### PR DESCRIPTION
Fixes rare test_peer_recovery flakiness as we started to compare tmp control file.

https://neondb.slack.com/archives/C04KGFVUWUQ/p1702310929657179
