### PR TITLE
refactor(NeonEnv): shutdown of child processes

### DIFF
--- a/test_runner/fixtures/broker.py
+++ b/test_runner/fixtures/broker.py
@@ -54,7 +54,10 @@ class NeonBroker:
             else:
                 break  # success
 
-    def stop(self):
+    def stop(self, immediate: bool = False):
         if self.handle is not None:
-            self.handle.terminate()
+            if immediate:
+                self.handle.kill()
+            else:
+                self.handle.terminate()
             self.handle.wait()

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -757,7 +757,7 @@ class NeonEnvBuilder:
                 immediate=True,
                 # if the test threw an exception, don't check for errors
                 # as a failing assertion would cause the cleanup below to fail
-                ps_assert_metric_no_errors=(exc_type is not None),
+                ps_assert_metric_no_errors=(exc_type is None),
             )
             cleanup_error = None
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -953,7 +953,7 @@ class NeonEnv:
                 pageserver.assert_no_metric_errors()
             pageserver.stop(immediate=immediate)
         self.attachment_service.stop(immediate=immediate)
-        self.broker.stop()
+        self.broker.stop(immediate=immediate)
 
     @property
     def pageserver(self) -> NeonPageserver:

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -753,20 +753,12 @@ class NeonEnvBuilder:
         # Stop all the nodes.
         if self.env:
             log.info("Cleaning up all storage and compute nodes")
-            self.env.endpoints.stop_all()
-            for sk in self.env.safekeepers:
-                sk.stop(immediate=True)
-
-            for pageserver in self.env.pageservers:
+            self.env.stop(
+                immediate=True,
                 # if the test threw an exception, don't check for errors
                 # as a failing assertion would cause the cleanup below to fail
-                if exc_type is not None:
-                    pageserver.assert_no_metric_errors()
-
-                pageserver.stop(immediate=True)
-
-            self.env.attachment_service.stop(immediate=True)
-
+                ps_assert_metric_no_errors=(exc_type is not None),
+            )
             cleanup_error = None
 
             if self.scrub_on_exit:
@@ -948,6 +940,20 @@ class NeonEnv:
 
         for safekeeper in self.safekeepers:
             safekeeper.start()
+
+    def stop(self, immediate=False, ps_assert_metric_no_errors=False):
+        """
+        After this method returns, there should be no child processes running.
+        """
+        self.endpoints.stop_all()
+        for sk in self.safekeepers:
+            sk.stop(immediate=immediate)
+        for pageserver in self.pageservers:
+            if ps_assert_metric_no_errors:
+                pageserver.assert_no_metric_errors()
+            pageserver.stop(immediate=immediate)
+        self.attachment_service.stop(immediate=immediate)
+        self.broker.stop()
 
     @property
     def pageserver(self) -> NeonPageserver:


### PR DESCRIPTION
Also shuts down `Broker`, which, before this PR, we did start in
`start()` but relied on the fixture to stop. Do it a bit earlier so
that, after `NeonEnv.stop()` returns, there are no child processes using
`repo_dir`.


Also, drive-by-fixes inverted logic around `ps_assert_metric_no_errors`,
missed during https://github.com/neondatabase/neon/pull/6295