### PR TITLE
test_remote_timeline_client_calls_started_metric: fix flakiness

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1616,6 +1616,10 @@ async fn timeline_compact_handler(
     if Some(true) == parse_query_param::<_, bool>(&request, "force_repartition")? {
         flags |= CompactFlags::ForceRepartition;
     }
+    if Some(true) == parse_query_param::<_, bool>(&request, "force_image_layer_creation")? {
+        flags |= CompactFlags::ForceImageLayerCreation;
+    }
+
     async {
         let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
         let timeline = active_timeline_of_active_tenant(tenant_shard_id, timeline_id).await?;
@@ -1642,6 +1646,10 @@ async fn timeline_checkpoint_handler(
     if Some(true) == parse_query_param::<_, bool>(&request, "force_repartition")? {
         flags |= CompactFlags::ForceRepartition;
     }
+    if Some(true) == parse_query_param::<_, bool>(&request, "force_image_layer_creation")? {
+        flags |= CompactFlags::ForceImageLayerCreation;
+    }
+
     async {
         let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
         let timeline = active_timeline_of_active_tenant(tenant_shard_id, timeline_id).await?;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -503,6 +503,7 @@ pub enum GetLogicalSizePriority {
 #[derive(enumset::EnumSetType)]
 pub(crate) enum CompactFlags {
     ForceRepartition,
+    ForceImageLayerCreation,
 }
 
 impl std::fmt::Debug for Timeline {
@@ -1157,7 +1158,12 @@ impl Timeline {
                 // 3. Create new image layers for partitions that have been modified
                 // "enough".
                 let layers = self
-                    .create_image_layers(&partitioning, lsn, false, &image_ctx)
+                    .create_image_layers(
+                        &partitioning,
+                        lsn,
+                        flags.contains(CompactFlags::ForceImageLayerCreation),
+                        &image_ctx,
+                    )
                     .await
                     .map_err(anyhow::Error::from)?;
                 if let Some(remote_client) = &self.remote_client {

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -549,11 +549,14 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         tenant_id: Union[TenantId, TenantShardId],
         timeline_id: TimelineId,
         force_repartition=False,
+        force_image_layer_creation=False,
     ):
         self.is_testing_enabled_or_skip()
         query = {}
         if force_repartition:
             query["force_repartition"] = "true"
+        if force_image_layer_creation:
+            query["force_image_layer_creation"] = "true"
 
         log.info(f"Requesting compact: tenant {tenant_id}, timeline {timeline_id}")
         res = self.put(
@@ -608,11 +611,14 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         tenant_id: Union[TenantId, TenantShardId],
         timeline_id: TimelineId,
         force_repartition=False,
+        force_image_layer_creation=False,
     ):
         self.is_testing_enabled_or_skip()
         query = {}
         if force_repartition:
             query["force_repartition"] = "true"
+        if force_image_layer_creation:
+            query["force_image_layer_creation"] = "true"
 
         log.info(f"Requesting checkpoint: tenant {tenant_id}, timeline {timeline_id}")
         res = self.put(

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -368,7 +368,6 @@ def test_remote_storage_upload_queue_retries(
         assert query_scalar(cur, "SELECT COUNT(*) FROM foo WHERE val = 'd'") == 20000
 
 
-@pytest.mark.repeat(100)
 def test_remote_timeline_client_calls_started_metric(
     neon_env_builder: NeonEnvBuilder,
 ):

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -390,6 +390,10 @@ def test_remote_timeline_client_calls_started_metric(
             "image_creation_threshold": "1",
         }
     )
+    env.pageserver.quiesce_tenants()
+    env.pageserver.stop(immediate=True)
+    pageserver_extra_env = {"RUST_LOG": "info,pageserver::tenant::timeline=debug"}
+    env.pageserver.start(extra_env_vars=pageserver_extra_env)
 
     tenant_id = env.initial_tenant
     timeline_id = env.initial_timeline
@@ -488,7 +492,7 @@ def test_remote_timeline_client_calls_started_metric(
     shutil.rmtree(dir_to_clear)
     os.mkdir(dir_to_clear)
 
-    env.pageserver.start()
+    env.pageserver.start(extra_env_vars=pageserver_extra_env)
     client = env.pageserver.http_client()
 
     env.pageserver.tenant_attach(tenant_id)

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -388,7 +388,7 @@ def test_remote_timeline_client_calls_started_metric(
             "gc_period": "0s",
             "compaction_period": "0s",
             # create image layers eagerly, so that GC can remove some layers
-            "image_creation_threshold": "1",
+            "image_creation_threshold": "0",
         }
     )
     env.pageserver.quiesce_tenants()

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -368,6 +368,7 @@ def test_remote_storage_upload_queue_retries(
         assert query_scalar(cur, "SELECT COUNT(*) FROM foo WHERE val = 'd'") == 20000
 
 
+@pytest.mark.repeat(100)
 def test_remote_timeline_client_calls_started_metric(
     neon_env_builder: NeonEnvBuilder,
 ):

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -389,10 +389,6 @@ def test_remote_timeline_client_calls_started_metric(
             "compaction_period": "0s",
         }
     )
-    env.pageserver.quiesce_tenants()
-    env.pageserver.stop(immediate=True)
-    pageserver_extra_env = {"RUST_LOG": "info,pageserver::tenant::timeline=debug"}
-    env.pageserver.start(extra_env_vars=pageserver_extra_env)
 
     tenant_id = env.initial_tenant
     timeline_id = env.initial_timeline
@@ -496,7 +492,7 @@ def test_remote_timeline_client_calls_started_metric(
     shutil.rmtree(dir_to_clear)
     os.mkdir(dir_to_clear)
 
-    env.pageserver.start(extra_env_vars=pageserver_extra_env)
+    env.pageserver.start()
     client = env.pageserver.http_client()
 
     env.pageserver.tenant_attach(tenant_id)


### PR DESCRIPTION
fixes https://github.com/neondatabase/neon/issues/6889

# Problem

The failure in the last 3 flaky runs on `main` is 

```
test_runner/regress/test_remote_storage.py:460: in test_remote_timeline_client_calls_started_metric
    churn("a", "b")
test_runner/regress/test_remote_storage.py:457: in churn
    assert gc_result["layers_removed"] > 0
E   assert 0 > 0
```

That's this code

https://github.com/neondatabase/neon/blob/cd449d66ea29ad2d7269458e90623c3ae40e1816/test_runner/regress/test_remote_storage.py#L448-L460

So, the test expects GC to remove some layers but the GC doesn't.

# Fix

My impression is that the VACUUM isn't re-using pages aggressively enough, but I can't really prove that. Tried to analyze the layer map dump but it's too complex.

So, this PR:

- Creates more churn by doing the overwrite twice.
- Forces image layer creation.

It also drive-by removes the redundant call to timeline_compact, because, timeline_checkpoint already does that internally.


