### PR TITLE
refactor: move DeltaLayerWriter::finish S3_UPLOAD_LIMIT check upstack

### DIFF
--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -39,7 +39,7 @@ use crate::tenant::Timeline;
 use crate::virtual_file::{self, VirtualFile};
 use crate::{walrecord, TEMP_FILE_SUFFIX};
 use crate::{DELTA_FILE_MAGIC, STORAGE_FORMAT_VERSION};
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use pageserver_api::models::LayerAccessKind;
 use pageserver_api::shard::TenantShardId;
@@ -488,17 +488,6 @@ impl DeltaLayerWriterInner {
             .metadata()
             .await
             .context("get file metadata to determine size")?;
-
-        // 5GB limit for objects without multipart upload (which we don't want to use)
-        // Make it a little bit below to account for differing GB units
-        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html
-        const S3_UPLOAD_LIMIT: u64 = 4_500_000_000;
-        ensure!(
-            metadata.len() <= S3_UPLOAD_LIMIT,
-            "Created delta layer file at {} of size {} above limit {S3_UPLOAD_LIMIT}!",
-            file.path,
-            metadata.len()
-        );
 
         // Note: Because we opened the file in write-only mode, we cannot
         // reuse the same VirtualFile for reading later. That's why we don't


### PR DESCRIPTION
Before this PR, when we failed the S3_UPLOAD_LIMIT check, we'd leave the temp file on disk without cleaning it up, higher level code would retry flushing the layer, quickly exhausting local disk space.

PR #6612, which was merged concurrently, added error handling to `DeltaLayerWriter::finish` to clean up the temp file.

However, it didn't address the fact that actually, `finish()` is the wrong abstraction level for the S3_UPLOAD_LIMIT check.
**Writing the delta layer _file_ finished _fine_. It's just that we don't like its size. But we shouldn't implement size policy / assumptions at that low level.**

So, this PR moves the S3_UPLOAD_LIMIT to the callers, which are at the abstraction level where we do care about this size policy, i.e., where we actually start using the `struct Layer` instead of just the layer _file_, schedule an upload for it, etc.

With regard to the original issue, the `finish()` call will now succeed, but the size limit check will still fail.
So, nothing about handling of the fundamental issue changes of us writing putting too much data into the layer. That's for #6624 to solve.

Related:
- fix the leakage: #6623
- fix the root cause: #6624

