### PR TITLE
CI: cancel old e2e-tests on new commits

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,6 +22,8 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
   NEXTEST_RETRIES: 3
+  # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
   check-permissions:
@@ -44,6 +46,20 @@ jobs:
         echo >&2 "${MESSAGE}"
 
         exit 1
+
+  cancel-previous-e2e-tests:
+    needs: [ check-permissions ]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel previous e2e-tests runs for this PR
+        env:
+          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
+        run: |
+          gh workflow --repo neondatabase/cloud \
+            run cancel-previous-in-concurrency-group.yml \
+              --field concurrency_group="${{ env.E2E_CONCURRENCY_GROUP }}"
 
   tag:
     needs: [ check-permissions ]
@@ -684,9 +700,6 @@ jobs:
               \"description\": \"[$REMOTE_REPO] Remote CI job is about to start\"
             }"
 
-          # Pass current concurrency group to the e2e-tests CI job to make sure e2e-tests job won't have unneeded parallel runs
-          CONCURRENCY_GROUP="${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}"
-
           curl -f -X POST \
           https://api.github.com/repos/$REMOTE_REPO/actions/workflows/testing.yml/dispatches \
           -H "Accept: application/vnd.github.v3+json" \
@@ -700,7 +713,7 @@ jobs:
                 \"remote_repo\": \"${{ github.repository }}\",
                 \"storage_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
                 \"compute_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
-                \"concurrency_group\": \"${CONCURRENCY_GROUP}\"
+                \"concurrency_group\": \"${{ env.E2E_CONCURRENCY_GROUP }}\"
               }
             }"
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -684,6 +684,9 @@ jobs:
               \"description\": \"[$REMOTE_REPO] Remote CI job is about to start\"
             }"
 
+          # Pass current concurrency group to the e2e-tests CI job to make sure e2e-tests job won't have unneeded parallel runs
+          CONCURRENCY_GROUP="${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}"
+
           curl -f -X POST \
           https://api.github.com/repos/$REMOTE_REPO/actions/workflows/testing.yml/dispatches \
           -H "Accept: application/vnd.github.v3+json" \
@@ -696,7 +699,8 @@ jobs:
                 \"commit_hash\": \"$COMMIT_SHA\",
                 \"remote_repo\": \"${{ github.repository }}\",
                 \"storage_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
-                \"compute_image_tag\": \"${{ needs.tag.outputs.build-tag }}\"
+                \"compute_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
+                \"concurrency_group\": \"${CONCURRENCY_GROUP}\"
               }
             }"
 


### PR DESCRIPTION
## Problem

Triggered `e2e-tests` job is not cancelled along with other jobs in a PR if the PR get new commits. We can improve the situation by setting `concurrency_group` for the remote workflow (https://github.com/neondatabase/cloud/pull/9622 adds `concurrency_group` group input to the remote workflow). 

Ref https://neondb.slack.com/archives/C059ZC138NR/p1706087124297569

Should be merged after https://github.com/neondatabase/cloud/pull/9622 (won't work without it)

## Summary of changes
- Set `concurrency_group` parameter when triggering `e2e-tests`
- At the beginning of a CI pipeline trigger Cloud's `cancel-previous-in-concurrency-group.yml` workflow which cancels previously triggered e2e-tests 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
