### PR TITLE
compute_ctl: only try zenith_admin if could not authenticate

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -791,7 +791,9 @@ impl ComputeNode {
                         .set_username("zenith_admin")
                         .map_err(|_| anyhow::anyhow!("invalid connstr"))?;
 
-                    let mut client = Client::connect(zenith_admin_connstr.as_str(), NoTls)?;
+                    let mut client =
+                        Client::connect(zenith_admin_connstr.as_str(), NoTls)
+                            .context("broken cloud_admin credential: tried connecting with cloud_admin but could not authenticate, and zenith_admin does not work either")?;
                     // Disable forwarding so that users don't get a cloud_admin role
                     client.simple_query("SET neon.forward_ddl = false")?;
                     client.simple_query("CREATE USER cloud_admin WITH SUPERUSER")?;

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -777,36 +777,32 @@ impl ComputeNode {
         // but we can create a new one and grant it all privileges.
         let connstr = self.connstr.clone();
         let mut client = match Client::connect(connstr.as_str(), NoTls) {
-            Err(e) => {
-                if let Some(code) = e.code() {
-                    if code == &SqlState::INVALID_PASSWORD {
-                        // connect with zenith_admin if cloud_admin could not authenticate
-                        info!(
-                            "cannot connect to postgres: {}, retrying with `zenith_admin` username",
-                            e
-                        );
-                        let mut zenith_admin_connstr = connstr.clone();
+            Err(e) => match e.code() {
+                Some(&SqlState::INVALID_PASSWORD)
+                | Some(&SqlState::INVALID_AUTHORIZATION_SPECIFICATION) => {
+                    // connect with zenith_admin if cloud_admin could not authenticate
+                    info!(
+                        "cannot connect to postgres: {}, retrying with `zenith_admin` username",
+                        e
+                    );
+                    let mut zenith_admin_connstr = connstr.clone();
 
-                        zenith_admin_connstr
-                            .set_username("zenith_admin")
-                            .map_err(|_| anyhow::anyhow!("invalid connstr"))?;
+                    zenith_admin_connstr
+                        .set_username("zenith_admin")
+                        .map_err(|_| anyhow::anyhow!("invalid connstr"))?;
 
-                        let mut client = Client::connect(zenith_admin_connstr.as_str(), NoTls)?;
-                        // Disable forwarding so that users don't get a cloud_admin role
-                        client.simple_query("SET neon.forward_ddl = false")?;
-                        client.simple_query("CREATE USER cloud_admin WITH SUPERUSER")?;
-                        client.simple_query("GRANT zenith_admin TO cloud_admin")?;
-                        drop(client);
+                    let mut client = Client::connect(zenith_admin_connstr.as_str(), NoTls)?;
+                    // Disable forwarding so that users don't get a cloud_admin role
+                    client.simple_query("SET neon.forward_ddl = false")?;
+                    client.simple_query("CREATE USER cloud_admin WITH SUPERUSER")?;
+                    client.simple_query("GRANT zenith_admin TO cloud_admin")?;
+                    drop(client);
 
-                        // reconnect with connstring with expected name
-                        Client::connect(connstr.as_str(), NoTls)?
-                    } else {
-                        return Err(e.into());
-                    }
-                } else {
-                    return Err(e.into());
+                    // reconnect with connstring with expected name
+                    Client::connect(connstr.as_str(), NoTls)?
                 }
-            }
+                _ => return Err(e.into()),
+            },
             Ok(client) => client,
         };
 


### PR DESCRIPTION
## Problem

Fix https://github.com/neondatabase/neon/issues/6498

## Summary of changes

Only re-authenticate with zenith_admin if authentication fails. Otherwise, directly return the error message.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
