### PR TITLE
test: assert we eventually free space

### DIFF
--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -818,16 +818,13 @@ class PageserverHttpClient(requests.Session):
         ).raise_for_status()
 
     def timeline_wait_logical_size(self, tenant_id: TenantId, timeline_id: TimelineId) -> int:
-        def sizes_are_equal():
-            timeline_details = self.timeline_detail(
-                tenant_id, timeline_id, include_non_incremental_logical_size=True
-            )
-            current_logical_size = timeline_details["current_logical_size"]
-            non_incremental = timeline_details["current_logical_size_non_incremental"]
-
-            assert current_logical_size == non_incremental
-            return non_incremental
-
-        last_size = wait_until(20, 0.5, sizes_are_equal)
-        assert last_size is not None
-        return last_size
+        detail = self.timeline_detail(
+            tenant_id,
+            timeline_id,
+            include_non_incremental_logical_size=True,
+            force_await_initial_logical_size=True,
+        )
+        current_logical_size = detail["current_logical_size"]
+        non_incremental = detail["current_logical_size_non_incremental"]
+        assert current_logical_size == non_incremental
+        return current_logical_size

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -827,4 +827,5 @@ class PageserverHttpClient(requests.Session):
         current_logical_size = detail["current_logical_size"]
         non_incremental = detail["current_logical_size_non_incremental"]
         assert current_logical_size == non_incremental
+        assert isinstance(current_logical_size, int)
         return current_logical_size

--- a/test_runner/regress/test_disk_usage_eviction.py
+++ b/test_runner/regress/test_disk_usage_eviction.py
@@ -808,7 +808,7 @@ def test_statvfs_pressure_usage(eviction_env: EvictionEnv):
         post_eviction_total_size, _, _ = env.timelines_du(env.pageserver)
         assert post_eviction_total_size < 0.33 * total_size, "we requested max 33% usage"
 
-    wait_until(10, 1, less_than_max_usage_pct)
+    wait_until(2, 2, less_than_max_usage_pct)
 
 
 def test_statvfs_pressure_min_avail_bytes(eviction_env: EvictionEnv):
@@ -854,7 +854,7 @@ def test_statvfs_pressure_min_avail_bytes(eviction_env: EvictionEnv):
             total_size - post_eviction_total_size >= min_avail_bytes
         ), f"we requested at least {min_avail_bytes} worth of free space"
 
-    wait_until(10, 1, more_than_min_avail_bytes_freed)
+    wait_until(2, 2, more_than_min_avail_bytes_freed)
 
 
 def test_secondary_mode_eviction(eviction_env_ha: EvictionEnv):

--- a/test_runner/regress/test_disk_usage_eviction.py
+++ b/test_runner/regress/test_disk_usage_eviction.py
@@ -183,9 +183,15 @@ class EvictionEnv:
             ),
         )
 
+        # we now do initial logical size calculation on startup, which on debug builds can fight with the every second task
+        for tenant_id, timeline_id in self.timelines:
+            pageserver_http = self.neon_env.get_tenant_pageserver(tenant_id).http_client()
+            pageserver_http.timeline_wait_logical_size(tenant_id, timeline_id)
+
         def statvfs_called():
             assert pageserver.log_contains(".*running mocked statvfs.*")
 
+        # we most likely have already completed multiple runs
         wait_until(10, 1, statvfs_called)
 
 

--- a/test_runner/regress/test_disk_usage_eviction.py
+++ b/test_runner/regress/test_disk_usage_eviction.py
@@ -155,6 +155,15 @@ class EvictionEnv:
         mock_behavior,
         eviction_order: EvictionOrder,
     ):
+        """
+        Starts pageserver up with mocked statvfs setup. The startup is
+        problematic because of dueling initial logical size calculations
+        requiring layers and disk usage based task evicting.
+
+        Returns after initial logical sizes are complete, but the phase of disk
+        usage eviction task is unknown; it might need to run one more iteration
+        before assertions can be made.
+        """
         disk_usage_config = {
             "period": period,
             "max_usage_pct": max_usage_pct,
@@ -183,7 +192,7 @@ class EvictionEnv:
             ),
         )
 
-        # we now do initial logical size calculation on startup, which on debug builds can fight with the every second task
+        # we now do initial logical size calculation on startup, which on debug builds can fight with disk usage based eviction
         for tenant_id, timeline_id in self.timelines:
             pageserver_http = self.neon_env.get_tenant_pageserver(tenant_id).http_client()
             pageserver_http.timeline_wait_logical_size(tenant_id, timeline_id)


### PR DESCRIPTION
in `test_statvfs_pressure_{usage,min_avail_bytes}` we now race against initial logical size calculation on-demand downloading the layers. first wait out the initial logical sizes, then change the final asserts to be "eventual", which is not great but it is faster than failing and retrying.

this issue seems to happen only in debug mode tests.

Fixes: #6510