### PR TITLE
Add workaround for macOS >= 14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ brew install protobuf openssl flex bison icu4c pkg-config
 echo 'export PATH="$(brew --prefix openssl)/bin:$PATH"' >> ~/.zshrc
 ```
 
+On macOS >= 14.2, to workaround `FATAL:  postmaster became multithreaded during startup` [issue](https://www.postgresql.org/message-id/flat/CYMBV0OT7216.JNRUO6R6GH86%40neon.tech):
+```
+brew install bayandin/tap/curl-without-ipv6
+```
+
 2. [Install Rust](https://www.rust-lang.org/tools/install)
 ```
 # recommended approach from https://www.rust-lang.org/tools/install

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ echo 'export PATH="$(brew --prefix openssl)/bin:$PATH"' >> ~/.zshrc
 
 On macOS >= 14.2, to workaround `FATAL:  postmaster became multithreaded during startup` [issue](https://www.postgresql.org/message-id/flat/CYMBV0OT7216.JNRUO6R6GH86%40neon.tech):
 ```
-brew install bayandin/tap/curl-without-ipv6
+brew install neondatabase/tap/curl-without-ipv6
 ```
 
 2. [Install Rust](https://www.rust-lang.org/tools/install)

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -584,7 +584,7 @@ impl Endpoint {
         // if `shared_preload_libraries` contains a library that linked to libcurl.
         // A possible workaround is use libcurl built without IPv6 support and set proper `DYLD_LIBRARY_PATH`.
         //
-        // Such curl can be installed via `brew install bayandin/tap/curl-without-ipv6`.
+        // Such curl can be installed via `brew install neondatabase/tap/curl-without-ipv6`.
         // If it is not installed, the code is basically a no-op.
         //
         // Ref: https://www.postgresql.org/message-id/flat/CYMBV0OT7216.JNRUO6R6GH86%40neon.tech


### PR DESCRIPTION
## Problem

On macOS >= 14.2 Postgres fails to start with `FATAL:  postmaster became multithreaded during startup`, for details see a comment in `control_plane/src/endpoint.rs` and the following threads:

- pgsql-hackers [thread](https://www.postgresql.org/message-id/flat/CYMBV0OT7216.JNRUO6R6GH86%40neon.tech) 
- Internal [thread](https://neondb.slack.com/archives/C036U0GRMRB/p1703247015380189?thread_ts=1702600432.661789&cid=C036U0GRMRB) 

## Summary of changes
- Recommend installing `brew install neondatabase/tap/curl-without-ipv6` on macOS >= 14.2
- Add `curl-without-ipv6` to `DYLD_LIBRARY_PATH`

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
