### PR TITLE
Introduce a warning threshold for large values

### DIFF
--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -33,6 +33,9 @@ impl Value {
     }
 }
 
+/// The maximum size of a value supported by the pageserver
+pub const MAX_VALUE_SIZE: usize = 10_000_000;
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
The pageserver is not well equipped to store large values, and it was never designed for them. A lot of large values in succession can cause bad issues (#6624), and we don't support splitting up values across multiple layer files so we cannot store values of sizes like 5 GB.
 
This adds a warning for large values.