### PR TITLE
CI(vm-compute-node-image): add docker auth for vm-builder

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -887,6 +887,18 @@ jobs:
         run: |
           docker pull 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
 
+      # Use custom DOCKER_CONFIG directory to avoid conflicts with default settings
+      # The default value is ~/.docker
+      - name: Set custom docker config directory
+        run: |
+          mkdir -p .docker-custom
+          echo DOCKER_CONFIG=$(pwd)/.docker-custom >> $GITHUB_ENV
+
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
+
       - name: Build vm image
         run: |
           ./vm-builder \
@@ -894,8 +906,14 @@ jobs:
             -src=369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}} \
             -dst=369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
 
+      - name: Remove custom docker config directory
+        if: always()
+        run: |
+          rm -rf .docker-custom
+
       - name: Pushing vm-compute-node image
         run: |
+          unset DOCKER_CONFIG
           docker push 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-${{ matrix.version }}:${{needs.tag.outputs.build-tag}}
 
   test-images:


### PR DESCRIPTION
## Problem
```
2024/02/19 15:57:36 Setup docker connection
2024/02/19 [15](https://github.com/neondatabase/neon/actions/runs/7960954540/job/21732689596#step:5:16):57:36 Build docker image for virtual machine (disk size 1G): 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v15:7960954540
Step 1/53 : FROM debian:bullseye-slim as libcgroup-builder
bullseye-slim: Pulling from library/debian
2024/02/19 15:57:38 toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```
Ref https://github.com/neondatabase/neon/actions/runs/7960954540/job/21732689596

## Summary of changes
- Add docker auth for `vm-compute-node-image` job

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
