### PR TITLE
proxy: refactor how neon-options are handled

### DIFF
--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -4,7 +4,7 @@ pub mod backend;
 pub use backend::BackendType;
 
 mod credentials;
-pub use credentials::{check_peer_addr_is_in_list, endpoint_sni, ClientCredentials};
+pub use credentials::{check_peer_addr_is_in_list, endpoint_sni, ComputeUserInfoMaybeEndpoint};
 
 mod password_hack;
 pub use password_hack::parse_endpoint_param;

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -4,7 +4,7 @@ pub mod backend;
 pub use backend::BackendType;
 
 mod credentials;
-pub use credentials::{check_peer_addr_is_in_list, ClientCredentials};
+pub use credentials::{check_peer_addr_is_in_list, endpoint_sni, ClientCredentials};
 
 mod password_hack;
 pub use password_hack::parse_endpoint_param;

--- a/proxy/src/auth/backend.rs
+++ b/proxy/src/auth/backend.rs
@@ -14,6 +14,7 @@ use crate::console::AuthSecret;
 use crate::context::RequestMonitoring;
 use crate::proxy::connect_compute::handle_try_wake;
 use crate::proxy::retry::retry_after;
+use crate::proxy::NeonOptions;
 use crate::scram;
 use crate::stream::Stream;
 use crate::{
@@ -129,7 +130,7 @@ pub struct ComputeCredentials<T> {
 
 pub struct ComputeUserInfoNoEndpoint {
     pub user: SmolStr,
-    pub cache_key: SmolStr,
+    pub options: NeonOptions,
 }
 
 pub struct ComputeUserInfo {
@@ -150,7 +151,7 @@ impl TryFrom<ClientCredentials> for ComputeUserInfo {
     fn try_from(creds: ClientCredentials) -> Result<Self, Self::Error> {
         let inner = ComputeUserInfoNoEndpoint {
             user: creds.user,
-            cache_key: creds.cache_key,
+            options: creds.options,
         };
         match creds.project {
             None => Err(inner),

--- a/proxy/src/auth/backend.rs
+++ b/proxy/src/auth/backend.rs
@@ -39,7 +39,7 @@ use tracing::{error, info, warn};
 /// * When `T` is `()`, it's just a regular auth backend selector
 ///   which we use in [`crate::config::ProxyConfig`].
 ///
-/// * However, when we substitute `T` with [`ClientCredentials`],
+/// * However, when we substitute `T` with [`ComputeUserInfoMaybeEndpoint`],
 ///   this helps us provide the credentials only to those auth
 ///   backends which require them for the authentication process.
 pub enum BackendType<'a, T> {

--- a/proxy/src/auth/backend/classic.rs
+++ b/proxy/src/auth/backend/classic.rs
@@ -54,7 +54,7 @@ pub(super) async fn authenticate(
                 sasl::Outcome::Success(key) => key,
                 sasl::Outcome::Failure(reason) => {
                     info!("auth backend failed with an error: {reason}");
-                    return Err(auth::AuthError::auth_failed(&*creds.inner.user));
+                    return Err(auth::AuthError::auth_failed(&*creds.user));
                 }
             };
 

--- a/proxy/src/auth/backend/hacks.rs
+++ b/proxy/src/auth/backend/hacks.rs
@@ -36,7 +36,7 @@ pub async fn authenticate_cleartext(
         sasl::Outcome::Success(key) => key,
         sasl::Outcome::Failure(reason) => {
             info!("auth backend failed with an error: {reason}");
-            return Err(auth::AuthError::auth_failed(&*info.inner.user));
+            return Err(auth::AuthError::auth_failed(&*info.user));
         }
     };
 
@@ -67,7 +67,8 @@ pub async fn password_hack_no_authentication(
     // Report tentative success; compute node will check the password anyway.
     Ok(ComputeCredentials {
         info: ComputeUserInfo {
-            inner: info,
+            user: info.user,
+            options: info.options,
             endpoint: payload.endpoint,
         },
         keys: payload.password,

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tracing::{info, warn};
 
 #[derive(Debug, Error, PartialEq, Eq, Clone)]
-pub enum ClientCredsParseError {
+pub enum ComputeUserInfoParseError {
     #[error("Parameter '{0}' is missing in startup packet.")]
     MissingKey(&'static str),
 
@@ -33,12 +33,12 @@ pub enum ClientCredsParseError {
     MalformedProjectName(SmolStr),
 }
 
-impl UserFacingError for ClientCredsParseError {}
+impl UserFacingError for ComputeUserInfoParseError {}
 
 /// Various client credentials which we use for authentication.
 /// Note that we don't store any kind of client key or password here.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ClientCredentials {
+pub struct ComputeUserInfoMaybeEndpoint {
     pub user: SmolStr,
     // TODO: this is a severe misnomer! We should think of a new name ASAP.
     pub project: Option<SmolStr>,
@@ -46,7 +46,7 @@ pub struct ClientCredentials {
     pub options: NeonOptions,
 }
 
-impl ClientCredentials {
+impl ComputeUserInfoMaybeEndpoint {
     #[inline]
     pub fn project(&self) -> Option<&str> {
         self.project.as_deref()
@@ -56,26 +56,26 @@ impl ClientCredentials {
 pub fn endpoint_sni<'a>(
     sni: &'a str,
     common_names: &HashSet<String>,
-) -> Result<&'a str, ClientCredsParseError> {
+) -> Result<&'a str, ComputeUserInfoParseError> {
     let Some((subdomain, common_name)) = sni.split_once('.') else {
-        return Err(ClientCredsParseError::UnknownCommonName { cn: sni.into() });
+        return Err(ComputeUserInfoParseError::UnknownCommonName { cn: sni.into() });
     };
     if !common_names.contains(common_name) {
-        return Err(ClientCredsParseError::UnknownCommonName {
+        return Err(ComputeUserInfoParseError::UnknownCommonName {
             cn: common_name.into(),
         });
     }
     Ok(subdomain)
 }
 
-impl ClientCredentials {
+impl ComputeUserInfoMaybeEndpoint {
     pub fn parse(
         ctx: &mut RequestMonitoring,
         params: &StartupMessageParams,
         sni: Option<&str>,
         common_names: Option<&HashSet<String>>,
-    ) -> Result<Self, ClientCredsParseError> {
-        use ClientCredsParseError::*;
+    ) -> Result<Self, ComputeUserInfoParseError> {
+        use ComputeUserInfoParseError::*;
 
         // Some parameters are stored in the startup message.
         let get_param = |key| params.get(key).ok_or(MissingKey(key));
@@ -206,16 +206,16 @@ fn project_name_valid(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ClientCredsParseError::*;
+    use ComputeUserInfoParseError::*;
 
     #[test]
     fn parse_bare_minimum() -> anyhow::Result<()> {
         // According to postgresql, only `user` should be required.
         let options = StartupMessageParams::new([("user", "john_doe")]);
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, None, None)?;
-        assert_eq!(creds.user, "john_doe");
-        assert_eq!(creds.project, None);
+        let user_info = ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, None, None)?;
+        assert_eq!(user_info.user, "john_doe");
+        assert_eq!(user_info.project, None);
 
         Ok(())
     }
@@ -228,9 +228,9 @@ mod tests {
             ("foo", "bar"),        // should be ignored
         ]);
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, None, None)?;
-        assert_eq!(creds.user, "john_doe");
-        assert_eq!(creds.project, None);
+        let user_info = ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, None, None)?;
+        assert_eq!(user_info.user, "john_doe");
+        assert_eq!(user_info.project, None);
 
         Ok(())
     }
@@ -243,10 +243,11 @@ mod tests {
         let common_names = Some(["localhost".into()].into());
 
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, sni, common_names.as_ref())?;
-        assert_eq!(creds.user, "john_doe");
-        assert_eq!(creds.project.as_deref(), Some("foo"));
-        assert_eq!(creds.options.get_cache_key("foo"), "foo");
+        let user_info =
+            ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, sni, common_names.as_ref())?;
+        assert_eq!(user_info.user, "john_doe");
+        assert_eq!(user_info.project.as_deref(), Some("foo"));
+        assert_eq!(user_info.options.get_cache_key("foo"), "foo");
 
         Ok(())
     }
@@ -259,9 +260,9 @@ mod tests {
         ]);
 
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, None, None)?;
-        assert_eq!(creds.user, "john_doe");
-        assert_eq!(creds.project.as_deref(), Some("bar"));
+        let user_info = ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, None, None)?;
+        assert_eq!(user_info.user, "john_doe");
+        assert_eq!(user_info.project.as_deref(), Some("bar"));
 
         Ok(())
     }
@@ -274,9 +275,9 @@ mod tests {
         ]);
 
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, None, None)?;
-        assert_eq!(creds.user, "john_doe");
-        assert_eq!(creds.project.as_deref(), Some("bar"));
+        let user_info = ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, None, None)?;
+        assert_eq!(user_info.user, "john_doe");
+        assert_eq!(user_info.project.as_deref(), Some("bar"));
 
         Ok(())
     }
@@ -292,9 +293,9 @@ mod tests {
         ]);
 
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, None, None)?;
-        assert_eq!(creds.user, "john_doe");
-        assert!(creds.project.is_none());
+        let user_info = ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, None, None)?;
+        assert_eq!(user_info.user, "john_doe");
+        assert!(user_info.project.is_none());
 
         Ok(())
     }
@@ -307,9 +308,9 @@ mod tests {
         ]);
 
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, None, None)?;
-        assert_eq!(creds.user, "john_doe");
-        assert!(creds.project.is_none());
+        let user_info = ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, None, None)?;
+        assert_eq!(user_info.user, "john_doe");
+        assert!(user_info.project.is_none());
 
         Ok(())
     }
@@ -322,9 +323,10 @@ mod tests {
         let common_names = Some(["localhost".into()].into());
 
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, sni, common_names.as_ref())?;
-        assert_eq!(creds.user, "john_doe");
-        assert_eq!(creds.project.as_deref(), Some("baz"));
+        let user_info =
+            ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, sni, common_names.as_ref())?;
+        assert_eq!(user_info.user, "john_doe");
+        assert_eq!(user_info.project.as_deref(), Some("baz"));
 
         Ok(())
     }
@@ -336,14 +338,16 @@ mod tests {
         let common_names = Some(["a.com".into(), "b.com".into()].into());
         let sni = Some("p1.a.com");
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, sni, common_names.as_ref())?;
-        assert_eq!(creds.project.as_deref(), Some("p1"));
+        let user_info =
+            ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, sni, common_names.as_ref())?;
+        assert_eq!(user_info.project.as_deref(), Some("p1"));
 
         let common_names = Some(["a.com".into(), "b.com".into()].into());
         let sni = Some("p1.b.com");
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, sni, common_names.as_ref())?;
-        assert_eq!(creds.project.as_deref(), Some("p1"));
+        let user_info =
+            ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, sni, common_names.as_ref())?;
+        assert_eq!(user_info.project.as_deref(), Some("p1"));
 
         Ok(())
     }
@@ -357,8 +361,9 @@ mod tests {
         let common_names = Some(["localhost".into()].into());
 
         let mut ctx = RequestMonitoring::test();
-        let err = ClientCredentials::parse(&mut ctx, &options, sni, common_names.as_ref())
-            .expect_err("should fail");
+        let err =
+            ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, sni, common_names.as_ref())
+                .expect_err("should fail");
         match err {
             InconsistentProjectNames { domain, option } => {
                 assert_eq!(option, "first");
@@ -376,8 +381,9 @@ mod tests {
         let common_names = Some(["example.com".into()].into());
 
         let mut ctx = RequestMonitoring::test();
-        let err = ClientCredentials::parse(&mut ctx, &options, sni, common_names.as_ref())
-            .expect_err("should fail");
+        let err =
+            ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, sni, common_names.as_ref())
+                .expect_err("should fail");
         match err {
             UnknownCommonName { cn } => {
                 assert_eq!(cn, "localhost");
@@ -396,10 +402,11 @@ mod tests {
         let sni = Some("project.localhost");
         let common_names = Some(["localhost".into()].into());
         let mut ctx = RequestMonitoring::test();
-        let creds = ClientCredentials::parse(&mut ctx, &options, sni, common_names.as_ref())?;
-        assert_eq!(creds.project.as_deref(), Some("project"));
+        let user_info =
+            ComputeUserInfoMaybeEndpoint::parse(&mut ctx, &options, sni, common_names.as_ref())?;
+        assert_eq!(user_info.project.as_deref(), Some("project"));
         assert_eq!(
-            creds.options.get_cache_key("project"),
+            user_info.options.get_cache_key("project"),
             "project endpoint_type:read_write lsn:0/2"
         );
 

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -32,7 +32,7 @@ pub struct MetricCollectionConfig {
 
 pub struct TlsConfig {
     pub config: Arc<rustls::ServerConfig>,
-    pub common_names: Option<HashSet<String>>,
+    pub common_names: HashSet<String>,
     pub cert_resolver: Arc<CertResolver>,
 }
 
@@ -97,7 +97,7 @@ pub fn configure_tls(
 
     Ok(TlsConfig {
         config,
-        common_names: Some(common_names),
+        common_names,
         cert_resolver,
     })
 }

--- a/proxy/src/console.rs
+++ b/proxy/src/console.rs
@@ -6,7 +6,7 @@ pub mod messages;
 
 /// Wrappers for console APIs and their mocks.
 pub mod provider;
-pub use provider::{errors, Api, AuthSecret, CachedNodeInfo, ConsoleReqExtra, NodeInfo};
+pub use provider::{errors, Api, AuthSecret, CachedNodeInfo, NodeInfo};
 
 /// Various cache-related types.
 pub mod caches {

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -9,7 +9,6 @@ use crate::{
     compute,
     config::{CacheOptions, ProjectInfoCacheOptions},
     context::RequestMonitoring,
-    proxy::NeonOptions,
     scram,
 };
 use async_trait::async_trait;
@@ -198,19 +197,6 @@ pub mod errors {
     }
 }
 
-/// Extra query params we'd like to pass to the console.
-pub struct ConsoleReqExtra {
-    pub options: NeonOptions,
-}
-
-impl ConsoleReqExtra {
-    // https://swagger.io/docs/specification/serialization/ DeepObject format
-    // paramName[prop1]=value1&paramName[prop2]=value2&....
-    pub fn options_as_deep_object(&self) -> Vec<(String, SmolStr)> {
-        self.options.to_deep_object()
-    }
-}
-
 /// Auth secret which is managed by the cloud.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum AuthSecret {
@@ -275,7 +261,6 @@ pub trait Api {
     async fn wake_compute(
         &self,
         ctx: &mut RequestMonitoring,
-        extra: &ConsoleReqExtra,
         creds: &ComputeUserInfo,
     ) -> Result<CachedNodeInfo, errors::WakeComputeError>;
 }

--- a/proxy/src/console/provider/mock.rs
+++ b/proxy/src/console/provider/mock.rs
@@ -2,7 +2,7 @@
 
 use super::{
     errors::{ApiError, GetAuthInfoError, WakeComputeError},
-    AuthInfo, AuthSecret, CachedNodeInfo, ConsoleReqExtra, NodeInfo,
+    AuthInfo, AuthSecret, CachedNodeInfo, NodeInfo,
 };
 use crate::cache::Cached;
 use crate::console::provider::{CachedAllowedIps, CachedRoleSecret};
@@ -172,7 +172,6 @@ impl super::Api for Api {
     async fn wake_compute(
         &self,
         _ctx: &mut RequestMonitoring,
-        _extra: &ConsoleReqExtra,
         _creds: &ComputeUserInfo,
     ) -> Result<CachedNodeInfo, WakeComputeError> {
         self.do_wake_compute()

--- a/proxy/src/console/provider/mock.rs
+++ b/proxy/src/console/provider/mock.rs
@@ -50,7 +50,7 @@ impl Api {
 
     async fn do_get_auth_info(
         &self,
-        creds: &ComputeUserInfo,
+        user_info: &ComputeUserInfo,
     ) -> Result<AuthInfo, GetAuthInfoError> {
         let (secret, allowed_ips) = async {
             // Perhaps we could persist this connection, but then we'd have to
@@ -63,7 +63,7 @@ impl Api {
             let secret = match get_execute_postgres_query(
                 &client,
                 "select rolpassword from pg_catalog.pg_authid where rolname = $1",
-                &[&&*creds.inner.user],
+                &[&&*user_info.user],
                 "rolpassword",
             )
             .await?
@@ -74,14 +74,14 @@ impl Api {
                     secret.or_else(|| parse_md5(&entry).map(AuthSecret::Md5))
                 }
                 None => {
-                    warn!("user '{}' does not exist", creds.inner.user);
+                    warn!("user '{}' does not exist", user_info.user);
                     None
                 }
             };
             let allowed_ips = match get_execute_postgres_query(
                 &client,
                 "select allowed_ips from neon_control_plane.endpoints where endpoint_id = $1",
-                &[&creds.endpoint.as_str()],
+                &[&user_info.endpoint.as_str()],
                 "allowed_ips",
             )
             .await?
@@ -149,10 +149,10 @@ impl super::Api for Api {
     async fn get_role_secret(
         &self,
         _ctx: &mut RequestMonitoring,
-        creds: &ComputeUserInfo,
+        user_info: &ComputeUserInfo,
     ) -> Result<Option<CachedRoleSecret>, GetAuthInfoError> {
         Ok(self
-            .do_get_auth_info(creds)
+            .do_get_auth_info(user_info)
             .await?
             .secret
             .map(CachedRoleSecret::new_uncached))
@@ -161,10 +161,10 @@ impl super::Api for Api {
     async fn get_allowed_ips(
         &self,
         _ctx: &mut RequestMonitoring,
-        creds: &ComputeUserInfo,
+        user_info: &ComputeUserInfo,
     ) -> Result<CachedAllowedIps, GetAuthInfoError> {
         Ok(Cached::new_uncached(Arc::new(
-            self.do_get_auth_info(creds).await?.allowed_ips,
+            self.do_get_auth_info(user_info).await?.allowed_ips,
         )))
     }
 
@@ -172,7 +172,7 @@ impl super::Api for Api {
     async fn wake_compute(
         &self,
         _ctx: &mut RequestMonitoring,
-        _creds: &ComputeUserInfo,
+        _user_info: &ComputeUserInfo,
     ) -> Result<CachedNodeInfo, WakeComputeError> {
         self.do_wake_compute()
             .map_ok(CachedNodeInfo::new_uncached)

--- a/proxy/src/console/provider/neon.rs
+++ b/proxy/src/console/provider/neon.rs
@@ -55,7 +55,7 @@ impl Api {
     async fn do_get_auth_info(
         &self,
         ctx: &mut RequestMonitoring,
-        creds: &ComputeUserInfo,
+        user_info: &ComputeUserInfo,
     ) -> Result<AuthInfo, GetAuthInfoError> {
         let request_id = uuid::Uuid::new_v4().to_string();
         let application_name = ctx.console_application_name();
@@ -68,8 +68,8 @@ impl Api {
                 .query(&[("session_id", ctx.session_id)])
                 .query(&[
                     ("application_name", application_name.as_str()),
-                    ("project", creds.endpoint.as_str()),
-                    ("role", creds.inner.user.as_str()),
+                    ("project", user_info.endpoint.as_str()),
+                    ("role", user_info.user.as_str()),
                 ])
                 .build()?;
 
@@ -110,7 +110,7 @@ impl Api {
     async fn do_wake_compute(
         &self,
         ctx: &mut RequestMonitoring,
-        creds: &ComputeUserInfo,
+        user_info: &ComputeUserInfo,
     ) -> Result<NodeInfo, WakeComputeError> {
         let request_id = uuid::Uuid::new_v4().to_string();
         let application_name = ctx.console_application_name();
@@ -123,10 +123,10 @@ impl Api {
                 .query(&[("session_id", ctx.session_id)])
                 .query(&[
                     ("application_name", application_name.as_str()),
-                    ("project", creds.endpoint.as_str()),
+                    ("project", user_info.endpoint.as_str()),
                 ]);
 
-            let options = creds.inner.options.to_deep_object();
+            let options = user_info.options.to_deep_object();
             if !options.is_empty() {
                 request_builder = request_builder.query(&options);
             }
@@ -171,14 +171,14 @@ impl super::Api for Api {
     async fn get_role_secret(
         &self,
         ctx: &mut RequestMonitoring,
-        creds: &ComputeUserInfo,
+        user_info: &ComputeUserInfo,
     ) -> Result<Option<CachedRoleSecret>, GetAuthInfoError> {
-        let ep = &creds.endpoint;
-        let user = &creds.inner.user;
+        let ep = &user_info.endpoint;
+        let user = &user_info.user;
         if let Some(role_secret) = self.caches.project_info.get_role_secret(ep, user) {
             return Ok(Some(role_secret));
         }
-        let auth_info = self.do_get_auth_info(ctx, creds).await?;
+        let auth_info = self.do_get_auth_info(ctx, user_info).await?;
         let project_id = auth_info.project_id.unwrap_or(ep.clone());
         if let Some(secret) = &auth_info.secret {
             self.caches
@@ -197,9 +197,9 @@ impl super::Api for Api {
     async fn get_allowed_ips(
         &self,
         ctx: &mut RequestMonitoring,
-        creds: &ComputeUserInfo,
+        user_info: &ComputeUserInfo,
     ) -> Result<CachedAllowedIps, GetAuthInfoError> {
-        let ep = &creds.endpoint;
+        let ep = &user_info.endpoint;
         if let Some(allowed_ips) = self.caches.project_info.get_allowed_ips(ep) {
             ALLOWED_IPS_BY_CACHE_OUTCOME
                 .with_label_values(&["hit"])
@@ -209,9 +209,9 @@ impl super::Api for Api {
         ALLOWED_IPS_BY_CACHE_OUTCOME
             .with_label_values(&["miss"])
             .inc();
-        let auth_info = self.do_get_auth_info(ctx, creds).await?;
+        let auth_info = self.do_get_auth_info(ctx, user_info).await?;
         let allowed_ips = Arc::new(auth_info.allowed_ips);
-        let user = &creds.inner.user;
+        let user = &user_info.user;
         let project_id = auth_info.project_id.unwrap_or(ep.clone());
         if let Some(secret) = &auth_info.secret {
             self.caches
@@ -228,9 +228,9 @@ impl super::Api for Api {
     async fn wake_compute(
         &self,
         ctx: &mut RequestMonitoring,
-        creds: &ComputeUserInfo,
+        user_info: &ComputeUserInfo,
     ) -> Result<CachedNodeInfo, WakeComputeError> {
-        let key = creds.endpoint_cache_key();
+        let key = user_info.endpoint_cache_key();
 
         // Every time we do a wakeup http request, the compute node will stay up
         // for some time (highly depends on the console's scale-to-zero policy);
@@ -252,7 +252,7 @@ impl super::Api for Api {
             }
         }
 
-        let node = self.do_wake_compute(ctx, creds).await?;
+        let node = self.do_wake_compute(ctx, user_info).await?;
         let (_, cached) = self.caches.node_info.insert(key.clone(), node);
         info!(key = &*key, "created a cache entry for compute node info");
 

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use anyhow::{bail, Context};
 use futures::TryFutureExt;
+use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use pq_proto::{BeMessage as Be, FeStartupPacket, StartupMessageParams};
 use regex::Regex;
@@ -504,12 +505,12 @@ impl NeonOptions {
     }
 
     fn parse_from_iter<'a>(options: impl Iterator<Item = &'a str>) -> Self {
-        Self(
-            options
-                .filter_map(neon_option)
-                .map(|(k, v)| (k.into(), v.into()))
-                .collect(),
-        )
+        let mut options = options
+            .filter_map(neon_option)
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect_vec();
+        options.sort();
+        Self(options)
     }
 
     pub fn get_cache_key(&self, prefix: &str) -> SmolStr {

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -9,7 +9,7 @@ use crate::{
     cancellation::{self, CancelMap},
     compute,
     config::{AuthenticationConfig, ProxyConfig, TlsConfig},
-    console::{self, messages::MetricsAuxInfo},
+    console::messages::MetricsAuxInfo,
     context::RequestMonitoring,
     metrics::{
         NUM_BYTES_PROXIED_COUNTER, NUM_BYTES_PROXIED_PER_CLIENT_COUNTER,
@@ -454,13 +454,9 @@ impl<S: AsyncRead + AsyncWrite + Unpin> Client<'_, S> {
             }
         }
 
-        let extra = console::ConsoleReqExtra {
-            options: NeonOptions::parse_params(params),
-        };
-
         let user = creds.get_user().to_owned();
         let auth_result = match creds
-            .authenticate(ctx, &extra, &mut stream, mode.allow_cleartext(), config)
+            .authenticate(ctx, &mut stream, mode.allow_cleartext(), config)
             .await
         {
             Ok(auth_result) => auth_result,
@@ -478,7 +474,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> Client<'_, S> {
         node_info.allow_self_signed_compute = allow_self_signed_compute;
 
         let aux = node_info.aux.clone();
-        let mut node = connect_to_compute(ctx, &TcpMechanism { params }, node_info, &extra, &creds)
+        let mut node = connect_to_compute(ctx, &TcpMechanism { params }, node_info, &creds)
             .or_else(|e| stream.throw_error(e))
             .await?;
 
@@ -524,8 +520,8 @@ impl NeonOptions {
             .collect()
     }
 
-    /// https://swagger.io/docs/specification/serialization/ DeepObject format
-    /// paramName[prop1]=value1&paramName[prop2]=value2&....
+    /// <https://swagger.io/docs/specification/serialization/> DeepObject format
+    /// `paramName[prop1]=value1&paramName[prop2]=value2&...`
     pub fn to_deep_object(&self) -> Vec<(String, SmolStr)> {
         self.0
             .iter()

--- a/proxy/src/proxy/connect_compute.rs
+++ b/proxy/src/proxy/connect_compute.rs
@@ -128,7 +128,6 @@ pub async fn connect_to_compute<M: ConnectMechanism>(
     ctx: &mut RequestMonitoring,
     mechanism: &M,
     mut node_info: console::CachedNodeInfo,
-    extra: &console::ConsoleReqExtra,
     creds: &auth::BackendType<'_, auth::backend::ComputeUserInfo>,
 ) -> Result<M::Connection, M::Error>
 where
@@ -160,9 +159,9 @@ where
     info!("compute node's state has likely changed; requesting a wake-up");
     let node_info = loop {
         let wake_res = match creds {
-            auth::BackendType::Console(api, creds) => api.wake_compute(ctx, extra, creds).await,
+            auth::BackendType::Console(api, creds) => api.wake_compute(ctx, creds).await,
             #[cfg(feature = "testing")]
-            auth::BackendType::Postgres(api, creds) => api.wake_compute(ctx, extra, creds).await,
+            auth::BackendType::Postgres(api, creds) => api.wake_compute(ctx, creds).await,
             // nothing to do?
             auth::BackendType::Link(_) => return Err(err.into()),
             // test backend

--- a/proxy/src/proxy/connect_compute.rs
+++ b/proxy/src/proxy/connect_compute.rs
@@ -128,7 +128,7 @@ pub async fn connect_to_compute<M: ConnectMechanism>(
     ctx: &mut RequestMonitoring,
     mechanism: &M,
     mut node_info: console::CachedNodeInfo,
-    creds: &auth::BackendType<'_, auth::backend::ComputeUserInfo>,
+    user_info: &auth::BackendType<'_, auth::backend::ComputeUserInfo>,
 ) -> Result<M::Connection, M::Error>
 where
     M::ConnectError: ShouldRetry + std::fmt::Debug,
@@ -158,10 +158,10 @@ where
     // if we failed to connect, it's likely that the compute node was suspended, wake a new compute node
     info!("compute node's state has likely changed; requesting a wake-up");
     let node_info = loop {
-        let wake_res = match creds {
-            auth::BackendType::Console(api, creds) => api.wake_compute(ctx, creds).await,
+        let wake_res = match user_info {
+            auth::BackendType::Console(api, user_info) => api.wake_compute(ctx, user_info).await,
             #[cfg(feature = "testing")]
-            auth::BackendType::Postgres(api, creds) => api.wake_compute(ctx, creds).await,
+            auth::BackendType::Postgres(api, user_info) => api.wake_compute(ctx, user_info).await,
             // nothing to do?
             auth::BackendType::Link(_) => return Err(err.into()),
             // test backend

--- a/proxy/src/proxy/tests.rs
+++ b/proxy/src/proxy/tests.rs
@@ -83,7 +83,7 @@ fn generate_tls_config<'a>(
         let mut cert_resolver = CertResolver::new();
         cert_resolver.add_cert(key, vec![cert], true)?;
 
-        let common_names = Some(cert_resolver.get_common_names());
+        let common_names = cert_resolver.get_common_names();
 
         TlsConfig {
             config,
@@ -493,7 +493,9 @@ fn helper_create_connect_info(
     auth::BackendType<'_, ComputeUserInfo>,
 ) {
     let cache = helper_create_cached_node_info();
-    let extra = console::ConsoleReqExtra { options: vec![] };
+    let extra = console::ConsoleReqExtra {
+        options: NeonOptions(vec![]),
+    };
     let creds = auth::BackendType::Test(mechanism);
     (cache, extra, creds)
 }

--- a/proxy/src/proxy/tests.rs
+++ b/proxy/src/proxy/tests.rs
@@ -7,7 +7,7 @@ use super::retry::ShouldRetry;
 use super::*;
 use crate::auth::backend::{ComputeUserInfo, TestBackend};
 use crate::config::CertResolver;
-use crate::console::{CachedNodeInfo, NodeInfo};
+use crate::console::{self, CachedNodeInfo, NodeInfo};
 use crate::proxy::retry::{retry_after, NUM_RETRIES_CONNECT};
 use crate::{auth, http, sasl, scram};
 use async_trait::async_trait;
@@ -487,17 +487,10 @@ fn helper_create_cached_node_info() -> CachedNodeInfo {
 
 fn helper_create_connect_info(
     mechanism: &TestConnectMechanism,
-) -> (
-    CachedNodeInfo,
-    console::ConsoleReqExtra,
-    auth::BackendType<'_, ComputeUserInfo>,
-) {
+) -> (CachedNodeInfo, auth::BackendType<'_, ComputeUserInfo>) {
     let cache = helper_create_cached_node_info();
-    let extra = console::ConsoleReqExtra {
-        options: NeonOptions(vec![]),
-    };
     let creds = auth::BackendType::Test(mechanism);
-    (cache, extra, creds)
+    (cache, creds)
 }
 
 #[tokio::test]
@@ -505,8 +498,8 @@ async fn connect_to_compute_success() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Connect]);
-    let (cache, extra, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &extra, &creds)
+    let (cache, creds) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
         .await
         .unwrap();
     mechanism.verify();
@@ -517,8 +510,8 @@ async fn connect_to_compute_retry() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Retry, Wake, Retry, Connect]);
-    let (cache, extra, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &extra, &creds)
+    let (cache, creds) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
         .await
         .unwrap();
     mechanism.verify();
@@ -530,8 +523,8 @@ async fn connect_to_compute_non_retry_1() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Retry, Wake, Retry, Fail]);
-    let (cache, extra, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &extra, &creds)
+    let (cache, creds) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
         .await
         .unwrap_err();
     mechanism.verify();
@@ -543,8 +536,8 @@ async fn connect_to_compute_non_retry_2() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Fail, Wake, Retry, Connect]);
-    let (cache, extra, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &extra, &creds)
+    let (cache, creds) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
         .await
         .unwrap();
     mechanism.verify();
@@ -560,8 +553,8 @@ async fn connect_to_compute_non_retry_3() {
         Retry, Wake, Retry, Retry, Retry, Retry, Retry, Retry, Retry, Retry, Retry, Retry, Retry,
         Retry, Retry, Retry, Retry, /* the 17th time */ Retry,
     ]);
-    let (cache, extra, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &extra, &creds)
+    let (cache, creds) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
         .await
         .unwrap_err();
     mechanism.verify();
@@ -573,8 +566,8 @@ async fn wake_retry() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Retry, WakeRetry, Wake, Connect]);
-    let (cache, extra, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &extra, &creds)
+    let (cache, creds) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
         .await
         .unwrap();
     mechanism.verify();
@@ -586,8 +579,8 @@ async fn wake_non_retry() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Retry, WakeFail]);
-    let (cache, extra, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &extra, &creds)
+    let (cache, creds) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
         .await
         .unwrap_err();
     mechanism.verify();

--- a/proxy/src/proxy/tests.rs
+++ b/proxy/src/proxy/tests.rs
@@ -489,8 +489,8 @@ fn helper_create_connect_info(
     mechanism: &TestConnectMechanism,
 ) -> (CachedNodeInfo, auth::BackendType<'_, ComputeUserInfo>) {
     let cache = helper_create_cached_node_info();
-    let creds = auth::BackendType::Test(mechanism);
-    (cache, creds)
+    let user_info = auth::BackendType::Test(mechanism);
+    (cache, user_info)
 }
 
 #[tokio::test]
@@ -498,8 +498,8 @@ async fn connect_to_compute_success() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Connect]);
-    let (cache, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
+    let (cache, user_info) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &user_info)
         .await
         .unwrap();
     mechanism.verify();
@@ -510,8 +510,8 @@ async fn connect_to_compute_retry() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Retry, Wake, Retry, Connect]);
-    let (cache, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
+    let (cache, user_info) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &user_info)
         .await
         .unwrap();
     mechanism.verify();
@@ -523,8 +523,8 @@ async fn connect_to_compute_non_retry_1() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Retry, Wake, Retry, Fail]);
-    let (cache, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
+    let (cache, user_info) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &user_info)
         .await
         .unwrap_err();
     mechanism.verify();
@@ -536,8 +536,8 @@ async fn connect_to_compute_non_retry_2() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Fail, Wake, Retry, Connect]);
-    let (cache, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
+    let (cache, user_info) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &user_info)
         .await
         .unwrap();
     mechanism.verify();
@@ -553,8 +553,8 @@ async fn connect_to_compute_non_retry_3() {
         Retry, Wake, Retry, Retry, Retry, Retry, Retry, Retry, Retry, Retry, Retry, Retry, Retry,
         Retry, Retry, Retry, Retry, /* the 17th time */ Retry,
     ]);
-    let (cache, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
+    let (cache, user_info) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &user_info)
         .await
         .unwrap_err();
     mechanism.verify();
@@ -566,8 +566,8 @@ async fn wake_retry() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Retry, WakeRetry, Wake, Connect]);
-    let (cache, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
+    let (cache, user_info) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &user_info)
         .await
         .unwrap();
     mechanism.verify();
@@ -579,8 +579,8 @@ async fn wake_non_retry() {
     use ConnectAction::*;
     let mut ctx = RequestMonitoring::test();
     let mechanism = TestConnectMechanism::new(vec![Retry, WakeFail]);
-    let (cache, creds) = helper_create_connect_info(&mechanism);
-    connect_to_compute(&mut ctx, &mechanism, cache, &creds)
+    let (cache, user_info) = helper_create_connect_info(&mechanism);
+    connect_to_compute(&mut ctx, &mechanism, cache, &user_info)
         .await
         .unwrap_err();
     mechanism.verify();

--- a/proxy/src/serverless/conn_pool.rs
+++ b/proxy/src/serverless/conn_pool.rs
@@ -49,7 +49,7 @@ pub struct ConnInfo {
 impl ConnInfo {
     // hm, change to hasher to avoid cloning?
     pub fn db_and_user(&self) -> (SmolStr, SmolStr) {
-        (self.dbname.clone(), self.user_info.inner.user.clone())
+        (self.dbname.clone(), self.user_info.user.clone())
     }
 
     pub fn endpoint_cache_key(&self) -> SmolStr {
@@ -63,10 +63,10 @@ impl fmt::Display for ConnInfo {
         write!(
             f,
             "{}@{}/{}?{}",
-            self.user_info.inner.user,
+            self.user_info.user,
             self.user_info.endpoint,
             self.dbname,
-            self.user_info.inner.options.get_cache_key("")
+            self.user_info.options.get_cache_key("")
         )
     }
 }
@@ -574,7 +574,7 @@ async fn connect_to_compute_once(
     let mut session = ctx.session_id;
 
     let (client, mut connection) = config
-        .user(&conn_info.user_info.inner.user)
+        .user(&conn_info.user_info.user)
         .password(&*conn_info.password)
         .dbname(&conn_info.dbname)
         .connect_timeout(timeout)

--- a/proxy/src/serverless/sql_over_http.rs
+++ b/proxy/src/serverless/sql_over_http.rs
@@ -29,7 +29,6 @@ use utils::http::error::ApiError;
 use utils::http::json::json_response;
 
 use crate::auth::backend::ComputeUserInfo;
-use crate::auth::backend::ComputeUserInfoNoEndpoint;
 use crate::auth::endpoint_sni;
 use crate::config::HttpConfig;
 use crate::config::TlsConfig;
@@ -203,10 +202,8 @@ fn get_conn_info(
 
     let user_info = ComputeUserInfo {
         endpoint,
-        inner: ComputeUserInfoNoEndpoint {
-            user: username,
-            options: options.unwrap_or_default(),
-        },
+        user: username,
+        options: options.unwrap_or_default(),
     };
 
     Ok(ConnInfo {

--- a/proxy/src/serverless/sql_over_http.rs
+++ b/proxy/src/serverless/sql_over_http.rs
@@ -28,6 +28,8 @@ use url::Url;
 use utils::http::error::ApiError;
 use utils::http::json::json_response;
 
+use crate::auth::backend::ComputeUserInfo;
+use crate::auth::backend::ComputeUserInfoNoEndpoint;
 use crate::auth::endpoint_sni;
 use crate::config::HttpConfig;
 use crate::config::TlsConfig;
@@ -199,12 +201,18 @@ fn get_conn_info(
         }
     }
 
-    Ok(ConnInfo {
-        username,
-        dbname: dbname.into(),
+    let user_info = ComputeUserInfo {
         endpoint,
+        inner: ComputeUserInfoNoEndpoint {
+            user: username,
+            options: options.unwrap_or_default(),
+        },
+    };
+
+    Ok(ConnInfo {
+        user_info,
+        dbname: dbname.into(),
         password: password.into(),
-        options: options.unwrap_or_default(),
     })
 }
 


### PR DESCRIPTION
## Problem

HTTP connection pool was not respecting the PitR options.

## Summary of changes

1. refactor neon_options a bit to allow easier access to cache_key
2. make HTTP not go through `StartupMessageParams`
3. expose SNI processing to replace what was removed in step 2.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
