### PR TITLE
Stop postgres in immediate mode in VM image.

### DIFF
--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -18,7 +18,7 @@ commands:
     sysvInitAction: respawn
     shell: '/bin/sql_exporter -config.file=/etc/sql_exporter.yml'
 shutdownHook: |
-  su -p postgres --session-command '/usr/local/bin/pg_ctl stop -D /var/db/postgres/compute/pgdata -m fast --wait -t 10'
+  su -p postgres --session-command '/usr/local/bin/pg_ctl stop -D /var/db/postgres/compute/pgdata -m immediate --wait -t 10'
 files:
   - filename: pgbouncer.ini
     content: |


### PR DESCRIPTION
PR #6712 might add a delay in graceful shutdown without change to compute -> sk protocol to force sync of control file on safekeeper to persist commit_lsn, so use 'immediate' mode instead; 'fast' one isn't useful for neon anyway.
