### PR TITLE
Hopefully stabilize test_bad_connection.py

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -396,9 +396,9 @@ impl ComputeNode {
     // Gets the basebackup in a retry loop
     #[instrument(skip_all, fields(%lsn))]
     pub fn get_basebackup(&self, compute_state: &ComputeState, lsn: Lsn) -> Result<()> {
-        let mut retry_period_ms = 500;
+        let mut retry_period_ms = 500.0;
         let mut attempts = 0;
-        let max_attempts = 5;
+        let max_attempts = 10;
         loop {
             let result = self.try_get_basebackup(compute_state, lsn);
             match result {
@@ -410,8 +410,8 @@ impl ComputeNode {
                         "Failed to get basebackup: {} (attempt {}/{})",
                         e, attempts, max_attempts
                     );
-                    std::thread::sleep(std::time::Duration::from_millis(retry_period_ms));
-                    retry_period_ms *= 2;
+                    std::thread::sleep(std::time::Duration::from_millis(retry_period_ms as u64));
+                    retry_period_ms *= 1.5;
                 }
                 Err(_) => {
                     return result;

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -656,7 +656,7 @@ impl Endpoint {
         // Wait for it to start
         let mut attempt = 0;
         const ATTEMPT_INTERVAL: Duration = Duration::from_millis(100);
-        const MAX_ATTEMPTS: u32 = 10 * 30; // Wait up to 30 s
+        const MAX_ATTEMPTS: u32 = 10 * 60; // Wait up to 1 min
         loop {
             attempt += 1;
             match self.get_status().await {

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -656,7 +656,7 @@ impl Endpoint {
         // Wait for it to start
         let mut attempt = 0;
         const ATTEMPT_INTERVAL: Duration = Duration::from_millis(100);
-        const MAX_ATTEMPTS: u32 = 10 * 60; // Wait up to 1 min
+        const MAX_ATTEMPTS: u32 = 10 * 90; // Wait up to 1.5 min
         loop {
             attempt += 1;
             match self.get_status().await {

--- a/test_runner/regress/test_bad_connection.py
+++ b/test_runner/regress/test_bad_connection.py
@@ -15,13 +15,7 @@ def test_compute_pageserver_connection_stress(neon_env_builder: NeonEnvBuilder):
     pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "50%return(15)"))
 
     env.neon_cli.create_branch("test_compute_pageserver_connection_stress")
-    try:
-        endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")
-    except Exception:
-        pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "off"))
-        # We might still fail to get the basebackup, so just turn off the failpoint here
-        endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")
-        pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "50%return(15)"))
+    endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")
 
     pg_conn = endpoint.connect()
     cur = pg_conn.cursor()

--- a/test_runner/regress/test_bad_connection.py
+++ b/test_runner/regress/test_bad_connection.py
@@ -17,7 +17,7 @@ def test_compute_pageserver_connection_stress(neon_env_builder: NeonEnvBuilder):
     env.neon_cli.create_branch("test_compute_pageserver_connection_stress")
     try:
         endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")
-    except:
+    except Exception:
         pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "off"))
         # We might still fail to get the basebackup, so just turn off the failpoint here
         endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")

--- a/test_runner/regress/test_bad_connection.py
+++ b/test_runner/regress/test_bad_connection.py
@@ -15,7 +15,13 @@ def test_compute_pageserver_connection_stress(neon_env_builder: NeonEnvBuilder):
     pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "50%return(15)"))
 
     env.neon_cli.create_branch("test_compute_pageserver_connection_stress")
-    endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")
+    try:
+        endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")
+    except:
+        pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "off"))
+        # We might still fail to get the basebackup, so just turn off the failpoint here
+        endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")
+        pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "50%return(15)"))
 
     pg_conn = endpoint.connect()
     cur = pg_conn.cursor()


### PR DESCRIPTION
## Problem
It seems that even though we have a retry on basebackup, it still sometimes fails to fetch it with the failpoint enabled, resulting in a test error.

## Summary of changes
If we fail to get the basebackup, disable the failpoint and try again. 
