### PR TITLE
feat(walredo): various observability improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "bytes",
+ "chrono",
  "const_format",
  "enum-map",
  "hex",

--- a/libs/pageserver_api/Cargo.toml
+++ b/libs/pageserver_api/Cargo.toml
@@ -20,6 +20,7 @@ strum_macros.workspace = true
 hex.workspace = true
 thiserror.workspace = true
 humantime-serde.workspace = true
+chrono.workspace = true
 
 workspace_hack.workspace = true
 

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -454,6 +454,8 @@ pub struct TenantDetails {
     #[serde(flatten)]
     pub tenant_info: TenantInfo,
 
+    pub walredo: Option<WalRedoManagerStatus>,
+
     pub timelines: Vec<TimelineId>,
 }
 
@@ -639,6 +641,12 @@ pub enum DownloadRemoteLayersTaskState {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TimelineGcRequest {
     pub gc_horizon: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WalRedoManagerStatus {
+    pub last_successful_redo_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub pid: Option<u32>,
 }
 
 // Wrapped in libpq CopyData

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -645,7 +645,7 @@ pub struct TimelineGcRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalRedoManagerStatus {
-    pub last_successful_redo_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_redo_at: Option<chrono::DateTime<chrono::Utc>>,
     pub pid: Option<u32>,
 }
 

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -959,6 +959,7 @@ async fn tenant_status(
                 attachment_status: state.attachment_status(),
                 generation: tenant.generation().into(),
             },
+            walredo: tenant.wal_redo_manager_status(),
             timelines: tenant.list_timeline_ids(),
         })
     }

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -1651,11 +1651,18 @@ pub(crate) static WAL_REDO_RECORD_COUNTER: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+#[rustfmt::skip]
 pub(crate) static WAL_REDO_PROCESS_LAUNCH_DURATION_HISTOGRAM: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "pageserver_wal_redo_process_launch_duration",
         "Histogram of the duration of successful WalRedoProcess::launch calls",
-        redo_histogram_time_buckets!(),
+        vec![
+            0.0002, 0.0004, 0.0006, 0.0008, 0.0010,
+            0.0020, 0.0040, 0.0060, 0.0080, 0.0100,
+            0.0200, 0.0400, 0.0600, 0.0800, 0.1000,
+            0.2000, 0.4000, 0.6000, 0.8000, 1.0000,
+            1.5000, 2.0000, 2.5000, 3.0000, 4.0000, 10.0000
+        ],
     )
     .expect("failed to define a metric")
 });

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -679,7 +679,7 @@ impl WalRedoProcess {
     //
     // Start postgres binary in special WAL redo mode.
     //
-    #[instrument(skip_all,fields(pg_version=pg_version))]
+    #[instrument(skip_all,fields(tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug(), pg_version=pg_version))]
     fn launch(
         conf: &'static PageServerConf,
         tenant_shard_id: TenantShardId,
@@ -1187,7 +1187,6 @@ mod tests {
     use bytes::Bytes;
     use pageserver_api::shard::TenantShardId;
     use std::str::FromStr;
-    use tracing::Instrument;
     use utils::{id::TenantId, lsn::Lsn};
 
     #[tokio::test]
@@ -1212,7 +1211,6 @@ mod tests {
                 short_records(),
                 14,
             )
-            .instrument(h.span())
             .await
             .unwrap();
 
@@ -1240,7 +1238,6 @@ mod tests {
                 short_records(),
                 14,
             )
-            .instrument(h.span())
             .await
             .unwrap();
 
@@ -1261,7 +1258,6 @@ mod tests {
                 short_records(),
                 16, /* 16 currently produces stderr output on startup, which adds a nice extra edge */
             )
-            .instrument(h.span())
             .await
             .unwrap_err();
     }
@@ -1290,7 +1286,6 @@ mod tests {
         // underscored because unused, except for removal at drop
         _repo_dir: camino_tempfile::Utf8TempDir,
         manager: PostgresRedoManager,
-        tenant_shard_id: TenantShardId,
     }
 
     impl RedoHarness {
@@ -1307,11 +1302,7 @@ mod tests {
             Ok(RedoHarness {
                 _repo_dir: repo_dir,
                 manager,
-                tenant_shard_id,
             })
-        }
-        fn span(&self) -> tracing::Span {
-            tracing::info_span!("RedoHarness", tenant_id=%self.tenant_shard_id.tenant_id, shard_id=%self.tenant_shard_id.shard_slug())
         }
     }
 }

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -183,8 +183,8 @@ impl PostgresRedoManager {
 
     pub(crate) fn status(&self) -> Option<WalRedoManagerStatus> {
         Some(WalRedoManagerStatus {
-            last_successful_redo_at: {
-                let at = self.last_successful_redo_at.lock().unwrap().clone();
+            last_redo_at: {
+                let at = self.last_redo_at.lock().unwrap().clone();
                 at.and_then(|at| {
                     let age = at.elapsed();
                     // map any chrono errors silently to None here
@@ -270,7 +270,6 @@ impl PostgresRedoManager {
                                 let duration = start.elapsed();
                                 WAL_REDO_PROCESS_LAUNCH_DURATION_HISTOGRAM
                                     .observe(duration.as_secs_f64());
-                                crate::span::debug_assert_current_span_has_tenant_id();
                                 info!(
                                     duration_ms = duration.as_millis(),
                                     pid = proc.id(),

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -184,7 +184,7 @@ impl PostgresRedoManager {
     pub(crate) fn status(&self) -> Option<WalRedoManagerStatus> {
         Some(WalRedoManagerStatus {
             last_redo_at: {
-                let at = self.last_redo_at.lock().unwrap().clone();
+                let at = *self.last_redo_at.lock().unwrap();
                 at.and_then(|at| {
                     let age = at.elapsed();
                     // map any chrono errors silently to None here
@@ -694,7 +694,7 @@ impl WalRedoProcess {
             .arg("--wal-redo")
             // the child doesn't process this arg, but, having it in the argv helps indentify the
             // walredo process for a particular tenant when debugging a pagserver
-            .args(&["--tenant-shard-id", &format!("{tenant_shard_id}")])
+            .args(["--tenant-shard-id", &format!("{tenant_shard_id}")])
             .stdin(Stdio::piped())
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())


### PR DESCRIPTION
- log when we start walredo process
- include tenant shard id in walredo argv
- dump some basic walredo state in tenant details api
- more suitable walredo process launch histogram buckets
- avoid duplicate tracing labels in walredo launch spans