### PR TITLE
pageserver: fix AUX key vectored get validation

### DIFF
--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -1677,7 +1677,7 @@ struct RelDirectory {
     rels: HashSet<(Oid, u8)>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq)]
 pub(crate) struct AuxFilesDirectory {
     pub(crate) files: HashMap<String, Bytes>,
 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -930,8 +930,8 @@ impl Timeline {
                 (Ok(seq_aux_dir), Ok(vec_aux_dir)) => {
                     assert_eq!(
                         seq_aux_dir, vec_aux_dir,
-                        "Mismatch for key {} - keyspace={:?} lsn={}: {:?} != {:?}",
-                        key, keyspace, lsn, seq_aux_dir, vec_aux_dir
+                        "Mismatch for key {} - keyspace={:?} lsn={}",
+                        key, keyspace, lsn
                     );
                 }
                 (Err(_), Err(_)) => {}


### PR DESCRIPTION
## Problem
The value reconstruct of AUX_FILES_KEY from records is not deterministic since it uses a hash map under the hood.
This caused vectored get validation failures when enabled in staging.

## Summary of changes
Deserialise AUX_FILES_KEY blobs comparing. All other keys should reconstruct deterministically,
so we simply compare the blobs.

## Testing
Tested this locally with data extracted from a tenant which ran into this problem in staging.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
