### PR TITLE
Fix XID comparison in  test_vm_bit_clear_on_heap_lock test

### DIFF
--- a/test_runner/regress/test_vm_bits.py
+++ b/test_runner/regress/test_vm_bits.py
@@ -1,4 +1,3 @@
-import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnv, fork_at_current_lsn
 

--- a/test_runner/regress/test_vm_bits.py
+++ b/test_runner/regress/test_vm_bits.py
@@ -191,7 +191,7 @@ def test_vm_bit_clear_on_heap_lock(neon_simple_env: NeonEnv):
         tup = cur.fetchall()
         log.info(f"tuple = {tup}")
         xmax = tup[0][1]
-        assert xmax == xmax_before
+        assert xmax == "0" or xmax == xmax_before
 
         if i % 50 == 0:
             cur.execute("select datfrozenxid from pg_database where datname='postgres'")
@@ -211,3 +211,4 @@ def test_vm_bit_clear_on_heap_lock(neon_simple_env: NeonEnv):
     cur.execute("select xmin, xmax, * from vmtest_lock where id = 40000 for update")
     tup = cur.fetchall()
     log.info(f"tuple = {tup}")
+    cur.execute("commit transaction")

--- a/test_runner/regress/test_vm_bits.py
+++ b/test_runner/regress/test_vm_bits.py
@@ -118,8 +118,6 @@ def test_vm_bit_clear(neon_simple_env: NeonEnv):
 # Test that the ALL_FROZEN VM bit is cleared correctly at a HEAP_LOCK
 # record.
 #
-# FIXME: This test is broken
-@pytest.mark.skip("See https://github.com/neondatabase/neon/pull/6412#issuecomment-1902072541")
 def test_vm_bit_clear_on_heap_lock(neon_simple_env: NeonEnv):
     env = neon_simple_env
 
@@ -153,7 +151,7 @@ def test_vm_bit_clear_on_heap_lock(neon_simple_env: NeonEnv):
     # Remember the XID. We will use it later to verify that we have consumed a lot of
     # XIDs after this.
     cur.execute("select pg_current_xact_id()")
-    locking_xid = cur.fetchall()[0][0]
+    locking_xid = int(cur.fetchall()[0][0])
 
     # Stop and restart postgres, to clear the buffer cache.
     #
@@ -198,13 +196,13 @@ def test_vm_bit_clear_on_heap_lock(neon_simple_env: NeonEnv):
 
         if i % 50 == 0:
             cur.execute("select datfrozenxid from pg_database where datname='postgres'")
-            datfrozenxid = cur.fetchall()[0][0]
+            datfrozenxid = int(cur.fetchall()[0][0])
             if datfrozenxid > locking_xid:
                 break
 
     cur.execute("select pg_current_xact_id()")
-    curr_xid = cur.fetchall()[0][0]
-    assert int(curr_xid) - int(locking_xid) >= 100000
+    curr_xid = int(cur.fetchall()[0][0])
+    assert curr_xid - locking_xid >= 100000
 
     # Now, if the VM all-frozen bit was not correctly cleared on
     # replay, we will try to fetch the status of the XID that was


### PR DESCRIPTION
## Problem

xid are compared as strings test_vm_bit_clear_on_heap_lock test
See https://github.com/neondatabase/neon/pull/6412#issuecomment-1902072541

## Summary of changes

Cat xid to integer

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
