### PR TITLE
Minor logging improvements

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -676,7 +676,7 @@ async fn get_lsn_by_timestamp_handler(
     let result = timeline
         .find_lsn_for_timestamp(timestamp_pg, &cancel, &ctx)
         .await?;
-    #[derive(serde::Serialize)]
+    #[derive(serde::Serialize, Debug)]
     struct Result {
         lsn: Lsn,
         kind: &'static str,
@@ -687,7 +687,14 @@ async fn get_lsn_by_timestamp_handler(
         LsnForTimestamp::Past(lsn) => (lsn, "past"),
         LsnForTimestamp::NoData(lsn) => (lsn, "nodata"),
     };
-    json_response(StatusCode::OK, Result { lsn, kind })
+    let result = Result { lsn, kind };
+    tracing::info!(
+        lsn=?result.lsn,
+        kind=result.kind,
+        timestamp = timestamp_raw.into_owned(),
+        "lsn_by_timestamp finished"
+    );
+    json_response(StatusCode::OK, result)
 }
 
 async fn get_timestamp_of_lsn_handler(

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -690,8 +690,8 @@ async fn get_lsn_by_timestamp_handler(
     let result = Result { lsn, kind };
     tracing::info!(
         lsn=?result.lsn,
-        kind=result.kind,
-        timestamp = timestamp_raw.into_owned(),
+        kind=%result.kind,
+        timestamp=%timestamp_raw,
         "lsn_by_timestamp finished"
     );
     json_response(StatusCode::OK, result)

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2828,6 +2828,7 @@ impl Timeline {
     }
 
     /// Flush one frozen in-memory layer to disk, as a new delta layer.
+    #[instrument(skip_all, fields(layer=%frozen_layer))]
     async fn flush_frozen_layer(
         self: &Arc<Self>,
         frozen_layer: Arc<InMemoryLayer>,


### PR DESCRIPTION
* log when `lsn_by_timestamp` finished together with its result
* add back logging of the layer name as suggested in https://github.com/neondatabase/neon/pull/6549#discussion_r1475756808