### PR TITLE
Create timeout on proxy<->cplane communication

### DIFF
--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -92,7 +92,7 @@ struct ProxyCliArgs {
     #[clap(long, default_value = "15s", value_parser = humantime::parse_duration)]
     handshake_timeout: tokio::time::Duration,
     /// timeout for the control plane requests
-    #[clap(long, default_value = "15s", value_parser = humantime::parse_duration)]
+    #[clap(long, default_value = "70s", value_parser = humantime::parse_duration)]
     cplane_timeout: tokio::time::Duration,
     /// http endpoint to receive periodic metric updates
     #[clap(long)]

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -19,10 +19,14 @@ use reqwest_middleware::RequestBuilder;
 /// This is the preferred way to create new http clients,
 /// because it takes care of observability (OpenTelemetry).
 /// We deliberately don't want to replace this with a public static.
-pub fn new_client(rate_limiter_config: rate_limiter::RateLimiterConfig) -> ClientWithMiddleware {
+pub fn new_client(
+    rate_limiter_config: rate_limiter::RateLimiterConfig,
+    timeout: Duration,
+) -> ClientWithMiddleware {
     let client = reqwest::ClientBuilder::new()
         .dns_resolver(Arc::new(GaiResolver::default()))
         .connection_verbose(true)
+        .timeout(timeout)
         .build()
         .expect("Failed to create http client");
 

--- a/proxy/src/usage_metrics.rs
+++ b/proxy/src/usage_metrics.rs
@@ -237,6 +237,7 @@ mod tests {
     use std::{
         net::TcpListener,
         sync::{Arc, Mutex},
+        time::Duration,
     };
 
     use anyhow::Error;
@@ -279,7 +280,7 @@ mod tests {
         tokio::spawn(server);
 
         let metrics = Metrics::default();
-        let client = http::new_client(RateLimiterConfig::default());
+        let client = http::new_client(RateLimiterConfig::default(), Duration::from_secs(15));
         let endpoint = Url::parse(&format!("http://{addr}")).unwrap();
         let now = Utc::now();
 


### PR DESCRIPTION
## Problem

There is no timeout on the communication between proxy and cplane

## Summary of changes

Set up timeout with the default value to 70s (it's 60s on the cplane side)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
