### PR TITLE
Create rel_dir when database is created from WAL

### DIFF
--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -989,6 +989,17 @@ impl<'a> DatadirModification<'a> {
         Ok(())
     }
 
+    pub async fn create_rel_dir(&mut self, spcnode: Oid, dbnode: Oid) -> anyhow::Result<()> {
+        let buf = RelDirectory::ser(&RelDirectory {
+            rels: HashSet::new(),
+        })?;
+        self.put(
+            rel_dir_to_key(spcnode, dbnode),
+            Value::Image(Bytes::from(buf)),
+        );
+        Ok(())
+    }
+
     /// Store a relmapper file (pg_filenode.map) in the repository
     pub async fn put_relmap_file(
         &mut self,
@@ -1167,9 +1178,6 @@ impl<'a> DatadirModification<'a> {
             // Update the entry with the new size.
             let buf = nblocks.to_le_bytes();
             self.put(size_key, Value::Image(Bytes::from(buf.to_vec())));
-
-            // Update relation size cache
-            self.tline.set_cached_rel_size(rel, self.lsn, nblocks);
 
             // Update relation size cache
             self.tline.set_cached_rel_size(rel, self.lsn, nblocks);

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -156,6 +156,10 @@ impl WalIngest {
                     }
                 } else if pg_version == 15 {
                     if info == postgres_ffi::v15::bindings::XLOG_DBASE_CREATE_WAL_LOG {
+                        let createdb = XlCreateDatabaseFromWal::decode(&mut buf);
+                        modification
+                            .create_rel_dir(createdb.tablespace_id, createdb.db_id)
+                            .await?;
                         debug!("XLOG_DBASE_CREATE_WAL_LOG: noop");
                     } else if info == postgres_ffi::v15::bindings::XLOG_DBASE_CREATE_FILE_COPY {
                         // The XLOG record was renamed between v14 and v15,
@@ -176,6 +180,10 @@ impl WalIngest {
                     }
                 } else if pg_version == 16 {
                     if info == postgres_ffi::v16::bindings::XLOG_DBASE_CREATE_WAL_LOG {
+                        let createdb = XlCreateDatabaseFromWal::decode(&mut buf);
+                        modification
+                            .create_rel_dir(createdb.tablespace_id, createdb.db_id)
+                            .await?;
                         debug!("XLOG_DBASE_CREATE_WAL_LOG: noop");
                     } else if info == postgres_ffi::v16::bindings::XLOG_DBASE_CREATE_FILE_COPY {
                         // The XLOG record was renamed between v14 and v15,

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -523,6 +523,22 @@ impl XlCreateDatabase {
 
 #[repr(C)]
 #[derive(Debug)]
+pub struct XlCreateDatabaseFromWal {
+    pub db_id: Oid,
+    pub tablespace_id: Oid,
+}
+
+impl XlCreateDatabaseFromWal {
+    pub fn decode(buf: &mut Bytes) -> XlCreateDatabaseFromWal {
+        XlCreateDatabaseFromWal {
+            db_id: buf.get_u32_le(),
+            tablespace_id: buf.get_u32_le(),
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
 pub struct XlDropDatabase {
     pub db_id: Oid,
     pub n_tablespaces: Oid, /* number of tablespace IDs */


### PR DESCRIPTION
## Problem

See https://github.com/neondatabase/neon/issues/6674

FSM page can be accessed before rel_dir is initialized for the database

## Summary of changes

Create rel_dir when database is create from WAL

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
