### PR TITLE
fix(build): production flamegraphs are useless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY --chown=nonroot . .
 # Show build caching stats to check if it was used in the end.
 # Has to be the part of the same RUN since cachepot daemon is killed in the end of this RUN, losing the compilation stats.
 RUN set -e \
-    && mold -run cargo build  \
+    && RUSTFLAGS="-Clinker=clang -Clink-arg=-fuse-ld=mold -Clink-arg=-Wl,--no-rosegment" cargo build  \
       --bin pg_sni_router  \
       --bin pageserver  \
       --bin pagectl  \

--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ testing locally, it is convenient to run just one set of permutations, like this
 DEFAULT_PG_VERSION=15 BUILD_TYPE=release ./scripts/pytest
 ```
 
+## Flamegraphs
+
+You may find yourself in need of flamegraphs for software in this repository.
+You can use [`flamegraph-rs`](https://github.com/flamegraph-rs/flamegraph) or the original [`flamegraph.pl`](https://github.com/brendangregg/FlameGraph). Your choice!
+
+>[!IMPORTANT]
+> If you're using `lld` or `mold`, you need the `--no-rosegment` linker argument.
+> It's a [general thing with Rust / lld / mold](https://crbug.com/919499#c16), not specific to this repository.
+> See [this PR for further instructions](https://github.com/neondatabase/neon/pull/6764).
+
 ## Documentation
 
 [docs](/docs) Contains a top-level overview of all available markdown documentation.


### PR DESCRIPTION
# Problem

Running a flamegraph on a pageserver build today yields a flamegraph with sort-of flattened stacks:

![before (current release builds)](https://github.com/neondatabase/neon/assets/956573/73b27ab6-5e5d-47b1-95d9-cfe164e7ef4b)


# Analysis

We use `mold` to link the production binaries.

It seems that, similar to when using `lld`, it's necessary to set `--no-rosegment` , as is also [recommended by the `flamegraph-rs` tools](https://github.com/flamegraph-rs/flamegraph/blame/1d7be186ff16cc90eaef815e7481a88f9a3a3b88/README.md#L21-L23).

Setting it fixes the issue on my workstation.
I don't use `mold -run` there, but instead use `mold` by setting default `rustflags` in my `~/.cargo/config.toml`:

```
# repeat / adjust for your target arch
[target.x86_64-unknown-linux-gnu]
linker = "clang"
rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold", "-Clink-arg=-Wl,--no-rosegment"]
```

![after](https://github.com/neondatabase/neon/assets/956573/297aa772-b7cb-4e83-b85e-61730199f6a1)

# Solution For Production Binaries

Our production binaries are the ones built inside docker, see `./Dockerfile`.

It would be nice if we could just make the setting once, somewhere inside `$checkout/Cargo.toml` or `$checkout/.cargo/config.toml`.
That way, all developers, _and the artifact builds, would automatically get the correct flags.

Sadly, the various ways to configure the rust compiler flags in cargo [don't compose well](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags).
I.e., there's a strict priority order and one replaces the other.

So, this PR sets the right rust compiler flags through the`RUSTFLAGS`  env var, which is otherwise unset in the Dockerfile, so, we don't have to worry about losing any flag overrides.

This PR also augments the README with a hint on how to get proper flamegraphs on developer builds.


