### PR TITLE
pageserver: shard splitting refinements (parent deletion, hard linking)

### DIFF
--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -1570,8 +1570,6 @@ impl TenantManager {
             let timelines = parent_shard.timelines.lock().unwrap().clone();
             let parent_timelines = timelines.keys().cloned().collect::<Vec<_>>();
             for timeline in timelines.values() {
-                // let timeline_layers_stream = timeline.layers.read().await.resident_layers();
-                // let timeline_layers = timeline_layers_stream.collect::<Vec<_>>().await;
                 let timeline_layers = timeline
                     .layers
                     .read()

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -1603,7 +1603,9 @@ impl TenantManager {
 
             // Since we will do a large number of small filesystem metadata operations, batch them into
             // spawn_blocking calls rather than doing each one as a tokio::fs round-trip.
+            let span = tracing::info_span!("link_layers", child=%child.shard_id);
             let jh = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+                let _e = span.entered();
                 for dir in create_dirs {
                     if let Err(e) = std::fs::create_dir_all(&dir) {
                         // Ignore AlreadyExists errors, drop out on all other errors

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -1585,6 +1585,7 @@ impl TenantManager {
                     parent_layers.push(relative_path.to_owned());
                 }
             }
+            debug_assert!(!parent_layers.is_empty(), "shutdown cannot empty the layermap");
             (parent_timelines, parent_layers)
         };
         for child in child_shards {

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -1564,6 +1564,8 @@ impl TenantManager {
         parent_shard: &Tenant,
         child_shards: Vec<TenantShardId>,
     ) -> anyhow::Result<()> {
+        debug_assert_current_span_has_tenant_id();
+
         let parent_path = self.conf.tenant_path(parent_shard.get_tenant_shard_id());
         let (parent_timelines, parent_layers) = {
             let mut parent_layers = Vec::new();

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -1643,9 +1643,9 @@ impl TenantManager {
             match jh.await {
                 Ok(Ok(())) => {
                     tracing::info!(
-                        "Linked {} layers into child shard {}",
-                        parent_layers.len(),
-                        child
+                        count=parent_layers.len(),
+                        child=shard.shard_id,
+                        "Hard-linked layers into child shard",
                     );
                 }
                 Ok(Err(e)) => {

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -1603,7 +1603,7 @@ impl TenantManager {
 
             // Since we will do a large number of small filesystem metadata operations, batch them into
             // spawn_blocking calls rather than doing each one as a tokio::fs round-trip.
-            let span = tracing::info_span!("link_layers", child=%child.shard_id);
+            let span = tracing::info_span!("link_layers", tenant_id=%child.tenant_id, shard_id=%child.shard_slug());
             let jh = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
                 let _e = span.entered();
                 for dir in create_dirs {
@@ -1645,8 +1645,9 @@ impl TenantManager {
             match jh.await {
                 Ok(Ok(())) => {
                     tracing::info!(
-                        count=parent_layers.len(),
-                        child=shard.shard_id,
+                        count = parent_layers.len(),
+                        tenant_id = %child.tenant_id,
+                        shard_id = %child.shard_slug(),
                         "Hard-linked layers into child shard",
                     );
                 }

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -2,6 +2,7 @@
 //! page server.
 
 use camino::{Utf8DirEntry, Utf8Path, Utf8PathBuf};
+use futures::stream::StreamExt;
 use itertools::Itertools;
 use pageserver_api::key::Key;
 use pageserver_api::models::ShardParameters;
@@ -31,7 +32,6 @@ use crate::control_plane_client::{
     ControlPlaneClient, ControlPlaneGenerationsApi, RetryForeverError,
 };
 use crate::deletion_queue::DeletionQueueClient;
-use crate::disk_usage_eviction_task::EvictionLayer;
 use crate::metrics::{TENANT, TENANT_MANAGER as METRICS};
 use crate::task_mgr::{self, TaskKind};
 use crate::tenant::config::{
@@ -1570,17 +1570,16 @@ impl TenantManager {
             let timelines = parent_shard.timelines.lock().unwrap().clone();
             let parent_timelines = timelines.keys().cloned().collect::<Vec<_>>();
             for timeline in timelines.values() {
-                let timeline_layers = timeline.get_local_layers_for_disk_usage_eviction().await;
-                for layer in timeline_layers.resident_layers.into_iter().map(|r| r.layer) {
-                    let layer = match layer {
-                        EvictionLayer::Attached(l) => l,
-                        EvictionLayer::Secondary(_) => {
-                            // Unreachable, because we fetched layers from an object of type `Tenant`, it can
-                            // only return attached layers
-                            unreachable!();
-                        }
-                    };
-
+                // let timeline_layers_stream = timeline.layers.read().await.resident_layers();
+                // let timeline_layers = timeline_layers_stream.collect::<Vec<_>>().await;
+                let timeline_layers = timeline
+                    .layers
+                    .read()
+                    .await
+                    .resident_layers()
+                    .collect::<Vec<_>>()
+                    .await;
+                for layer in timeline_layers {
                     let relative_path = layer
                         .local_path()
                         .strip_prefix(&parent_path)

--- a/test_runner/regress/test_sharding.py
+++ b/test_runner/regress/test_sharding.py
@@ -194,6 +194,18 @@ def test_sharding_split_smoke(
 
     assert len(pre_split_pageserver_ids) == 4
 
+    def shards_on_disk(shard_ids):
+        for pageserver in env.pageservers:
+            for shard_id in shard_ids:
+                if pageserver.tenant_dir(shard_id).exists():
+                    return True
+
+        return False
+
+    old_shard_ids = [TenantShardId(tenant_id, i, shard_count) for i in range(0, shard_count)]
+    # Before split, old shards exist
+    assert shards_on_disk(old_shard_ids)
+
     env.attachment_service.tenant_shard_split(tenant_id, shard_count=split_shard_count)
 
     post_split_pageserver_ids = [loc["node_id"] for loc in env.attachment_service.locate(tenant_id)]
@@ -201,6 +213,9 @@ def test_sharding_split_smoke(
     assert len(post_split_pageserver_ids) == split_shard_count
     assert len(set(post_split_pageserver_ids)) == shard_count
     assert set(post_split_pageserver_ids) == set(pre_split_pageserver_ids)
+
+    # The old parent shards should no longer exist on disk
+    assert not shards_on_disk(old_shard_ids)
 
     workload.validate()
 


### PR DESCRIPTION
## Problem

- We weren't deleting parent shard contents once the split was done
- Re-downloading layers into child shards is wasteful

## Summary of changes

- Hard-link layers into child chart local storage during split
- Delete parent shards content at the end

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
