### PR TITLE
stop reading local `metadata` file

### DIFF
--- a/pageserver/src/tenant/metadata.rs
+++ b/pageserver/src/tenant/metadata.rs
@@ -294,17 +294,6 @@ pub enum LoadMetadataError {
     Decode(#[from] anyhow::Error),
 }
 
-pub fn load_metadata(
-    conf: &'static PageServerConf,
-    tenant_shard_id: &TenantShardId,
-    timeline_id: &TimelineId,
-) -> Result<TimelineMetadata, LoadMetadataError> {
-    let metadata_path = conf.metadata_path(tenant_shard_id, timeline_id);
-    let metadata_bytes = std::fs::read(metadata_path)?;
-
-    Ok(TimelineMetadata::from_bytes(&metadata_bytes)?)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4849,7 +4849,7 @@ mod tests {
             TenantHarness::create("two_layer_eviction_attempts_at_the_same_time").unwrap();
 
         let ctx = any_context();
-        let tenant = harness.try_load(&ctx).await.unwrap();
+        let tenant = harness.do_try_load(&ctx).await.unwrap();
         let timeline = tenant
             .create_test_timeline(TimelineId::generate(), Lsn(0x10), 14, &ctx)
             .await


### PR DESCRIPTION
Problem
-------

The local `metadata` file is effectively unused if remote storage is configured, because remote storage is the authority.
We do write and read it, but, we never use its contents.

In particular, during startup, we write each metadata file with the contents fetched from remote storage during `preload`.
Effectively, that's a `VirtualFile::crashsafe_overwrite` for each timeline.

Further, it turns out that we can delete a bunch of legacy code if we stop caring about the `metadata` file.

Refs:
- noticed this in #6765
- ... which is part of adding tokio-epoll-uring to the write path (#6663)

Solution
--------

This PR removes any code that reads the file.

We continue to write (and delete it) as before.

Once we've released this version and are sure we won't roll back, we will remove the code that writes it.
That'll happen in https://github.com/neondatabase/neon/pull/6769.


The price is that it's now required to run with remote storage anymore.
We agree that we want to get there eventually, so this is the first step.
see https://github.com/neondatabase/neon/issues/4099


Review
------

Reviewers should not just check the changes in this PR (which are code deletions, mostly).
But also they should ensure that after this change, absence of the file does not change any outcomes.

This means auditing the code base for, example,
- reads of the file
- `stat` of the file
- removal of the file where `NotFound` isn't treated as if it is success
- etc

