### PR TITLE
test: figure out the relative eviction order assertions

### DIFF
--- a/test_runner/regress/test_disk_usage_eviction.py
+++ b/test_runner/regress/test_disk_usage_eviction.py
@@ -121,7 +121,7 @@ class EvictionEnv:
         }
 
     def count_layers_per_tenant(self, pageserver: NeonPageserver) -> Dict[TenantId, int]:
-        ret = Counter()
+        ret: Counter[TenantId] = Counter()
 
         for tenant_id, timeline_id in self.timelines:
             timeline_dir = pageserver.timeline_dir(tenant_id, timeline_id)


### PR DESCRIPTION
I just failed to see this earlier on #6136. layer counts are used as an abstraction, and each of the two tenants lose proportionally about the same amount of layers. sadly there is no difference in between `relative_spare` and `relative_equal` as both of these end up evicting the exact same amount of layers, but I'll try to add later another test for those.

Cc: #5304