### PR TITLE
upgrade mio 0.8.10 => 0.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",


### PR DESCRIPTION
## Problem

`cargo deny` fails ([an example](https://github.com/neondatabase/neon/actions/runs/8144556960/job/22258924744))
- https://rustsec.org/advisories/RUSTSEC-2024-0019
- https://github.com/tokio-rs/mio/security/advisories/GHSA-r8w9-5wcg-vfj7

>  The vulnerability is Windows-specific, and can only happen if you are using named pipes. Other IO resources are not affected.



## Summary of changes
- Upgrade mio from 0.8.10 to 0.8.11

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
