### PR TITLE
fix(per-tenant throttling): incorrect `allowed_rps` field in log message

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -337,7 +337,7 @@ impl ThrottleConfig {
     }
     /// The requests per second allowed  by the given config.
     pub fn steady_rps(&self) -> f64 {
-        (self.refill_amount.get() as f64) / (self.refill_interval.as_secs_f64()) / 1e3
+        (self.refill_amount.get() as f64) / (self.refill_interval.as_secs_f64())
     }
 }
 


### PR DESCRIPTION
The `refill_interval` switched from a milliseconds usize to a Duration during a review follow-up, hence this slipped through manual testing.

Part of https://github.com/neondatabase/neon/issues/5899