### PR TITLE
Always update VM at replica

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -2907,6 +2907,13 @@ neon_redo_read_buffer_filter(XLogReaderState *record, uint8 block_id)
 	if (!OidIsValid(NInfoGetDbOid(rinfo)))
 		return false;
 
+	/*
+	 * Always apply updates of VM because otherwise index-only scan may return wrong results
+	 * based on the wrong assumption that page is still all visible
+	 */
+	if (forknum == VISIBILITYMAP_FORKNUM)
+		return false;
+
 	CopyNRelFileInfoToBufTag(tag, rinfo);
 	tag.forkNum = forknum;
 	tag.blockNum = blkno;


### PR DESCRIPTION
## Problem


In `heap_xlog_visible` we skip update of VM page at replica (`neon_redo_read_buffer_filter`) if it is not present in shared buffers.
Assume that there is update operation which clears all visible flag in heap page and VM.
But we do not apply this operation at replica because pages are not present in shared buffers.
As a result, we can perform some index-only scan which may return incorrect result because VM was not updated

## Summary of changes

Always apply VM updates at replica 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
