### PR TITLE
fix: one instance of "leaked" started evictions count

### DIFF
--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -29,6 +29,9 @@ use super::{
 
 use utils::generation::Generation;
 
+#[cfg(test)]
+mod tests;
+
 /// A Layer contains all data in a "rectangle" consisting of a range of keys and
 /// range of LSNs.
 ///

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1061,6 +1061,8 @@ impl LayerInner {
             // we could had already scheduled the deletion at the time.
             //
             // FIXME: this is not true anymore, we can safely evict wanted deleted files.
+
+            LAYER_IMPL_METRICS.inc_eviction_cancelled(EvictionCancelled::WantedDeleted);
         } else if can_evict && evict {
             let span = tracing::info_span!(parent: None, "layer_evict", tenant_id = %self.desc.tenant_shard_id.tenant_id, shard_id = %self.desc.tenant_shard_id.shard_slug(), timeline_id = %self.desc.timeline_id, layer=%self, %version);
 
@@ -1693,6 +1695,7 @@ enum EvictionCancelled {
     LostToDownload,
     /// After eviction, there was a new layer access which cancelled the eviction.
     UpgradedBackOnAccess,
+    WantedDeleted,
 }
 
 impl EvictionCancelled {
@@ -1706,6 +1709,7 @@ impl EvictionCancelled {
             EvictionCancelled::AlreadyReinitialized => "already_reinitialized",
             EvictionCancelled::LostToDownload => "lost_to_download",
             EvictionCancelled::UpgradedBackOnAccess => "upgraded_back_on_access",
+            EvictionCancelled::WantedDeleted => "wanted_deleted",
         }
     }
 }

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -1,0 +1,260 @@
+use futures::StreamExt;
+use tokio::task::JoinSet;
+use utils::{
+    completion::{self, Completion},
+    id::TimelineId,
+};
+
+use super::*;
+use crate::tenant::harness::TenantHarness;
+
+#[test]
+fn residency_check_while_evict_and_wait_on_clogged_spawn_blocking() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .start_paused(true)
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        let h =
+            TenantHarness::create("residency_check_while_evict_and_wait_on_clogged_spawn_blocking")
+                .unwrap();
+        utils::logging::replace_panic_hook_with_tracing_panic_hook().forget();
+        let (tenant, ctx) = h.load().await;
+
+        let timeline = tenant
+            .create_test_timeline(TimelineId::generate(), Lsn(0x10), 14, &ctx)
+            .await
+            .unwrap();
+
+        let layer = {
+            let mut layers = {
+                let layers = timeline.layers.read().await;
+                layers.resident_layers().collect::<Vec<_>>().await
+            };
+
+            assert_eq!(layers.len(), 1);
+
+            layers.swap_remove(0)
+        };
+
+        // setup done
+
+        let resident = layer.keep_resident().await.unwrap();
+
+        let mut evict_and_wait = std::pin::pin!(layer.evict_and_wait());
+
+        // drive the future to await on the status channel
+        tokio::time::timeout(std::time::Duration::from_secs(3600), &mut evict_and_wait)
+            .await
+            .expect_err("should had been a timeout since we are holding the layer resident");
+        assert_eq!(1, LAYER_IMPL_METRICS.started_evictions.get());
+
+        // make the eviction attempt a noop because the layer is also wanted as deleted.
+        // we could now evict wanted deleted layers because we unlink the layers from index_part.json
+        // right away, but that has not been implemented. alternatively we could cause a version
+        // mismatch by incrementing the ` layer.0.version.fetch_add(1, Ordering::Relaxed)`.
+        //
+        // testability would be simpler if there was a separate actor for these.
+
+        // clog up BACKGROUND_RUNTIME spawn_blocking
+        let (completion, mut js) = consume_all_background_runtime_spawn_blocking_threads().await;
+
+        // now the eviction cannot proceed because the threads are consumed while completion exists
+        drop(resident);
+
+        // this resets the wanted eviction. in the bug situation, it could had been executed by
+        // eviction_task or disk usage based eviction while eviction_task was waiting on
+        // `Layer::evict_and_wait`.
+        //
+        // because no actual eviction happened, we get to just reinitialize the DownloadedLayer
+        layer
+            .keep_resident()
+            .await
+            .expect("keep_resident should had reinitialized without downloading");
+
+        // because the keep_resident check alters wanted evicted without sending a message, we will never get completed
+        let e = tokio::time::timeout(std::time::Duration::from_secs(3600), &mut evict_and_wait)
+            .await
+            .expect("no timeout, because keep_resident re-initialized")
+            .expect_err("eviction should not have succeeded because re-initialized");
+
+        // works as intended: evictions lose to "downloads"
+        assert!(matches!(e, EvictionError::Downloaded), "{e:?}");
+        assert_eq!(0, LAYER_IMPL_METRICS.completed_evictions.get());
+
+        // this is not wrong: the eviction is technically still "on the way" it's still queued
+        // because spawn_blocking is clogged up
+        assert_eq!(
+            0,
+            LAYER_IMPL_METRICS
+                .cancelled_evictions
+                .values()
+                .map(|ctr| ctr.get())
+                .sum::<u64>()
+        );
+
+        let mut second_eviction = std::pin::pin!(layer.evict_and_wait());
+
+        tokio::time::timeout(std::time::Duration::from_secs(3600), &mut second_eviction)
+            .await
+            .expect_err("timeout because spawn_blocking is clogged");
+
+        assert_eq!(2, LAYER_IMPL_METRICS.started_evictions.get());
+
+        drop(completion);
+        while let Some(res) = js.join_next().await {
+            res.unwrap();
+        }
+
+        tokio::time::timeout(std::time::Duration::from_secs(3600), &mut second_eviction)
+            .await
+            .expect("eviction goes through now that spawn_blocking is unclogged")
+            .expect("eviction should succeed, because version matches");
+
+        assert_eq!(1, LAYER_IMPL_METRICS.completed_evictions.get());
+
+        // now we finally can observe the original spawn_blocking failing
+        assert_eq!(
+            1,
+            LAYER_IMPL_METRICS
+                .cancelled_evictions
+                .values()
+                .map(|ctr| ctr.get())
+                .sum::<u64>()
+        );
+    });
+}
+
+#[test]
+fn residency_check_while_evict_and_wait_on_wanted_deleted() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .start_paused(true)
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        let h = TenantHarness::create("residency_check_while_evict_and_wait_on_wanted_deleted")
+            .unwrap();
+        utils::logging::replace_panic_hook_with_tracing_panic_hook().forget();
+        let (tenant, ctx) = h.load().await;
+
+        let timeline = tenant
+            .create_test_timeline(TimelineId::generate(), Lsn(0x10), 14, &ctx)
+            .await
+            .unwrap();
+
+        let layer = {
+            let mut layers = {
+                let layers = timeline.layers.read().await;
+                layers.resident_layers().collect::<Vec<_>>().await
+            };
+
+            assert_eq!(layers.len(), 1);
+
+            layers.swap_remove(0)
+        };
+
+        // setup done
+
+        let resident = layer.keep_resident().await.unwrap();
+
+        {
+            let mut evict_and_wait = std::pin::pin!(layer.evict_and_wait());
+
+            // drive the future to await on the status channel
+            tokio::time::timeout(std::time::Duration::from_secs(3600), &mut evict_and_wait)
+                .await
+                .expect_err("should had been a timeout since we are holding the layer resident");
+
+            // make the eviction attempt a noop because the layer is also wanted as deleted.
+            // we could now evict wanted deleted layers because we unlink the layers from index_part.json
+            // right away, but that has not been implemented. alternatively we could cause a version
+            // mismatch by incrementing the ` layer.0.version.fetch_add(1, Ordering::Relaxed)`.
+            layer.delete_on_drop();
+
+            drop(resident);
+
+            // make sure the eviction task gets to run
+            cycle_background_runtime_spawn_blocking().await;
+
+            layer
+                .keep_resident()
+                .await
+                .expect("keep_resident should had reinitialized");
+
+            // because the keep_resident check alters wanted evicted without sending a message, we will never get completed
+            let e = tokio::time::timeout(std::time::Duration::from_secs(3600), &mut evict_and_wait)
+                .await
+                .expect("no timeout should be hit because keep_resident re-initialized it")
+                .expect_err("evict_and_wait should had failed because of re-initialization");
+
+            // works as intended
+            assert!(matches!(e, EvictionError::Downloaded), "{e:?}");
+        }
+
+        {
+            let mut layers = timeline.layers.write().await;
+            layers.finish_gc_timeline(&[layer]);
+        }
+
+        cycle_background_runtime_spawn_blocking().await;
+
+        assert_eq!(1, LAYER_IMPL_METRICS.started_deletes.get());
+        assert_eq!(1, LAYER_IMPL_METRICS.completed_deletes.get());
+
+        assert_eq!(1, LAYER_IMPL_METRICS.started_evictions.get());
+        assert_eq!(
+            1,
+            LAYER_IMPL_METRICS.completed_evictions.get()
+                + LAYER_IMPL_METRICS
+                    .cancelled_evictions
+                    .values()
+                    .map(|x| x.get())
+                    .sum::<u64>()
+        );
+    });
+}
+
+/// All `crate::task_mgr::BACKGROUND_RUNTIME` spawn_blocking threads will be consumed momentarily
+/// by this or it will not complete.
+///
+/// This should be no issue nowdays, because nextest runs each test in it's own process.
+async fn consume_all_background_runtime_spawn_blocking_threads() -> (Completion, JoinSet<()>) {
+    let (completion, barrier) = completion::channel();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+
+    let assumed_max_blocking_threads = 512;
+
+    let mut blocking_tasks = JoinSet::new();
+
+    for _ in 0..assumed_max_blocking_threads {
+        let barrier = barrier.clone();
+        let tx = tx.clone();
+        blocking_tasks.spawn_blocking_on(
+            move || {
+                tx.blocking_send(()).unwrap();
+                drop(tx);
+                tokio::runtime::Handle::current().block_on(barrier.wait());
+            },
+            crate::task_mgr::BACKGROUND_RUNTIME.handle(),
+        );
+    }
+
+    drop(barrier);
+
+    for _ in 0..assumed_max_blocking_threads {
+        rx.recv().await.unwrap();
+    }
+
+    (completion, blocking_tasks)
+}
+
+async fn cycle_background_runtime_spawn_blocking() {
+    let (_, mut js) = consume_all_background_runtime_spawn_blocking_threads().await;
+    while let Some(res) = js.join_next().await {
+        res.unwrap();
+    }
+}


### PR DESCRIPTION
Found while trying to reproduce #6928, there is a case where pending deletion is not also counted as a cancelled eviction. This should be fixed per my FIXME there, but I'd rather continue trying to understand the hang.