### PR TITLE
pageserver: fix sharding emitting empty image layers during compaction

### DIFF
--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -52,7 +52,7 @@ pub fn write_postgres_conf(
         writeln!(file, "neon.pageserver_connstring={}", escape_conf_value(s))?;
     }
     if let Some(stripe_size) = spec.shard_stripe_size {
-        writeln!(file, "neon.stripe_size={}", stripe_size)?;
+        writeln!(file, "neon.stripe_size={stripe_size}")?;
     }
     if !spec.safekeeper_connstrings.is_empty() {
         writeln!(

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -51,6 +51,9 @@ pub fn write_postgres_conf(
     if let Some(s) = &spec.pageserver_connstring {
         writeln!(file, "neon.pageserver_connstring={}", escape_conf_value(s))?;
     }
+    if let Some(stripe_size) = spec.shard_stripe_size {
+        writeln!(file, "neon.stripe_size={}", stripe_size)?;
+    }
     if !spec.safekeeper_connstrings.is_empty() {
         writeln!(
             file,

--- a/libs/pageserver_api/src/shard.rs
+++ b/libs/pageserver_api/src/shard.rs
@@ -471,10 +471,12 @@ impl ShardIdentity {
     pub fn is_key_disposable(&self, key: &Key) -> bool {
         if key_is_shard0(key) {
             // Q: Why can't we dispose of shard0 content if we're not shard 0?
-            // A: because the WAL ingestion logic currently ingests some shard 0
-            //    content on all shards, even though it's only read on shard 0.  If we
-            //    dropped it, then subsequent WAL ingest to these keys would encounter
-            //    an error.
+            // A1: because the WAL ingestion logic currently ingests some shard 0
+            //     content on all shards, even though it's only read on shard 0.  If we
+            //     dropped it, then subsequent WAL ingest to these keys would encounter
+            //     an error.
+            // A2: because key_is_shard0 also covers relation size keys, which are written
+            //     on all shards even though they're only maintained accurately on shard 0.
             false
         } else {
             !self.is_key_local(key)

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3375,7 +3375,7 @@ impl Timeline {
                 // we don't leave gaps between image layers, leave `start` where it is, so that the next
                 // layer we write will cover the key range that we just scanned.
                 tracing::debug!(
-                    "create_image_layers: no data in range {}-{}",
+                    "no data in range {}-{}",
                     img_range.start,
                     img_range.end
                 );

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3374,11 +3374,7 @@ impl Timeline {
                 // partition does not cover any keys owned by this shard.  In this case, to ensure
                 // we don't leave gaps between image layers, leave `start` where it is, so that the next
                 // layer we write will cover the key range that we just scanned.
-                tracing::debug!(
-                    "no data in range {}-{}",
-                    img_range.start,
-                    img_range.end
-                );
+                tracing::debug!("no data in range {}-{}", img_range.start, img_range.end);
             }
         }
         // All layers that the GC wanted us to create have now been created.

--- a/test_runner/regress/test_sharding.py
+++ b/test_runner/regress/test_sharding.py
@@ -313,10 +313,6 @@ def test_sharding_compaction(neon_env_builder: NeonEnvBuilder, stripe_size: int)
             if layer.kind == "Image":
                 image_layer_sizes[layer.layer_file_name] = layer.layer_file_size
 
-                # Pageserver should assert rather than emit an empty layer file, but double check here
-                assert layer.layer_file_size is not None
-                assert layer.layer_file_size > 0
-
         shard_has_image_layers.append(len(image_layer_sizes) > 1)
 
         log.info(f"Shard {shard_id} layer sizes: {json.dumps(image_layer_sizes, indent=2)}")

--- a/test_runner/regress/test_sharding.py
+++ b/test_runner/regress/test_sharding.py
@@ -313,6 +313,10 @@ def test_sharding_compaction(neon_env_builder: NeonEnvBuilder, stripe_size: int)
             if layer.kind == "Image":
                 image_layer_sizes[layer.layer_file_name] = layer.layer_file_size
 
+                # Pageserver should assert rather than emit an empty layer file, but double check here
+                assert layer.layer_file_size is not None
+                assert layer.layer_file_size > 0
+
         shard_has_image_layers.append(len(image_layer_sizes) > 1)
 
         log.info(f"Shard {shard_id} layer sizes: {json.dumps(image_layer_sizes, indent=2)}")

--- a/test_runner/regress/test_sharding.py
+++ b/test_runner/regress/test_sharding.py
@@ -1,6 +1,3 @@
-import json
-
-import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import (
     NeonEnvBuilder,
@@ -257,76 +254,4 @@ def test_sharding_split_smoke(
         log.info(f"Migrating shard {migrate_shard} from {ps_id} to {destination}")
         env.neon_cli.tenant_migrate(migrate_shard, destination, timeout_secs=10)
 
-    workload.validate()
-
-
-# Stripe sizes in number of pages.
-TINY_STRIPES = 16
-LARGE_STRIPES = 32768
-
-
-@pytest.mark.parametrize("stripe_size", [TINY_STRIPES, LARGE_STRIPES])
-def test_sharding_compaction(neon_env_builder: NeonEnvBuilder, stripe_size: int):
-    """
-    Use small stripes, small layers, and small compaction thresholds to exercise how compaction
-    and image layer generation interacts with sharding.
-    """
-
-    TENANT_CONF = {
-        # small checkpointing and compaction targets to ensure we generate many upload operations
-        "checkpoint_distance": f"{128 * 1024}",
-        "compaction_threshold": "1",
-        "compaction_target_size": f"{128 * 1024}",
-        # no PITR horizon, we specify the horizon when we request on-demand GC
-        "pitr_interval": "0s",
-        # disable background compaction and GC. We invoke it manually when we want it to happen.
-        "gc_period": "0s",
-        "compaction_period": "0s",
-        # create image layers eagerly, so that GC can remove some layers
-        "image_creation_threshold": "1",
-    }
-
-    neon_env_builder.num_pageservers = 4
-    env = neon_env_builder.init_start(
-        initial_tenant_conf=TENANT_CONF,
-        initial_tenant_shard_count=4,
-        initial_tenant_shard_stripe_size=stripe_size,
-    )
-
-    tenant_id = env.initial_tenant
-    timeline_id = env.initial_timeline
-
-    workload = Workload(env, tenant_id, timeline_id)
-    workload.init()
-    workload.write_rows(64)
-    workload.churn_rows(64)
-
-    # Assert that we got some image layers: this is important because this test's purpose is to exercise the sharding changes
-    # to Timeline::create_image_layers, so if we weren't creating any image layers we wouldn't be doing our job.
-    shard_has_image_layers = []
-    for shard in env.attachment_service.locate(tenant_id):
-        pageserver = env.get_pageserver(shard["node_id"])
-        shard_id = shard["shard_id"]
-        layer_map = pageserver.http_client().layer_map_info(shard_id, timeline_id)
-        image_layer_sizes = {}
-        for layer in layer_map.historic_layers:
-            if layer.kind == "Image":
-                image_layer_sizes[layer.layer_file_name] = layer.layer_file_size
-
-        shard_has_image_layers.append(len(image_layer_sizes) > 1)
-
-        log.info(f"Shard {shard_id} layer sizes: {json.dumps(image_layer_sizes, indent=2)}")
-
-        # TODO: once keyspace partitioning is updated, assert that layer sizes are as expected
-        # (see https://github.com/neondatabase/neon/issues/6774)
-
-    if stripe_size == TINY_STRIPES:
-        # Expect writes were scattered across all pageservers: they should all have compacted some image layers
-        assert all(shard_has_image_layers)
-    else:
-        # With large stripes, it is expected that most of our writes went to one pageserver, so we just require
-        # that at least one of them has some image layers.
-        assert any(shard_has_image_layers)
-
-    # Assert that everything is still readable
     workload.validate()


### PR DESCRIPTION
## Problem

Sharded tenants would sometimes try to write empty image layers during compaction: this was more noticeable on larger databases.
- https://github.com/neondatabase/neon/issues/6755

**Note to reviewers: the last commit is a refactor that de-intents a whole block, I recommend reviewing the earlier commits one by one to see the real changes**

## Summary of changes

- Fix a case where when we drop a key during compaction, we might fail to write out keys (this was broken when vectored get was added)
- If an image layer is empty, then do not try and write it out, but leave `start` where it is so that if the subsequent key range meets criteria for writing an image layer, we will extend its key range to cover the empty area.
- Add a compaction test that configures small layers and compaction thresholds, and asserts that we really successfully did image layer generation.  This fails before the fix.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
