### PR TITLE
Bump vm-builder v0.21.0 -> v0.23.2

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -894,7 +894,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.23.1
+      VM_BUILDER_VERSION: v0.23.2
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -867,7 +867,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.23.0
+      VM_BUILDER_VERSION: v0.23.1
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -867,7 +867,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.21.0
+      VM_BUILDER_VERSION: v0.23.0
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Relevant changes were all from v0.23.0:

- neondatabase/autoscaling#724
  - IIRC this requires additional changes to redirect the logs through the socket. cc @Omrigan - happy to do that in this PR or a follow-up. 
- neondatabase/autoscaling#726
- neondatabase/autoscaling#732

cc @neondatabase/autoscaling

---

NOTE: This may or may not work, until neondatabase/cloud#9675 is merged to update cloud CI.

NOTE: Do not merge until after the platform release 2024-01-29 (next Monday). We want this to sit on staging for a while longer.