### PR TITLE
pagebench: fix percentiles reporting

### DIFF
--- a/pageserver/pagebench/src/util/request_stats.rs
+++ b/pageserver/pagebench/src/util/request_stats.rs
@@ -66,13 +66,10 @@ impl serde::Serialize for LatencyPercentiles {
     {
         use serde::ser::SerializeMap;
         let mut ser = serializer.serialize_map(Some(LATENCY_PERCENTILES.len()))?;
-        for (i, p) in LATENCY_PERCENTILES.iter().enumerate() {
+        for (p, v) in LATENCY_PERCENTILES.iter().zip(&self.latency_percentiles) {
             ser.serialize_entry(
                 &format!("p{p}"),
-                &format!(
-                    "{}",
-                    &humantime::format_duration(self.latency_percentiles[i])
-                ),
+                &format!("{}", humantime::format_duration(*v)),
             )?;
         }
         ser.end()

--- a/pageserver/pagebench/src/util/request_stats.rs
+++ b/pageserver/pagebench/src/util/request_stats.rs
@@ -66,12 +66,12 @@ impl serde::Serialize for LatencyPercentiles {
     {
         use serde::ser::SerializeMap;
         let mut ser = serializer.serialize_map(Some(LATENCY_PERCENTILES.len()))?;
-        for p in LATENCY_PERCENTILES {
+        for (i, p) in LATENCY_PERCENTILES.iter().enumerate() {
             ser.serialize_entry(
                 &format!("p{p}"),
                 &format!(
                     "{}",
-                    &humantime::format_duration(self.latency_percentiles[0])
+                    &humantime::format_duration(self.latency_percentiles[i])
                 ),
             )?;
         }


### PR DESCRIPTION
Before this patch, pagebench was always showing the same value.

refs https://github.com/neondatabase/neon/issues/6509