### PR TITLE
fix(pagebench): #6325 broke running without `--runtime`

### DIFF
--- a/pageserver/pagebench/src/cmd/getpage_latest_lsn.rs
+++ b/pageserver/pagebench/src/cmd/getpage_latest_lsn.rs
@@ -349,10 +349,10 @@ async fn main_impl(
 
     let work_sender_task = tokio::spawn(work_sender);
 
+    info!("waiting for everything to become ready");
+    start_work_barrier.wait().await;
+    info!("work started");
     if let Some(runtime) = args.runtime {
-        info!("waiting for everything to become ready");
-        start_work_barrier.wait().await;
-        info!("work started");
         tokio::time::sleep(runtime.into()).await;
         info!("runtime over, signalling cancellation");
         cancel.cancel();


### PR DESCRIPTION
After PR #6325, when running without --runtime, we wouldn't wait for
start_work_barrier, causing the benchmark to not start at all.
