### PR TITLE
zenbenchmark: attach perf results to allure report

### DIFF
--- a/test_runner/fixtures/benchmark_fixture.py
+++ b/test_runner/fixtures/benchmark_fixture.py
@@ -4,6 +4,7 @@ import enum
 import json
 import os
 import re
+import tempfile
 import timeit
 from contextlib import contextmanager
 from datetime import datetime
@@ -12,9 +13,11 @@ from pathlib import Path
 # Type-related stuff
 from typing import Callable, ClassVar, Dict, Iterator, Optional
 
+import allure
 import pytest
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
+from _pytest.fixtures import FixtureRequest
 from _pytest.terminal import TerminalReporter
 
 from fixtures.log_helper import log
@@ -411,13 +414,29 @@ class NeonBenchmarker:
 
 
 @pytest.fixture(scope="function")
-def zenbenchmark(record_property: Callable[[str, object], None]) -> Iterator[NeonBenchmarker]:
+def zenbenchmark(
+    request: FixtureRequest,
+    record_property: Callable[[str, object], None],
+) -> Iterator[NeonBenchmarker]:
     """
     This is a python decorator for benchmark fixtures. It contains functions for
     recording measurements, and prints them out at the end.
     """
     benchmarker = NeonBenchmarker(record_property)
     yield benchmarker
+
+    with tempfile.NamedTemporaryFile(mode="w") as tmp:
+        results = {}
+        for _, recorded_property in request.node.user_properties:
+            name = recorded_property["name"]
+            value = recorded_property["value"]
+            unit = recorded_property["unit"]
+            results[name] = f"{value} {unit}"
+
+        json.dump(results, tmp, indent=2)
+        tmp.flush()
+
+        allure.attach.file(tmp.name, "benchmarks-results.json", allure.attachment_type.JSON)
 
 
 def pytest_addoption(parser: Parser):

--- a/test_runner/fixtures/benchmark_fixture.py
+++ b/test_runner/fixtures/benchmark_fixture.py
@@ -427,9 +427,10 @@ def zenbenchmark(
     results = {}
     for _, recorded_property in request.node.user_properties:
         name = recorded_property["name"]
-        value = recorded_property["value"]
-        unit = recorded_property["unit"]
-        results[name] = f"{value} {unit}"
+        value = str(recorded_property["value"])
+        if (unit := recorded_property["unit"].strip()) != "":
+            value += f" {unit}"
+        results[name] = value
 
     content = json.dumps(results, indent=2)
     allure.attach(

--- a/test_runner/fixtures/benchmark_fixture.py
+++ b/test_runner/fixtures/benchmark_fixture.py
@@ -4,7 +4,6 @@ import enum
 import json
 import os
 import re
-import tempfile
 import timeit
 from contextlib import contextmanager
 from datetime import datetime
@@ -425,18 +424,19 @@ def zenbenchmark(
     benchmarker = NeonBenchmarker(record_property)
     yield benchmarker
 
-    with tempfile.NamedTemporaryFile(mode="w") as tmp:
-        results = {}
-        for _, recorded_property in request.node.user_properties:
-            name = recorded_property["name"]
-            value = recorded_property["value"]
-            unit = recorded_property["unit"]
-            results[name] = f"{value} {unit}"
+    results = {}
+    for _, recorded_property in request.node.user_properties:
+        name = recorded_property["name"]
+        value = recorded_property["value"]
+        unit = recorded_property["unit"]
+        results[name] = f"{value} {unit}"
 
-        json.dump(results, tmp, indent=2)
-        tmp.flush()
-
-        allure.attach.file(tmp.name, "benchmarks-results.json", allure.attachment_type.JSON)
+    content = json.dumps(results, indent=2)
+    allure.attach(
+        content,
+        "benchmarks.json",
+        allure.attachment_type.JSON,
+    )
 
 
 def pytest_addoption(parser: Parser):


### PR DESCRIPTION
## Problem

For PRs with `run-benchmarks` label, we don't upload results to the db which makes it harder to debug perf tests. The only way to see some numbers is by examining GitHub Action output which is really inconvenient.
This PR adds zenbenchmark to Allure reports.

## Summary of changes
- Create a json file with zenbenchmark results and attach it to allure report

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
