### PR TITLE
proxy console force http2

### DIFF
--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -32,7 +32,6 @@ pub fn new_client(rate_limiter_config: rate_limiter::RateLimiterConfig) -> Clien
 
 pub fn new_client_with_timeout(default_timout: Duration) -> ClientWithMiddleware {
     let timeout_client = reqwest::ClientBuilder::new()
-        .http2_prior_knowledge()
         .connection_verbose(true)
         .timeout(default_timout)
         .build()


### PR DESCRIPTION
## Problem

HTTP1.1 only supports connection re-use, not multiplexing

## Summary of changes

Force HTTP2. (I expect this won't work)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
