### PR TITLE
Bump vm-builder v0.19.0 -> v0.21.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -857,7 +857,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.19.0
+      VM_BUILDER_VERSION: v0.21.0
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Only applicable change was

- neondatabase/autoscaling#650

Tagged relevant teams for review for visibility, just in case.