### PR TITLE
Proxy error reworking

### DIFF
--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -134,18 +134,18 @@ impl UserFacingError for AuthError {
 }
 
 impl ReportableError for AuthError {
-    fn get_error_type(&self) -> crate::error::ErrorKind {
+    fn get_error_kind(&self) -> crate::error::ErrorKind {
         use AuthErrorImpl::*;
         match self.0.as_ref() {
-            Link(e) => e.get_error_type(),
-            GetAuthInfo(e) => e.get_error_type(),
-            WakeCompute(e) => e.get_error_type(),
-            Sasl(e) => e.get_error_type(),
+            Link(e) => e.get_error_kind(),
+            GetAuthInfo(e) => e.get_error_kind(),
+            WakeCompute(e) => e.get_error_kind(),
+            Sasl(e) => e.get_error_kind(),
             AuthFailed(_) => crate::error::ErrorKind::User,
             BadAuthMethod(_) => crate::error::ErrorKind::User,
             MalformedPassword(_) => crate::error::ErrorKind::User,
             MissingEndpointName => crate::error::ErrorKind::User,
-            Io(_) => crate::error::ErrorKind::Disconnect,
+            Io(_) => crate::error::ErrorKind::ClientDisconnect,
             IpAddressNotAllowed => crate::error::ErrorKind::User,
             TooManyConnections => crate::error::ErrorKind::RateLimit,
             UserTimeout(_) => crate::error::ErrorKind::User,

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -5,7 +5,8 @@ pub use backend::BackendType;
 
 mod credentials;
 pub use credentials::{
-    check_peer_addr_is_in_list, endpoint_sni, ComputeUserInfoMaybeEndpoint, IpPattern,
+    check_peer_addr_is_in_list, endpoint_sni, ComputeUserInfoMaybeEndpoint,
+    ComputeUserInfoParseError, IpPattern,
 };
 
 mod password_hack;

--- a/proxy/src/auth/backend/classic.rs
+++ b/proxy/src/auth/backend/classic.rs
@@ -45,9 +45,9 @@ pub(super) async fn authenticate(
                 }
             )
             .await
-            .map_err(|error| {
+            .map_err(|e| {
                 warn!("error processing scram messages error = authentication timed out, execution time exeeded {} seconds", config.scram_protocol_timeout.as_secs());
-                auth::io::Error::new(auth::io::ErrorKind::TimedOut, error)
+                auth::AuthError::user_timeout(e)
             })??;
 
             let client_key = match auth_outcome {

--- a/proxy/src/auth/backend/link.rs
+++ b/proxy/src/auth/backend/link.rs
@@ -14,10 +14,6 @@ use tracing::{info, info_span};
 
 #[derive(Debug, Error)]
 pub enum LinkAuthError {
-    /// Authentication error reported by the console.
-    #[error("Authentication failed: {0}")]
-    AuthFailed(String),
-
     #[error(transparent)]
     WaiterRegister(#[from] waiters::RegisterError),
 
@@ -30,18 +26,13 @@ pub enum LinkAuthError {
 
 impl UserFacingError for LinkAuthError {
     fn to_string_client(&self) -> String {
-        use LinkAuthError::*;
-        match self {
-            AuthFailed(_) => self.to_string(),
-            _ => "Internal error".to_string(),
-        }
+        "Internal error".to_string()
     }
 }
 
 impl ReportableError for LinkAuthError {
     fn get_error_type(&self) -> crate::error::ErrorKind {
         match self {
-            LinkAuthError::AuthFailed(_) => crate::error::ErrorKind::User,
             LinkAuthError::WaiterRegister(_) => crate::error::ErrorKind::Service,
             LinkAuthError::WaiterWait(_) => crate::error::ErrorKind::Service,
             LinkAuthError::Io(_) => crate::error::ErrorKind::Disconnect,

--- a/proxy/src/auth/backend/link.rs
+++ b/proxy/src/auth/backend/link.rs
@@ -2,7 +2,7 @@ use crate::{
     auth, compute,
     console::{self, provider::NodeInfo},
     context::RequestMonitoring,
-    error::UserFacingError,
+    error::{ReportableError, UserFacingError},
     stream::PqStream,
     waiters,
 };
@@ -34,6 +34,17 @@ impl UserFacingError for LinkAuthError {
         match self {
             AuthFailed(_) => self.to_string(),
             _ => "Internal error".to_string(),
+        }
+    }
+}
+
+impl ReportableError for LinkAuthError {
+    fn get_error_type(&self) -> crate::error::ErrorKind {
+        match self {
+            LinkAuthError::AuthFailed(_) => crate::error::ErrorKind::User,
+            LinkAuthError::WaiterRegister(_) => crate::error::ErrorKind::Service,
+            LinkAuthError::WaiterWait(_) => crate::error::ErrorKind::Service,
+            LinkAuthError::Io(_) => crate::error::ErrorKind::Disconnect,
         }
     }
 }

--- a/proxy/src/auth/backend/link.rs
+++ b/proxy/src/auth/backend/link.rs
@@ -31,11 +31,11 @@ impl UserFacingError for LinkAuthError {
 }
 
 impl ReportableError for LinkAuthError {
-    fn get_error_type(&self) -> crate::error::ErrorKind {
+    fn get_error_kind(&self) -> crate::error::ErrorKind {
         match self {
             LinkAuthError::WaiterRegister(_) => crate::error::ErrorKind::Service,
             LinkAuthError::WaiterWait(_) => crate::error::ErrorKind::Service,
-            LinkAuthError::Io(_) => crate::error::ErrorKind::Disconnect,
+            LinkAuthError::Io(_) => crate::error::ErrorKind::ClientDisconnect,
         }
     }
 }

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -1,8 +1,12 @@
 //! User credentials used in authentication.
 
 use crate::{
-    auth::password_hack::parse_endpoint_param, context::RequestMonitoring, error::UserFacingError,
-    metrics::NUM_CONNECTION_ACCEPTED_BY_SNI, proxy::NeonOptions, serverless::SERVERLESS_DRIVER_SNI,
+    auth::password_hack::parse_endpoint_param,
+    context::RequestMonitoring,
+    error::{ReportableError, UserFacingError},
+    metrics::NUM_CONNECTION_ACCEPTED_BY_SNI,
+    proxy::NeonOptions,
+    serverless::SERVERLESS_DRIVER_SNI,
     EndpointId, RoleName,
 };
 use itertools::Itertools;
@@ -38,6 +42,12 @@ pub enum ComputeUserInfoParseError {
 }
 
 impl UserFacingError for ComputeUserInfoParseError {}
+
+impl ReportableError for ComputeUserInfoParseError {
+    fn get_error_type(&self) -> crate::error::ErrorKind {
+        crate::error::ErrorKind::User
+    }
+}
 
 /// Various client credentials which we use for authentication.
 /// Note that we don't store any kind of client key or password here.

--- a/proxy/src/auth/credentials.rs
+++ b/proxy/src/auth/credentials.rs
@@ -44,7 +44,7 @@ pub enum ComputeUserInfoParseError {
 impl UserFacingError for ComputeUserInfoParseError {}
 
 impl ReportableError for ComputeUserInfoParseError {
-    fn get_error_type(&self) -> crate::error::ErrorKind {
+    fn get_error_kind(&self) -> crate::error::ErrorKind {
         crate::error::ErrorKind::User
     }
 }

--- a/proxy/src/bin/pg_sni_router.rs
+++ b/proxy/src/bin/pg_sni_router.rs
@@ -272,5 +272,10 @@ async fn handle_client(
     let client = tokio::net::TcpStream::connect(destination).await?;
 
     let metrics_aux: MetricsAuxInfo = Default::default();
-    proxy::proxy::passthrough::proxy_pass(ctx, tls_stream, client, metrics_aux).await
+
+    // doesn't yet matter as pg-sni-router doesn't report analytics logs
+    ctx.set_success();
+    ctx.log();
+
+    proxy::proxy::passthrough::proxy_pass(tls_stream, client, metrics_aux).await
 }

--- a/proxy/src/bin/pg_sni_router.rs
+++ b/proxy/src/bin/pg_sni_router.rs
@@ -240,7 +240,9 @@ async fn ssl_handshake<S: AsyncRead + AsyncWrite + Unpin>(
                 ?unexpected,
                 "unexpected startup packet, rejecting connection"
             );
-            stream.throw_error_str(ERR_INSECURE_CONNECTION).await?
+            stream
+                .throw_error_str(ERR_INSECURE_CONNECTION, proxy::error::ErrorKind::User)
+                .await?
         }
     }
 }

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -1,24 +1,48 @@
-use anyhow::Context;
 use dashmap::DashMap;
 use pq_proto::CancelKeyData;
 use std::{net::SocketAddr, sync::Arc};
+use thiserror::Error;
 use tokio::net::TcpStream;
 use tokio_postgres::{CancelToken, NoTls};
 use tracing::info;
+
+use crate::error::ReportableError;
 
 /// Enables serving `CancelRequest`s.
 #[derive(Default)]
 pub struct CancelMap(DashMap<CancelKeyData, Option<CancelClosure>>);
 
+#[derive(Debug, Error)]
+pub enum CancelError {
+    #[error("query cancellation key not found: {0}")]
+    KeyNotFound(CancelKeyData),
+    #[error("{0}")]
+    IO(#[from] std::io::Error),
+    #[error("{0}")]
+    Postgres(#[from] tokio_postgres::Error),
+}
+
+impl ReportableError for CancelError {
+    fn get_error_type(&self) -> crate::error::ErrorKind {
+        match self {
+            // not really user error, but :shrug:
+            // not really an error either... need to handle at some point to forward to other proxies
+            CancelError::KeyNotFound(_) => crate::error::ErrorKind::User,
+            CancelError::IO(_) => crate::error::ErrorKind::Compute,
+            CancelError::Postgres(_) => crate::error::ErrorKind::Compute,
+        }
+    }
+}
+
 impl CancelMap {
     /// Cancel a running query for the corresponding connection.
-    pub async fn cancel_session(&self, key: CancelKeyData) -> anyhow::Result<()> {
+    pub async fn cancel_session(&self, key: CancelKeyData) -> Result<(), CancelError> {
         // NB: we should immediately release the lock after cloning the token.
         let cancel_closure = self
             .0
             .get(&key)
             .and_then(|x| x.clone())
-            .with_context(|| format!("query cancellation key not found: {key}"))?;
+            .ok_or(CancelError::KeyNotFound(key))?;
 
         info!("cancelling query per user's request using key {key}");
         cancel_closure.try_cancel_query().await
@@ -81,7 +105,7 @@ impl CancelClosure {
     }
 
     /// Cancels the query running on user's compute node.
-    pub async fn try_cancel_query(self) -> anyhow::Result<()> {
+    async fn try_cancel_query(self) -> Result<(), CancelError> {
         let socket = TcpStream::connect(self.socket_addr).await?;
         self.cancel_token.cancel_query_raw(socket, NoTls).await?;
 

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -24,6 +24,9 @@ impl ReportableError for CancelError {
     fn get_error_kind(&self) -> crate::error::ErrorKind {
         match self {
             CancelError::IO(_) => crate::error::ErrorKind::Compute,
+            CancelError::Postgres(e) if e.as_db_error().is_some() => {
+                crate::error::ErrorKind::Postgres
+            }
             CancelError::Postgres(_) => crate::error::ErrorKind::Compute,
         }
     }

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -21,7 +21,7 @@ pub enum CancelError {
 }
 
 impl ReportableError for CancelError {
-    fn get_error_type(&self) -> crate::error::ErrorKind {
+    fn get_error_kind(&self) -> crate::error::ErrorKind {
         match self {
             CancelError::IO(_) => crate::error::ErrorKind::Compute,
             CancelError::Postgres(_) => crate::error::ErrorKind::Compute,

--- a/proxy/src/compute.rs
+++ b/proxy/src/compute.rs
@@ -1,6 +1,10 @@
 use crate::{
-    auth::parse_endpoint_param, cancellation::CancelClosure, console::errors::WakeComputeError,
-    context::RequestMonitoring, error::UserFacingError, metrics::NUM_DB_CONNECTIONS_GAUGE,
+    auth::parse_endpoint_param,
+    cancellation::CancelClosure,
+    console::errors::WakeComputeError,
+    context::RequestMonitoring,
+    error::{ReportableError, UserFacingError},
+    metrics::NUM_DB_CONNECTIONS_GAUGE,
     proxy::neon_option,
 };
 use futures::{FutureExt, TryFutureExt};
@@ -54,6 +58,17 @@ impl UserFacingError for ConnectionError {
             },
             WakeComputeError(err) => err.to_string_client(),
             _ => COULD_NOT_CONNECT.to_owned(),
+        }
+    }
+}
+
+impl ReportableError for ConnectionError {
+    fn get_error_type(&self) -> crate::error::ErrorKind {
+        match self {
+            ConnectionError::Postgres(_) => crate::error::ErrorKind::Compute,
+            ConnectionError::CouldNotConnect(_) => crate::error::ErrorKind::Compute,
+            ConnectionError::TlsError(_) => crate::error::ErrorKind::Compute,
+            ConnectionError::WakeComputeError(e) => e.get_error_type(),
         }
     }
 }

--- a/proxy/src/compute.rs
+++ b/proxy/src/compute.rs
@@ -65,6 +65,9 @@ impl UserFacingError for ConnectionError {
 impl ReportableError for ConnectionError {
     fn get_error_kind(&self) -> crate::error::ErrorKind {
         match self {
+            ConnectionError::Postgres(e) if e.as_db_error().is_some() => {
+                crate::error::ErrorKind::Postgres
+            }
             ConnectionError::Postgres(_) => crate::error::ErrorKind::Compute,
             ConnectionError::CouldNotConnect(_) => crate::error::ErrorKind::Compute,
             ConnectionError::TlsError(_) => crate::error::ErrorKind::Compute,

--- a/proxy/src/compute.rs
+++ b/proxy/src/compute.rs
@@ -63,12 +63,12 @@ impl UserFacingError for ConnectionError {
 }
 
 impl ReportableError for ConnectionError {
-    fn get_error_type(&self) -> crate::error::ErrorKind {
+    fn get_error_kind(&self) -> crate::error::ErrorKind {
         match self {
             ConnectionError::Postgres(_) => crate::error::ErrorKind::Compute,
             ConnectionError::CouldNotConnect(_) => crate::error::ErrorKind::Compute,
             ConnectionError::TlsError(_) => crate::error::ErrorKind::Compute,
-            ConnectionError::WakeComputeError(e) => e.get_error_type(),
+            ConnectionError::WakeComputeError(e) => e.get_error_kind(),
         }
     }
 }

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -20,7 +20,7 @@ use tracing::info;
 
 pub mod errors {
     use crate::{
-        error::{io_error, UserFacingError},
+        error::{io_error, ReportableError, UserFacingError},
         http,
         proxy::retry::ShouldRetry,
     };
@@ -77,6 +77,15 @@ pub mod errors {
                     _ => REQUEST_FAILED.to_owned(),
                 },
                 _ => REQUEST_FAILED.to_owned(),
+            }
+        }
+    }
+
+    impl ReportableError for ApiError {
+        fn get_error_type(&self) -> crate::error::ErrorKind {
+            match self {
+                ApiError::Console { .. } => crate::error::ErrorKind::ControlPlane,
+                ApiError::Transport(_) => crate::error::ErrorKind::ControlPlane,
             }
         }
     }
@@ -150,6 +159,16 @@ pub mod errors {
             }
         }
     }
+
+    impl ReportableError for GetAuthInfoError {
+        fn get_error_type(&self) -> crate::error::ErrorKind {
+            match self {
+                GetAuthInfoError::BadSecret => crate::error::ErrorKind::ControlPlane,
+                GetAuthInfoError::ApiError(_) => crate::error::ErrorKind::ControlPlane,
+            }
+        }
+    }
+
     #[derive(Debug, Error)]
     pub enum WakeComputeError {
         #[error("Console responded with a malformed compute address: {0}")]
@@ -191,6 +210,16 @@ pub mod errors {
                 ApiError(e) => e.to_string_client(),
 
                 TimeoutError => "timeout while acquiring the compute resource lock".to_owned(),
+            }
+        }
+    }
+
+    impl ReportableError for WakeComputeError {
+        fn get_error_type(&self) -> crate::error::ErrorKind {
+            match self {
+                WakeComputeError::BadComputeAddress(_) => crate::error::ErrorKind::ControlPlane,
+                WakeComputeError::ApiError(e) => e.get_error_type(),
+                WakeComputeError::TimeoutError => crate::error::ErrorKind::RateLimit,
             }
         }
     }

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -82,7 +82,7 @@ pub mod errors {
     }
 
     impl ReportableError for ApiError {
-        fn get_error_type(&self) -> crate::error::ErrorKind {
+        fn get_error_kind(&self) -> crate::error::ErrorKind {
             match self {
                 ApiError::Console { .. } => crate::error::ErrorKind::ControlPlane,
                 ApiError::Transport(_) => crate::error::ErrorKind::ControlPlane,
@@ -161,7 +161,7 @@ pub mod errors {
     }
 
     impl ReportableError for GetAuthInfoError {
-        fn get_error_type(&self) -> crate::error::ErrorKind {
+        fn get_error_kind(&self) -> crate::error::ErrorKind {
             match self {
                 GetAuthInfoError::BadSecret => crate::error::ErrorKind::ControlPlane,
                 GetAuthInfoError::ApiError(_) => crate::error::ErrorKind::ControlPlane,
@@ -215,10 +215,10 @@ pub mod errors {
     }
 
     impl ReportableError for WakeComputeError {
-        fn get_error_type(&self) -> crate::error::ErrorKind {
+        fn get_error_kind(&self) -> crate::error::ErrorKind {
             match self {
                 WakeComputeError::BadComputeAddress(_) => crate::error::ErrorKind::ControlPlane,
-                WakeComputeError::ApiError(e) => e.get_error_type(),
+                WakeComputeError::ApiError(e) => e.get_error_kind(),
                 WakeComputeError::TimeoutError => crate::error::ErrorKind::RateLimit,
             }
         }

--- a/proxy/src/context.rs
+++ b/proxy/src/context.rs
@@ -110,16 +110,16 @@ impl RequestMonitoring {
         self.user = Some(user);
     }
 
-    pub fn set_error_kind(&mut self, error: ErrorKind) {
+    pub fn set_error_kind(&mut self, kind: ErrorKind) {
         ERROR_BY_KIND
-            .with_label_values(&[error.to_metric_label()])
+            .with_label_values(&[kind.to_metric_label()])
             .inc();
         if let Some(ep) = &self.endpoint_id {
             ENDPOINT_ERRORS_BY_KIND
-                .with_label_values(&[error.to_metric_label()])
+                .with_label_values(&[kind.to_metric_label()])
                 .measure(ep);
         }
-        self.error_kind = Some(error);
+        self.error_kind = Some(kind);
     }
 
     pub fn set_success(&mut self) {

--- a/proxy/src/context.rs
+++ b/proxy/src/context.rs
@@ -8,8 +8,10 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::{
-    console::messages::MetricsAuxInfo, error::ErrorKind, metrics::LatencyTimer, BranchId,
-    EndpointId, ProjectId, RoleName,
+    console::messages::MetricsAuxInfo,
+    error::ErrorKind,
+    metrics::{LatencyTimer, ENDPOINT_ERRORS_BY_KIND, ERROR_BY_KIND},
+    BranchId, EndpointId, ProjectId, RoleName,
 };
 
 pub mod parquet;
@@ -109,6 +111,14 @@ impl RequestMonitoring {
     }
 
     pub fn set_error_kind(&mut self, error: ErrorKind) {
+        ERROR_BY_KIND
+            .with_label_values(&[error.to_metric_label()])
+            .inc();
+        if let Some(ep) = &self.endpoint_id {
+            ENDPOINT_ERRORS_BY_KIND
+                .with_label_values(&[error.to_metric_label()])
+                .measure(ep);
+        }
         self.error_kind = Some(error);
     }
 

--- a/proxy/src/context.rs
+++ b/proxy/src/context.rs
@@ -108,6 +108,10 @@ impl RequestMonitoring {
         self.user = Some(user);
     }
 
+    pub fn set_error_kind(&mut self, error: ErrorKind) {
+        self.error_kind = Some(error);
+    }
+
     pub fn set_success(&mut self) {
         self.success = true;
     }

--- a/proxy/src/context/parquet.rs
+++ b/proxy/src/context/parquet.rs
@@ -108,7 +108,7 @@ impl From<RequestMonitoring> for RequestData {
             branch: value.branch.as_deref().map(String::from),
             protocol: value.protocol,
             region: value.region,
-            error: value.error_kind.as_ref().map(|e| e.to_str()),
+            error: value.error_kind.as_ref().map(|e| e.to_metric_label()),
             success: value.success,
             duration_us: SystemTime::from(value.first_packet)
                 .elapsed()

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -29,7 +29,7 @@ pub trait UserFacingError: ReportableError {
     }
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum ErrorKind {
     /// Wrong password, unknown endpoint, protocol violation, etc...
     User,
@@ -59,6 +59,17 @@ impl ErrorKind {
             ErrorKind::Service => "internal service error",
             ErrorKind::ControlPlane => "non-retryable control plane error",
             ErrorKind::Compute => "non-retryable compute error (or exhausted retry capacity)",
+        }
+    }
+
+    pub fn to_metric_label(&self) -> &'static str {
+        match self {
+            ErrorKind::User => "user",
+            ErrorKind::Disconnect => "disconnect",
+            ErrorKind::RateLimit => "ratelimit",
+            ErrorKind::Service => "service",
+            ErrorKind::ControlPlane => "controlplane",
+            ErrorKind::Compute => "compute",
         }
     }
 }

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -17,7 +17,7 @@ pub fn log_error<E: fmt::Display>(e: E) -> E {
 /// NOTE: This trait should not be implemented for [`anyhow::Error`], since it
 /// is way too convenient and tends to proliferate all across the codebase,
 /// ultimately leading to accidental leaks of sensitive data.
-pub trait UserFacingError: fmt::Display {
+pub trait UserFacingError: ReportableError {
     /// Format the error for client, stripping all sensitive info.
     ///
     /// Although this might be a no-op for many types, it's highly
@@ -61,4 +61,8 @@ impl ErrorKind {
             ErrorKind::Compute => "non-retryable compute error (or exhausted retry capacity)",
         }
     }
+}
+
+pub trait ReportableError: fmt::Display + Send + 'static {
+    fn get_error_type(&self) -> ErrorKind;
 }

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -66,3 +66,9 @@ impl ErrorKind {
 pub trait ReportableError: fmt::Display + Send + 'static {
     fn get_error_type(&self) -> ErrorKind;
 }
+
+impl ReportableError for tokio::time::error::Elapsed {
+    fn get_error_type(&self) -> ErrorKind {
+        ErrorKind::RateLimit
+    }
+}

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -35,7 +35,7 @@ pub enum ErrorKind {
     User,
 
     /// Network error between user and proxy. Not necessarily user error
-    Disconnect,
+    ClientDisconnect,
 
     /// Proxy self-imposed rate limits
     RateLimit,
@@ -54,7 +54,7 @@ impl ErrorKind {
     pub fn to_str(&self) -> &'static str {
         match self {
             ErrorKind::User => "request failed due to user error",
-            ErrorKind::Disconnect => "client disconnected",
+            ErrorKind::ClientDisconnect => "client disconnected",
             ErrorKind::RateLimit => "request cancelled due to rate limit",
             ErrorKind::Service => "internal service error",
             ErrorKind::ControlPlane => "non-retryable control plane error",
@@ -65,7 +65,7 @@ impl ErrorKind {
     pub fn to_metric_label(&self) -> &'static str {
         match self {
             ErrorKind::User => "user",
-            ErrorKind::Disconnect => "disconnect",
+            ErrorKind::ClientDisconnect => "clientdisconnect",
             ErrorKind::RateLimit => "ratelimit",
             ErrorKind::Service => "service",
             ErrorKind::ControlPlane => "controlplane",
@@ -75,11 +75,11 @@ impl ErrorKind {
 }
 
 pub trait ReportableError: fmt::Display + Send + 'static {
-    fn get_error_type(&self) -> ErrorKind;
+    fn get_error_kind(&self) -> ErrorKind;
 }
 
 impl ReportableError for tokio::time::error::Elapsed {
-    fn get_error_type(&self) -> ErrorKind {
+    fn get_error_kind(&self) -> ErrorKind {
         ErrorKind::RateLimit
     }
 }

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -46,6 +46,9 @@ pub enum ErrorKind {
     /// Error communicating with control plane
     ControlPlane,
 
+    /// Postgres error
+    Postgres,
+
     /// Error communicating with compute
     Compute,
 }
@@ -58,7 +61,10 @@ impl ErrorKind {
             ErrorKind::RateLimit => "request cancelled due to rate limit",
             ErrorKind::Service => "internal service error",
             ErrorKind::ControlPlane => "non-retryable control plane error",
-            ErrorKind::Compute => "non-retryable compute error (or exhausted retry capacity)",
+            ErrorKind::Postgres => "postgres error",
+            ErrorKind::Compute => {
+                "non-retryable compute connection error (or exhausted retry capacity)"
+            }
         }
     }
 
@@ -69,6 +75,7 @@ impl ErrorKind {
             ErrorKind::RateLimit => "ratelimit",
             ErrorKind::Service => "service",
             ErrorKind::ControlPlane => "controlplane",
+            ErrorKind::Postgres => "postgres",
             ErrorKind::Compute => "compute",
         }
     }

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -274,3 +274,22 @@ pub static CONNECTING_ENDPOINTS: Lazy<HyperLogLogVec<32>> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static ERROR_BY_KIND: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "proxy_errors_total",
+        "Number of errors by a given classification",
+        &["type"],
+    )
+    .unwrap()
+});
+
+pub static ENDPOINT_ERRORS_BY_KIND: Lazy<HyperLogLogVec<32>> = Lazy::new(|| {
+    register_hll_vec!(
+        32,
+        "proxy_endpoints_affected_by_errors",
+        "Number of endpoints affected by errors of a given classification",
+        &["type"],
+    )
+    .unwrap()
+});

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -122,7 +122,7 @@ pub async fn task_main(
                 match res {
                     Err(e) => {
                         // todo: log and push to ctx the error kind
-                        ctx.set_error_kind(e.get_error_type());
+                        ctx.set_error_kind(e.get_error_kind());
                         ctx.log();
                         Err(e.into())
                     }
@@ -212,13 +212,13 @@ pub enum ClientRequestError {
 }
 
 impl ReportableError for ClientRequestError {
-    fn get_error_type(&self) -> crate::error::ErrorKind {
+    fn get_error_kind(&self) -> crate::error::ErrorKind {
         match self {
-            ClientRequestError::Cancellation(e) => e.get_error_type(),
-            ClientRequestError::Handshake(e) => e.get_error_type(),
+            ClientRequestError::Cancellation(e) => e.get_error_kind(),
+            ClientRequestError::Handshake(e) => e.get_error_kind(),
             ClientRequestError::HandshakeTimeout(_) => crate::error::ErrorKind::RateLimit,
-            ClientRequestError::ReportedError(e) => e.get_error_type(),
-            ClientRequestError::PrepareClient(_) => crate::error::ErrorKind::Disconnect,
+            ClientRequestError::ReportedError(e) => e.get_error_kind(),
+            ClientRequestError::PrepareClient(_) => crate::error::ErrorKind::ClientDisconnect,
         }
     }
 }

--- a/proxy/src/proxy/handshake.rs
+++ b/proxy/src/proxy/handshake.rs
@@ -39,7 +39,7 @@ impl ReportableError for HandshakeError {
             HandshakeError::InsecureConnection => crate::error::ErrorKind::User,
             HandshakeError::MissingCertificate => todo!(),
             HandshakeError::StreamUpgradeError(upgrade) => match upgrade {
-                StreamUpgradeError::AlreadyTls => crate::error::ErrorKind::User,
+                StreamUpgradeError::AlreadyTls => crate::error::ErrorKind::Service,
                 StreamUpgradeError::Io(_) => crate::error::ErrorKind::Disconnect,
             },
             HandshakeError::Io(_) => crate::error::ErrorKind::Disconnect,

--- a/proxy/src/proxy/handshake.rs
+++ b/proxy/src/proxy/handshake.rs
@@ -32,7 +32,7 @@ pub enum HandshakeError {
 }
 
 impl ReportableError for HandshakeError {
-    fn get_error_type(&self) -> crate::error::ErrorKind {
+    fn get_error_kind(&self) -> crate::error::ErrorKind {
         match self {
             HandshakeError::EarlyData => crate::error::ErrorKind::User,
             HandshakeError::ProtocolViolation => crate::error::ErrorKind::User,
@@ -42,10 +42,10 @@ impl ReportableError for HandshakeError {
             HandshakeError::MissingCertificate => crate::error::ErrorKind::Service,
             HandshakeError::StreamUpgradeError(upgrade) => match upgrade {
                 StreamUpgradeError::AlreadyTls => crate::error::ErrorKind::Service,
-                StreamUpgradeError::Io(_) => crate::error::ErrorKind::Disconnect,
+                StreamUpgradeError::Io(_) => crate::error::ErrorKind::ClientDisconnect,
             },
-            HandshakeError::Io(_) => crate::error::ErrorKind::Disconnect,
-            HandshakeError::ReportedError(e) => e.get_error_type(),
+            HandshakeError::Io(_) => crate::error::ErrorKind::ClientDisconnect,
+            HandshakeError::ReportedError(e) => e.get_error_kind(),
         }
     }
 }

--- a/proxy/src/sasl.rs
+++ b/proxy/src/sasl.rs
@@ -10,7 +10,7 @@ mod channel_binding;
 mod messages;
 mod stream;
 
-use crate::error::UserFacingError;
+use crate::error::{ReportableError, UserFacingError};
 use std::io;
 use thiserror::Error;
 
@@ -44,6 +44,18 @@ impl UserFacingError for Error {
             ChannelBindingFailed(m) => m.to_string(),
             ChannelBindingBadMethod(m) => format!("unsupported channel binding method {m}"),
             _ => "authentication protocol violation".to_string(),
+        }
+    }
+}
+
+impl ReportableError for Error {
+    fn get_error_type(&self) -> crate::error::ErrorKind {
+        match self {
+            Error::ChannelBindingFailed(_) => crate::error::ErrorKind::User,
+            Error::ChannelBindingBadMethod(_) => crate::error::ErrorKind::User,
+            Error::BadClientMessage(_) => crate::error::ErrorKind::User,
+            Error::MissingBinding => crate::error::ErrorKind::Service,
+            Error::Io(_) => crate::error::ErrorKind::Disconnect,
         }
     }
 }

--- a/proxy/src/sasl.rs
+++ b/proxy/src/sasl.rs
@@ -49,13 +49,13 @@ impl UserFacingError for Error {
 }
 
 impl ReportableError for Error {
-    fn get_error_type(&self) -> crate::error::ErrorKind {
+    fn get_error_kind(&self) -> crate::error::ErrorKind {
         match self {
             Error::ChannelBindingFailed(_) => crate::error::ErrorKind::User,
             Error::ChannelBindingBadMethod(_) => crate::error::ErrorKind::User,
             Error::BadClientMessage(_) => crate::error::ErrorKind::User,
             Error::MissingBinding => crate::error::ErrorKind::Service,
-            Error::Io(_) => crate::error::ErrorKind::Disconnect,
+            Error::Io(_) => crate::error::ErrorKind::ClientDisconnect,
         }
     }
 }

--- a/proxy/src/serverless.rs
+++ b/proxy/src/serverless.rs
@@ -230,11 +230,11 @@ async fn request_handler(
 
         ws_connections.spawn(
             async move {
-                let mut ctx = RequestMonitoring::new(session_id, peer_addr, "ws", &config.region);
+                let ctx = RequestMonitoring::new(session_id, peer_addr, "ws", &config.region);
 
                 if let Err(e) = websocket::serve_websocket(
                     config,
-                    &mut ctx,
+                    ctx,
                     websocket,
                     cancel_map,
                     host,
@@ -251,9 +251,9 @@ async fn request_handler(
         // Return the response so the spawned future can continue.
         Ok(response)
     } else if request.uri().path() == "/sql" && request.method() == Method::POST {
-        let mut ctx = RequestMonitoring::new(session_id, peer_addr, "http", &config.region);
+        let ctx = RequestMonitoring::new(session_id, peer_addr, "http", &config.region);
 
-        sql_over_http::handle(config, &mut ctx, request, sni_hostname, backend).await
+        sql_over_http::handle(config, ctx, request, sni_hostname, backend).await
     } else if request.uri().path() == "/sql" && request.method() == Method::OPTIONS {
         Response::builder()
             .header("Allow", "OPTIONS, POST")

--- a/proxy/src/serverless/conn_pool.rs
+++ b/proxy/src/serverless/conn_pool.rs
@@ -16,12 +16,16 @@ use std::{
 use tokio::time::Instant;
 use tokio_postgres::tls::NoTlsStream;
 use tokio_postgres::{AsyncMessage, ReadyForQueryStatus, Socket};
+use uuid::Uuid;
 
 use crate::console::messages::MetricsAuxInfo;
 use crate::metrics::{ENDPOINT_POOLS, GC_LATENCY, NUM_OPEN_CLIENTS_IN_HTTP_POOL};
 use crate::usage_metrics::{Ids, MetricCounter, USAGE_METRICS};
 use crate::{
-    auth::backend::ComputeUserInfo, context::RequestMonitoring, metrics::NUM_DB_CONNECTIONS_GAUGE,
+    auth::{backend::ComputeUserInfo, AuthError},
+    console::errors::{GetAuthInfoError, WakeComputeError},
+    context::RequestMonitoring,
+    metrics::NUM_DB_CONNECTIONS_GAUGE,
     DbName, EndpointCacheKey, RoleName,
 };
 
@@ -261,6 +265,23 @@ pub struct GlobalConnPoolOptions {
     pub max_total_conns: usize,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ConnPoolError {
+    #[error("pooled connection closed at inconsistent state")]
+    ConnectionClosedAbruptly(#[from] tokio::sync::watch::error::SendError<Uuid>),
+    #[error("could not connection to compute")]
+    ConnectionError(#[from] tokio_postgres::Error),
+
+    #[error("could not get auth info")]
+    GetAuthInfo(#[from] GetAuthInfoError),
+    #[error("user not authenticated")]
+    AuthError(#[from] AuthError),
+    #[error("wake_compute returned error")]
+    WakeCompute(#[from] WakeComputeError),
+    #[error("wake_compute returned nothing")]
+    NoComputeInfo,
+}
+
 impl<C: ClientInnerExt> GlobalConnPool<C> {
     pub fn new(config: &'static crate::config::HttpConfig) -> Arc<Self> {
         let shards = config.pool_options.pool_shards;
@@ -358,7 +379,7 @@ impl<C: ClientInnerExt> GlobalConnPool<C> {
         self: &Arc<Self>,
         ctx: &mut RequestMonitoring,
         conn_info: &ConnInfo,
-    ) -> anyhow::Result<Option<Client<C>>> {
+    ) -> Result<Option<Client<C>>, ConnPoolError> {
         let mut client: Option<ClientInner<C>> = None;
 
         let endpoint_pool = self.get_or_create_endpoint_pool(&conn_info.endpoint_cache_key());

--- a/proxy/src/serverless/json.rs
+++ b/proxy/src/serverless/json.rs
@@ -60,6 +60,20 @@ fn json_array_to_pg_array(value: &Value) -> Option<String> {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum JsonConversionError {
+    #[error("internal error compute returned invalid data: {0}")]
+    AsTextError(tokio_postgres::Error),
+    #[error("parse int error: {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+    #[error("parse float error: {0}")]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+    #[error("parse json error: {0}")]
+    ParseJsonError(#[from] serde_json::Error),
+    #[error("unbalanced array")]
+    UnbalancedArray,
+}
+
 //
 // Convert postgres row with text-encoded values to JSON object
 //
@@ -68,7 +82,7 @@ pub fn pg_text_row_to_json(
     columns: &[Type],
     raw_output: bool,
     array_mode: bool,
-) -> Result<Value, anyhow::Error> {
+) -> Result<Value, JsonConversionError> {
     let iter = row
         .columns()
         .iter()
@@ -76,7 +90,7 @@ pub fn pg_text_row_to_json(
         .enumerate()
         .map(|(i, (column, typ))| {
             let name = column.name();
-            let pg_value = row.as_text(i)?;
+            let pg_value = row.as_text(i).map_err(JsonConversionError::AsTextError)?;
             let json_value = if raw_output {
                 match pg_value {
                     Some(v) => Value::String(v.to_string()),
@@ -92,10 +106,10 @@ pub fn pg_text_row_to_json(
         // drop keys and aggregate into array
         let arr = iter
             .map(|r| r.map(|(_key, val)| val))
-            .collect::<Result<Vec<Value>, anyhow::Error>>()?;
+            .collect::<Result<Vec<Value>, JsonConversionError>>()?;
         Ok(Value::Array(arr))
     } else {
-        let obj = iter.collect::<Result<Map<String, Value>, anyhow::Error>>()?;
+        let obj = iter.collect::<Result<Map<String, Value>, JsonConversionError>>()?;
         Ok(Value::Object(obj))
     }
 }
@@ -103,7 +117,7 @@ pub fn pg_text_row_to_json(
 //
 // Convert postgres text-encoded value to JSON value
 //
-fn pg_text_to_json(pg_value: Option<&str>, pg_type: &Type) -> Result<Value, anyhow::Error> {
+fn pg_text_to_json(pg_value: Option<&str>, pg_type: &Type) -> Result<Value, JsonConversionError> {
     if let Some(val) = pg_value {
         if let Kind::Array(elem_type) = pg_type.kind() {
             return pg_array_parse(val, elem_type);
@@ -142,7 +156,7 @@ fn pg_text_to_json(pg_value: Option<&str>, pg_type: &Type) -> Result<Value, anyh
 // values. Unlike postgres we don't check that all nested arrays have the same
 // dimensions, we just return them as is.
 //
-fn pg_array_parse(pg_array: &str, elem_type: &Type) -> Result<Value, anyhow::Error> {
+fn pg_array_parse(pg_array: &str, elem_type: &Type) -> Result<Value, JsonConversionError> {
     _pg_array_parse(pg_array, elem_type, false).map(|(v, _)| v)
 }
 
@@ -150,7 +164,7 @@ fn _pg_array_parse(
     pg_array: &str,
     elem_type: &Type,
     nested: bool,
-) -> Result<(Value, usize), anyhow::Error> {
+) -> Result<(Value, usize), JsonConversionError> {
     let mut pg_array_chr = pg_array.char_indices();
     let mut level = 0;
     let mut quote = false;
@@ -170,7 +184,7 @@ fn _pg_array_parse(
         entry: &mut String,
         entries: &mut Vec<Value>,
         elem_type: &Type,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), JsonConversionError> {
         if !entry.is_empty() {
             // While in usual postgres response we get nulls as None and everything else
             // as Some(&str), in arrays we get NULL as unquoted 'NULL' string (while
@@ -234,7 +248,7 @@ fn _pg_array_parse(
     }
 
     if level != 0 {
-        return Err(anyhow::anyhow!("unbalanced array"));
+        return Err(JsonConversionError::UnbalancedArray);
     }
 
     Ok((Value::Array(entries), 0))

--- a/proxy/src/serverless/sql_over_http.rs
+++ b/proxy/src/serverless/sql_over_http.rs
@@ -192,7 +192,7 @@ pub async fn handle(
                 r
             }
             Err(e) => {
-                // ctx.set_error_kind(e.get_error_type());
+                // TODO: ctx.set_error_kind(e.get_error_type());
 
                 let mut message = format!("{:?}", e);
                 let db_error = e
@@ -270,7 +270,7 @@ pub async fn handle(
             }
         },
         Err(e) => {
-            ctx.set_error_kind(e.get_error_type());
+            ctx.set_error_kind(e.get_error_kind());
 
             let message = format!(
                 "HTTP-Connection timed out, execution time exeeded {} seconds",
@@ -283,8 +283,6 @@ pub async fn handle(
             )?
         }
     };
-
-    ctx.log();
 
     response.headers_mut().insert(
         "Access-Control-Allow-Origin",

--- a/proxy/src/serverless/websocket.rs
+++ b/proxy/src/serverless/websocket.rs
@@ -2,7 +2,7 @@ use crate::{
     cancellation::CancelMap,
     config::ProxyConfig,
     context::RequestMonitoring,
-    error::io_error,
+    error::{io_error, ReportableError},
     proxy::{handle_client, ClientMode},
     rate_limiter::EndpointRateLimiter,
 };
@@ -151,9 +151,9 @@ pub async fn serve_websocket(
     match res {
         Err(e) => {
             // todo: log and push to ctx the error kind
-            // ctx.set_error_kind(e.get_error_type())
+            ctx.set_error_kind(e.get_error_type());
             ctx.log();
-            Err(e)
+            Err(e.into())
         }
         Ok(None) => {
             ctx.set_success();

--- a/proxy/src/serverless/websocket.rs
+++ b/proxy/src/serverless/websocket.rs
@@ -151,7 +151,7 @@ pub async fn serve_websocket(
     match res {
         Err(e) => {
             // todo: log and push to ctx the error kind
-            ctx.set_error_kind(e.get_error_type());
+            ctx.set_error_kind(e.get_error_kind());
             ctx.log();
             Err(e.into())
         }

--- a/proxy/src/stream.rs
+++ b/proxy/src/stream.rs
@@ -91,7 +91,7 @@ impl std::error::Error for ReportedError {
 }
 
 impl ReportableError for ReportedError {
-    fn get_error_type(&self) -> ErrorKind {
+    fn get_error_kind(&self) -> ErrorKind {
         self.error_kind
     }
 }
@@ -149,7 +149,7 @@ impl<S: AsyncWrite + Unpin> PqStream<S> {
     where
         E: UserFacingError + Into<anyhow::Error>,
     {
-        let error_kind = error.get_error_type();
+        let error_kind = error.get_error_kind();
         let msg = error.to_string_client();
         tracing::info!(
             kind=error_kind.to_metric_label(),


### PR DESCRIPTION
## Problem

Taking my ideas from https://github.com/neondatabase/neon/pull/6283 and doing a bit less radical changes. smaller commits.

We currently don't report error classifications in proxy as the current error handling made it hard to do so.

## Summary of changes

1. Add a `ReportableError` trait that all errors will implement. This provides the error classification functionality.
2. Handle Client requests a strongly typed error
    * this error is a `ReportableError` and is logged appropriately
3. The handle client error only has a few possible error types, to account for the fact that at this point errors should be returned to the user.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
