### PR TITLE
pageserver: circuit breakers on pathological amplification, repeated compaction failures

### DIFF
--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -400,6 +400,11 @@ impl PageServerNode {
                 .map(|x| x.parse::<bool>())
                 .transpose()
                 .context("Failed to parse 'lazy_slru_download' as bool")?,
+            enforce_circuit_breakers: settings
+                .remove("enforce_circuit_breakers")
+                .map(|x| x.parse::<bool>())
+                .transpose()
+                .context("Failed to parse 'enforce_circuit_breakers' as bool")?,
         };
         if !settings.is_empty() {
             bail!("Unrecognized tenant settings: {settings:?}")
@@ -505,6 +510,11 @@ impl PageServerNode {
                     .map(|x| x.parse::<bool>())
                     .transpose()
                     .context("Failed to parse 'lazy_slru_download' as bool")?,
+                enforce_circuit_breakers: settings
+                    .remove("enforce_circuit_breakers")
+                    .map(|x| x.parse::<bool>())
+                    .transpose()
+                    .context("Failed to parse 'enforce_circuit_breakers' as bool")?,
             }
         };
 

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -283,6 +283,7 @@ pub struct TenantConfig {
     pub gc_feedback: Option<bool>,
     pub heatmap_period: Option<String>,
     pub lazy_slru_download: Option<bool>,
+    pub enforce_circuit_breakers: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/libs/utils/src/circuit_breaker.rs
+++ b/libs/utils/src/circuit_breaker.rs
@@ -1,0 +1,90 @@
+use std::time::{Duration, Instant};
+
+/// Circuit breakers are for operations that are expensive and fallible: if they fail repeatedly,
+/// we will stop attempting them for some period of time, to avoid denial-of-service from retries, and
+/// to mitigate the log spam from repeated failures.
+pub struct CircuitBreaker {
+    /// Consecutive failures since last success
+    fail_count: usize,
+
+    /// How many consecutive failures before we break the circuit
+    fail_threshold: usize,
+
+    /// If circuit is broken, when was it broken?
+    broken_at: Option<Instant>,
+
+    /// If set, we will auto-reset the circuit this long after it was broken.  If None, broken
+    /// circuits stay broken forever, or until success() is called.
+    reset_period: Option<Duration>,
+
+    /// If this is true, no actual circuit-breaking happens.  This is for overriding a circuit breaker
+    /// to permit something to keep running even if it would otherwise have tripped it.
+    short_circuit: bool,
+}
+
+impl CircuitBreaker {
+    pub fn new(fail_threshold: usize, reset_period: Option<Duration>) -> Self {
+        Self {
+            fail_count: 0,
+            fail_threshold,
+            broken_at: None,
+            reset_period,
+            short_circuit: false,
+        }
+    }
+
+    pub fn short_circuit() -> Self {
+        Self {
+            fail_threshold: 0,
+            fail_count: 0,
+            broken_at: None,
+            reset_period: None,
+            short_circuit: true,
+        }
+    }
+
+    pub fn fail(&mut self) {
+        if self.short_circuit {
+            return;
+        }
+
+        self.fail_count += 1;
+        if self.broken_at.is_none() && self.fail_count >= self.fail_threshold {
+            self.break_circuit();
+        }
+    }
+
+    /// Call this after successfully executing an operation
+    pub fn success(&mut self) {
+        self.fail_count = 0;
+        self.broken_at = None;
+    }
+
+    /// Call this before attempting an operation, and skip the operation if we are currently broken.
+    pub fn is_broken(&mut self) -> bool {
+        if self.short_circuit {
+            return false;
+        }
+
+        if let Some(broken_at) = self.broken_at {
+            match self.reset_period {
+                Some(reset_period) if broken_at.elapsed() > reset_period => {
+                    self.reset_circuit();
+                    false
+                }
+                _ => true,
+            }
+        } else {
+            false
+        }
+    }
+
+    fn break_circuit(&mut self) {
+        self.broken_at = Some(Instant::now())
+    }
+
+    fn reset_circuit(&mut self) {
+        self.broken_at = None;
+        self.fail_count = 0;
+    }
+}

--- a/libs/utils/src/lib.rs
+++ b/libs/utils/src/lib.rs
@@ -87,6 +87,8 @@ pub mod failpoint_support;
 
 pub mod yielding_loop;
 
+pub mod circuit_breaker;
+
 /// This is a shortcut to embed git sha into binaries and avoid copying the same build script to all packages
 ///
 /// we have several cases:

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1655,6 +1655,17 @@ impl Timeline {
         ));
     }
 
+    /// For terminating wal ingestion without tearing down the rest of the Timeline (i.e. reads to
+    /// already ingested data should still work)
+    pub(super) async fn kill_wal_receiver(&self) {
+        task_mgr::shutdown_tasks(
+            Some(TaskKind::WalReceiverManager),
+            Some(self.tenant_shard_id),
+            Some(self.timeline_id),
+        )
+        .await;
+    }
+
     /// Initialize with an empty layer map. Used when creating a new timeline.
     pub(super) fn init_empty_layer_map(&self, start_lsn: Lsn) {
         let mut layers = self.layers.try_write().expect(

--- a/test_runner/regress/test_attach_tenant_config.py
+++ b/test_runner/regress/test_attach_tenant_config.py
@@ -174,6 +174,7 @@ def test_fully_custom_config(positive_env: NeonEnv):
         "pitr_interval": "1m",
         "lagging_wal_timeout": "23m",
         "lazy_slru_download": True,
+        "enforce_circuit_breakers": True,
         "max_lsn_wal_lag": 230000,
         "min_resident_size_override": 23,
         "trace_read_requests": True,


### PR DESCRIPTION
## Problem

See ticket: #6738 

Under some circumstances, a misbehaving postgres can create problems for the pageserver:
- Writing corrupt data can cause pageserver to emit endless warnings when trying to compact
- Writing WAL contents that generate pathologically large physical state.

To avoid impact on other tenants on the pageserver, and to help find issues sooner, the pageserver should take action against tenants that are misbehaving in these ways.

## Summary of changes

- Add `enforce_circuit_breakers` tenant config.  Defaulting to false for the first deployment of this.  Later we will set it to true by default, and it will only be set to false during an incident if we actively want a particular tenant to be permitted to violate limits.
- During tenant compaction, check storage amplification and halt WAL ingress if it violates a threshold (1000x)
- Add a `CircuitBreaker` type for counting failures and disabling an operation after too many failures
- Use a `CircuitBreaker` for tenant compaction, with a policy that after 5 failures we'll give up trying to compact for an hour.

**Why not use the `failsafe` crate?** -- it uses a mutex internally, and when we use one of these circuit breakers on e.g. a page request path, that is too much overhead (though we use a mutex in the compaction case, as this is called infrequently)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
