### PR TITLE
CI(pin-build-tools-image): pass secrets to the job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1249,3 +1249,4 @@ jobs:
     uses: ./.github/workflows/pin-build-tools-image.yml
     with:
       from-tag: ${{ needs.build-build-tools-image.outputs.image-tag }}
+    secrets: inherit


### PR DESCRIPTION
## Problem

`pin-build-tools-image` job doesn't have access to secrets and thus fails.

Missed in the original PR https://github.com/neondatabase/neon/pull/6795

Examples of a fixed workflow run: https://github.com/neondatabase/neon/actions/runs/8081421341/job/22079978298?pr=6949

## Summary of changes
- pass secrets to `pin-build-tools-image` job

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
