### PR TITLE
Propagate apply_lsn  from SK to PS to prevent GC from collecting objects which may be still requested by replica

### DIFF
--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -290,6 +290,7 @@ impl Endpoint {
         conf.append("wal_log_hints", "off");
         conf.append("max_replication_slots", "10");
         conf.append("hot_standby", "on");
+        conf.append("hot_standby_feedback", "on");
         conf.append("shared_buffers", "1MB");
         conf.append("fsync", "off");
         conf.append("max_connections", "100");

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -307,6 +307,9 @@ impl Endpoint {
         // Load the 'neon' extension
         conf.append("shared_preload_libraries", "neon");
 
+		// It is only for testing, in real environment this GUC is passed by control plane
+		conf.append("neon.primary_is_running", "on");
+
         conf.append_line("");
         // Replication-related configurations, such as WAL sending
         match &self.mode {

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1005,7 +1005,7 @@ mod tests {
         // Test serialization/deserialization of PagestreamFeMessage
         let messages = vec![
             PagestreamFeMessage::Exists(PagestreamExistsRequest {
-                horizon: Lsn.MAX,
+                horizon: Lsn::MAX,
                 lsn: Lsn(4),
                 rel: RelTag {
                     forknum: 1,
@@ -1025,7 +1025,7 @@ mod tests {
                 },
             }),
             PagestreamFeMessage::GetPage(PagestreamGetPageRequest {
-                latest: Lsn.MAX,
+                horizon: Lsn::MAX,
                 lsn: Lsn(4),
                 rel: RelTag {
                     forknum: 1,
@@ -1036,7 +1036,7 @@ mod tests {
                 blkno: 7,
             }),
             PagestreamFeMessage::DbSize(PagestreamDbSizeRequest {
-                latest: Lsn::MAX,
+                horizon: Lsn::MAX,
                 lsn: Lsn(4),
                 dbnode: 7,
             }),

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1015,7 +1015,7 @@ mod tests {
                 },
             }),
             PagestreamFeMessage::Nblocks(PagestreamNblocksRequest {
-                horizon: Lsn(4),
+                horizon: Lsn::INVALID,
                 lsn: Lsn(4),
                 rel: RelTag {
                     forknum: 1,
@@ -1026,7 +1026,7 @@ mod tests {
             }),
             PagestreamFeMessage::GetPage(PagestreamGetPageRequest {
                 horizon: Lsn::MAX,
-                lsn: Lsn(4),
+                lsn: Lsn::INVALID,
                 rel: RelTag {
                     forknum: 1,
                     spcnode: 2,

--- a/libs/postgres_ffi/src/xlog_utils.rs
+++ b/libs/postgres_ffi/src/xlog_utils.rs
@@ -119,11 +119,6 @@ pub fn generate_pg_control(
     // Generate new pg_control needed for bootstrap
     checkpoint.redo = normalize_lsn(lsn, WAL_SEGMENT_SIZE).0;
 
-    //reset some fields we don't want to preserve
-    //TODO Check this.
-    //We may need to determine the value from twophase data.
-    checkpoint.oldestActiveXid = 0;
-
     //save new values in pg_control
     pg_control.checkPoint = 0;
     pg_control.checkPointCopy = checkpoint;

--- a/libs/safekeeper_api/src/models.rs
+++ b/libs/safekeeper_api/src/models.rs
@@ -52,7 +52,7 @@ pub struct SkTimelineInfo {
     pub http_connstr: Option<String>,
     // Minimum of all active RO replicas flush LSN
     #[serde(default = "lsn_invalid")]
-    pub standby_flush_lsn: Lsn,
+    pub standby_horizon: Lsn,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/libs/safekeeper_api/src/models.rs
+++ b/libs/safekeeper_api/src/models.rs
@@ -50,6 +50,7 @@ pub struct SkTimelineInfo {
     pub safekeeper_connstr: Option<String>,
     #[serde(default)]
     pub http_connstr: Option<String>,
+    // Minimum of all active RO replicas flush LSN
     #[serde(default = "lsn_invalid")]
     pub standby_flush_lsn: Lsn,
 }

--- a/libs/safekeeper_api/src/models.rs
+++ b/libs/safekeeper_api/src/models.rs
@@ -50,6 +50,8 @@ pub struct SkTimelineInfo {
     pub safekeeper_connstr: Option<String>,
     #[serde(default)]
     pub http_connstr: Option<String>,
+    #[serde(default = "lsn_invalid")]
+    pub standby_flush_lsn: Lsn,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/pageserver/pagebench/src/cmd/getpage_latest_lsn.rs
+++ b/pageserver/pagebench/src/cmd/getpage_latest_lsn.rs
@@ -288,7 +288,11 @@ async fn main_impl(
                                 num_client: rng.gen_range(0..args.num_clients.get()),
                             },
                             PagestreamGetPageRequest {
-                                latest: rng.gen_bool(args.req_latest_probability),
+                                horizon: if rng.gen_bool(args.req_latest_probability) {
+                                    Lsn::MAX
+                                } else {
+                                    r.timeline_lsn
+                                },
                                 lsn: r.timeline_lsn,
                                 rel: rel_tag,
                                 blkno: block_no,
@@ -335,7 +339,11 @@ async fn main_impl(
                                     let (rel_tag, block_no) = key_to_rel_block(key)
                                         .expect("we filter non-rel-block keys out above");
                                     PagestreamGetPageRequest {
-                                        latest: rng.gen_bool(args.req_latest_probability),
+                                        horizon: if rng.gen_bool(args.req_latest_probability) {
+                                            Lsn::MAX
+                                        } else {
+                                            r.timeline_lsn
+                                        },
                                         lsn: r.timeline_lsn,
                                         rel: rel_tag,
                                         blkno: block_no,

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -357,9 +357,10 @@ where
 
     /// Add contents of relfilenode `src`, naming it as `dst`.
     async fn add_rel(&mut self, src: RelTag, dst: RelTag) -> anyhow::Result<()> {
+        let horizon = self.lsn; // we do not need latest version
         let nblocks = self
             .timeline
-            .get_rel_size(src, Version::Lsn(self.lsn), false, self.ctx)
+            .get_rel_size(src, Version::Lsn(self.lsn), horizon, self.ctx)
             .await?;
 
         // If the relation is empty, create an empty file
@@ -380,7 +381,7 @@ where
             for blknum in startblk..endblk {
                 let img = self
                     .timeline
-                    .get_rel_page_at_lsn(src, blknum, Version::Lsn(self.lsn), false, self.ctx)
+                    .get_rel_page_at_lsn(src, blknum, Version::Lsn(self.lsn), horizon, self.ctx)
                     .await?;
                 segment_data.extend_from_slice(&img[..]);
             }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -848,7 +848,11 @@ impl PageServerHandler {
         ctx: &RequestContext,
     ) -> Result<Lsn, PageStreamError> {
         let last_record_lsn = timeline.get_last_record_lsn();
-		let request_horizon = if horizon == Lsn::INVALID { lsn } else { horizon };
+        let request_horizon = if horizon == Lsn::INVALID {
+            lsn
+        } else {
+            horizon
+        };
         let effective_lsn = Lsn::max(lsn, Lsn::min(request_horizon, last_record_lsn));
         if effective_lsn > last_record_lsn {
             timeline.wait_lsn(effective_lsn, ctx).await?;

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -867,6 +867,10 @@ impl PageServerHandler {
         ctx: &RequestContext,
     ) -> Result<Lsn, PageStreamError> {
         let last_record_lsn = timeline.get_last_record_lsn();
+        // Horizon = 0 (INVALID) is treated as LSN interval degenerated to point [lsn,lsn].
+        // It as done mostly for convenience (because such get_page commands are widely used in tests) and
+        // also seems to be logical: Lsn::MAX moves upper boundary of LSN interval till last_record_lsn and
+        // Lsn(0) moves upper boundary to lower boundary.
         let request_horizon = if horizon == Lsn::INVALID {
             lsn
         } else {

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1175,7 +1175,7 @@ impl PageServerHandler {
 
         let latest_gc_cutoff_lsn = timeline.get_latest_gc_cutoff_lsn();
         let lsn =
-            Self::wait_or_get_last_lsn(timeline, req.lsn, req.latest, &latest_gc_cutoff_lsn, ctx)
+            Self::wait_or_get_last_lsn(timeline, req.lsn, req.horizon, &latest_gc_cutoff_lsn, ctx)
                 .await?;
 
         let kind = SlruKind::from_repr(req.kind)

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -631,6 +631,25 @@ impl PageServerHandler {
                         span,
                     )
                 }
+                PagestreamFeMessage::GetLatestPage(old_req) => {
+                    let req = PagestreamGetPageRequest {
+                        horizon: if old_req.latest {
+                            Lsn::MAX
+                        } else {
+                            old_req.lsn
+                        },
+                        lsn: old_req.lsn,
+                        rel: old_req.rel,
+                        blkno: old_req.blkno,
+                    };
+                    let span = tracing::info_span!("handle_get_page_at_lsn_request", rel = %req.rel, blkno = %req.blkno, req_lsn = %req.lsn);
+                    (
+                        self.handle_get_page_at_lsn_request(tenant_id, timeline_id, &req, &ctx)
+                            .instrument(span.clone())
+                            .await,
+                        span,
+                    )
+                }
                 PagestreamFeMessage::GetPage(req) => {
                     // shard_id is filled in by the handler
                     let span = tracing::info_span!("handle_get_page_at_lsn_request", rel = %req.rel, blkno = %req.blkno, req_lsn = %req.lsn);

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -169,7 +169,7 @@ impl Timeline {
         tag: RelTag,
         blknum: BlockNumber,
         version: Version<'_>,
-        latest: bool,
+        horizon: Lsn,
         ctx: &RequestContext,
     ) -> Result<Bytes, PageReconstructError> {
         if tag.relnode == 0 {
@@ -178,7 +178,7 @@ impl Timeline {
             ));
         }
 
-        let nblocks = self.get_rel_size(tag, version, latest, ctx).await?;
+        let nblocks = self.get_rel_size(tag, version, horizon, ctx).await?;
         if blknum >= nblocks {
             debug!(
                 "read beyond EOF at {} blk {} at {}, size is {}: returning all-zeros page",
@@ -200,7 +200,7 @@ impl Timeline {
         spcnode: Oid,
         dbnode: Oid,
         version: Version<'_>,
-        latest: bool,
+        horizon: Lsn,
         ctx: &RequestContext,
     ) -> Result<usize, PageReconstructError> {
         let mut total_blocks = 0;
@@ -208,7 +208,7 @@ impl Timeline {
         let rels = self.list_rels(spcnode, dbnode, version, ctx).await?;
 
         for rel in rels {
-            let n_blocks = self.get_rel_size(rel, version, latest, ctx).await?;
+            let n_blocks = self.get_rel_size(rel, version, horizon, ctx).await?;
             total_blocks += n_blocks as usize;
         }
         Ok(total_blocks)
@@ -219,7 +219,7 @@ impl Timeline {
         &self,
         tag: RelTag,
         version: Version<'_>,
-        latest: bool,
+        horizon: Lsn,
         ctx: &RequestContext,
     ) -> Result<BlockNumber, PageReconstructError> {
         if tag.relnode == 0 {
@@ -233,7 +233,7 @@ impl Timeline {
         }
 
         if (tag.forknum == FSM_FORKNUM || tag.forknum == VISIBILITYMAP_FORKNUM)
-            && !self.get_rel_exists(tag, version, latest, ctx).await?
+            && !self.get_rel_exists(tag, version, horizon, ctx).await?
         {
             // FIXME: Postgres sometimes calls smgrcreate() to create
             // FSM, and smgrnblocks() on it immediately afterwards,
@@ -246,14 +246,8 @@ impl Timeline {
         let mut buf = version.get(self, key, ctx).await?;
         let nblocks = buf.get_u32_le();
 
-        if latest {
-            // Update relation size cache only if "latest" flag is set.
-            // This flag is set by compute when it is working with most recent version of relation.
-            // Typically master compute node always set latest=true.
-            // Please notice, that even if compute node "by mistake" specifies old LSN but set
-            // latest=true, then it can not cause cache corruption, because with latest=true
-            // pageserver choose max(request_lsn, last_written_lsn) and so cached value will be
-            // associated with most recent value of LSN.
+        if horizon == Lsn::MAX {
+            // Update relation size cache only if latest version is requested.
             self.update_cached_rel_size(tag, version.get_lsn(), nblocks);
         }
         Ok(nblocks)
@@ -264,7 +258,7 @@ impl Timeline {
         &self,
         tag: RelTag,
         version: Version<'_>,
-        _latest: bool,
+        _horizon: Lsn,
         ctx: &RequestContext,
     ) -> Result<bool, PageReconstructError> {
         if tag.relnode == 0 {
@@ -1066,7 +1060,7 @@ impl<'a> DatadirModification<'a> {
     ) -> anyhow::Result<()> {
         let total_blocks = self
             .tline
-            .get_db_size(spcnode, dbnode, Version::Modified(self), true, ctx)
+            .get_db_size(spcnode, dbnode, Version::Modified(self), Lsn::MAX, ctx)
             .await?;
 
         // Remove entry from dbdir
@@ -1157,7 +1151,7 @@ impl<'a> DatadirModification<'a> {
         anyhow::ensure!(rel.relnode != 0, RelationError::InvalidRelnode);
         if self
             .tline
-            .get_rel_exists(rel, Version::Modified(self), true, ctx)
+            .get_rel_exists(rel, Version::Modified(self), Lsn::MAX, ctx)
             .await?
         {
             let size_key = rel_size_to_key(rel);

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4209,6 +4209,9 @@ impl Timeline {
             new_gc_cutoff
         };
 
+        // Reset standby horizon to ignore  it if it is not updated till next GC
+        self.standby_horizon.store(Lsn::INVALID);
+
         let res = self
             .gc_timeline(horizon_cutoff, pitr_cutoff, retain_lsns, new_gc_cutoff)
             .instrument(

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -215,6 +215,8 @@ pub struct Timeline {
     // Atomic would be more appropriate here.
     last_freeze_ts: RwLock<Instant>,
 
+    pub(crate) standby_flush_lsn: AtomicLsn,
+
     // WAL redo manager. `None` only for broken tenants.
     walredo_mgr: Option<Arc<super::WalRedoManager>>,
 
@@ -1540,6 +1542,7 @@ impl Timeline {
 
                 compaction_lock: tokio::sync::Mutex::default(),
                 gc_lock: tokio::sync::Mutex::default(),
+                standby_flush_lsn: AtomicLsn::new(0),
             };
             result.repartition_threshold =
                 result.get_checkpoint_distance() / REPARTITION_FREQ_IN_CHECKPOINT_DISTANCE;
@@ -4198,7 +4201,11 @@ impl Timeline {
             (horizon_cutoff, pitr_cutoff, retain_lsns)
         };
 
-        let new_gc_cutoff = Lsn::min(horizon_cutoff, pitr_cutoff);
+        let mut new_gc_cutoff = Lsn::min(horizon_cutoff, pitr_cutoff);
+        let standby_flush_lsn = self.standby_flush_lsn.load();
+        if standby_flush_lsn != Lsn::INVALID && standby_flush_lsn < new_gc_cutoff {
+            new_gc_cutoff = standby_flush_lsn;
+        }
 
         let res = self
             .gc_timeline(horizon_cutoff, pitr_cutoff, retain_lsns, new_gc_cutoff)

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4201,11 +4201,13 @@ impl Timeline {
             (horizon_cutoff, pitr_cutoff, retain_lsns)
         };
 
-        let mut new_gc_cutoff = Lsn::min(horizon_cutoff, pitr_cutoff);
+        let new_gc_cutoff = Lsn::min(horizon_cutoff, pitr_cutoff);
         let standby_flush_lsn = self.standby_flush_lsn.load();
-        if standby_flush_lsn != Lsn::INVALID && standby_flush_lsn < new_gc_cutoff {
-            new_gc_cutoff = standby_flush_lsn;
-        }
+        let new_gc_cutoff = if standby_flush_lsn != Lsn::INVALID {
+            Lsn::min(standby_flush_lsn, new_gc_cutoff)
+        } else {
+            new_gc_cutoff
+        };
 
         let res = self
             .gc_timeline(horizon_cutoff, pitr_cutoff, retain_lsns, new_gc_cutoff)

--- a/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
@@ -553,9 +553,12 @@ impl ConnectionManagerState {
     fn register_timeline_update(&mut self, timeline_update: SafekeeperTimelineInfo) {
         WALRECEIVER_BROKER_UPDATES.inc();
 
-        self.timeline
-            .standby_horizon
-            .store(Lsn(timeline_update.standby_horizon));
+        if timeline_update.standby_horizon != 0 {
+            // ignore reports from safekeepers mnot connected to replicas
+            self.timeline
+                .standby_horizon
+                .store(Lsn(timeline_update.standby_horizon));
+        }
 
         let new_safekeeper_id = NodeId(timeline_update.safekeeper_id);
         let old_entry = self.wal_stream_candidates.insert(

--- a/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
@@ -554,8 +554,8 @@ impl ConnectionManagerState {
         WALRECEIVER_BROKER_UPDATES.inc();
 
         self.timeline
-            .standby_flush_lsn
-            .store(Lsn(timeline_update.standby_flush_lsn));
+            .standby_horizon
+            .store(Lsn(timeline_update.standby_horizon));
 
         let new_safekeeper_id = NodeId(timeline_update.safekeeper_id);
         let old_entry = self.wal_stream_candidates.insert(
@@ -923,7 +923,7 @@ mod tests {
                 remote_consistent_lsn: 0,
                 peer_horizon_lsn: 0,
                 local_start_lsn: 0,
-                standby_flush_lsn: 0,
+                standby_horizon: 0,
                 safekeeper_connstr: safekeeper_connstr.to_owned(),
                 http_connstr: safekeeper_connstr.to_owned(),
                 availability_zone: None,

--- a/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
@@ -553,6 +553,10 @@ impl ConnectionManagerState {
     fn register_timeline_update(&mut self, timeline_update: SafekeeperTimelineInfo) {
         WALRECEIVER_BROKER_UPDATES.inc();
 
+        info!(
+            "Safekeeper info update: standby_horizon(cutoff)={}",
+            timeline_update.standby_horizon
+        );
         if timeline_update.standby_horizon != 0 {
             // ignore reports from safekeepers mnot connected to replicas
             self.timeline

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1019,7 +1019,7 @@ impl WalIngest {
 
             let nblocks = modification
                 .tline
-                .get_rel_size(src_rel, Version::Modified(modification), true, ctx)
+                .get_rel_size(src_rel, Version::Modified(modification), Lsn::MAX, ctx)
                 .await?;
             let dst_rel = RelTag {
                 spcnode: tablespace_id,
@@ -1057,7 +1057,7 @@ impl WalIngest {
                         src_rel,
                         blknum,
                         Version::Modified(modification),
-                        true,
+                        Lsn::MAX,
                         ctx,
                     )
                     .await?;
@@ -1227,7 +1227,7 @@ impl WalIngest {
                 };
                 if modification
                     .tline
-                    .get_rel_exists(rel, Version::Modified(modification), true, ctx)
+                    .get_rel_exists(rel, Version::Modified(modification), Lsn::MAX, ctx)
                     .await?
                 {
                     self.put_rel_drop(modification, rel, ctx).await?;
@@ -1526,7 +1526,7 @@ impl WalIngest {
             nblocks
         } else if !modification
             .tline
-            .get_rel_exists(rel, Version::Modified(modification), true, ctx)
+            .get_rel_exists(rel, Version::Modified(modification), Lsn::MAX, ctx)
             .await?
         {
             // create it with 0 size initially, the logic below will extend it
@@ -1538,7 +1538,7 @@ impl WalIngest {
         } else {
             modification
                 .tline
-                .get_rel_size(rel, Version::Modified(modification), true, ctx)
+                .get_rel_size(rel, Version::Modified(modification), Lsn::MAX, ctx)
                 .await?
         };
 
@@ -1635,14 +1635,14 @@ async fn get_relsize(
 ) -> anyhow::Result<BlockNumber> {
     let nblocks = if !modification
         .tline
-        .get_rel_exists(rel, Version::Modified(modification), true, ctx)
+        .get_rel_exists(rel, Version::Modified(modification), Lsn::MAX, ctx)
         .await?
     {
         0
     } else {
         modification
             .tline
-            .get_rel_size(rel, Version::Modified(modification), true, ctx)
+            .get_rel_size(rel, Version::Modified(modification), Lsn::MAX, ctx)
             .await?
     };
     Ok(nblocks)

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1719,29 +1719,29 @@ mod tests {
         // The relation was created at LSN 2, not visible at LSN 1 yet.
         assert_eq!(
             tline
-                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x10)), false, &ctx)
+                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x10)), Lsn::INVALID, &ctx)
                 .await?,
             false
         );
         assert!(tline
-            .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x10)), false, &ctx)
+            .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x10)), Lsn::INVALID, &ctx)
             .await
             .is_err());
         assert_eq!(
             tline
-                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x20)), false, &ctx)
+                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x20)), Lsn::INVALID, &ctx)
                 .await?,
             true
         );
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x20)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x20)), Lsn::INVALID, &ctx)
                 .await?,
             1
         );
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x50)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
                 .await?,
             3
         );
@@ -1749,46 +1749,46 @@ mod tests {
         // Check page contents at each LSN
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x20)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x20)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 0 at 2")
         );
 
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x30)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x30)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 0 at 3")
         );
 
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x40)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x40)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 0 at 3")
         );
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 1, Version::Lsn(Lsn(0x40)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 1, Version::Lsn(Lsn(0x40)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 1 at 4")
         );
 
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x50)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 0 at 3")
         );
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 1, Version::Lsn(Lsn(0x50)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 1, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 1 at 4")
         );
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 2, Version::Lsn(Lsn(0x50)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 2, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 2 at 5")
         );
@@ -1804,19 +1804,19 @@ mod tests {
         // Check reported size and contents after truncation
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x60)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x60)), Lsn::INVALID, &ctx)
                 .await?,
             2
         );
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x60)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x60)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 0 at 3")
         );
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 1, Version::Lsn(Lsn(0x60)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 1, Version::Lsn(Lsn(0x60)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 1 at 4")
         );
@@ -1824,13 +1824,13 @@ mod tests {
         // should still see the truncated block with older LSN
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x50)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
                 .await?,
             3
         );
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 2, Version::Lsn(Lsn(0x50)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 2, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 2 at 5")
         );
@@ -1843,7 +1843,7 @@ mod tests {
         m.commit(&ctx).await?;
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x68)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x68)), Lsn::INVALID, &ctx)
                 .await?,
             0
         );
@@ -1856,19 +1856,19 @@ mod tests {
         m.commit(&ctx).await?;
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x70)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x70)), Lsn::INVALID, &ctx)
                 .await?,
             2
         );
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x70)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 0, Version::Lsn(Lsn(0x70)), Lsn::INVALID, &ctx)
                 .await?,
             ZERO_PAGE
         );
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 1, Version::Lsn(Lsn(0x70)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 1, Version::Lsn(Lsn(0x70)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 1")
         );
@@ -1881,21 +1881,21 @@ mod tests {
         m.commit(&ctx).await?;
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x80)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x80)), Lsn::INVALID, &ctx)
                 .await?,
             1501
         );
         for blk in 2..1500 {
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blk, Version::Lsn(Lsn(0x80)), false, &ctx)
+                    .get_rel_page_at_lsn(TESTREL_A, blk, Version::Lsn(Lsn(0x80)), Lsn::INVALID, &ctx)
                     .await?,
                 ZERO_PAGE
             );
         }
         assert_eq!(
             tline
-                .get_rel_page_at_lsn(TESTREL_A, 1500, Version::Lsn(Lsn(0x80)), false, &ctx)
+                .get_rel_page_at_lsn(TESTREL_A, 1500, Version::Lsn(Lsn(0x80)), Lsn::INVALID, &ctx)
                 .await?,
             TEST_IMG("foo blk 1500")
         );
@@ -1922,13 +1922,13 @@ mod tests {
         // Check that rel exists and size is correct
         assert_eq!(
             tline
-                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x20)), false, &ctx)
+                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x20)), Lsn::INVALID, &ctx)
                 .await?,
             true
         );
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x20)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x20)), Lsn::INVALID, &ctx)
                 .await?,
             1
         );
@@ -1941,7 +1941,7 @@ mod tests {
         // Check that rel is not visible anymore
         assert_eq!(
             tline
-                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x30)), false, &ctx)
+                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x30)), Lsn::INVALID, &ctx)
                 .await?,
             false
         );
@@ -1959,13 +1959,13 @@ mod tests {
         // Check that rel exists and size is correct
         assert_eq!(
             tline
-                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x40)), false, &ctx)
+                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x40)), Lsn::INVALID, &ctx)
                 .await?,
             true
         );
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x40)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x40)), Lsn::INVALID, &ctx)
                 .await?,
             1
         );
@@ -1998,24 +1998,24 @@ mod tests {
         // The relation was created at LSN 20, not visible at LSN 1 yet.
         assert_eq!(
             tline
-                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x10)), false, &ctx)
+                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x10)), Lsn::INVALID, &ctx)
                 .await?,
             false
         );
         assert!(tline
-            .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x10)), false, &ctx)
+            .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x10)), Lsn::INVALID, &ctx)
             .await
             .is_err());
 
         assert_eq!(
             tline
-                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x20)), false, &ctx)
+                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x20)), Lsn::INVALID, &ctx)
                 .await?,
             true
         );
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x20)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x20)), Lsn::INVALID, &ctx)
                 .await?,
             relsize
         );
@@ -2026,7 +2026,7 @@ mod tests {
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(lsn), false, &ctx)
+                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(lsn), Lsn::INVALID, &ctx)
                     .await?,
                 TEST_IMG(&data)
             );
@@ -2043,7 +2043,7 @@ mod tests {
         // Check reported size and contents after truncation
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x60)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x60)), Lsn::INVALID, &ctx)
                 .await?,
             1
         );
@@ -2053,7 +2053,7 @@ mod tests {
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x60)), false, &ctx)
+                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x60)), Lsn::INVALID, &ctx)
                     .await?,
                 TEST_IMG(&data)
             );
@@ -2062,7 +2062,7 @@ mod tests {
         // should still see all blocks with older LSN
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x50)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
                 .await?,
             relsize
         );
@@ -2071,7 +2071,7 @@ mod tests {
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x50)), false, &ctx)
+                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
                     .await?,
                 TEST_IMG(&data)
             );
@@ -2091,13 +2091,13 @@ mod tests {
 
         assert_eq!(
             tline
-                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x80)), false, &ctx)
+                .get_rel_exists(TESTREL_A, Version::Lsn(Lsn(0x80)), Lsn::INVALID, &ctx)
                 .await?,
             true
         );
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x80)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(0x80)), Lsn::INVALID, &ctx)
                 .await?,
             relsize
         );
@@ -2107,7 +2107,7 @@ mod tests {
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x80)), false, &ctx)
+                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x80)), Lsn::INVALID, &ctx)
                     .await?,
                 TEST_IMG(&data)
             );
@@ -2141,7 +2141,7 @@ mod tests {
 
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(lsn)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(lsn)), Lsn::INVALID, &ctx)
                 .await?,
             RELSEG_SIZE + 1
         );
@@ -2155,7 +2155,7 @@ mod tests {
         m.commit(&ctx).await?;
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(lsn)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(lsn)), Lsn::INVALID, &ctx)
                 .await?,
             RELSEG_SIZE
         );
@@ -2170,7 +2170,7 @@ mod tests {
         m.commit(&ctx).await?;
         assert_eq!(
             tline
-                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(lsn)), false, &ctx)
+                .get_rel_size(TESTREL_A, Version::Lsn(Lsn(lsn)), Lsn::INVALID, &ctx)
                 .await?,
             RELSEG_SIZE - 1
         );
@@ -2188,7 +2188,7 @@ mod tests {
             m.commit(&ctx).await?;
             assert_eq!(
                 tline
-                    .get_rel_size(TESTREL_A, Version::Lsn(Lsn(lsn)), false, &ctx)
+                    .get_rel_size(TESTREL_A, Version::Lsn(Lsn(lsn)), Lsn::INVALID, &ctx)
                     .await?,
                 size as BlockNumber
             );

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1888,7 +1888,13 @@ mod tests {
         for blk in 2..1500 {
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blk, Version::Lsn(Lsn(0x80)), Lsn::INVALID, &ctx)
+                    .get_rel_page_at_lsn(
+                        TESTREL_A,
+                        blk,
+                        Version::Lsn(Lsn(0x80)),
+                        Lsn::INVALID,
+                        &ctx
+                    )
                     .await?,
                 ZERO_PAGE
             );
@@ -2053,7 +2059,13 @@ mod tests {
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x60)), Lsn::INVALID, &ctx)
+                    .get_rel_page_at_lsn(
+                        TESTREL_A,
+                        blkno,
+                        Version::Lsn(Lsn(0x60)),
+                        Lsn::INVALID,
+                        &ctx
+                    )
                     .await?,
                 TEST_IMG(&data)
             );
@@ -2071,7 +2083,13 @@ mod tests {
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x50)), Lsn::INVALID, &ctx)
+                    .get_rel_page_at_lsn(
+                        TESTREL_A,
+                        blkno,
+                        Version::Lsn(Lsn(0x50)),
+                        Lsn::INVALID,
+                        &ctx
+                    )
                     .await?,
                 TEST_IMG(&data)
             );
@@ -2107,7 +2125,13 @@ mod tests {
             let data = format!("foo blk {} at {}", blkno, lsn);
             assert_eq!(
                 tline
-                    .get_rel_page_at_lsn(TESTREL_A, blkno, Version::Lsn(Lsn(0x80)), Lsn::INVALID, &ctx)
+                    .get_rel_page_at_lsn(
+                        TESTREL_A,
+                        blkno,
+                        Version::Lsn(Lsn(0x80)),
+                        Lsn::INVALID,
+                        &ctx
+                    )
                     .await?,
                 TEST_IMG(&data)
             );

--- a/pgxn/neon/neon.c
+++ b/pgxn/neon/neon.c
@@ -30,6 +30,8 @@
 PG_MODULE_MAGIC;
 void		_PG_init(void);
 
+bool primary_is_running = false;
+
 void
 _PG_init(void)
 {
@@ -47,6 +49,16 @@ _PG_init(void)
 	InitControlPlaneConnector();
 
 	pg_init_extension_server();
+
+	DefineCustomBoolVariable(
+		"neon.primary_is_running",
+		"For replica it is true, if primary is running, false otherwise",
+		NULL,
+		&primary_is_running,
+		false,
+		PGC_POSTMASTER,
+		0,
+		NULL, NULL, NULL);
 
 	/*
 	 * Important: This must happen after other parts of the extension are

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -79,7 +79,7 @@ typedef enum {
 typedef struct
 {
 	NeonMessageTag tag;
-	bool		latest;			/* if true, request latest page version */
+	XLogRecPtr	horizon;		/* uppe boundary for page LSN */
 	XLogRecPtr	lsn;			/* request page version @ this LSN */
 } NeonRequest;
 

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -33,9 +33,10 @@ typedef enum
 	/* pagestore_client -> pagestore */
 	T_NeonExistsRequest = 0,
 	T_NeonNblocksRequest,
-	T_NeonGetPageRequest,
+	T_NeonGetLatestPageRequest, /* old format of get_page command */
 	T_NeonDbSizeRequest,
 	T_NeonGetSlruSegmentRequest,
+	T_NeonGetPageRequest,
 
 	/* pagestore -> pagestore_client */
 	T_NeonExistsResponse = 100,

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -121,7 +121,7 @@ static bool (*old_redo_read_buffer_filter) (XLogReaderState *record, uint8 block
 static XLogRecPtr
 neon_get_horizon(bool latest)
 {
-	return latest ? MAX_LSN : RecoveryInProgress() ? GetXLogReplayRecPtr(NULL) : InvalidXlogRecPtr; /* horizon=InvalidXlogRecPtr is replaced with request_lsn at PS */
+	return latest ? MAX_LSN : RecoveryInProgress() ? GetXLogReplayRecPtr(NULL) : InvalidXLogRecPtr; /* horizon=InvalidXlogRecPtr is replaced with request_lsn at PS */
 }
 
 /*

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1063,7 +1063,7 @@ nm_pack_request(NeonRequest *msg)
 			{
 				NeonGetSlruSegmentRequest *msg_req = (NeonGetSlruSegmentRequest *) msg;
 
-				pq_sendbyte(&s, msg_req->req.latest);
+				pq_sendint64(&s, msg_req->req.horizon);
 				pq_sendint64(&s, msg_req->req.lsn);
 				pq_sendbyte(&s, msg_req->kind);
 				pq_sendint32(&s, msg_req->segno);
@@ -1265,7 +1265,7 @@ nm_to_string(NeonMessage *msg)
 				appendStringInfo(&s, ", \"kind\": %u", msg_req->kind);
 				appendStringInfo(&s, ", \"segno\": %u", msg_req->segno);
 				appendStringInfo(&s, ", \"lsn\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_req->req.lsn));
-				appendStringInfo(&s, ", \"latest\": %d", msg_req->req.latest);
+				appendStringInfo(&s, ", \"horizon\": \"%X/%X\"", LSN_FORMAT_ARGS(msg_req->req.horizon));
 				appendStringInfoChar(&s, '}');
 				break;
 			}
@@ -2832,7 +2832,7 @@ neon_read_slru_segment(SMgrRelation reln, const char* path, int segno, void* buf
 	NeonResponse *resp;
 	NeonGetSlruSegmentRequest request = {
 		.req.tag = T_NeonGetSlruSegmentRequest,
-		.req.latest = false,
+		.req.horizon =  InvalidXLogRecPtr,
 		.req.lsn = request_lsn,
 
 		.kind = kind,

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -1838,23 +1838,24 @@ static void
 CombineHotStanbyFeedbacks(HotStandbyFeedback *hs, WalProposer *wp)
 {
 	hs->ts = 0;
-	hs->xmin.value = InvalidFullTransactionId;
-	hs->catalog_xmin.value = InvalidFullTransactionId;
+	hs->xmin = InvalidFullTransactionId;
+	hs->catalog_xmin = InvalidFullTransactionId;
 
 	for (int i = 0; i < wp->n_safekeepers; i++)
 	{
-		if (wp->safekeeper[i].appendResponse.hs.ts != 0)
+		elog(LOG, "hs.ts=%ld hs.xmin=%ld", wp->safekeeper[i].appendResponse.hs.ts, wp->safekeeper[i].appendResponse.hs.xmin);
+ 		if (wp->safekeeper[i].appendResponse.hs.ts != 0)
 		{
 			HotStandbyFeedback *skhs = &wp->safekeeper[i].appendResponse.hs;
 
 			if (FullTransactionIdIsNormal(skhs->xmin)
-				&& (hs->xmin.value == InvalidFullTransactionId || FullTransactionIdPrecedes(skhs->xmin, hs->xmin)))
+				&& (!FullTransactionIdIsValid(hs->xmin) || FullTransactionIdPrecedes(skhs->xmin, hs->xmin)))
 			{
 				hs->xmin = skhs->xmin;
 				hs->ts = skhs->ts;
 			}
 			if (FullTransactionIdIsNormal(skhs->catalog_xmin)
-				&& (hs->xmin.value == InvalidFullTransactionId || FullTransactionIdPrecedes(skhs->catalog_xmin, hs->catalog_xmin)))
+				&& (!FullTransactionIdIsValid(hs->catalog_xmin) || FullTransactionIdPrecedes(skhs->catalog_xmin, hs->catalog_xmin)))
 			{
 				hs->catalog_xmin = skhs->catalog_xmin;
 				hs->ts = skhs->ts;

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -1843,7 +1843,6 @@ CombineHotStanbyFeedbacks(HotStandbyFeedback *hs, WalProposer *wp)
 
 	for (int i = 0; i < wp->n_safekeepers; i++)
 	{
-		elog(LOG, "hs.ts=%ld hs.xmin=%d", wp->safekeeper[i].appendResponse.hs.ts, XidFromFullTransactionId(wp->safekeeper[i].appendResponse.hs.xmin));
  		if (wp->safekeeper[i].appendResponse.hs.ts != 0)
 		{
 			HotStandbyFeedback *skhs = &wp->safekeeper[i].appendResponse.hs;
@@ -1919,7 +1918,7 @@ walprop_pg_process_safekeeper_feedback(WalProposer *wp, XLogRecPtr commitLsn)
 	if (hsFeedback.ts != 0 && memcmp(&hsFeedback, &quorumFeedback.hs, sizeof hsFeedback) != 0)
 	{
 		quorumFeedback.hs = hsFeedback;
-		elog(LOG, "ProcessStandbyHSFeedback(xmin=%d, catalog_xmin=%d", XidFromFullTransactionId(hsFeedback.xmin), XidFromFullTransactionId(hsFeedback.catalog_xmin));
+		elog(DEBUG2, "ProcessStandbyHSFeedback(xmin=%d, catalog_xmin=%d", XidFromFullTransactionId(hsFeedback.xmin), XidFromFullTransactionId(hsFeedback.catalog_xmin));
 		ProcessStandbyHSFeedback(hsFeedback.ts,
 								 XidFromFullTransactionId(hsFeedback.xmin),
 								 EpochFromFullTransactionId(hsFeedback.xmin),

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -1923,12 +1923,14 @@ walprop_pg_process_safekeeper_feedback(WalProposer *wp, XLogRecPtr commitLsn)
 	if (hsFeedback.ts != 0 && memcmp(&hsFeedback, &quorumFeedback.hs, sizeof hsFeedback) != 0)
 	{
 		quorumFeedback.hs = hsFeedback;
+		elog(LOG, "ProcessStandbyHSFeedback(xmin=%d, catalog_xmin=%d", XidFromFullTransactionId(hsFeedback.xmin), XidFromFullTransactionId(hsFeedback.catalog_xmin));
 		ProcessStandbyHSFeedback(hsFeedback.ts,
 								 XidFromFullTransactionId(hsFeedback.xmin),
 								 EpochFromFullTransactionId(hsFeedback.xmin),
 								 XidFromFullTransactionId(hsFeedback.catalog_xmin),
 								 EpochFromFullTransactionId(hsFeedback.catalog_xmin));
-	}
+	} else
+		elog(LOG, "Skip HSFeedback ts=%ld, xmin=%d, catalog_xmin=%d", hsFeedback.ts, XidFromFullTransactionId(hsFeedback.xmin), XidFromFullTransactionId(hsFeedback.catalog_xmin));
 }
 
 static XLogRecPtr

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -1843,7 +1843,7 @@ CombineHotStanbyFeedbacks(HotStandbyFeedback *hs, WalProposer *wp)
 
 	for (int i = 0; i < wp->n_safekeepers; i++)
 	{
-		elog(LOG, "hs.ts=%ld hs.xmin=%ld", wp->safekeeper[i].appendResponse.hs.ts, wp->safekeeper[i].appendResponse.hs.xmin);
+		elog(LOG, "hs.ts=%ld hs.xmin=%d", wp->safekeeper[i].appendResponse.hs.ts, XidFromFullTransactionId(wp->safekeeper[i].appendResponse.hs.xmin));
  		if (wp->safekeeper[i].appendResponse.hs.ts != 0)
 		{
 			HotStandbyFeedback *skhs = &wp->safekeeper[i].appendResponse.hs;
@@ -1925,8 +1925,7 @@ walprop_pg_process_safekeeper_feedback(WalProposer *wp, XLogRecPtr commitLsn)
 								 EpochFromFullTransactionId(hsFeedback.xmin),
 								 XidFromFullTransactionId(hsFeedback.catalog_xmin),
 								 EpochFromFullTransactionId(hsFeedback.catalog_xmin));
-	} else
-		elog(LOG, "Skip HSFeedback ts=%ld, xmin=%d, catalog_xmin=%d", hsFeedback.ts, XidFromFullTransactionId(hsFeedback.xmin), XidFromFullTransactionId(hsFeedback.catalog_xmin));
+	}
 }
 
 static XLogRecPtr

--- a/safekeeper/src/http/routes.rs
+++ b/safekeeper/src/http/routes.rs
@@ -350,7 +350,7 @@ async fn record_safekeeper_info(mut request: Request<Body>) -> Result<Response<B
         backup_lsn: sk_info.backup_lsn.0,
         local_start_lsn: sk_info.local_start_lsn.0,
         availability_zone: None,
-        standby_flush_lsn: sk_info.standby_flush_lsn.0,
+        standby_horizon: sk_info.standby_horizon.0,
     };
 
     let tli = GlobalTimelines::get(ttid).map_err(ApiError::from)?;

--- a/safekeeper/src/http/routes.rs
+++ b/safekeeper/src/http/routes.rs
@@ -350,6 +350,7 @@ async fn record_safekeeper_info(mut request: Request<Body>) -> Result<Response<B
         backup_lsn: sk_info.backup_lsn.0,
         local_start_lsn: sk_info.local_start_lsn.0,
         availability_zone: None,
+        standby_flush_lsn: sk_info.standby_flush_lsn.0,
     };
 
     let tli = GlobalTimelines::get(ttid).map_err(ApiError::from)?;

--- a/safekeeper/src/send_wal.rs
+++ b/safekeeper/src/send_wal.rs
@@ -37,8 +37,6 @@ const STANDBY_STATUS_UPDATE_TAG_BYTE: u8 = b'r';
 // neon extension of replication protocol
 const NEON_STATUS_UPDATE_TAG_BYTE: u8 = b'z';
 
-const MAX_STANDBY_LAG: u64 = 1024 * 1024 * 1024; // 1Gb
-
 type FullTransactionId = u64;
 
 /// Hot standby feedback received from replica
@@ -270,27 +268,21 @@ impl WalSendersShared {
                     agg.ts = max(agg.ts, hs_feedback.ts);
                 }
                 let reply = standby_feedback.reply;
-                if reply.write_lsn != Lsn::INVALID
-                    && self.agg_ps_feedback.last_received_lsn < reply.write_lsn + MAX_STANDBY_LAG
-                {
+                if reply.write_lsn != Lsn::INVALID {
                     if reply_agg.write_lsn != Lsn::INVALID {
                         reply_agg.write_lsn = Lsn::min(reply_agg.write_lsn, reply.write_lsn);
                     } else {
                         reply_agg.write_lsn = reply.write_lsn;
                     }
                 }
-                if reply.flush_lsn != Lsn::INVALID
-                    && self.agg_ps_feedback.last_received_lsn < reply.flush_lsn + MAX_STANDBY_LAG
-                {
+                if reply.flush_lsn != Lsn::INVALID {
                     if reply_agg.flush_lsn != Lsn::INVALID {
                         reply_agg.flush_lsn = Lsn::min(reply_agg.flush_lsn, reply.flush_lsn);
                     } else {
                         reply_agg.flush_lsn = reply.flush_lsn;
                     }
                 }
-                if reply.apply_lsn != Lsn::INVALID
-                    && self.agg_ps_feedback.last_received_lsn < reply.apply_lsn + MAX_STANDBY_LAG
-                {
+                if reply.apply_lsn != Lsn::INVALID {
                     if reply_agg.apply_lsn != Lsn::INVALID {
                         reply_agg.apply_lsn = Lsn::min(reply_agg.apply_lsn, reply.apply_lsn);
                     } else {

--- a/safekeeper/src/send_wal.rs
+++ b/safekeeper/src/send_wal.rs
@@ -259,7 +259,7 @@ impl WalSendersShared {
                     } else {
                         agg.xmin = hs_feedback.xmin;
                     }
-                    agg.ts = min(agg.ts, hs_feedback.ts);
+                    agg.ts = max(agg.ts, hs_feedback.ts);
                 }
                 if hs_feedback.catalog_xmin != INVALID_FULL_TRANSACTION_ID {
                     if agg.catalog_xmin != INVALID_FULL_TRANSACTION_ID {
@@ -267,7 +267,7 @@ impl WalSendersShared {
                     } else {
                         agg.catalog_xmin = hs_feedback.catalog_xmin;
                     }
-                    agg.ts = min(agg.ts, hs_feedback.ts);
+                    agg.ts = max(agg.ts, hs_feedback.ts);
                 }
                 let reply = standby_feedback.reply;
                 if reply.write_lsn != Lsn::INVALID

--- a/safekeeper/src/send_wal.rs
+++ b/safekeeper/src/send_wal.rs
@@ -167,6 +167,10 @@ impl WalSenders {
     fn record_standby_reply(self: &Arc<WalSenders>, id: WalSenderId, reply: &StandbyReply) {
         let mut shared = self.mutex.lock();
         let slot = shared.get_slot_mut(id);
+        info!(
+            "Record standby reply: ts={} apply_lsn={}",
+            reply.reply_ts, reply.apply_lsn
+        );
         match &mut slot.feedback {
             ReplicationFeedback::Standby(sf) => sf.reply = *reply,
             ReplicationFeedback::Pageserver(_) => {

--- a/safekeeper/src/state.rs
+++ b/safekeeper/src/state.rs
@@ -124,6 +124,7 @@ pub struct TimelineMemState {
     pub remote_consistent_lsn: Lsn,
     #[serde(with = "hex")]
     pub proposer_uuid: PgUuid,
+    pub standby_flush_lsn: Lsn,
 }
 
 /// Safekeeper persistent state plus in memory layer, to avoid frequent fsyncs
@@ -148,6 +149,7 @@ where
                 peer_horizon_lsn: state.peer_horizon_lsn,
                 remote_consistent_lsn: state.remote_consistent_lsn,
                 proposer_uuid: state.proposer_uuid,
+                standby_flush_lsn: Lsn::INVALID,
             },
             pers: state,
         }

--- a/safekeeper/src/state.rs
+++ b/safekeeper/src/state.rs
@@ -124,7 +124,7 @@ pub struct TimelineMemState {
     pub remote_consistent_lsn: Lsn,
     #[serde(with = "hex")]
     pub proposer_uuid: PgUuid,
-    pub standby_flush_lsn: Lsn,
+    pub standby_horizon: Lsn,
 }
 
 /// Safekeeper persistent state plus in memory layer, to avoid frequent fsyncs
@@ -149,7 +149,7 @@ where
                 peer_horizon_lsn: state.peer_horizon_lsn,
                 remote_consistent_lsn: state.remote_consistent_lsn,
                 proposer_uuid: state.proposer_uuid,
-                standby_flush_lsn: Lsn::INVALID,
+                standby_horizon: Lsn::INVALID,
             },
             pers: state,
         }

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -270,7 +270,7 @@ impl SharedState {
             backup_lsn: self.sk.state.inmem.backup_lsn.0,
             local_start_lsn: self.sk.state.local_start_lsn.0,
             availability_zone: conf.availability_zone.clone(),
-            standby_flush_lsn: self.sk.state.inmem.standby_flush_lsn.0,
+            standby_horizon: self.sk.state.inmem.standby_horizon.0,
         }
     }
 
@@ -632,7 +632,7 @@ impl Timeline {
                 let (ps_feedback, standby_feedback) = self.walsenders.get_feedbacks();
                 resp.hs_feedback = standby_feedback.hs_feedback;
                 resp.pageserver_feedback = ps_feedback;
-                shared_state.sk.state.inmem.standby_flush_lsn = standby_feedback.reply.flush_lsn;
+                shared_state.sk.state.inmem.standby_horizon = standby_feedback.reply.apply_lsn;
             }
 
             commit_lsn = shared_state.sk.state.inmem.commit_lsn;

--- a/storage_broker/benches/rps.rs
+++ b/storage_broker/benches/rps.rs
@@ -147,6 +147,7 @@ async fn publish(client: Option<BrokerClientChannel>, n_keys: u64) {
                 http_connstr: "zenith-1-sk-1.local:7677".to_owned(),
                 local_start_lsn: 0,
                 availability_zone: None,
+                standby_flush_lsn: 0,
             };
             counter += 1;
             yield info;

--- a/storage_broker/benches/rps.rs
+++ b/storage_broker/benches/rps.rs
@@ -147,7 +147,7 @@ async fn publish(client: Option<BrokerClientChannel>, n_keys: u64) {
                 http_connstr: "zenith-1-sk-1.local:7677".to_owned(),
                 local_start_lsn: 0,
                 availability_zone: None,
-                standby_flush_lsn: 0,
+                standby_horizon: 0,
             };
             counter += 1;
             yield info;

--- a/storage_broker/proto/broker.proto
+++ b/storage_broker/proto/broker.proto
@@ -42,7 +42,7 @@ message SafekeeperTimelineInfo {
     uint64 remote_consistent_lsn = 7;
     uint64 peer_horizon_lsn = 8;
     uint64 local_start_lsn = 9;
-    uint64 standby_flush_lsn = 14;
+    uint64 standby_horizon = 14;
     // A connection string to use for WAL receiving.
     string safekeeper_connstr = 10;
     // HTTP endpoint connection string

--- a/storage_broker/proto/broker.proto
+++ b/storage_broker/proto/broker.proto
@@ -42,6 +42,7 @@ message SafekeeperTimelineInfo {
     uint64 remote_consistent_lsn = 7;
     uint64 peer_horizon_lsn = 8;
     uint64 local_start_lsn = 9;
+    uint64 standby_flush_lsn = 14;
     // A connection string to use for WAL receiving.
     string safekeeper_connstr = 10;
     // HTTP endpoint connection string

--- a/storage_broker/src/bin/storage_broker.rs
+++ b/storage_broker/src/bin/storage_broker.rs
@@ -734,6 +734,7 @@ mod tests {
             http_connstr: "neon-1-sk-1.local:7677".to_owned(),
             local_start_lsn: 0,
             availability_zone: None,
+            standby_flush_lsn: 0,
         })
     }
 

--- a/storage_broker/src/bin/storage_broker.rs
+++ b/storage_broker/src/bin/storage_broker.rs
@@ -734,7 +734,7 @@ mod tests {
             http_connstr: "neon-1-sk-1.local:7677".to_owned(),
             local_start_lsn: 0,
             availability_zone: None,
-            standby_flush_lsn: 0,
+            standby_horizon: 0,
         })
     }
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -4087,6 +4087,7 @@ def tenant_get_shards(
         # Assume an unsharded tenant
         return [(TenantShardId(tenant_id, 0, 0), override_pageserver or env.pageserver)]
 
+
 def wait_replica_caughtup(primary: Endpoint, secondary: Endpoint):
     primary_lsn = primary.safe_psql_scalar(
         "SELECT pg_current_wal_flush_lsn()::text", log_query=False
@@ -4100,6 +4101,7 @@ def wait_replica_caughtup(primary: Endpoint, secondary: Endpoint):
         if caught_up:
             return
         time.sleep(1)
+
 
 def wait_for_last_flush_lsn(
     env: NeonEnv,

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -4089,12 +4089,12 @@ def tenant_get_shards(
 
 
 def wait_replica_caughtup(primary: Endpoint, secondary: Endpoint):
-    primary_lsn = primary.safe_psql_scalar(
-        "SELECT pg_current_wal_flush_lsn()::text", log_query=False
+    primary_lsn = Lsn(
+        primary.safe_psql_scalar("SELECT pg_current_wal_flush_lsn()", log_query=False)
     )
     while True:
-        secondary_lsn = secondary.safe_psql_scalar(
-            "SELECT pg_last_wal_replay_lsn()", log_query=False
+        secondary_lsn = Lsn(
+            secondary.safe_psql_scalar("SELECT pg_last_wal_replay_lsn()", log_query=False)
         )
         caught_up = secondary_lsn >= primary_lsn
         log.info(f"caughtup={caught_up}, primary_lsn={primary_lsn}, secondary_lsn={secondary_lsn}")

--- a/test_runner/regress/test_hot_standby.py
+++ b/test_runner/regress/test_hot_standby.py
@@ -5,6 +5,7 @@ import time
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, wait_replica_caughtup
 
+
 # Check for corrupted WAL messages which might otherwise go unnoticed if
 # reconnection fixes this.
 def scan_standby_log_for_errors(secondary):

--- a/test_runner/regress/test_hot_standby.py
+++ b/test_runner/regress/test_hot_standby.py
@@ -3,7 +3,7 @@ import re
 import time
 
 from fixtures.log_helper import log
-from fixtures.neon_fixtures import Endpoint, NeonEnv, wait_replica_caughtup
+from fixtures.neon_fixtures import NeonEnv, wait_replica_caughtup
 
 # Check for corrupted WAL messages which might otherwise go unnoticed if
 # reconnection fixes this.

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -1,5 +1,5 @@
-import time
 import threading
+import time
 
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, PgBin

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -1,8 +1,7 @@
 import threading
-import time
 
 from fixtures.log_helper import log
-from fixtures.neon_fixtures import NeonEnv, PgBin
+from fixtures.neon_fixtures import NeonEnv, PgBin, wait_replica_caughtup
 
 
 def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
@@ -34,7 +33,7 @@ def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
         t.start()
 
         with env.endpoints.new_replica_start(origin=primary, endpoint_id="secondary") as secondary:
-            time.sleep(2)
+            wait_replica_caughtup(primary, secondary)
             for _ in range(1, n_iterations):
                 primary_lsn = primary.safe_psql_scalar(
                     "SELECT pg_current_wal_flush_lsn()::text", log_query=False

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -1,3 +1,4 @@
+import time
 import threading
 
 from fixtures.log_helper import log
@@ -33,6 +34,7 @@ def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
         t.start()
 
         with env.endpoints.new_replica_start(origin=primary, endpoint_id="secondary") as secondary:
+            time.sleep(2)
             for _ in range(1, n_iterations):
                 primary_lsn = primary.safe_psql_scalar(
                     "SELECT pg_current_wal_flush_lsn()::text", log_query=False

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -1,5 +1,4 @@
 import threading
-import time
 
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, PgBin, wait_replica_caughtup

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, PgBin
@@ -33,6 +34,7 @@ def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
         t.start()
 
         with env.endpoints.new_replica_start(origin=primary, endpoint_id="secondary") as secondary:
+            time.sleep(10)
             for _ in range(1, n_iterations):
                 primary_lsn = primary.safe_psql_scalar(
                     "SELECT pg_current_wal_flush_lsn()::text", log_query=False

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -1,5 +1,5 @@
-import time
 import threading
+import time
 
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, PgBin, wait_replica_caughtup
@@ -8,7 +8,6 @@ from fixtures.neon_fixtures import NeonEnv, PgBin, wait_replica_caughtup
 def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
     env = neon_simple_env
     n_iterations = 10
-    max_retries = 10
 
     # Use aggressive GC and checkpoint settings
     tenant, _ = env.neon_cli.create_tenant(
@@ -36,7 +35,9 @@ def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
 
         with env.endpoints.new_replica_start(origin=primary, endpoint_id="secondary") as secondary:
             wait_replica_caughtup(primary, secondary)
-            time.sleep(1) # Without this sleep replica sometime failed to find relation: could not open relation with OID 16404
+            time.sleep(
+                1
+            )  # Without this sleep replica sometime failed to find relation: could not open relation with OID 16404
             for _ in range(1, n_iterations):
                 primary_lsn = primary.safe_psql_scalar(
                     "SELECT pg_current_wal_flush_lsn()::text", log_query=False
@@ -44,19 +45,16 @@ def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
                 secondary_lsn = secondary.safe_psql_scalar(
                     "SELECT pg_last_wal_replay_lsn()", log_query=False
                 )
-                retries = 0
-                while True:
-                    try:
-                        balance = secondary.safe_psql_scalar(
-                            "select sum(abalance) from pgbench_accounts"
-                        )
-                        break
-                    except Exception as error:
-                        print(f"Query failed: {error}")
-                        if retries < max_retries:
-                            retries += 1
-                        else:
-                            raise
+                try:
+                    balance = secondary.safe_psql_scalar(
+                        "select sum(abalance) from pgbench_accounts"
+                    )
+                except Exception as error:
+                    print(f"Query failed: {error}")
+                    if not str(error).startswith(
+                        "canceling statement due to conflict with recovery"
+                    ):
+                        raise
                 log.info(
                     f"primary_lsn={primary_lsn}, secondary_lsn={secondary_lsn}, balance={balance}"
                 )

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -1,5 +1,4 @@
 import threading
-import time
 
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, PgBin
@@ -34,7 +33,6 @@ def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
         t.start()
 
         with env.endpoints.new_replica_start(origin=primary, endpoint_id="secondary") as secondary:
-            time.sleep(10)
             for _ in range(1, n_iterations):
                 primary_lsn = primary.safe_psql_scalar(
                     "SELECT pg_current_wal_flush_lsn()::text", log_query=False

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -11,7 +11,7 @@ def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
     # Use aggressive GC and checkpoint settings
     tenant, _ = env.neon_cli.create_tenant(
         conf={
-            "gc_period": "15 s", # should not be smaller than wal_receiver_status_interval
+            "gc_period": "15 s",  # should not be smaller than wal_receiver_status_interval
             "gc_horizon": f"{1024 ** 2}",
             "checkpoint_distance": f"{1024 ** 2}",
             "compaction_target_size": f"{1024 ** 2}",

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -1,0 +1,43 @@
+import threading
+
+from fixtures.log_helper import log
+from fixtures.neon_fixtures import Endpoint, NeonEnv, PgBin
+
+def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
+    env = neon_simple_env
+    n_iterations = 10
+
+    # Use aggressive GC and checkpoint settings
+    tenant, _ = env.neon_cli.create_tenant(
+        conf={
+            "gc_period": "5 s",
+            "gc_horizon": f"{1024 ** 2}",
+            "checkpoint_distance": f"{1024 ** 2}",
+            "compaction_target_size": f"{1024 ** 2}",
+            # set PITR interval to be small, so we can do GC
+            "pitr_interval": "5 s",
+        }
+    )
+
+    def run_pgbench(connstr: str):
+        log.info(f"Start a pgbench workload on pg {connstr}")
+        pg_bin.run_capture(["pgbench", "-T30", connstr])
+
+    with env.endpoints.create_start(
+        branch_name="main",
+        endpoint_id="primary",
+        tenant_id=tenant
+    ) as primary:
+        pg_bin.run_capture(["pgbench", "-i", "-s10", primary.connstr()])
+
+        t = threading.Thread(target=run_pgbench, args=(primary.connstr(),), daemon=True)
+        t.start()
+
+        with env.endpoints.new_replica_start(origin=primary, endpoint_id="secondary") as secondary:
+            for i in range(1,n_iterations):
+                primary_lsn = primary.safe_psql_scalar("SELECT pg_current_wal_flush_lsn()::text", log_query=False)
+                secondary_lsn = secondary.safe_psql_scalar("SELECT pg_last_wal_replay_lsn()", log_query=False)
+                balance = secondary.safe_psql_scalar("select sum(abalance) from pgbench_accounts")
+                log.info(f"primary_lsn={primary_lsn}, secondary_lsn={secondary_lsn}, balance={balance}")
+
+        t.join()

--- a/test_runner/regress/test_replication_lag.py
+++ b/test_runner/regress/test_replication_lag.py
@@ -50,9 +50,7 @@ def test_replication_lag(neon_simple_env: NeonEnv, pg_bin: PgBin):
                     )
                 except Exception as error:
                     print(f"Query failed: {error}")
-                    if not str(error).startswith(
-                        "canceling statement due to conflict with recovery"
-                    ):
+                    if "canceling statement due to conflict with recovery" not in str(error):
                         raise
 
         t.join()

--- a/test_runner/regress/test_replication_start.py
+++ b/test_runner/regress/test_replication_start.py
@@ -1,0 +1,26 @@
+from fixtures.log_helper import log
+from fixtures.neon_fixtures import NeonEnv, wait_replica_caughtup
+
+
+def test_replication_start(neon_simple_env: NeonEnv):
+    env = neon_simple_env
+
+    with env.endpoints.create_start(branch_name="main", endpoint_id="primary") as primary:
+        with primary.connect() as p_con:
+            with p_con.cursor() as p_cur:
+                p_cur.execute("begin")
+                p_cur.execute("create table t(pk integer primary key, payload integer)")
+                p_cur.execute("insert into t values (generate_series(1,100000), 0)")
+                p_cur.execute("select txid_current()")
+                xid = p_cur.fetchall()[0][0]
+                log.info(f"Master transaction {xid}")
+                with env.endpoints.new_replica_start(
+                    origin=primary, endpoint_id="secondary"
+                ) as secondary:
+                    wait_replica_caughtup(primary, secondary)
+                    with secondary.connect() as s_con:
+                        with s_con.cursor() as s_cur:
+                            s_cur.execute("select * from pg_class")
+                            p_cur.execute("commit")
+                            wait_replica_caughtup(primary, secondary)
+                            s_cur.execute("select * from t where pk = 1")

--- a/trace/src/main.rs
+++ b/trace/src/main.rs
@@ -7,7 +7,9 @@ use std::{
     io::BufReader,
 };
 
-use pageserver_api::models::{PagestreamFeMessage, PagestreamGetPageRequest};
+use pageserver_api::models::{
+    PagestreamFeMessage, PagestreamGetLatestPageRequest, PagestreamGetPageRequest,
+};
 use utils::id::{ConnectionId, TenantId, TimelineId};
 
 use clap::{Parser, Subcommand};
@@ -51,9 +53,11 @@ enum Command {
 //      - detect any prefetching anomalies by looking for negative deltas during seqscan
 fn analyze_trace<R: std::io::Read>(mut reader: R) {
     let mut total = 0; // Total requests traced
+    let mut old = 0; // Old requests traced
     let mut cross_rel = 0; // Requests that ask for different rel than previous request
     let mut deltas = HashMap::<i32, u32>::new(); // Consecutive blkno differences
     let mut prev: Option<PagestreamGetPageRequest> = None;
+    let mut old_prev: Option<PagestreamGetLatestPageRequest> = None;
 
     // Compute stats
     while let Ok(msg) = PagestreamFeMessage::parse(&mut reader) {
@@ -61,6 +65,20 @@ fn analyze_trace<R: std::io::Read>(mut reader: R) {
             PagestreamFeMessage::Exists(_) => {}
             PagestreamFeMessage::Nblocks(_) => {}
             PagestreamFeMessage::GetSlruSegment(_) => {}
+            PagestreamFeMessage::GetLatestPage(req) => {
+                total += 1;
+                old += 1;
+
+                if let Some(prev) = old_prev {
+                    if prev.rel == req.rel {
+                        let delta = (req.blkno as i32) - (prev.blkno as i32);
+                        deltas.entry(delta).and_modify(|c| *c += 1).or_insert(1);
+                    } else {
+                        cross_rel += 1;
+                    }
+                }
+                old_prev = Some(req);
+            }
             PagestreamFeMessage::GetPage(req) => {
                 total += 1;
 
@@ -83,6 +101,7 @@ fn analyze_trace<R: std::io::Read>(mut reader: R) {
     deltas.retain(|_, count| *count > 300);
     other -= deltas.len();
     dbg!(total);
+    dbg!(old);
     dbg!(cross_rel);
     dbg!(other);
     dbg!(deltas);

--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,5 +1,5 @@
 {
-    "postgres-v16": "70675be8c27bf861fee555eecd199f2e0f921d1b",
-    "postgres-v15": "d7d3a44f3219b189b161df030f4ca0229f0d06dc",
-    "postgres-v14": "56539d3142a9fb23a2cffb4e4104159978cf29aa"
+    "postgres-v16": "289a8a141452393913eb80d94a72883a024aeac1",
+    "postgres-v15": "f6de2c28de3ec34413075d7325b5d81712841147",
+    "postgres-v14": "57ba2f88ebb3e0739e5dec24e8105cb2325cbdd3"
 }

--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,5 +1,5 @@
 {
     "postgres-v16": "70675be8c27bf861fee555eecd199f2e0f921d1b",
     "postgres-v15": "d7d3a44f3219b189b161df030f4ca0229f0d06dc",
-    "postgres-v14": "08d37139bf30ca1167c64c3404074970cfe66f5a"
+    "postgres-v14": "56539d3142a9fb23a2cffb4e4104159978cf29aa"
 }

--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,5 +1,5 @@
 {
-    "postgres-v16": "f7ea954989a2e7901f858779cff55259f203479a",
-    "postgres-v15": "81e16cd537053f49e175d4a08ab7c8aec3d9b535",
-    "postgres-v14": "be7a65fe67dc81d85bbcbebb13e00d94715f4b88"
+    "postgres-v16": "70675be8c27bf861fee555eecd199f2e0f921d1b",
+    "postgres-v15": "d7d3a44f3219b189b161df030f4ca0229f0d06dc",
+    "postgres-v14": "08d37139bf30ca1167c64c3404074970cfe66f5a"
 }

--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,5 +1,5 @@
 {
-    "postgres-v16": "289a8a141452393913eb80d94a72883a024aeac1",
-    "postgres-v15": "f6de2c28de3ec34413075d7325b5d81712841147",
-    "postgres-v14": "57ba2f88ebb3e0739e5dec24e8105cb2325cbdd3"
+    "postgres-v16": "0d4eb408a1242f8564ba2bfa57a1ea601dc99a4c",
+    "postgres-v15": "d4d552ce42e40f29909f1c6613c57ecda6ea6933",
+    "postgres-v14": "23a19fe0a4f6e56f4540afabe6825281c9d02cd1"
 }

--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,5 +1,5 @@
 {
-    "postgres-v16": "0d4eb408a1242f8564ba2bfa57a1ea601dc99a4c",
-    "postgres-v15": "d4d552ce42e40f29909f1c6613c57ecda6ea6933",
-    "postgres-v14": "23a19fe0a4f6e56f4540afabe6825281c9d02cd1"
+    "postgres-v16": "3f96a5b0c70e48b9142f0c9b496c7c04c93bec8b",
+    "postgres-v15": "e2a0a8aa75ff2fa70af87cb86ba6fb7f575e3155",
+    "postgres-v14": "7eb44da047e68cf6785d27388c482abd02fe2a2d"
 }


### PR DESCRIPTION
## Problem

Lagged replica can request objects which are beyond PiTR boundary ands so collected by GC

https://github.com/neondatabase/neon/issues/6211

## Summary of changes

Take in account `standby_flush_lsn` when calculation `gc_cutoff`

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
