### PR TITLE
tests: improve stability of  tests using `wait_for_upload_queue_empty`

### DIFF
--- a/test_runner/fixtures/pageserver/utils.py
+++ b/test_runner/fixtures/pageserver/utils.py
@@ -237,11 +237,6 @@ def wait_for_upload_queue_empty(
             },
         )
 
-        # If some label sets are present in started but not finished, evidently we aren't finished yet.
-        if len(started) != len(finished):
-            time.sleep(wait_period_secs)
-            continue
-
         # this is `started left join finished`; if match, subtracting start from finished, resulting in queue depth
         remaining_labels = ["shard_id", "file_kind", "op_kind"]
         tl: List[Tuple[Any, float]] = []


### PR DESCRIPTION
## Problem

PR #6834 introduced an assertion that the sets of metric labels on finished operations should equal those on started operations, which is not true if no operations have finished yet for a particular set of labels.

## Summary of changes

- Instead of asserting out, fall through and let the check for empty queue fail, so that we will continue in the retry loop

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
