### PR TITLE
fix(flaky): typo Stopping/Stopped

### DIFF
--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -130,7 +130,7 @@ pub(super) struct UploadQueueStopped {
 pub(crate) enum NotInitialized {
     #[error("queue is in state Uninitialized")]
     Uninitialized,
-    #[error("queue is in state Stopping")]
+    #[error("queue is in state Stopped")]
     Stopped,
     #[error("queue is shutting down")]
     ShuttingDown,


### PR DESCRIPTION
introduced in 8dee9908f83fdebea1dfd36304272bdbe684ad5c, should help with the #6681 common problem which is just a mismatched allowed error.