### PR TITLE
vm-image-spec: build pgbouncer from Neon's fork

### DIFF
--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -166,17 +166,18 @@ build: |
   RUN set -e \
       && apt-get update \
       && apt-get install -y \
-          curl \
           build-essential \
-          pkg-config \
-          libevent-dev
+          git \
+          libevent-dev \
+          libtool \
+          pkg-config
 
-  ENV PGBOUNCER_VERSION 1.21.0
-  ENV PGBOUNCER_GITPATH 1_21_0
+  # Note, we use pgbouncer from neondatabase/pgbouncer fork, which could contain extra commits
+  ENV PGBOUNCER_TAG pgbouncer_1_21_0-neon-1
   RUN set -e \
-      && curl -sfSL https://github.com/pgbouncer/pgbouncer/releases/download/pgbouncer_${PGBOUNCER_GITPATH}/pgbouncer-${PGBOUNCER_VERSION}.tar.gz -o pgbouncer-${PGBOUNCER_VERSION}.tar.gz \
-      && tar xzvf pgbouncer-${PGBOUNCER_VERSION}.tar.gz \
-      && cd pgbouncer-${PGBOUNCER_VERSION} \
+      && git clone --recurse-submodules --depth 1 --branch ${PGBOUNCER_TAG} https://github.com/neondatabase/pgbouncer.git pgbouncer \
+      && cd pgbouncer \
+      && ./autogen.sh \
       && LDFLAGS=-static ./configure --prefix=/usr/local/pgbouncer --without-openssl \
       && make -j $(nproc) \
       && make install

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -166,12 +166,11 @@ build: |
   RUN set -e \
       && apt-get update \
       && apt-get install -y \
-          build-essential \
           curl \
+          build-essential \
+          pkg-config \
           libevent-dev \
-          libssl-dev \
-          patchutils \
-          pkg-config
+          libssl-dev
 
   ENV PGBOUNCER_VERSION 1.21.0
   ENV PGBOUNCER_GITPATH 1_21_0
@@ -179,7 +178,6 @@ build: |
       && curl -sfSL https://github.com/pgbouncer/pgbouncer/releases/download/pgbouncer_${PGBOUNCER_GITPATH}/pgbouncer-${PGBOUNCER_VERSION}.tar.gz -o pgbouncer-${PGBOUNCER_VERSION}.tar.gz \
       && tar xzvf pgbouncer-${PGBOUNCER_VERSION}.tar.gz \
       && cd pgbouncer-${PGBOUNCER_VERSION} \
-      && curl https://github.com/pgbouncer/pgbouncer/commit/a7b3c0a5f4caa9dbe92743d04cf1e28c4c05806c.patch | filterdiff --include a/src/server.c | patch -p1 \
       && LDFLAGS=-static ./configure --prefix=/usr/local/pgbouncer --without-openssl \
       && make -j $(nproc) \
       && make install

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -169,8 +169,7 @@ build: |
           curl \
           build-essential \
           pkg-config \
-          libevent-dev \
-          libssl-dev
+          libevent-dev
 
   ENV PGBOUNCER_VERSION 1.21.0
   ENV PGBOUNCER_GITPATH 1_21_0

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -172,15 +172,16 @@ build: |
           libtool \
           pkg-config
 
-  # Note, we use pgbouncer from neondatabase/pgbouncer fork, which could contain extra commits
+  # Note, we use pgbouncer from neondatabase/pgbouncer fork, which could contain extra commits.
+  # Use `dist_man_MANS=` to skip manpage generation (which requires python3/pandoc)
   ENV PGBOUNCER_TAG pgbouncer_1_21_0-neon-1
   RUN set -e \
       && git clone --recurse-submodules --depth 1 --branch ${PGBOUNCER_TAG} https://github.com/neondatabase/pgbouncer.git pgbouncer \
       && cd pgbouncer \
       && ./autogen.sh \
       && LDFLAGS=-static ./configure --prefix=/usr/local/pgbouncer --without-openssl \
-      && make -j $(nproc) \
-      && make install
+      && make -j $(nproc) dist_man_MANS= \
+      && make install dist_man_MANS=
 merge: |
   # tweak nofile limits
   RUN set -e \


### PR DESCRIPTION
## Problem

We need to add one more patch to pgbouncer (for https://github.com/neondatabase/neon/issues/5801). I've decided to cherry-pick all required patches to a pgbouncer fork (`neondatabase/pgbouncer`) and use it instead.

See https://github.com/neondatabase/pgbouncer/releases/tag/pgbouncer_1_21_0-neon-1

## Summary of changes
- Revert the previous patch (for deallocate/discard all) — the fork already contains it.
- Remove `libssl-dev` dependency — we build pgbouncer without `openssl` support.
- Clone tag and build pgbouncer from source code.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
