### PR TITLE
cleanup around `attach`

### DIFF
--- a/libs/utils/src/generation.rs
+++ b/libs/utils/src/generation.rs
@@ -90,6 +90,7 @@ impl Generation {
         }
     }
 
+    #[track_caller]
     pub fn next(&self) -> Generation {
         match self {
             Self::Valid(n) => Self::Valid(*n + 1),

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -500,7 +500,7 @@ async fn timeline_create_handler(
 
         match tenant.create_timeline(
             new_timeline_id,
-            request_data.ancestor_timeline_id.map(TimelineId::from),
+            request_data.ancestor_timeline_id,
             request_data.ancestor_start_lsn,
             request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
             request_data.existing_initdb_timeline_id,

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -488,7 +488,9 @@ async fn timeline_create_handler(
     let state = get_state(&request);
 
     async {
-        let tenant = state.tenant_manager.get_attached_tenant_shard(tenant_shard_id, false)?;
+        let tenant = state
+            .tenant_manager
+            .get_attached_tenant_shard(tenant_shard_id, false)?;
 
         tenant.wait_to_become_active(ACTIVE_TENANT_TIMEOUT).await?;
 
@@ -498,48 +500,62 @@ async fn timeline_create_handler(
             tracing::info!("bootstrapping");
         }
 
-        match tenant.create_timeline(
-            new_timeline_id,
-            request_data.ancestor_timeline_id,
-            request_data.ancestor_start_lsn,
-            request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
-            request_data.existing_initdb_timeline_id,
-            state.broker_client.clone(),
-            &ctx,
-        )
-        .await {
+        match tenant
+            .create_timeline(
+                new_timeline_id,
+                request_data.ancestor_timeline_id,
+                request_data.ancestor_start_lsn,
+                request_data.pg_version.unwrap_or(crate::DEFAULT_PG_VERSION),
+                request_data.existing_initdb_timeline_id,
+                state.broker_client.clone(),
+                &ctx,
+            )
+            .await
+        {
             Ok(new_timeline) => {
                 // Created. Construct a TimelineInfo for it.
-                let timeline_info = build_timeline_info_common(&new_timeline, &ctx, tenant::timeline::GetLogicalSizePriority::User)
-                    .await
-                    .map_err(ApiError::InternalServerError)?;
+                let timeline_info = build_timeline_info_common(
+                    &new_timeline,
+                    &ctx,
+                    tenant::timeline::GetLogicalSizePriority::User,
+                )
+                .await
+                .map_err(ApiError::InternalServerError)?;
                 json_response(StatusCode::CREATED, timeline_info)
             }
             Err(_) if tenant.cancel.is_cancelled() => {
                 // In case we get some ugly error type during shutdown, cast it into a clean 503.
-                json_response(StatusCode::SERVICE_UNAVAILABLE, HttpErrorBody::from_msg("Tenant shutting down".to_string()))
+                json_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    HttpErrorBody::from_msg("Tenant shutting down".to_string()),
+                )
             }
-            Err(tenant::CreateTimelineError::Conflict | tenant::CreateTimelineError::AlreadyCreating) => {
-                json_response(StatusCode::CONFLICT, ())
-            }
-            Err(tenant::CreateTimelineError::AncestorLsn(err)) => {
-                json_response(StatusCode::NOT_ACCEPTABLE, HttpErrorBody::from_msg(
-                    format!("{err:#}")
-                ))
-            }
-            Err(e @ tenant::CreateTimelineError::AncestorNotActive) => {
-                json_response(StatusCode::SERVICE_UNAVAILABLE, HttpErrorBody::from_msg(e.to_string()))
-            }
-            Err(tenant::CreateTimelineError::ShuttingDown) => {
-                json_response(StatusCode::SERVICE_UNAVAILABLE,HttpErrorBody::from_msg("tenant shutting down".to_string()))
-            }
+            Err(
+                tenant::CreateTimelineError::Conflict
+                | tenant::CreateTimelineError::AlreadyCreating,
+            ) => json_response(StatusCode::CONFLICT, ()),
+            Err(tenant::CreateTimelineError::AncestorLsn(err)) => json_response(
+                StatusCode::NOT_ACCEPTABLE,
+                HttpErrorBody::from_msg(format!("{err:#}")),
+            ),
+            Err(e @ tenant::CreateTimelineError::AncestorNotActive) => json_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                HttpErrorBody::from_msg(e.to_string()),
+            ),
+            Err(tenant::CreateTimelineError::ShuttingDown) => json_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                HttpErrorBody::from_msg("tenant shutting down".to_string()),
+            ),
             Err(tenant::CreateTimelineError::Other(err)) => Err(ApiError::InternalServerError(err)),
         }
     }
     .instrument(info_span!("timeline_create",
         tenant_id = %tenant_shard_id.tenant_id,
         shard_id = %tenant_shard_id.shard_slug(),
-        timeline_id = %new_timeline_id, lsn=?request_data.ancestor_start_lsn, pg_version=?request_data.pg_version))
+        timeline_id = %new_timeline_id,
+        lsn=?request_data.ancestor_start_lsn,
+        pg_version=?request_data.pg_version
+    ))
     .await
 }
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -4050,7 +4050,6 @@ pub(crate) mod harness {
             info_span!("TenantHarness", tenant_id=%self.tenant_shard_id.tenant_id, shard_id=%self.tenant_shard_id.shard_slug())
         }
 
-        #[cfg(test)]
         pub(crate) async fn load(&self) -> (Arc<Tenant>, RequestContext) {
             let ctx = RequestContext::new(TaskKind::UnitTest, DownloadBehavior::Error);
             (
@@ -4160,7 +4159,6 @@ pub(crate) mod harness {
     }
 
     // Mock WAL redo manager that doesn't do much
-    #[cfg(test)]
     pub(crate) struct TestRedoManager;
 
     impl TestRedoManager {

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -4063,7 +4063,6 @@ pub(crate) mod harness {
 
         /// For tests that specifically want to exercise the local load path, which does
         /// not use remote storage.
-        #[cfg(test)]
         pub(crate) async fn try_load_local(
             &self,
             ctx: &RequestContext,
@@ -4072,7 +4071,6 @@ pub(crate) mod harness {
         }
 
         /// The 'load' in this function is either a local load or a normal attachment,
-        #[cfg(test)]
         pub(crate) async fn try_load(&self, ctx: &RequestContext) -> anyhow::Result<Arc<Tenant>> {
             // If we have nothing in remote storage, must use load_local instead of attach: attach
             // will error out if there are no timelines.
@@ -4087,8 +4085,7 @@ pub(crate) mod harness {
             self.do_try_load(ctx, mode).await
         }
 
-        #[cfg(test)]
-        #[instrument(skip_all, fields(tenant_id=%self.tenant_shard_id.tenant_id, shard_id=%self.tenant_shard_id.shard_slug(), ?mode))]
+        #[instrument(skip_all, fields(?mode))]
         async fn do_try_load(
             &self,
             ctx: &RequestContext,
@@ -4132,7 +4129,6 @@ pub(crate) mod harness {
             Ok(tenant)
         }
 
-        #[cfg(test)]
         fn remote_empty(&self) -> bool {
             let tenant_path = self.conf.tenant_path(&self.tenant_shard_id);
             let remote_tenant_dir = self

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -644,10 +644,10 @@ impl Tenant {
 
         // The attach task will carry a GateGuard, so that shutdown() reliably waits for it to drop out if
         // we shut down while attaching.
-        let Ok(attach_gate_guard) = tenant.gate.enter() else {
-            // We just created the Tenant: nothing else can have shut it down yet
-            unreachable!();
-        };
+        let attach_gate_guard = tenant
+            .gate
+            .enter()
+            .expect("We just created the Tenant: nothing else can have shut it down yet");
 
         // Do all the hard work in the background
         let tenant_clone = Arc::clone(&tenant);

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -761,7 +761,7 @@ impl Tenant {
                     },
                     (SpawnMode::Normal, Some(remote_storage)) => {
                         let _preload_timer = TENANT.preload.start_timer();
-                        let span = tracing::info_span!(parent: None, "attach_preload", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug());
+                        let span = tracing::info_span!("attach_preload");
                         let res = tenant_clone
                             .preload(remote_storage, task_mgr::shutdown_token())
                             .instrument(span)
@@ -883,6 +883,7 @@ impl Tenant {
         remote_storage: &GenericRemoteStorage,
         cancel: CancellationToken,
     ) -> anyhow::Result<TenantPreload> {
+        span::debug_assert_current_span_has_tenant_id();
         // Get list of remote timelines
         // download index files for every tenant timeline
         info!("listing remote timelines");

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -811,21 +811,20 @@ impl Tenant {
                         info!("ready for backgound jobs barrier");
                     }
 
-                    match DeleteTenantFlow::resume_from_attach(
+                    let deleted = DeleteTenantFlow::resume_from_attach(
                         deletion,
                         &tenant_clone,
                         preload,
                         tenants,
                         &ctx,
                     )
-                    .await
-                    {
-                        Err(err) => {
-                            make_broken(&tenant_clone, anyhow::anyhow!(err));
-                            return Ok(());
-                        }
-                        Ok(()) => return Ok(()),
+                    .await;
+
+                    if let Err(e) = deleted {
+                        make_broken(&tenant_clone, anyhow::anyhow!(e));
                     }
+
+                    return Ok(());
                 }
 
                 // We will time the duration of the attach phase unless this is a creation (attach will do no work)

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -763,12 +763,11 @@ impl Tenant {
                         None
                     },
                     (SpawnMode::Normal, Some(remote_storage)) => {
+                        let span = tracing::info_span!(parent: None, "attach_preload", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug());
                         Some(
                             match tenant_clone
                                 .preload(remote_storage, task_mgr::shutdown_token())
-                                .instrument(
-                                    tracing::info_span!(parent: None, "attach_preload", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug()),
-                                )
+                                .instrument(span)
                                 .await {
                                     Ok(p) => {
                                         preload_timer.observe_duration();

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -765,22 +765,19 @@ impl Tenant {
                     (SpawnMode::Normal, Some(remote_storage)) => {
                         let span = tracing::info_span!(parent: None, "attach_preload", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug());
                         let res = tenant_clone
-                                .preload(remote_storage, task_mgr::shutdown_token())
-                                .instrument(span)
-                                .await;
-                        Some(
-                            match res {
-                                    Ok(p) => {
-                                        preload_timer.observe_duration();
-                                        p
-                                    }
-                                        ,
-                                    Err(e) => {
-                                        make_broken(&tenant_clone, anyhow::anyhow!(e));
-                                            return Ok(());
-                                    }
-                                },
-                        )
+                            .preload(remote_storage, task_mgr::shutdown_token())
+                            .instrument(span)
+                            .await;
+                        match res {
+                            Ok(p) => {
+                                preload_timer.observe_duration();
+                                Some(p)
+                            },
+                            Err(e) => {
+                                make_broken(&tenant_clone, anyhow::anyhow!(e));
+                                return Ok(());
+                            }
+                        }
                     }
                     (SpawnMode::Normal, None) => {
                         None

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -863,11 +863,7 @@ impl Tenant {
 
                 Ok(())
             }
-            .instrument({
-                let span = tracing::info_span!(parent: None, "attach", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug(), gen=?generation);
-                span.follows_from(Span::current());
-                span
-            }),
+            .instrument(tracing::info_span!(parent: None, "attach", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug(), gen=?generation)),
         );
         Ok(tenant)
     }

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -4085,7 +4085,7 @@ pub(crate) mod harness {
             self.do_try_load(ctx, mode).await
         }
 
-        #[instrument(skip_all, fields(?mode))]
+        #[instrument(skip_all, fields(tenant_id=%self.tenant_shard_id.tenant_id, shard_id=%self.tenant_shard_id.shard_slug(), ?mode))]
         async fn do_try_load(
             &self,
             ctx: &RequestContext,

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -764,11 +764,12 @@ impl Tenant {
                     },
                     (SpawnMode::Normal, Some(remote_storage)) => {
                         let span = tracing::info_span!(parent: None, "attach_preload", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug());
-                        Some(
-                            match tenant_clone
+                        let res = tenant_clone
                                 .preload(remote_storage, task_mgr::shutdown_token())
                                 .instrument(span)
-                                .await {
+                                .await;
+                        Some(
+                            match res {
                                     Ok(p) => {
                                         preload_timer.observe_duration();
                                         p

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -855,15 +855,9 @@ impl Tenant {
                 // logical size calculations: if logical size calculation semaphore is saturated,
                 // then warmup will wait for that before proceeding to the next tenant.
                 if let AttachType::Warmup(_permit) = attach_type {
-                    let mut futs = FuturesUnordered::new();
-                    let timelines: Vec<_> = tenant_clone.timelines.lock().unwrap().values().cloned().collect();
-                    for t in timelines {
-                        futs.push(t.await_initial_logical_size())
-                    }
+                    let mut futs: FuturesUnordered<_> = tenant_clone.timelines.lock().unwrap().values().cloned().map(|t| t.await_initial_logical_size()).collect();
                     tracing::info!("Waiting for initial logical sizes while warming up...");
-                    while futs.next().await.is_some() {
-
-                    }
+                    while futs.next().await.is_some() {}
                     tracing::info!("Warm-up complete");
                 }
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -761,10 +761,9 @@ impl Tenant {
                     },
                     (SpawnMode::Normal, Some(remote_storage)) => {
                         let _preload_timer = TENANT.preload.start_timer();
-                        let span = tracing::info_span!("attach_preload");
                         let res = tenant_clone
                             .preload(remote_storage, task_mgr::shutdown_token())
-                            .instrument(span)
+                            .instrument(tracing::info_span!("attach_preload"))
                             .await;
                         match res {
                             Ok(p) => Some(p),

--- a/pageserver/src/tenant/delete.rs
+++ b/pageserver/src/tenant/delete.rs
@@ -496,11 +496,7 @@ impl DeleteTenantFlow {
                 };
                 Ok(())
             }
-            .instrument({
-                let span = tracing::info_span!(parent: None, "delete_tenant", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug());
-                span.follows_from(Span::current());
-                span
-            }),
+            .instrument(tracing::info_span!(parent: None, "delete_tenant", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug())),
         );
     }
 

--- a/pageserver/src/tenant/delete.rs
+++ b/pageserver/src/tenant/delete.rs
@@ -6,7 +6,7 @@ use pageserver_api::{models::TenantState, shard::TenantShardId};
 use remote_storage::{GenericRemoteStorage, RemotePath};
 use tokio::sync::OwnedMutexGuard;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, instrument, Instrument, Span};
+use tracing::{error, instrument, Instrument};
 
 use utils::{backoff, completion, crashsafe, fs_ext, id::TimelineId};
 

--- a/pageserver/src/tenant/timeline/delete.rs
+++ b/pageserver/src/tenant/timeline/delete.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::Context;
 use pageserver_api::{models::TimelineState, shard::TenantShardId};
 use tokio::sync::OwnedMutexGuard;
-use tracing::{debug, error, info, instrument, warn, Instrument, Span};
+use tracing::{debug, error, info, instrument, warn, Instrument};
 use utils::{crashsafe, fs_ext, id::TimelineId};
 
 use crate::{

--- a/pageserver/src/tenant/timeline/delete.rs
+++ b/pageserver/src/tenant/timeline/delete.rs
@@ -541,12 +541,7 @@ impl DeleteTimelineFlow {
                 };
                 Ok(())
             }
-            .instrument({
-                let span =
-                    tracing::info_span!(parent: None, "delete_timeline", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug(),timeline_id=%timeline_id);
-                span.follows_from(Span::current());
-                span
-            }),
+            .instrument(tracing::info_span!(parent: None, "delete_timeline", tenant_id=%tenant_shard_id.tenant_id, shard_id=%tenant_shard_id.shard_slug(),timeline_id=%timeline_id)),
         );
     }
 


### PR DESCRIPTION
The smaller changes I found while looking around #6584.

- rustfmt was not able to format handle_timeline_create
- fix Generation::get_suffix always allocating
- Generation was missing a `#[track_caller]` for panicky method
- attach has a lot of issues, but even with this PR it cannot be formatted by rustfmt
- moved the `preload` span to be on top of `attach` -- it is awaited inline
- make disconnected panic! or unreachable! into expect, expect_err