### PR TITLE
fix(heavier_once_cell): assertion failure can be hit

### DIFF
--- a/libs/utils/src/sync/heavier_once_cell.rs
+++ b/libs/utils/src/sync/heavier_once_cell.rs
@@ -297,6 +297,7 @@ pub struct InitPermit(Arc<tokio::sync::Semaphore>);
 
 impl Drop for InitPermit {
     fn drop(&mut self) {
+        debug_assert_eq!(self.0.available_permits(), 0);
         self.0.add_permits(1);
     }
 }


### PR DESCRIPTION
@problame noticed that the `tokio::sync::AcquireError` branch assertion can be hit like in the first commit. We haven't seen this yet in production, but I'd prefer not to see it there. There `take_and_deinit` is being used, but this race must be quite timing sensitive.