### PR TITLE
s3_scrubber: updates for sharding

### DIFF
--- a/test_runner/regress/test_pageserver_generations.py
+++ b/test_runner/regress/test_pageserver_generations.py
@@ -254,7 +254,9 @@ def test_generations_upgrade(neon_env_builder: NeonEnvBuilder):
     metadata_summary = S3Scrubber(
         neon_env_builder.test_output_dir, neon_env_builder
     ).scan_metadata()
-    assert metadata_summary["count"] == 1  # Scrubber should have seen our timeline
+    assert metadata_summary["tenant_count"] == 1  # Scrubber should have seen our timeline
+    assert metadata_summary["timeline_count"] == 1
+    assert metadata_summary["timeline_shard_count"] == 1
     assert not metadata_summary["with_errors"]
     assert not metadata_summary["with_warnings"]
 


### PR DESCRIPTION
This is a lightweight change to keep the scrubber providing sensible output when using sharding.

- The timeline count was wrong when using sharding
- When checking for tenant existence, we didn't re-use results between different shards in the same tenant

Closes: https://github.com/neondatabase/neon/issues/5929

