### PR TITLE
control_plane/attachment_service: make --path optional

### DIFF
--- a/control_plane/attachment_service/src/main.rs
+++ b/control_plane/attachment_service/src/main.rs
@@ -11,7 +11,6 @@ use attachment_service::service::{Config, Service};
 use camino::Utf8PathBuf;
 use clap::Parser;
 use metrics::launch_timestamp::LaunchTimestamp;
-use std::str::FromStr;
 use std::sync::Arc;
 use tokio::signal::unix::SignalKind;
 use utils::auth::{JwtAuth, SwappableJwtAuth};
@@ -63,9 +62,7 @@ async fn main() -> anyhow::Result<()> {
         GIT_VERSION,
         launch_ts.to_string(),
         BUILD_TAG,
-        args.path
-            .as_ref()
-            .unwrap_or(&Utf8PathBuf::from_str("<none>").unwrap()),
+        args.path.as_ref().unwrap_or(&Utf8PathBuf::from("<none>")),
         args.listen
     );
 


### PR DESCRIPTION
## Problem

The `--path` argument is only used in testing, for compat tests that use a JSON snapshot of state rather than the postgres database.  In regular deployments, it should be omitted (currently one has to specify `--path ""`)

## Summary of changes

Make `--path` optional.


## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
