### PR TITLE
for #6743 (walredo benches to async): finish the change

### DIFF
--- a/pageserver/benches/bench_walredo.rs
+++ b/pageserver/benches/bench_walredo.rs
@@ -101,10 +101,10 @@ fn add_multithreaded_walredo_requesters(
 
     let cancel = CancellationToken::new();
 
-    let barrier = Arc::new(tokio::sync::Barrier::new(requesters as usize + 1));
+    let barrier = Arc::new(tokio::sync::Barrier::new(requesters + 1));
 
     let jhs = (0..requesters)
-        .map(|requester| {
+        .map(|_| {
             let manager = manager.clone();
             let barrier = barrier.clone();
             let cancel = cancel.clone();
@@ -120,9 +120,7 @@ fn add_multithreaded_walredo_requesters(
                 };
                 tokio::select! {
                     _ = work_loop => {},
-                    _ = cancel.cancelled() => {
-                        return;
-                    }
+                    _ = cancel.cancelled() => { }
                 }
             })
         })


### PR DESCRIPTION
This PR finishes the work started by https://github.com/calinanca99 in  https://github.com/neondatabase/neon/pull/6743

- always use default worker thread count & explain rationale behind that
- fix deadlocks caused by remaining sync primitive
- increase thread counts
