### PR TITLE
Print checkpoint key contents with "pagectl print-layer-file"

### DIFF
--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -928,7 +928,7 @@ impl DeltaLayerInner {
                         println!("   CHECKPOINT: {:?}", checkpoint);
                     }
                     Value::WalRecord(_rec) => {
-                        format!(" unexpected walrecord for checkpoint key");
+                        println!("   unexpected walrecord value for checkpoint key");
                     }
                 }
             }


### PR DESCRIPTION
This was very useful in debugging the bugs fixed in #6410 and #6502.

There's a lot more we could do. This only adds the printing to delta layers, not image layers, for example, and it might be useful to print details of more record types. But this is a good start.
