### PR TITLE
Make RemoteStorage not use async_trait

### DIFF
--- a/libs/remote_storage/src/azure_blob.rs
+++ b/libs/remote_storage/src/azure_blob.rs
@@ -183,7 +183,6 @@ fn to_download_error(error: azure_core::Error) -> DownloadError {
     }
 }
 
-#[async_trait::async_trait]
 impl RemoteStorage for AzureBlobStorage {
     async fn list(
         &self,

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -262,7 +262,7 @@ impl std::error::Error for DownloadError {}
 /// Every storage, currently supported.
 /// Serves as a simple way to pass around the [`RemoteStorage`] without dealing with generics.
 #[derive(Clone)]
-// Require Clone for `Other`` due to https://github.com/rust-lang/rust/issues/26925
+// Require Clone for `Other` due to https://github.com/rust-lang/rust/issues/26925
 pub enum GenericRemoteStorage<Other: Clone = Arc<UnreliableWrapper>> {
     LocalFs(LocalFs),
     AwsS3(Arc<S3Bucket>),

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -142,7 +142,7 @@ pub struct Listing {
 /// Storage (potentially remote) API to manage its state.
 /// This storage tries to be unaware of any layered repository context,
 /// providing basic CRUD operations for storage files.
-#[async_trait::async_trait]
+#[allow(async_fn_in_trait)]
 pub trait RemoteStorage: Send + Sync + 'static {
     /// Lists all top level subdirectories for a given prefix
     /// Note: here we assume that if the prefix is passed it was obtained via remote_object_id
@@ -262,14 +262,15 @@ impl std::error::Error for DownloadError {}
 /// Every storage, currently supported.
 /// Serves as a simple way to pass around the [`RemoteStorage`] without dealing with generics.
 #[derive(Clone)]
-pub enum GenericRemoteStorage {
+// Require Clone for `Other`` due to https://github.com/rust-lang/rust/issues/26925
+pub enum GenericRemoteStorage<Other: Clone = Arc<UnreliableWrapper>> {
     LocalFs(LocalFs),
     AwsS3(Arc<S3Bucket>),
     AzureBlob(Arc<AzureBlobStorage>),
-    Unreliable(Arc<UnreliableWrapper>),
+    Unreliable(Other),
 }
 
-impl GenericRemoteStorage {
+impl<Other: RemoteStorage> GenericRemoteStorage<Arc<Other>> {
     pub async fn list(
         &self,
         prefix: Option<&RemotePath>,

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -157,7 +157,6 @@ impl LocalFs {
     }
 }
 
-#[async_trait::async_trait]
 impl RemoteStorage for LocalFs {
     async fn list(
         &self,

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -373,7 +373,6 @@ impl<S: Stream<Item = std::io::Result<Bytes>>> Stream for TimedDownload<S> {
     }
 }
 
-#[async_trait::async_trait]
 impl RemoteStorage for S3Bucket {
     async fn list(
         &self,

--- a/libs/remote_storage/src/simulate_failures.rs
+++ b/libs/remote_storage/src/simulate_failures.rs
@@ -94,56 +94,9 @@ impl UnreliableWrapper {
     }
 }
 
-#[derive(Clone)]
-struct VoidStorage;
+// We never construct this, so the type is not important, just has to not be UnreliableWrapper and impl RemoteStorage.
+type VoidStorage = crate::LocalFs;
 
-impl RemoteStorage for VoidStorage {
-    async fn list_prefixes(
-        &self,
-        _prefix: Option<&RemotePath>,
-    ) -> Result<Vec<RemotePath>, DownloadError> {
-        unimplemented!()
-    }
-    async fn list_files(&self, _prefix: Option<&RemotePath>) -> anyhow::Result<Vec<RemotePath>> {
-        unimplemented!()
-    }
-    async fn list(
-        &self,
-        _prefix: Option<&RemotePath>,
-        _mode: ListingMode,
-    ) -> anyhow::Result<Listing, DownloadError> {
-        unimplemented!()
-    }
-    async fn upload(
-        &self,
-        _from: impl Stream<Item = std::io::Result<Bytes>> + Send + Sync + 'static,
-        _data_size_bytes: usize,
-        _to: &RemotePath,
-        _metadata: Option<StorageMetadata>,
-    ) -> anyhow::Result<()> {
-        unimplemented!()
-    }
-    async fn download(&self, _from: &RemotePath) -> Result<Download, DownloadError> {
-        unimplemented!()
-    }
-    async fn download_byte_range(
-        &self,
-        _from: &RemotePath,
-        _start_inclusive: u64,
-        _end_exclusive: Option<u64>,
-    ) -> Result<Download, DownloadError> {
-        unimplemented!()
-    }
-    async fn delete(&self, _path: &RemotePath) -> anyhow::Result<()> {
-        unimplemented!()
-    }
-    async fn delete_objects<'a>(&self, _paths: &'a [RemotePath]) -> anyhow::Result<()> {
-        unimplemented!()
-    }
-    async fn copy(&self, _from: &RemotePath, _to: &RemotePath) -> anyhow::Result<()> {
-        unimplemented!()
-    }
-}
 impl RemoteStorage for UnreliableWrapper {
     async fn list_prefixes(
         &self,


### PR DESCRIPTION
Makes the `RemoteStorage` trait not be based on `async_trait` any more.

To avoid recursion in async (not supported by Rust), we made `GenericRemoteStorage` generic on the "Unreliable" variant. That allows us to have the unreliable wrapper never contain/call itself.

related earlier work: #6305