### PR TITLE
fix(page_service): walredo logging problem

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -332,11 +332,11 @@ enum PageStreamError {
     /// The entity required to serve the request (tenant or timeline) is not found,
     /// or is not found in a suitable state to serve a request.
     #[error("Not found: {0}")]
-    NotFound(std::borrow::Cow<'static, str>),
+    NotFound(Cow<'static, str>),
 
     /// Request asked for something that doesn't make sense, like an invalid LSN
     #[error("Bad request: {0}")]
-    BadRequest(std::borrow::Cow<'static, str>),
+    BadRequest(Cow<'static, str>),
 }
 
 impl From<PageReconstructError> for PageStreamError {

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -667,8 +667,10 @@ impl PageServerHandler {
                         // print the all details to the log with {:#}, but for the client the
                         // error message is enough.  Do not log if shutting down, as the anyhow::Error
                         // here includes cancellation which is not an error.
-                        let e = utils::error::report_compact_sources(&e);
-                        span.in_scope(|| error!("error reading relation or page version: {:#}", e));
+                        let full = utils::error::report_compact_sources(&e);
+                        span.in_scope(|| {
+                            error!("error reading relation or page version: {full:#}")
+                        });
                         PagestreamBeMessage::Error(PagestreamErrorResponse {
                             message: e.to_string(),
                         })

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -348,7 +348,7 @@ enum PageStreamError {
 fn walredo_failed_to_start_due_to_concurrent_deploy_current() {
     // spawn returns permission denied; we need to have it in our logs to ignore it
     // the contexts captured here are from writing this test.
-    let res = Err::<(), _>(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+    let res = Err::<(), _>(std::io::Error::from_raw_os_error(13))
         .context("spawn process")
         .context("launch walredo process")
         .context("Failed to reconstruct a page image:")
@@ -367,7 +367,7 @@ fn walredo_failed_to_start_due_to_concurrent_deploy_current() {
 
 #[test]
 fn walredo_failed_to_start_due_to_concurrent_deploy_fixed() {
-    let res = Err::<(), _>(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+    let res = Err::<(), _>(std::io::Error::from_raw_os_error(13))
         .context("spawn process")
         .context("launch walredo process")
         .context("reconstruct a page image at xyz@abc of N records on top of None")
@@ -380,7 +380,7 @@ fn walredo_failed_to_start_due_to_concurrent_deploy_fixed() {
 
     let s = format!("{e:#}");
 
-    assert_eq!("Read error: reconstruct a page image at xyz@abc of N records on top of None: launch walredo process: spawn process: permission denied", s);
+    assert_eq!("Read error: reconstruct a page image at xyz@abc of N records on top of None: launch walredo process: spawn process: Permission denied (os error 13)", s);
 }
 
 impl From<PageReconstructError> for PageStreamError {

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -667,6 +667,7 @@ impl PageServerHandler {
                         // print the all details to the log with {:#}, but for the client the
                         // error message is enough.  Do not log if shutting down, as the anyhow::Error
                         // here includes cancellation which is not an error.
+                        let e = utils::error::report_compact_sources(&e);
                         span.in_scope(|| error!("error reading relation or page version: {:#}", e));
                         PagestreamBeMessage::Error(PagestreamErrorResponse {
                             message: e.to_string(),

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -322,8 +322,13 @@ enum PageStreamError {
     Shutdown,
 
     /// Something went wrong reading a page: this likely indicates a pageserver bug
+    #[cfg(test)] // just demoing in the first commit
     #[error("Read error: {0}")]
-    Read(PageReconstructError),
+    ReadExisting(PageReconstructError),
+
+    /// Something went wrong reading a page: this likely indicates a pageserver bug
+    #[error("Read error")]
+    Read(#[source] PageReconstructError),
 
     /// Ran out of time waiting for an LSN
     #[error("LSN timeout: {0}")]
@@ -337,6 +342,45 @@ enum PageStreamError {
     /// Request asked for something that doesn't make sense, like an invalid LSN
     #[error("Bad request: {0}")]
     BadRequest(Cow<'static, str>),
+}
+
+#[test]
+fn walredo_failed_to_start_due_to_concurrent_deploy_current() {
+    // spawn returns permission denied; we need to have it in our logs to ignore it
+    // the contexts captured here are from writing this test.
+    let res = Err::<(), _>(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+        .context("spawn process")
+        .context("launch walredo process")
+        .context("Failed to reconstruct a page image:")
+        .map_err(PageReconstructError::WalRedo)
+        .map_err(PageStreamError::ReadExisting);
+
+    let e = res.unwrap_err();
+
+    let s = format!("{e:#}");
+
+    assert_eq!(
+        "Read error: Failed to reconstruct a page image:", s,
+        "this is not helpful in the logs"
+    );
+}
+
+#[test]
+fn walredo_failed_to_start_due_to_concurrent_deploy_fixed() {
+    let res = Err::<(), _>(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+        .context("spawn process")
+        .context("launch walredo process")
+        .context("reconstruct a page image at xyz@abc of N records on top of None")
+        .map_err(PageReconstructError::WalRedo)
+        .map_err(PageStreamError::Read);
+
+    let e = res.unwrap_err();
+
+    let e = utils::error::report_compact_sources(&e);
+
+    let s = format!("{e:#}");
+
+    assert_eq!("Read error: reconstruct a page image at xyz@abc of N records on top of None: launch walredo process: spawn process: permission denied", s);
 }
 
 impl From<PageReconstructError> for PageStreamError {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4383,12 +4383,14 @@ impl Timeline {
                 };
 
                 let last_rec_lsn = data.records.last().unwrap().0;
+                let base_img_lsn = data.img.as_ref().map(|x| x.0);
+                let n_records = data.records.len();
 
                 let img = match self
                     .walredo_mgr
                     .request_redo(key, request_lsn, data.img, data.records, self.pg_version)
                     .await
-                    .context("Failed to reconstruct a page image:")
+                    .with_context(|| format!("reconstruct a page image for {key:?}@{request_lsn} from {n_records} records on top of {base_img_lsn:?}"))
                 {
                     Ok(img) => img,
                     Err(e) => return Err(PageReconstructError::WalRedo(e)),

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4383,14 +4383,12 @@ impl Timeline {
                 };
 
                 let last_rec_lsn = data.records.last().unwrap().0;
-                let base_img_lsn = data.img.as_ref().map(|x| x.0);
-                let n_records = data.records.len();
 
                 let img = match self
                     .walredo_mgr
                     .request_redo(key, request_lsn, data.img, data.records, self.pg_version)
                     .await
-                    .with_context(|| format!("reconstruct a page image for {key:?}@{request_lsn} from {n_records} records on top of {base_img_lsn:?}"))
+                    .context("reconstruct a page image")
                 {
                     Ok(img) => img,
                     Err(e) => return Err(PageReconstructError::WalRedo(e)),


### PR DESCRIPTION
Fixes: #6459 by formatting full causes of an error to log, while keeping the top level string for end-user.

Changes user visible error detail from:

```
-DETAIL:  page server returned error: Read error: Failed to reconstruct a page image:
+DETAIL:  page server returned error: Read error
```

However on pageserver logs:

```
-ERROR page_service_conn_main{...}: error reading relation or page version: Read error: Failed to reconstruct a page image:
+ERROR page_service_conn_main{...}: error reading relation or page version: Read error: reconstruct a page image: launch walredo process: spawn process: Permission denied (os error 13)
```