### PR TITLE
Make initdb upload retries cancellable and seek to beginning

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3048,8 +3048,7 @@ impl Tenant {
                     3,
                     u32::MAX,
                     "persist_initdb_tar_zst",
-                    // TODO: use a cancellation token (https://github.com/neondatabase/neon/issues/5066)
-                    backoff::Cancel::new(CancellationToken::new(), || unreachable!()),
+                    backoff::Cancel::new(self.cancel.clone(), || anyhow::anyhow!("initdb upload cancelled")),
                 )
                 .await?;
 


### PR DESCRIPTION
* initdb uploads had no cancellation token, which means that when we were stuck in upload retries, we wouldn't be able to delete the timeline
* initdb uploads wouldn't rewind the file. this wasn't discovered in the purposefully unreliable test-s3 in pytest because those fail on the first byte always, not somewhere during the connection

slack thread: https://neondb.slack.com/archives/C033RQ5SPDH/p1702632247784079