### PR TITLE
test: adjust checkpoint distance in `test_layer_map`

### DIFF
--- a/test_runner/performance/test_layer_map.py
+++ b/test_runner/performance/test_layer_map.py
@@ -1,6 +1,5 @@
 import time
 
-import pytest
 from fixtures.neon_fixtures import NeonEnvBuilder
 
 

--- a/test_runner/performance/test_layer_map.py
+++ b/test_runner/performance/test_layer_map.py
@@ -1,5 +1,6 @@
 import time
 
+import pytest
 from fixtures.neon_fixtures import NeonEnvBuilder
 
 

--- a/test_runner/performance/test_layer_map.py
+++ b/test_runner/performance/test_layer_map.py
@@ -17,10 +17,10 @@ def test_layer_map(neon_env_builder: NeonEnvBuilder, zenbenchmark):
     tenant, _ = env.neon_cli.create_tenant(
         conf={
             "gc_period": "0s",
-            "checkpoint_distance": "8192",
+            "checkpoint_distance": "16384",
             "compaction_period": "1 s",
             "compaction_threshold": "1",
-            "compaction_target_size": "8192",
+            "compaction_target_size": "16384",
         }
     )
 


### PR DESCRIPTION
https://github.com/neondatabase/neon/commit/587cb705b898565d459d044df84d1ac2633f00bf changed the layer rolling logic to more closely obey the `checkpoint_distance` config.
Previously, this test was getting layers significantly larger than the 8K it was asking for. Now the
payload in the layers is closer to 8K (which means more layers in total).

Tweak the `checkpoint_distance` to get a number of layers morereasonable for this test.
Note that we still get more layers than before (~8K vs ~5K).
