### PR TITLE
bench: run branch_creation_many at 500, seeded

### DIFF
--- a/pageserver/src/tenant/tasks.rs
+++ b/pageserver/src/tenant/tasks.rs
@@ -101,6 +101,7 @@ pub fn start_background_loops(
                     _ = completion::Barrier::maybe_wait(background_jobs_can_start) => {}
                 };
                 compaction_loop(tenant, cancel)
+                    // If you rename this span, change the RUST_LOG env variable in test_runner/performance/test_branch_creation.py
                     .instrument(info_span!("compaction_loop", tenant_id = %tenant_shard_id.tenant_id, shard_id = %tenant_shard_id.shard_slug()))
                     .await;
                 Ok(())
@@ -198,7 +199,11 @@ async fn compaction_loop(tenant: Arc<Tenant>, cancel: CancellationToken) {
                 }
             };
 
-            warn_when_period_overrun(started_at.elapsed(), period, BackgroundLoopKind::Compaction);
+            let elapsed = started_at.elapsed();
+            warn_when_period_overrun(elapsed, period, BackgroundLoopKind::Compaction);
+
+            // the duration is recorded by performance tests by enabling debug in this function
+            tracing::debug!(elapsed_ms=elapsed.as_millis(), "compaction iteration complete");
 
             // Perhaps we did no work and the walredo process has been idle for some time:
             // give it a chance to shut down to avoid leaving walredo process running indefinitely.

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -89,6 +89,7 @@ def test_branch_creation_heavy_write(neon_compare: NeonCompare, n_branches: int)
     _record_branch_creation_durations(neon_compare, branch_creation_durations)
 
 
+@pytest.mark.repeat(5)
 @pytest.mark.parametrize("n_branches", [500, 1024])
 def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int):
     """

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -145,7 +145,7 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
     # period for compaction so it starts earlier
     env.pageserver.start(
         overrides=(
-            "--pageserver-config-override=tenant_config={ compaction_period = '1s', gc_period = '0s' }",
+            "--pageserver-config-override=tenant_config={ compaction_period = '3s', gc_period = '0s' }",
         ),
         # this does print more than we want, but the number should be comparable between runs
         extra_env_vars={
@@ -168,6 +168,7 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
 
     wait_and_record_startup_metrics(env.pageserver, neon_compare.zenbenchmark, "restart_after")
 
+    # wait for compaction to complete, which most likely has already done so multiple times
     msg, _ = wait_until(
         30,
         1,

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -90,8 +90,10 @@ def test_branch_creation_heavy_write(neon_compare: NeonCompare, n_branches: int)
 
 
 @pytest.mark.parametrize("n_branches", [500, 1024])
-# Test measures the latency of branch creation when creating a lot of branches.
 def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int):
+    """
+    Test measures the latency of branch creation when creating a lot of branches.
+    """
     env = neon_compare.env
 
     # seed the prng so we will measure the same structure every time

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -92,7 +92,6 @@ def test_branch_creation_heavy_write(neon_compare: NeonCompare, n_branches: int)
     _record_branch_creation_durations(neon_compare, branch_creation_durations)
 
 
-@pytest.mark.repeat(5)
 @pytest.mark.parametrize("n_branches", [500, 1024])
 @pytest.mark.parametrize("shape", ["one_ancestor", "random"])
 def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape: str):

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -134,8 +134,11 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
         # this sleeps 100ms between polls
         env.pageserver.stop()
 
+    startup_line = "INFO version: git(-env)?:"
+
+    # find the first line of the log file so we can find the next start later
     _, first_start = wait_until(
-        5, 1, lambda: env.pageserver.assert_log_contains("INFO version: git:")
+        5, 1, lambda: env.pageserver.assert_log_contains(startup_line)
     )
 
     # start without gc so we can time compaction with less noise; use shorter
@@ -151,7 +154,7 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
     )
 
     _, second_start = wait_until(
-        5, 1, lambda: env.pageserver.assert_log_contains("INFO version: git:", first_start)
+        5, 1, lambda: env.pageserver.assert_log_contains(startup_line, first_start)
     )
     env.pageserver.quiesce_tenants()
 

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -98,7 +98,7 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int):
     env = neon_compare.env
 
     # seed the prng so we will measure the same structure every time
-    random.seed("2024-02-29")
+    rng = random.Random("2024-02-29")
 
     env.neon_cli.create_branch("b0")
 
@@ -109,7 +109,8 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int):
 
     for i in range(n_branches):
         # random a source branch
-        p = random.randint(0, i)
+        p = rng.randint(0, i)
+
         timer = timeit.default_timer()
         env.neon_cli.create_branch("b{}".format(i + 1), "b{}".format(p))
         dur = timeit.default_timer() - timer

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -128,7 +128,11 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
 
     endpoint.stop_and_destroy()
 
-    env.pageserver.restart()
+    with neon_compare.record_duration("pageserver_shutdown"):
+        # this sleeps 100ms between polls
+        env.pageserver.stop()
+
+    env.pageserver.start()
     env.pageserver.quiesce_tenants()
 
     wait_and_record_startup_metrics(env.pageserver, neon_compare.zenbenchmark, "restart_after")

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -130,7 +130,7 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
 
     endpoint.stop_and_destroy()
 
-    with neon_compare.record_duration("pageserver_shutdown"):
+    with neon_compare.record_duration("shutdown"):
         # this sleeps 100ms between polls
         env.pageserver.stop()
 

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -89,10 +89,13 @@ def test_branch_creation_heavy_write(neon_compare: NeonCompare, n_branches: int)
     _record_branch_creation_durations(neon_compare, branch_creation_durations)
 
 
-@pytest.mark.parametrize("n_branches", [1024])
+@pytest.mark.parametrize("n_branches", [500, 1024])
 # Test measures the latency of branch creation when creating a lot of branches.
 def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int):
     env = neon_compare.env
+
+    # seed the prng so we will measure the same structure every time
+    random.seed("2024-02-29")
 
     env.neon_cli.create_branch("b0")
 

--- a/test_runner/performance/test_branch_creation.py
+++ b/test_runner/performance/test_branch_creation.py
@@ -4,7 +4,6 @@ import statistics
 import threading
 import time
 import timeit
-import uuid
 from contextlib import closing
 from typing import List
 
@@ -137,9 +136,7 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
     startup_line = "INFO version: git(-env)?:"
 
     # find the first line of the log file so we can find the next start later
-    _, first_start = wait_until(
-        5, 1, lambda: env.pageserver.assert_log_contains(startup_line)
-    )
+    _, first_start = wait_until(5, 1, lambda: env.pageserver.assert_log_contains(startup_line))
 
     # start without gc so we can time compaction with less noise; use shorter
     # period for compaction so it starts earlier
@@ -158,14 +155,6 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
     )
     env.pageserver.quiesce_tenants()
 
-    http_client = env.pageserver.http_client()
-    marker = uuid.uuid4().hex
-    http_client.post_tracing_event("info", marker)
-
-    _, position = wait_until(
-        10, 1, lambda: env.pageserver.assert_log_contains(marker, second_start)
-    )
-
     wait_and_record_startup_metrics(env.pageserver, neon_compare.zenbenchmark, "restart_after")
 
     # wait for compaction to complete, which most likely has already done so multiple times
@@ -173,7 +162,7 @@ def test_branch_creation_many(neon_compare: NeonCompare, n_branches: int, shape:
         30,
         1,
         lambda: env.pageserver.assert_log_contains(
-            f".*tenant_id={env.initial_tenant}.*: compaction iteration complete.*", position
+            f".*tenant_id={env.initial_tenant}.*: compaction iteration complete.*", second_start
         ),
     )
     needle = re.search(" elapsed_ms=([0-9]+)", msg)


### PR DESCRIPTION
We have a benchmark for creating a lot of branches, but it does random things, and the branch count is not what we is the largest maximum we aim to support. If this PR would stabilize the benchmark total duration it means that there are some structures which are very much slower than others. Then we should add a seed-outputting variant to help find and reproduce such cases.

Additionally, record for the benchmark:
- shutdown duration
- startup metrics once done (on restart)
- duration of first compaction completion via debug logging