### PR TITLE
fix(startup + remote_timeline_client): no-op deletion ops scheduled during startup

### DIFF
--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -823,6 +823,10 @@ impl RemoteTimelineClient {
         }
 
         // schedule the actual deletions
+        if with_metadata.is_empty() {
+            // avoid scheduling the op & bumping the metric
+            return;
+        }
         let op = UploadOp::Delete(Delete {
             layers: with_metadata,
         });


### PR DESCRIPTION
Before this PR, if remote storage is configured, `load_layer_map`'s call to `RemoteTimelineClient::schedule_layer_file_deletion` would schedule an empty UploadOp::Delete for each timeline.

It's jsut CPU overhead, no actual interaction with deletion queue on-disk state or S3, as far as I can tell.

However, it shows up in the "RemoteTimelineClient calls started metrics", which I'm refining in an orthogonal PR.
