### PR TITLE
Optimise e2e run

### DIFF
--- a/.github/workflows/approved-for-ci-run.yml
+++ b/.github/workflows/approved-for-ci-run.yml
@@ -93,6 +93,7 @@ jobs:
                                                        --body-file "body.md" \
                                                        --head "${BRANCH}" \
                                                        --base "main" \
+                                                       --label "run-e2e-test-in-draft" \
                                                        --draft
           fi
 

--- a/.github/workflows/approved-for-ci-run.yml
+++ b/.github/workflows/approved-for-ci-run.yml
@@ -93,7 +93,7 @@ jobs:
                                                        --body-file "body.md" \
                                                        --head "${BRANCH}" \
                                                        --base "main" \
-                                                       --label "run-e2e-test-in-draft" \
+                                                       --label "run-e2e-tests-in-draft" \
                                                        --draft
           fi
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-Build and Test-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
   check-permissions:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-e2e-tests-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
   check-permissions:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -695,8 +695,6 @@ jobs:
     if: ${{ !github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-tests-in-draft') || github.ref_name == 'main' }}
     needs: [ check-permissions, promote-images, tag ]
     uses: ./.github/workflows/trigger-e2e-tests.yml
-    with:
-      build-tag: needs.tag.outputs.build-tag
     secrets: inherit
 
   neon-image:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
   check-permissions:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -692,7 +692,7 @@ jobs:
             })
 
   trigger-e2e-tests:
-    if: ${{ (!github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-test-in-draft')) && !cancelled() }}
+    if: ${{ !github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-test-in-draft') }}
     needs: [ check-permissions, promote-images, tag ]
     uses: ./.github/workflows/trigger-e2e-tests.yml
     with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ defaults:
 
 concurrency:
   # Allow only one workflow per any non-`main` branch.
-  group: ${{ github.repository }}c-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
   cancel-in-progress: true
 
 env:
@@ -22,7 +22,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: Build and Test-${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-Build and Test-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
   check-permissions:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -693,7 +693,7 @@ jobs:
             })
 
   trigger-e2e-tests:
-    if: ${{ (!github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-test-in-draft')) && !cancelled()) }}
+    if: ${{ (!github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-test-in-draft')) && !cancelled() }}
     needs: [ check-permissions, promote-images, tag ]
     uses: ./.github/workflows/trigger-e2e-tests.yml
     with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -600,7 +600,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ debug ]
+        build_type: [ debug, release ]
     outputs:
         coverage-html: ${{ steps.upload-coverage-report-new.outputs.report-url }}
         coverage-json: ${{ steps.upload-coverage-report-new.outputs.summary-json }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -692,7 +692,7 @@ jobs:
             })
 
   trigger-e2e-tests:
-    if: ${{ !github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-test-in-draft') }}
+    if: ${{ !github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-tests-in-draft') || github.ref_name == 'main' }}
     needs: [ check-permissions, promote-images, tag ]
     uses: ./.github/workflows/trigger-e2e-tests.yml
     with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -692,7 +692,7 @@ jobs:
             })
 
   trigger-e2e-tests:
-    if: ${{ !github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-tests-in-draft') || github.ref_name == 'main' }}
+    if: ${{ !github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-tests-in-draft') || github.ref_name == 'main' || github.ref_name == 'release' }}
     needs: [ check-permissions, promote-images, tag ]
     uses: ./.github/workflows/trigger-e2e-tests.yml
     secrets: inherit

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -600,7 +600,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ debug, release ]
+        build_type: [ debug ]
     outputs:
         coverage-html: ${{ steps.upload-coverage-report-new.outputs.report-url }}
         coverage-json: ${{ steps.upload-coverage-report-new.outputs.summary-json }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
       - converted_to_draft
 
 defaults:
@@ -699,51 +698,12 @@ jobs:
             })
 
   trigger-e2e-tests:
-    if: ${{ !github.event.pull_request.draft && github.event.action == 'ready_for_review' && !cancelled()}}
+    if: ${{ !github.event.pull_request.draft && !cancelled()}}
     needs: [ check-permissions, promote-images, tag ]
-    runs-on: [ self-hosted, gen3, small ]
-    container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
-      options: --init
-    steps:
-      - name: Set PR's status to pending and request a remote CI test
-        run: |
-          # For pull requests, GH Actions set "github.sha" variable to point at a fake merge commit
-          # but we need to use a real sha of a latest commit in the PR's branch for the e2e job,
-          # to place a job run status update later.
-          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
-          # For non-PR kinds of runs, the above will produce an empty variable, pick the original sha value for those
-          COMMIT_SHA=${COMMIT_SHA:-${{ github.sha }}}
-
-          REMOTE_REPO="${{ github.repository_owner }}/cloud"
-
-          curl -f -X POST \
-          https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
-          -H "Accept: application/vnd.github.v3+json" \
-          --user "${{ secrets.CI_ACCESS_TOKEN }}" \
-          --data \
-            "{
-              \"state\": \"pending\",
-              \"context\": \"neon-cloud-e2e\",
-              \"description\": \"[$REMOTE_REPO] Remote CI job is about to start\"
-            }"
-
-          curl -f -X POST \
-          https://api.github.com/repos/$REMOTE_REPO/actions/workflows/testing.yml/dispatches \
-          -H "Accept: application/vnd.github.v3+json" \
-          --user "${{ secrets.CI_ACCESS_TOKEN }}" \
-          --data \
-            "{
-              \"ref\": \"main\",
-              \"inputs\": {
-                \"ci_job_name\": \"neon-cloud-e2e\",
-                \"commit_hash\": \"$COMMIT_SHA\",
-                \"remote_repo\": \"${{ github.repository }}\",
-                \"storage_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
-                \"compute_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
-                \"concurrency_group\": \"${{ env.E2E_CONCURRENCY_GROUP }}\"
-              }
-            }"
+    uses: ./.github/workflows/trigger-e2e-tests.yml
+    with:
+      build-tag: needs.tag.outputs.build-tag
+    secrets: inherit
 
   neon-image:
     needs: [ check-permissions, build-buildtools-image, tag ]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,11 +6,6 @@ on:
       - main
       - release
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - converted_to_draft
 
 defaults:
   run:
@@ -698,7 +693,7 @@ jobs:
             })
 
   trigger-e2e-tests:
-    if: ${{ !github.event.pull_request.draft && !cancelled()}}
+    if: ${{ (!github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-test-in-draft')) && !cancelled()) }}
     needs: [ check-permissions, promote-images, tag ]
     uses: ./.github/workflows/trigger-e2e-tests.yml
     with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ defaults:
 
 concurrency:
   # Allow only one workflow per any non-`main` branch.
-  group: Build and Test-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  group: ${{ github.repository }}c-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
   cancel-in-progress: true
 
 env:
@@ -22,7 +22,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: Build and Test-${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
   check-permissions:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ defaults:
 
 concurrency:
   # Allow only one workflow per any non-`main` branch.
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  group: Build and Test-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
   cancel-in-progress: true
 
 env:
@@ -90,7 +90,6 @@ jobs:
         id: build-tag
 
   build-buildtools-image:
-    if: github.event.action != 'ready_for_review'
     needs: [ check-permissions ]
     uses: ./.github/workflows/build_and_push_docker_image.yml
     with:
@@ -547,7 +546,7 @@ jobs:
 
   create-test-report:
     needs: [ check-permissions, regress-tests, coverage-report, benchmarks, build-buildtools-image ]
-    if: ${{ !cancelled() && contains(fromJSON('["skipped", "success"]'), needs.check-permissions.result) && github.event.action != 'ready_for_review' }}
+    if: ${{ !cancelled() && contains(fromJSON('["skipped", "success"]'), needs.check-permissions.result) }}
 
     runs-on: [ self-hosted, gen3, small ]
     container:
@@ -1022,7 +1021,6 @@ jobs:
         run: rm -rf ~/.ecr
 
   trigger-custom-extensions-build-and-wait:
-    if: github.event.action != 'ready_for_review'
     needs: [ check-permissions, tag ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -23,8 +23,9 @@ env:
 
 jobs:
   check-permissions:
+    # if the e2e test were already ran in draft mode then we can skip this when the PR is marked 'ready for review'
+    if : github.event.action == 'ready_for_review' && !contains( github.event.pull_request.labels.*.name, 'run-e2e-test-in-draft')
     runs-on: ubuntu-latest
-
     steps:
       - name: Disallow PRs from forks
         if: |
@@ -131,3 +132,27 @@ jobs:
                 \"concurrency_group\": \"${{ env.E2E_CONCURRENCY_GROUP }}\"
               }
             }"
+
+      - name: Update status of trigger e2e test job
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        with:
+          timeout_seconds: 60
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: |
+            REMOTE_REPO="${{ github.repository_owner }}/neon"
+            COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+            CI_JOB_NAME="Build and Test / trigger-e2e-tests"
+            ACTION_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            set -e
+            curl -f -X POST \
+              https://api.github.com/repos/$REMOTE_REPO/statuses/$COMMIT_HASH \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token ${{ secrets.ci_access_token }}" \
+              --data \
+                "{
+                  \"state\": \"success\",
+                  \"context\": \"$CI_JOB_NAME\",
+                  \"description\": \"[$LOCAL_REPO] The e2e test were triggered successfully\",
+                  \"target_url\": \"$ACTION_URL\"
+                }"

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -16,8 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
   E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -140,19 +140,16 @@ jobs:
           retry_wait_seconds: 60
           max_attempts: 3
           command: |
-            REMOTE_REPO="${{ github.repository_owner }}/neon"
             COMMIT_SHA=${{ github.event.pull_request.head.sha }}
             CI_JOB_NAME="Build and Test / trigger-e2e-tests"
-            ACTION_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             set -e
             curl -f -X POST \
-              https://api.github.com/repos/$REMOTE_REPO/statuses/$COMMIT_HASH \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: token ${{ secrets.ci_access_token }}" \
-              --data \
-                "{
-                  \"state\": \"success\",
-                  \"context\": \"$CI_JOB_NAME\",
-                  \"description\": \"[$LOCAL_REPO] The e2e test were triggered successfully\",
-                  \"target_url\": \"$ACTION_URL\"
-                }"
+                      https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
+                      -H "Accept: application/vnd.github.v3+json" \
+                      --user "${{ secrets.CI_ACCESS_TOKEN }}" \
+                      --data \
+                        "{
+                          \"state\": \"success\",
+                          \"context\": \"$CI_JOB_NAME\",
+                          \"description\": \"The e2e test were triggered successfully\"
+                        }"

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -1,0 +1,133 @@
+name: Trigger E2E Tests
+
+on:
+  pull_request:
+    types:
+      - ready_for_review
+  workflow_call:
+    inputs:
+      build-tag:
+        required: true
+        type: string
+
+concurrency:
+  # Allow only one workflow per any non-`main` branch.
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  cancel-in-progress: true
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
+  # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+
+jobs:
+  check-permissions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Disallow PRs from forks
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+
+        run: |
+          if [ "${{ contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}" = "true" ]; then
+            MESSAGE="Please create a PR from a branch of ${GITHUB_REPOSITORY} instead of a fork"
+          else
+            MESSAGE="The PR should be reviewed and labelled with 'approved-for-ci-run' to trigger a CI run"
+          fi
+          
+          echo >&2 "We don't run CI for PRs from forks"
+          echo >&2 "${MESSAGE}"
+          
+          exit 1
+
+  cancel-previous-e2e-tests:
+    needs: [ check-permissions ]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel previous e2e-tests runs for this PR
+        env:
+          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
+        run: |
+          gh workflow --repo neondatabase/cloud \
+            run cancel-previous-in-concurrency-group.yml \
+              --field concurrency_group="${{ env.E2E_CONCURRENCY_GROUP }}"
+
+  tag:
+    needs: [ check-permissions ]
+    runs-on: [ self-hosted, gen3, small ]
+    container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
+    outputs:
+      build-tag: ${{steps.build-tag.outputs.tag}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get build tag
+        run: |
+          echo run:$GITHUB_RUN_ID
+          echo ref:$GITHUB_REF_NAME
+          echo rev:$(git rev-list --count HEAD)
+          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
+            echo "tag=$(git rev-list --count HEAD)" >> $GITHUB_OUTPUT
+          elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
+            echo "tag=release-$(git rev-list --count HEAD)" >> $GITHUB_OUTPUT
+          else
+            echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
+            echo "tag=$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+        id: build-tag
+
+  trigger-e2e-tests:
+    needs: [ tag ]
+    runs-on: [ self-hosted, gen3, small ]
+    container:
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
+      options: --init
+    steps:
+      - name: Set PR's status to pending and request a remote CI test
+        run: |
+          # For pull requests, GH Actions set "github.sha" variable to point at a fake merge commit
+          # but we need to use a real sha of a latest commit in the PR's branch for the e2e job,
+          # to place a job run status update later.
+          COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+          # For non-PR kinds of runs, the above will produce an empty variable, pick the original sha value for those
+          COMMIT_SHA=${COMMIT_SHA:-${{ github.sha }}}
+
+          REMOTE_REPO="${{ github.repository_owner }}/cloud"
+
+          curl -f -X POST \
+          https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
+          -H "Accept: application/vnd.github.v3+json" \
+          --user "${{ secrets.CI_ACCESS_TOKEN }}" \
+          --data \
+            "{
+              \"state\": \"pending\",
+              \"context\": \"neon-cloud-e2e\",
+              \"description\": \"[$REMOTE_REPO] Remote CI job is about to start\"
+            }"
+
+          curl -f -X POST \
+          https://api.github.com/repos/$REMOTE_REPO/actions/workflows/testing.yml/dispatches \
+          -H "Accept: application/vnd.github.v3+json" \
+          --user "${{ secrets.CI_ACCESS_TOKEN }}" \
+          --data \
+            "{
+              \"ref\": \"main\",
+              \"inputs\": {
+                \"ci_job_name\": \"neon-cloud-e2e\",
+                \"commit_hash\": \"$COMMIT_SHA\",
+                \"remote_repo\": \"${{ github.repository }}\",
+                \"storage_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
+                \"compute_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
+                \"concurrency_group\": \"${{ env.E2E_CONCURRENCY_GROUP }}\"
+              }
+            }"

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -47,7 +47,7 @@ jobs:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
           CURRENT_BRANCH: ${{ github.head_ref }}
         run: |
-          BUILD_AND_TEST_RUN_ID=$(gh run list -b $CURRENT_BRANCH -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')"
+          BUILD_AND_TEST_RUN_ID=$(gh run list -b $CURRENT_BRANCH -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')
           echo build and test runid:$BUILD_AND_TEST_RUN_ID
           echo ref:$GITHUB_REF_NAME
           echo rev:$(git rev-list --count HEAD)

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -68,8 +68,9 @@ jobs:
         with:
             ref: ${{ github.ref }}
             running-workflow-name: 'neon-image'
-            repo-token: ${{ secret.GITHUB_TOKEN }}
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
             wait-interval: 20
+
       - name: Wait for compute-node-image to be build
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
@@ -77,20 +78,23 @@ jobs:
           running-workflow-name: 'compute-node-image'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
+
       - name: Wait for vm-compute-node-image to be build
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.ref }}
           running-workflow-name: 'vm-compute-node-image'
-          repo-token: ${{ secret.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
+
       - name: Wait for compute-tools-image to be build
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.ref }}
           running-workflow-name: 'compute-tools-image'
-          repo-token: ${{ secret.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
+
       - name: Set PR's status to pending and request a remote CI test
         run: |
           # For pull requests, GH Actions set "github.sha" variable to point at a fake merge commit

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -68,6 +68,34 @@ jobs:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init
     steps:
+      - name: Wait for neon-images to be build
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+            ref: ${{ github.ref }}
+            running-workflow-name: 'neon-image'
+            repo-token: ${{ secret.GITHUB_TOKEN }}
+            wait-interval: 20
+      - name: Wait for compute-node-image to be build
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          running-workflow-name: 'compute-node-image'
+          repo-token: ${{ secret.GITHUB_TOKEN }}
+          wait-interval: 20
+      - name: Wait for vm-compute-node-image to be build
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          running-workflow-name: 'vm-compute-node-image'
+          repo-token: ${{ secret.GITHUB_TOKEN }}
+          wait-interval: 20
+      - name: Wait for compute-tools-image to be build
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          running-workflow-name: 'compute-tools-image'
+          repo-token: ${{ secret.GITHUB_TOKEN }}
+          wait-interval: 20
       - name: Set PR's status to pending and request a remote CI test
         run: |
           # For pull requests, GH Actions set "github.sha" variable to point at a fake merge commit

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -44,21 +44,18 @@ jobs:
       - name: Get build tag
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
-          CURRENT_BRANCH: ${{ github.head_ref }}
+          CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }}
+          CURRENT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          BUILD_AND_TEST_RUN_ID=$(gh run list -b $CURRENT_BRANCH -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')
-          echo build and test runid:$BUILD_AND_TEST_RUN_ID
-          echo ref:$GITHUB_REF_NAME
-          echo rev:$(git rev-list --count HEAD)
           if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            echo "tag=$(git rev-list --count HEAD)" >> $GITHUB_OUTPUT
+            echo "tag=$(git rev-list --count HEAD)" | tee -a $GITHUB_OUTPUT
           elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
-            echo "tag=release-$(git rev-list --count HEAD)" >> $GITHUB_OUTPUT
+            echo "tag=release-$(git rev-list --count HEAD)" | tee -a $GITHUB_OUTPUT
           else
             echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
-            echo "tag=$BUILD_AND_TEST_RUN_ID" >> $GITHUB_OUTPUT
+            BUILD_AND_TEST_RUN_ID=$(gh run list -b $CURRENT_BRANCH -c $CURRENT_SHA -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')
+            echo "tag=$BUILD_AND_TEST_RUN_ID" | tee -a $GITHUB_OUTPUT
           fi
-        shell: bash
         id: build-tag
 
   trigger-e2e-tests:

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -72,7 +72,7 @@ jobs:
           for REPO in neon compute-tools compute-node-v14 vm-compute-node-v14 compute-node-v15 vm-compute-node-v15 compute-node-v16 vm-compute-node-v16; do
             OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
             if [ "$OUTPUT" == "" ]; then
-              echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+              echo "$REPO with image tag $TAG not found" >> $GITHUB_OUTPUT
               exit 1
             fi
           done

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          echo "runid=$(gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1 -q '.ID' --json number)" >> $GITHUB_OUTPUT
+          echo "runid=$(gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
 
   tag:
     needs: get-build-and-test-run-id

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -5,10 +5,6 @@ on:
     types:
       - ready_for_review
   workflow_call:
-    inputs:
-      build-tag:
-        required: true
-        type: string
 
 defaults:
   run:
@@ -66,13 +62,12 @@ jobs:
     needs: [ tag ]
     runs-on: [ self-hosted, gen3, small ]
     env:
-      TAG: ${{ github.event_name == 'pull_request' && needs.tag.outputs.build-tag || github.event.inputs.build-tag }}
+      TAG: ${{ needs.tag.outputs.build-tag }}
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init
     steps:
       - name: check if ecr image are present
-        id: check-ecr-image-present
         run: |
           for REPO in neon compute-tools compute-node-v14 vm-compute-node-v14 compute-node-v15 vm-compute-node-v15 compute-node-v16 vm-compute-node-v16; do
             OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           running-workflow-name: 'compute-node-image'
-          repo-token: ${{ secret.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
       - name: Wait for vm-compute-node-image to be build
         uses: lewagon/wait-on-check-action@v1.3.1

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -31,7 +31,6 @@ jobs:
               --field concurrency_group="${{ env.E2E_CONCURRENCY_GROUP }}"
 
   tag:
-    needs: get-build-and-test-run-id
     runs-on: [ ubuntu-latest ]
     container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
     outputs:

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -191,3 +191,4 @@ jobs:
                 \"concurrency_group\": \"${{ env.E2E_CONCURRENCY_GROUP }}\"
               }
             }"
+ 

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -44,10 +44,8 @@ jobs:
         id: run-id
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          echo "$GITHUB_CONTEXT"
-          echo "runid=$(gh run list -b ${{ github.event.pull_request.base.ref }} -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
+          echo "runid=$(gh run list -b ${{ github.head_ref }} -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
 
   tag:
     needs: get-build-and-test-run-id

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
     needs: [ tag ]
     runs-on: [ self-hosted, gen3, small ]
     env:
-      TAG: ${{ github.event.inputs.build-tag || needs.tag.outputs.build-tag }}
+      TAG: ${{ github.event_name == 'pull_request' && needs.tag.outputs.build-tag || github.event.inputs.build-tag }}
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Get build tag
         run: |
+          test=$(gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1)
           echo run:$GITHUB_RUN_ID
           echo ref:$GITHUB_REF_NAME
           echo rev:$(git rev-list --count HEAD)

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -71,7 +71,7 @@ jobs:
         id: check-ecr-image-present
         run: |
           REPO=neon
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -43,8 +43,10 @@ jobs:
           fetch-depth: 0
 
       - name: Get build tag
+        env:
+          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          test=$(gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1)
+          gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1
           echo run:$GITHUB_RUN_ID
           echo ref:$GITHUB_REF_NAME
           echo rev:$(git rev-list --count HEAD)

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -44,8 +44,9 @@ jobs:
         id: run-id
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
+          CURRENT_BRANCH: ${{ github.head_ref }}
         run: |
-          echo "runid=$(gh run list -b ${{ github.head_ref }} -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
+          echo "runid=$(gh run list -b $CURRENT_BRANCH -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
 
   tag:
     needs: get-build-and-test-run-id

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
     needs: [ tag ]
     runs-on: [ self-hosted, gen3, small ]
     env:
-      TAG:${{ github.event.inputs.build-tag }}
+      TAG: ${{ github.event.inputs.build-tag }}
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -32,7 +32,6 @@ jobs:
 
   tag:
     runs-on: [ ubuntu-latest ]
-    container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
     outputs:
       build-tag: ${{ steps.build-tag.outputs.tag }}
 

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -36,6 +36,10 @@ jobs:
       run-id: ${{ steps.run-id.outputs.runid }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Fetch RunId of latest build and test workflow
         id: run-id
         env:

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Fetch RunId of latest build and test workflow
         id: run-id
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
           echo "runid=$(gh run list -b ${{ github.head_ref }} -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -13,7 +13,7 @@ on:
 concurrency:
   # Allow only one workflow per any non-`main` branch.
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -43,8 +43,10 @@ jobs:
       - name: Fetch RunId of latest build and test workflow
         id: run-id
         env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
+          echo "$GITHUB_CONTEXT"
           echo "runid=$(gh run list -b ${{ github.event.pull_request.base.ref }} -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
 
   tag:

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           for REPO in neon compute-tools compute-node-v14 vm-compute-node-v14 compute-node-v15 vm-compute-node-v15 compute-node-v16 vm-compute-node-v16
           do
-            OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --output text)
+            OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
             if [ "$OUTPUT" == "" ]; then
               echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
               exit 1

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: Build and Test-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
 

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          echo "runid=$(gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
+          echo "runid=$(gh run list -b ${{ github.event.pull_request.base.ref }} -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
 
   tag:
     needs: get-build-and-test-run-id

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-e2e-tests-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha'
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-e2e-tests-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
 

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -144,7 +144,7 @@ jobs:
             curl -f -X POST \
                       https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
                       -H "Accept: application/vnd.github.v3+json" \
-                      --user "${{ secrets.CI_ACCESS_TOKEN }}" \
+                      -H "Authorization: token ${{ secrets.CI_ACCESS_TOKEN }}" \
                       --data \
                         "{
                           \"state\": \"success\",

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -106,24 +106,3 @@ jobs:
                 \"concurrency_group\": \"${{ env.E2E_CONCURRENCY_GROUP }}\"
               }
             }"
-
-      - name: Update status of trigger e2e test job
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-        with:
-          timeout_seconds: 60
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: |
-            COMMIT_SHA=${{ github.event.pull_request.head.sha }}
-            CI_JOB_NAME="Build and Test / trigger-e2e-tests"
-            set -e
-            curl -f -X POST \
-                      https://api.github.com/repos/${{ github.repository }}/statuses/$COMMIT_SHA \
-                      -H "Accept: application/vnd.github.v3+json" \
-                      -H "Authorization: token ${{ secrets.CI_ACCESS_TOKEN }}" \
-                      --data \
-                        "{
-                          \"state\": \"success\",
-                          \"context\": \"$CI_JOB_NAME\",
-                          \"description\": \"The e2e test were triggered successfully\"
-                        }"

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -61,6 +61,8 @@ jobs:
   trigger-e2e-tests:
     needs: [ tag ]
     runs-on: [ self-hosted, gen3, small ]
+    env:
+      TAG=${{ github.event.inputs.build-tag }}
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init
@@ -68,7 +70,6 @@ jobs:
       - name: check if ecr image are present
         id: check-ecr-image-present
         run: |
-          TAG=${{ github.event.inputs.build-tag }}
           REPO=neon
           OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -70,61 +70,14 @@ jobs:
       - name: check if ecr image are present
         id: check-ecr-image-present
         run: |
-          REPO=neon
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
-          if [ "$OUTPUT" == "" ]; then
-            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          REPO=compute-tools
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
-          if [ "$OUTPUT" == "" ]; then
-            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          REPO=compute-node-v14
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
-          if [ "$OUTPUT" == "" ]; then
-            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          REPO=vm-compute-node-v14
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
-          if [ "$OUTPUT" == "" ]; then
-            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          REPO=compute-node-v15
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
-          if [ "$OUTPUT" == "" ]; then
-            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          REPO=vm-compute-node-v15
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
-          if [ "$OUTPUT" == "" ]; then
-            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          REPO=compute-node-v16
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
-          if [ "$OUTPUT" == "" ]; then
-            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          REPO=vm-compute-node-v16
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
-          if [ "$OUTPUT" == "" ]; then
-            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
-            exit 1
-          fi
+          for REPO in neon compute-tools compute-node-v14 vm-compute-node-v14 compute-node-v15 vm-compute-node-v15 compute-node-v16 vm-compute-node-v16
+          do
+            OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --output text)
+            if [ "$OUTPUT" == "" ]; then
+              echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+          done
 
       - name: Set PR's status to pending and request a remote CI test
         run: |

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
   cancel-previous-e2e-tests:

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -71,56 +71,56 @@ jobs:
         id: check-ecr-image-present
         run: |
           REPO=neon
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=compute-tools
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=compute-node-v14
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=vm-compute-node-v14
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=compute-node-v15
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=vm-compute-node-v15
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=compute-node-v16
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=vm-compute-node-v16
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
     needs: [ tag ]
     runs-on: [ self-hosted, gen3, small ]
     env:
-      TAG=${{ github.event.inputs.build-tag }}
+      TAG:${{ github.event.inputs.build-tag }}
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -20,30 +20,7 @@ env:
   E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
-  check-permissions:
-    # if the e2e test were already ran in draft mode then we can skip this when the PR is marked 'ready for review'
-    if : github.event.action == 'ready_for_review' && !contains( github.event.pull_request.labels.*.name, 'run-e2e-test-in-draft')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Disallow PRs from forks
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository
-
-        run: |
-          if [ "${{ contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}" = "true" ]; then
-            MESSAGE="Please create a PR from a branch of ${GITHUB_REPOSITORY} instead of a fork"
-          else
-            MESSAGE="The PR should be reviewed and labelled with 'approved-for-ci-run' to trigger a CI run"
-          fi
-          
-          echo >&2 "We don't run CI for PRs from forks"
-          echo >&2 "${MESSAGE}"
-          
-          exit 1
-
   cancel-previous-e2e-tests:
-    needs: [ check-permissions ]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
@@ -57,7 +34,6 @@ jobs:
               --field concurrency_group="${{ env.E2E_CONCURRENCY_GROUP }}"
 
   tag:
-    needs: [ check-permissions ]
     runs-on: [ self-hosted, gen3, small ]
     container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
     outputs:

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -10,11 +10,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  # Allow only one workflow per any non-`main` branch.
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
-  cancel-in-progress: false
-
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
   E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -13,6 +13,8 @@ on:
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
   E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
 
 jobs:
   cancel-previous-e2e-tests:
@@ -63,39 +65,95 @@ jobs:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init
     steps:
-      - name: Wait for neon-images to be build
-        uses: lewagon/wait-on-check-action@v1.3.1
+      - name: check if ecr neon image
+        id: check-neon-ecr-image
+        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
         with:
-            ref: ${{ github.ref }}
-            running-workflow-name: 'neon-image'
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
-            wait-interval: 20
+          region: eu-central-1
+          repository-name: "neon"
+          image-tag: "${{ github.event.inputs.build-tag }}"
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Wait for compute-node-image to be build
-        uses: lewagon/wait-on-check-action@v1.3.1
+      - name: check if compute-tools image is build
+        if: ${{ steps.check-neon-ecr-image.outputs.image-exists == '0' }}
+        id: check-compute-tools-ecr-image
+        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
         with:
-          ref: ${{ github.ref }}
-          running-workflow-name: 'compute-node-image'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20
+          region: eu-central-1
+          repository-name: "compute-tools"
+          image-tag: "${{ github.event.inputs.build-tag }}"
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Wait for vm-compute-node-image to be build
-        uses: lewagon/wait-on-check-action@v1.3.1
+      - name: check if compute-node-v14 image is build
+        if: ${{ steps.check-compute-tools-ecr-image.outputs.image-exists == '0' }}
+        id: check-compute-node-v14-ecr-image
+        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
         with:
-          ref: ${{ github.ref }}
-          running-workflow-name: 'vm-compute-node-image'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20
+          region: eu-central-1
+          repository-name: "compute-node-v14"
+          image-tag: "${{ github.event.inputs.build-tag }}"
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Wait for compute-tools-image to be build
-        uses: lewagon/wait-on-check-action@v1.3.1
+      - name: check if vm-compute-node-v14 image is build
+        if: ${{ steps.check-compute-node-v14-ecr-image.outputs.image-exists == '0' }}
+        id: check-vm-compute-node-v14-ecr-image
+        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
         with:
-          ref: ${{ github.ref }}
-          running-workflow-name: 'compute-tools-image'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20
+          region: eu-central-1
+          repository-name: "vm-compute-node-v14"
+          image-tag: "${{ github.event.inputs.build-tag }}"
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: check if compute-node-v15 image is build
+        if: ${{ steps.check-vm-compute-node-v14-ecr-image.outputs.image-exists == '0' }}
+        id: check-compute-node-v15-ecr-image
+        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
+        with:
+          region: eu-central-1
+          repository-name: "compute-node-v15"
+          image-tag: "${{ github.event.inputs.build-tag }}"
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: check if vm-compute-node-v15 image is build
+        if: ${{ steps.check-compute-node-v15-ecr-image.outputs.image-exists == '0' }}
+        id: check-vm-compute-node-v15-ecr-image
+        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
+        with:
+          region: eu-central-1
+          repository-name: "vm-compute-node-v15"
+          image-tag: "${{ github.event.inputs.build-tag }}"
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: check if compute-node-v16 image is build
+        if: ${{ steps.check-vm-compute-node-v15-ecr-image.outputs.image-exists == '0' }}
+        id: check-compute-node-v16-ecr-image
+        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
+        with:
+          region: eu-central-1
+          repository-name: "compute-node-v16"
+          image-tag: "${{ github.event.inputs.build-tag }}"
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: check if vm-compute-node-v16 image is build
+        if: ${{ steps.check-compute-node-v16-ecr-image.outputs.image-exists == '0' }}
+        id: check-vm-compute-node-v16-ecr-image
+        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
+        with:
+          region: eu-central-1
+          repository-name: "vm-compute-node-v16"
+          image-tag: "${{ github.event.inputs.build-tag }}"
+          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
 
       - name: Set PR's status to pending and request a remote CI test
+        if: ${{ steps.check-vm-compute-node-v16-ecr-image.outputs.image-exists == '0' }}
         run: |
           # For pull requests, GH Actions set "github.sha" variable to point at a fake merge commit
           # but we need to use a real sha of a latest commit in the PR's branch for the e2e job,

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: Build and Test-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-e2e-tests-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha'
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
 

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -29,10 +29,22 @@ jobs:
           gh workflow --repo neondatabase/cloud \
             run cancel-previous-in-concurrency-group.yml \
               --field concurrency_group="${{ env.E2E_CONCURRENCY_GROUP }}"
-          
-          gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1
+
+  get-build-and-test-run-id:
+    runs-on: ubuntu-latest
+    outputs:
+      run-id: ${{ steps.run-id.outputs.runid }}
+
+    steps:
+      - name: Fetch RunId of latest build and test workflow
+        id: run-id
+        env:
+          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
+        run: |
+          echo "runid=$(gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1 -q '.ID' --json number)" >> $GITHUB_OUTPUT
 
   tag:
+    needs: get-build-and-test-run-id
     runs-on: [ self-hosted, gen3, small ]
     container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
     outputs:
@@ -47,8 +59,9 @@ jobs:
       - name: Get build tag
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
+          BUILD_AND_TEST_RUN_ID: ${{ needs.get-build-and-test-run-id.outputs.run-id }}
         run: |
-          echo run:$GITHUB_RUN_ID
+          echo build and test runid:$BUILD_AND_TEST_RUN_ID
           echo ref:$GITHUB_REF_NAME
           echo rev:$(git rev-list --count HEAD)
           if [[ "$GITHUB_REF_NAME" == "main" ]]; then
@@ -57,7 +70,7 @@ jobs:
             echo "tag=release-$(git rev-list --count HEAD)" >> $GITHUB_OUTPUT
           else
             echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
-            echo "tag=$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+            echo "tag=$BUILD_AND_TEST_RUN_ID" >> $GITHUB_OUTPUT
           fi
         shell: bash
         id: build-tag

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -71,56 +71,56 @@ jobs:
         id: check-ecr-image-present
         run: |
           REPO=neon
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=compute-tools
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=compute-node-v14
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=vm-compute-node-v14
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=compute-node-v15
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=vm-compute-node-v15
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=compute-node-v16
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1
           fi
           
           REPO=vm-compute-node-v16
-          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --image-ids imageTag=${TAG} --region eu-central-1 --query 'imageDetails[*].imagePushedAt' --output text)
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
           if [ "$OUTPUT" == "" ]; then
             echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
             exit 1

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -65,95 +65,67 @@ jobs:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init
     steps:
-      - name: check if ecr neon image
-        id: check-neon-ecr-image
-        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
-        with:
-          region: eu-central-1
-          repository-name: "neon"
-          image-tag: "${{ github.event.inputs.build-tag }}"
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-
-      - name: check if compute-tools image is build
-        if: ${{ steps.check-neon-ecr-image.outputs.image-exists == '0' }}
-        id: check-compute-tools-ecr-image
-        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
-        with:
-          region: eu-central-1
-          repository-name: "compute-tools"
-          image-tag: "${{ github.event.inputs.build-tag }}"
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-
-      - name: check if compute-node-v14 image is build
-        if: ${{ steps.check-compute-tools-ecr-image.outputs.image-exists == '0' }}
-        id: check-compute-node-v14-ecr-image
-        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
-        with:
-          region: eu-central-1
-          repository-name: "compute-node-v14"
-          image-tag: "${{ github.event.inputs.build-tag }}"
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-
-      - name: check if vm-compute-node-v14 image is build
-        if: ${{ steps.check-compute-node-v14-ecr-image.outputs.image-exists == '0' }}
-        id: check-vm-compute-node-v14-ecr-image
-        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
-        with:
-          region: eu-central-1
-          repository-name: "vm-compute-node-v14"
-          image-tag: "${{ github.event.inputs.build-tag }}"
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-
-      - name: check if compute-node-v15 image is build
-        if: ${{ steps.check-vm-compute-node-v14-ecr-image.outputs.image-exists == '0' }}
-        id: check-compute-node-v15-ecr-image
-        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
-        with:
-          region: eu-central-1
-          repository-name: "compute-node-v15"
-          image-tag: "${{ github.event.inputs.build-tag }}"
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-
-      - name: check if vm-compute-node-v15 image is build
-        if: ${{ steps.check-compute-node-v15-ecr-image.outputs.image-exists == '0' }}
-        id: check-vm-compute-node-v15-ecr-image
-        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
-        with:
-          region: eu-central-1
-          repository-name: "vm-compute-node-v15"
-          image-tag: "${{ github.event.inputs.build-tag }}"
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-
-      - name: check if compute-node-v16 image is build
-        if: ${{ steps.check-vm-compute-node-v15-ecr-image.outputs.image-exists == '0' }}
-        id: check-compute-node-v16-ecr-image
-        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
-        with:
-          region: eu-central-1
-          repository-name: "compute-node-v16"
-          image-tag: "${{ github.event.inputs.build-tag }}"
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-
-      - name: check if vm-compute-node-v16 image is build
-        if: ${{ steps.check-compute-node-v16-ecr-image.outputs.image-exists == '0' }}
-        id: check-vm-compute-node-v16-ecr-image
-        uses: mnmandahalf/check-ecr-image-exists@v0.1.5
-        with:
-          region: eu-central-1
-          repository-name: "vm-compute-node-v16"
-          image-tag: "${{ github.event.inputs.build-tag }}"
-          access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+      - name: check if ecr image are present
+        id: check-ecr-image-present
+        run: |
+          TAG=${{ github.event.inputs.build-tag }}
+          REPO=neon
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          if [ "$OUTPUT" == "" ]; then
+            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          REPO=compute-tools
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          if [ "$OUTPUT" == "" ]; then
+            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          REPO=compute-node-v14
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          if [ "$OUTPUT" == "" ]; then
+            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          REPO=vm-compute-node-v14
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          if [ "$OUTPUT" == "" ]; then
+            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          REPO=compute-node-v15
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          if [ "$OUTPUT" == "" ]; then
+            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          REPO=vm-compute-node-v15
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          if [ "$OUTPUT" == "" ]; then
+            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          REPO=compute-node-v16
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          if [ "$OUTPUT" == "" ]; then
+            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          REPO=vm-compute-node-v16
+          OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
+          if [ "$OUTPUT" == "" ]; then
+            echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
       - name: Set PR's status to pending and request a remote CI test
-        if: ${{ steps.check-vm-compute-node-v16-ecr-image.outputs.image-exists == '0' }}
         run: |
           # For pull requests, GH Actions set "github.sha" variable to point at a fake merge commit
           # but we need to use a real sha of a latest commit in the PR's branch for the e2e job,

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -29,6 +29,8 @@ jobs:
           gh workflow --repo neondatabase/cloud \
             run cancel-previous-in-concurrency-group.yml \
               --field concurrency_group="${{ env.E2E_CONCURRENCY_GROUP }}"
+          
+          gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1
 
   tag:
     runs-on: [ self-hosted, gen3, small ]
@@ -46,7 +48,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          gh run list -b $GITHUB_REF_NAME -w 'Build and Test' -L 1
           echo run:$GITHUB_RUN_ID
           echo ref:$GITHUB_REF_NAME
           echo rev:$(git rev-list --count HEAD)

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -30,27 +30,9 @@ jobs:
             run cancel-previous-in-concurrency-group.yml \
               --field concurrency_group="${{ env.E2E_CONCURRENCY_GROUP }}"
 
-  get-build-and-test-run-id:
-    runs-on: ubuntu-latest
-    outputs:
-      run-id: ${{ steps.run-id.outputs.runid }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Fetch RunId of latest build and test workflow
-        id: run-id
-        env:
-          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
-          CURRENT_BRANCH: ${{ github.head_ref }}
-        run: |
-          echo "runid=$(gh run list -b $CURRENT_BRANCH -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')" >> $GITHUB_OUTPUT
-
   tag:
     needs: get-build-and-test-run-id
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: [ ubuntu-latest ]
     container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
     outputs:
       build-tag: ${{ steps.build-tag.outputs.tag }}
@@ -64,8 +46,9 @@ jobs:
       - name: Get build tag
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
-          BUILD_AND_TEST_RUN_ID: ${{ needs.get-build-and-test-run-id.outputs.run-id }}
+          CURRENT_BRANCH: ${{ github.head_ref }}
         run: |
+          BUILD_AND_TEST_RUN_ID=$(gh run list -b $CURRENT_BRANCH -w 'Build and Test' -L 1 --json databaseId --jq '.[].databaseId')"
           echo build and test runid:$BUILD_AND_TEST_RUN_ID
           echo ref:$GITHUB_REF_NAME
           echo rev:$(git rev-list --count HEAD)

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: [ self-hosted, gen3, small ]
     container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
     outputs:
-      build-tag: ${{steps.build-tag.outputs.tag}}
+      build-tag: ${{ steps.build-tag.outputs.tag }}
 
     steps:
       - name: Checkout
@@ -62,7 +62,7 @@ jobs:
     needs: [ tag ]
     runs-on: [ self-hosted, gen3, small ]
     env:
-      TAG: ${{ github.event.inputs.build-tag }}
+      TAG: ${{ github.event.inputs.build-tag || needs.tag.outputs.build-tag }}
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init
@@ -112,8 +112,8 @@ jobs:
                 \"ci_job_name\": \"neon-cloud-e2e\",
                 \"commit_hash\": \"$COMMIT_SHA\",
                 \"remote_repo\": \"${{ github.repository }}\",
-                \"storage_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
-                \"compute_image_tag\": \"${{ needs.tag.outputs.build-tag }}\",
+                \"storage_image_tag\": \"${TAG}\",
+                \"compute_image_tag\": \"${TAG}\",
                 \"concurrency_group\": \"${{ env.E2E_CONCURRENCY_GROUP }}\"
               }
             }"

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
-  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  E2E_CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.head_ref }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
 
 jobs:
   cancel-previous-e2e-tests:

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+defaults:
+  run:
+    shell: bash -euxo pipefail {0}
+    
 env:
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
   E2E_CONCURRENCY_GROUP: ${{ github.repository }}-e2e-tests-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
@@ -70,8 +74,7 @@ jobs:
       - name: check if ecr image are present
         id: check-ecr-image-present
         run: |
-          for REPO in neon compute-tools compute-node-v14 vm-compute-node-v14 compute-node-v15 vm-compute-node-v15 compute-node-v16 vm-compute-node-v16
-          do
+          for REPO in neon compute-tools compute-node-v14 vm-compute-node-v14 compute-node-v15 vm-compute-node-v15 compute-node-v16 vm-compute-node-v16; do
             OUTPUT=$(aws ecr describe-images --repository-name ${REPO} --region eu-central-1 --query "imageDetails[?imageTags[?contains(@, '${TAG}')]]" --output text)
             if [ "$OUTPUT" == "" ]; then
               echo "$Repo with image tag $TAG not found" >> $GITHUB_OUTPUT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ _An instruction for maintainers_
 - If and only if it looks **safe** (i.e. it doesn't contain any malicious code which could expose secrets or harm the CI), then:
     - Press the "Approve and run" button in GitHub UI
     - Add the `approved-for-ci-run` label to the PR
-    - Currently draft PR will skip e2e test (only for internal contributors). After tuning the PR 'Ready to Review' CI will trigger e2e test
+    - Currently draft PR will skip e2e test (only for internal contributors). After turning the PR 'Ready to Review' CI will trigger e2e test
       - Add `run-e2e-tests-in-draft` label to run e2e test in draft PR (override above behaviour)
 
 Repeat all steps after any change to the PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ _An instruction for maintainers_
 - If and only if it looks **safe** (i.e. it doesn't contain any malicious code which could expose secrets or harm the CI), then:
     - Press the "Approve and run" button in GitHub UI
     - Add the `approved-for-ci-run` label to the PR
+    - Currently draft PR will skip e2e test (only for internal contributors). After tuning the PR 'Ready to Review' CI will trigger e2e test
+      - Add `run-e2e-tests-in-draft` label to run e2e test in draft PR (override above behaviour)
 
 Repeat all steps after any change to the PR.
 - When the changes are ready to get merged — merge the original PR (not the internal one)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ _An instruction for maintainers_
     - Add the `approved-for-ci-run` label to the PR
     - Currently draft PR will skip e2e test (only for internal contributors). After turning the PR 'Ready to Review' CI will trigger e2e test
       - Add `run-e2e-tests-in-draft` label to run e2e test in draft PR (override above behaviour)
+      - The `approved-for-ci-run` workflow will add `run-e2e-tests-in-draft` automatically to run e2e test for external contributors
 
 Repeat all steps after any change to the PR.
 - When the changes are ready to get merged — merge the original PR (not the internal one)


### PR DESCRIPTION
## Problem
We have finite amount of runners and intermediate results are often wanted before a PR is ready for merging. Currently all PRs get e2e tests run and this creates a lot of throwaway e2e results which may or may not get to start or complete before a new push.

## Summary of changes

1. Skip e2e test when PR is in draft mode
2. Run e2e when PR status changes from draft to ready for review (change this to having its trigger in below PR and update results of build and test)
3. Abstract e2e test in a Separate workflow and call it from the main workflow for the e2e test 
5. Add a label, if that label is present run e2e test in draft (run-e2e-test-in-draft)
6. Auto add a label(approve to ci) so that all the external contributors PR , e2e run in draft 
7. Document the new label changes and the above behaviour

Draft PR  : https://github.com/neondatabase/neon/actions/runs/7729128470
Ready To Review  : https://github.com/neondatabase/neon/actions/runs/7733779916
Draft PR with label : https://github.com/neondatabase/neon/actions/runs/7725691012/job/21062432342
and https://github.com/neondatabase/neon/actions/runs/7733854028

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
