### PR TITLE
fix(layer): remove the need to repair internal state

### DIFF
--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -2,7 +2,6 @@
 //! page server.
 
 use camino::{Utf8DirEntry, Utf8Path, Utf8PathBuf};
-use futures::stream::StreamExt;
 use itertools::Itertools;
 use pageserver_api::key::Key;
 use pageserver_api::models::ShardParameters;
@@ -1662,9 +1661,9 @@ impl TenantManager {
                     .layers
                     .read()
                     .await
-                    .resident_layers()
-                    .collect::<Vec<_>>()
-                    .await;
+                    .likely_resident_layers()
+                    .collect::<Vec<_>>();
+
                 for layer in timeline_layers {
                     let relative_path = layer
                         .local_path()

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -769,7 +769,9 @@ impl LayerInner {
                     either.downgrade()
                 }
                 None => {
-                    // FIXME: could this be by mistake?
+                    // we already have a scheduled eviction, which just has not gotten to run yet.
+                    // it might still race with a read access, but that could also get cancelled,
+                    // so let's say this is not evictable.
                     return Err(EvictionError::NotFound);
                 }
             }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -49,7 +49,9 @@ mod failpoints;
 /// An image layer is a snapshot of all the data in a key-range, at a single
 /// LSN.
 ///
-/// This type models the on-disk layers, which can be evicted and on-demand downloaded.
+/// This type models the on-disk layers, which can be evicted and on-demand downloaded. As a
+/// general goal, read accesses should always win eviction and eviction should not wait for
+/// download.
 ///
 /// ### State transitions
 ///
@@ -78,6 +80,10 @@ mod failpoints;
 ///  | file is present |<---------------------------| WantedEvicted(Weak<DownloadedLayer>) |
 ///  +-----------------+                            +--------------------------------------+
 /// ```
+///
+/// ### Unsupported
+///
+/// - Evicting by the operator deleting files from the filesystem
 ///
 /// [`InMemoryLayer`]: super::inmemory_layer::InMemoryLayer
 #[derive(Clone)]

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1418,10 +1418,6 @@ impl LayerInner {
                 // uninitialized. we must attempt even then, because a get_or_maybe_download was
                 // most likely cancelled.
                 //
-                // we could have ResidentOrWantedEvicted::Evicted, because get_or_maybe_download
-                // and wait_for_turn_and_evict go through take_and_deinit. this probably does not
-                // matter because these are quite rare situations.
-                //
                 // important here is not to touch any of the metrics; they've already been dealt
                 // with unless this deletion was caused by operator at filesystem level which is
                 // unsupported.

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1244,6 +1244,8 @@ impl LayerInner {
 
             let res = self.evict_blocking(&timeline, permit);
 
+            tracing::debug!(?res, "eviction completed");
+
             match res {
                 Ok(()) => LAYER_IMPL_METRICS.inc_completed_evictions(),
                 Err(e) => LAYER_IMPL_METRICS.inc_eviction_cancelled(e),

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -374,11 +374,11 @@ impl Layer {
     /// separatedly.
     #[cfg(any(feature = "testing", test))]
     pub(crate) fn wait_drop(&self) -> impl std::future::Future<Output = ()> + 'static {
-        let mut rx = self.0.status.subscribe();
+        let mut rx = self.0.status.as_ref().unwrap().subscribe();
 
         async move {
             loop {
-                if let Err(tokio::sync::broadcast::error::RecvError::Closed) = rx.recv().await {
+                if rx.changed().await.is_err() {
                     break;
                 }
             }
@@ -474,7 +474,7 @@ struct LayerInner {
     version: AtomicUsize,
 
     /// Allow subscribing to when the layer actually gets evicted.
-    status: tokio::sync::broadcast::Sender<Status>,
+    status: Option<tokio::sync::watch::Sender<Status>>,
 
     /// Counter for exponential backoff with the download
     consecutive_failures: AtomicUsize,
@@ -514,8 +514,9 @@ impl AsLayerDesc for LayerInner {
 
 #[derive(Debug, Clone, Copy)]
 enum Status {
+    Resident,
     Evicted,
-    Downloaded,
+    Downloading,
 }
 
 impl Drop for LayerInner {
@@ -534,7 +535,7 @@ impl Drop for LayerInner {
         let file_size = self.layer_desc().file_size;
         let timeline = self.timeline.clone();
         let meta = self.metadata();
-        let status = self.status.clone();
+        let status = self.status.take();
 
         crate::task_mgr::BACKGROUND_RUNTIME.spawn_blocking(move || {
             let _g = span.entered();
@@ -611,12 +612,16 @@ impl LayerInner {
             .timeline_path(&timeline.tenant_shard_id, &timeline.timeline_id)
             .join(desc.filename().to_string());
 
-        let (inner, version) = if let Some(inner) = downloaded {
+        let (inner, version, init_status) = if let Some(inner) = downloaded {
             let version = inner.version;
             let resident = ResidentOrWantedEvicted::Resident(inner);
-            (heavier_once_cell::OnceCell::new(resident), version)
+            (
+                heavier_once_cell::OnceCell::new(resident),
+                version,
+                Status::Resident,
+            )
         } else {
-            (heavier_once_cell::OnceCell::default(), 0)
+            (heavier_once_cell::OnceCell::default(), 0, Status::Evicted)
         };
 
         LayerInner {
@@ -630,7 +635,7 @@ impl LayerInner {
             wanted_evicted: AtomicBool::new(false),
             inner,
             version: AtomicUsize::new(version),
-            status: tokio::sync::broadcast::channel(1).0,
+            status: Some(tokio::sync::watch::channel(init_status).0),
             consecutive_failures: AtomicUsize::new(0),
             generation,
             shard,
@@ -653,11 +658,22 @@ impl LayerInner {
     /// Cancellation safe, however dropping the future and calling this method again might result
     /// in a new attempt to evict OR join the previously started attempt.
     pub(crate) async fn evict_and_wait(&self, timeout: Duration) -> Result<(), EvictionError> {
-        use tokio::sync::broadcast::error::RecvError;
-
         assert!(self.have_remote_client);
 
-        let mut rx = self.status.subscribe();
+        let mut rx = self.status.as_ref().unwrap().subscribe();
+
+        {
+            let current = rx.borrow_and_update();
+            match &*current {
+                Status::Resident => {
+                    // we might get lucky and evict this; continue
+                }
+                Status::Evicted | Status::Downloading => {
+                    // it is already evicted
+                    return Err(EvictionError::NotFound);
+                }
+            }
+        }
 
         let strong = {
             match self.inner.get() {
@@ -665,7 +681,10 @@ impl LayerInner {
                     self.wanted_evicted.store(true, Ordering::Relaxed);
                     either.downgrade()
                 }
-                None => return Err(EvictionError::NotFound),
+                None => {
+                    // FIXME: could this be by mistake?
+                    return Err(EvictionError::NotFound);
+                }
             }
         };
 
@@ -681,26 +700,24 @@ impl LayerInner {
             LAYER_IMPL_METRICS.inc_started_evictions();
         }
 
-        match tokio::time::timeout(timeout, rx.recv()).await {
-            Ok(Ok(Status::Evicted)) => Ok(()),
-            Ok(Ok(Status::Downloaded)) => Err(EvictionError::Downloaded),
-            Ok(Err(RecvError::Closed)) => {
-                unreachable!("sender cannot be dropped while we are in &self method")
-            }
-            Ok(Err(RecvError::Lagged(_))) => {
-                // this is quite unlikely, but we are blocking a lot in the async context, so
-                // we might be missing this because we are stuck on a LIFO slot on a thread
-                // which is busy blocking for a 1TB database create_image_layers.
-                //
-                // use however late (compared to the initial expressing of wanted) as the
-                // "outcome" now
-                LAYER_IMPL_METRICS.inc_broadcast_lagged();
-                match self.inner.get() {
-                    Some(_) => Err(EvictionError::Downloaded),
-                    None => Ok(()),
-                }
-            }
-            Err(_timeout) => Err(EvictionError::Timeout),
+        let changed = rx.changed();
+        let changed = tokio::time::timeout(timeout, changed).await;
+
+        let Ok(changed) = changed else {
+            return Err(EvictionError::Timeout);
+        };
+
+        let _: () = changed.expect("cannot be closed, because we are holding a strong reference");
+
+        let current = rx.borrow_and_update();
+
+        match &*current {
+            Status::Evicted => Ok(()),
+            // it surely was evicted in between, but then there was a new access
+            Status::Downloading => Ok(()),
+            // either the download which was started after eviction completed already, or it was
+            // never evicted
+            Status::Resident => Err(EvictionError::Downloaded),
         }
     }
 
@@ -730,8 +747,9 @@ impl LayerInner {
                     // previously a `evict_and_wait` was received.
                     self.wanted_evicted.store(false, Ordering::Relaxed);
 
-                    // error out any `evict_and_wait`
-                    drop(self.status.send(Status::Downloaded));
+                    // error out any `evict_and_wait` -- note we want to send this unconditionally
+                    // to break out any changed()
+                    self.status.as_ref().unwrap().send_replace(Status::Resident);
                     LAYER_IMPL_METRICS
                         .inc_eviction_cancelled(EvictionCancelled::UpgradedBackOnAccess);
 
@@ -867,7 +885,13 @@ impl LayerInner {
             async move {
                 let _guard = guard;
 
-                drop(this.status.send(Status::Downloaded));
+                // now that we have commited to downloading, send out an update to:
+                // - unhang any pending eviction
+                // - break out of evict_and_wait
+                this.status
+                    .as_ref()
+                    .unwrap()
+                    .send_replace(Status::Downloading);
 
                 let res = this.download_and_init(timeline, permit).await;
 
@@ -1005,10 +1029,8 @@ impl LayerInner {
         // we would like to do for prefetching which was not needed.
         self.wanted_evicted.store(false, Ordering::Release);
 
-        // re-send the notification we've already sent when we started to download, just so
-        // evict_and_wait does not need to wait for the download to complete. note that this is
-        // sent when initializing after finding the file on the disk.
-        drop(self.status.send(Status::Downloaded));
+        // no need to make the evict_and_wait wait for the actual download to complete
+        self.status.as_ref().unwrap().send_replace(Status::Resident);
 
         let res = Arc::new(DownloadedLayer {
             owner: Arc::downgrade(self),
@@ -1092,83 +1114,151 @@ impl LayerInner {
     }
 
     /// `DownloadedLayer` is being dropped, so it calls this method.
-    fn on_downloaded_layer_drop(self: Arc<LayerInner>, version: usize) {
+    fn on_downloaded_layer_drop(self: Arc<LayerInner>, only_version: usize) {
         let evict = self.wanted_evicted.load(Ordering::Acquire);
         let can_evict = self.have_remote_client;
 
         if can_evict && evict {
-            let span = tracing::info_span!(parent: None, "layer_evict", tenant_id = %self.desc.tenant_shard_id.tenant_id, shard_id = %self.desc.tenant_shard_id.shard_slug(), timeline_id = %self.desc.timeline_id, layer=%self, %version);
-
-            span.in_scope(|| tracing::debug!("eviction started"));
-
-            // downgrade for queueing, in case there's a tear down already ongoing we should not
-            // hold it alive.
-            let this = Arc::downgrade(&self);
-            drop(self);
+            let span = tracing::info_span!(parent: None, "layer_evict", tenant_id = %self.desc.tenant_shard_id.tenant_id, shard_id = %self.desc.tenant_shard_id.shard_slug(), timeline_id = %self.desc.timeline_id, layer=%self, version=%only_version);
 
             // NOTE: this scope *must* never call `self.inner.get` because evict_and_wait might
             // drop while the `self.inner` is being locked, leading to a deadlock.
 
-            crate::task_mgr::BACKGROUND_RUNTIME.spawn_blocking(move || {
-                let _g = span.entered();
+            let start_evicting = async move {
+                #[cfg(test)]
+                self.failpoint(failpoints::FailpointKind::WaitBeforeStartingEvicting)
+                    .await
+                    .expect("failpoint should not have errored");
 
-                // if LayerInner is already dropped here, do nothing because the delete on drop
-                // has already ran while we were in queue
-                let res = this
-                    .upgrade()
-                    .ok_or(EvictionCancelled::LayerGone)
-                    .and_then(|this| this.evict_blocking(version));
-                tracing::debug!(?res, "eviction completed");
-                match res {
-                    Ok(()) => LAYER_IMPL_METRICS.inc_completed_evictions(),
-                    Err(reason) => LAYER_IMPL_METRICS.inc_eviction_cancelled(reason),
+                tracing::debug!("eviction started");
+
+                let res = self.wait_for_turn_and_evict(only_version).await;
+                // metrics: ignore the Ok branch, it is not done yet
+                if let Err(e) = res {
+                    tracing::debug!(res=?Err::<(), _>(&e), "eviction completed");
+                    LAYER_IMPL_METRICS.inc_eviction_cancelled(e);
                 }
-            });
+            };
+
+            // first we spawn off the async part, then it will spawn_blocking the blocking part
+            crate::task_mgr::BACKGROUND_RUNTIME.spawn(start_evicting.instrument(span));
         }
     }
 
-    fn evict_blocking(&self, only_version: usize) -> Result<(), EvictionCancelled> {
-        // deleted or detached timeline, don't do anything.
-        let Some(timeline) = self.timeline.upgrade() else {
-            return Err(EvictionCancelled::TimelineGone);
-        };
+    async fn wait_for_turn_and_evict(
+        self: Arc<LayerInner>,
+        only_version: usize,
+    ) -> Result<(), EvictionCancelled> {
+        fn is_good_to_continue(status: &Status) -> Result<(), EvictionCancelled> {
+            use Status::*;
+            match status {
+                Resident => Ok(()),
+                Evicted => Err(EvictionCancelled::UnexpectedEvictedState),
+                Downloading => Err(EvictionCancelled::LostToDownload),
+            }
+        }
+
+        let timeline = self
+            .timeline
+            .upgrade()
+            .ok_or(EvictionCancelled::TimelineGone)?;
+
+        let mut rx = self
+            .status
+            .as_ref()
+            .expect("LayerInner cannot be dropped, holding strong ref")
+            .subscribe();
+
+        is_good_to_continue(&rx.borrow_and_update())?;
 
         let Ok(_gate) = timeline.gate.enter() else {
             return Err(EvictionCancelled::TimelineGone);
         };
 
-        // to avoid starting a new download while we evict, keep holding on to the
-        // permit.
-        let _permit = {
-            let maybe_downloaded = self.inner.get();
+        let permit = {
+            let mut wait = std::pin::pin!(self.inner.get_or_init_detached());
 
-            let (_weak, permit) = match maybe_downloaded {
-                Some(guard) => {
-                    if let ResidentOrWantedEvicted::WantedEvicted(_weak, version) = &*guard {
-                        if *version == only_version {
-                            guard.take_and_deinit()
-                        } else {
-                            // this was not for us; maybe there's another eviction job
-                            // TODO: does it make any sense to stall here? unique versions do not
-                            // matter, we only want to make sure not to evict a resident, which we
-                            // are not doing.
-                            return Err(EvictionCancelled::VersionCheckFailed);
-                        }
-                    } else {
-                        return Err(EvictionCancelled::AlreadyReinitialized);
+            let waited = loop {
+                // we must race to the Downloading starting, otherwise we would have to wait until the
+                // completion of the download
+                tokio::select! {
+                    res = &mut wait => break res,
+                    _ = rx.changed() => {
+                        is_good_to_continue(&rx.borrow_and_update())?;
+                        // two possibilities for Status::Resident:
+                        // - the layer was found locally from disk by a read
+                        // - we missed a bunch of updates and now the layer is
+                        // again downloaded -- assume we'll fail later on with
+                        // version check or AlreadyReinitialized
                     }
                 }
-                None => {
-                    // already deinitialized, perhaps get_or_maybe_download did this and is
-                    // currently waiting to reinitialize it
-                    return Err(EvictionCancelled::LostToDownload);
+            };
+
+            // re-check now that we have the guard or permit; all updates should have happened
+            // while holding the permit.
+            is_good_to_continue(&rx.borrow_and_update())?;
+
+            let (_weak, permit) = match waited {
+                Ok(guard) => {
+                    match &*guard {
+                        ResidentOrWantedEvicted::WantedEvicted(_weak, version)
+                            if *version == only_version =>
+                        {
+                            tracing::debug!(version, "deinitializing matching WantedEvicted");
+                            let (weak, permit) = guard.take_and_deinit();
+                            (Some(weak), permit)
+                        }
+                        ResidentOrWantedEvicted::WantedEvicted(_, version) => {
+                            // if we were not doing the version check, we would need to try to
+                            // upgrade the weak here to see if it really is dropped. version check
+                            // might be cheaper?
+                            tracing::debug!(
+                                version,
+                                only_version,
+                                "version mismatch, not deinitializing"
+                            );
+                            return Err(EvictionCancelled::VersionCheckFailed);
+                        }
+                        ResidentOrWantedEvicted::Resident(_) => {
+                            return Err(EvictionCancelled::AlreadyReinitialized);
+                        }
+                    }
+                }
+                Err(permit) => {
+                    tracing::debug!("continuing after cancelled get_or_maybe_download or eviction");
+                    (None, permit)
                 }
             };
 
             permit
         };
 
-        // now accesses to inner.get_or_init wait on the semaphore or the `_permit`
+        let span = tracing::Span::current();
+
+        // this is on purpose a detached spawn; we don't need to wait for it
+        //
+        // eviction completion reporting is the only thing hinging on this, and it can be just as
+        // well from a spawn_blocking thread.
+        crate::task_mgr::BACKGROUND_RUNTIME.spawn_blocking(move || {
+            let _span = span.entered();
+
+            let res = self.evict_blocking(&timeline, permit);
+
+            match res {
+                Ok(()) => LAYER_IMPL_METRICS.inc_completed_evictions(),
+                Err(e) => LAYER_IMPL_METRICS.inc_eviction_cancelled(e),
+            }
+        });
+
+        Ok(())
+    }
+
+    fn evict_blocking(
+        &self,
+        timeline: &Timeline,
+        _permit: heavier_once_cell::InitPermit,
+    ) -> Result<(), EvictionCancelled> {
+        // now accesses to `self.inner.get_or_init*` wait on the semaphore or the `_permit`
 
         self.access_stats.record_residence_event(
             LayerResidenceStatus::Evicted,
@@ -1216,7 +1306,7 @@ impl LayerInner {
         };
 
         // we are still holding the permit, so no new spawn_download_and_wait can happen
-        drop(self.status.send(Status::Evicted));
+        self.status.as_ref().unwrap().send_replace(Status::Evicted);
 
         *self.last_evicted_at.lock().unwrap() = Some(std::time::Instant::now());
 
@@ -1727,10 +1817,6 @@ impl LayerImplMetrics {
         self.rare_counters[RareEvent::PermanentLoadingFailure].inc();
     }
 
-    fn inc_broadcast_lagged(&self) {
-        self.rare_counters[RareEvent::EvictAndWaitLagged].inc();
-    }
-
     fn inc_init_cancelled(&self) {
         self.inits_cancelled.inc()
     }
@@ -1752,6 +1838,7 @@ enum EvictionCancelled {
     LostToDownload,
     /// After eviction, there was a new layer access which cancelled the eviction.
     UpgradedBackOnAccess,
+    UnexpectedEvictedState,
 }
 
 impl EvictionCancelled {
@@ -1765,6 +1852,7 @@ impl EvictionCancelled {
             EvictionCancelled::AlreadyReinitialized => "already_reinitialized",
             EvictionCancelled::LostToDownload => "lost_to_download",
             EvictionCancelled::UpgradedBackOnAccess => "upgraded_back_on_access",
+            EvictionCancelled::UnexpectedEvictedState => "unexpected_evicted_state",
         }
     }
 }
@@ -1792,7 +1880,6 @@ enum RareEvent {
     UpgradedWantedEvicted,
     InitWithoutDownload,
     PermanentLoadingFailure,
-    EvictAndWaitLagged,
 }
 
 impl RareEvent {
@@ -1806,7 +1893,6 @@ impl RareEvent {
             UpgradedWantedEvicted => "raced_wanted_evicted",
             InitWithoutDownload => "init_needed_no_download",
             PermanentLoadingFailure => "permanent_loading_failure",
-            EvictAndWaitLagged => "broadcast_lagged",
         }
     }
 }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -536,9 +536,10 @@ struct LayerInner {
     /// Do we want to delete locally and remotely this when `LayerInner` is dropped
     wanted_deleted: AtomicBool,
 
-    /// Do we want to evict this layer as soon as possible? After being set to `true`, all accesses
-    /// will try to downgrade [`ResidentOrWantedEvicted`], which will eventually trigger
-    /// [`LayerInner::on_downloaded_layer_drop`].
+    /// Do we want to evict this layer as soon as possible? Only set to `true` by [`Layer::evict_and_wait`].
+    ///
+    /// Exists only for optimization in [`LayerInner::on_downloaded_layer_drop`] to avoid spawning
+    /// a task.
     wanted_evicted: AtomicBool,
 
     /// Version is to make sure we will only evict a specific download of a file.

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1407,6 +1407,7 @@ impl LayerInner {
                 return Err(EvictionCancelled::FileNotFound);
             }
             Err(e) => {
+                // FIXME: this should probably be an abort
                 tracing::error!("failed to evict file from disk: {e:#}");
                 return Err(EvictionCancelled::RemoveFailed);
             }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -573,7 +573,7 @@ impl Drop for LayerInner {
         let meta = self.metadata();
         let status = self.status.take();
 
-        crate::task_mgr::BACKGROUND_RUNTIME.spawn_blocking(move || {
+        Self::spawn_blocking(move || {
             let _g = span.entered();
 
             // carry this until we are finished for [`Layer::wait_drop`] support
@@ -918,7 +918,7 @@ impl LayerInner {
             .enter()
             .map_err(|_| DownloadError::DownloadCancelled)?;
 
-        tokio::task::spawn(
+        Self::spawn(
             async move {
                 let _guard = guard;
 
@@ -1180,7 +1180,7 @@ impl LayerInner {
             };
 
             // first we spawn off the async part, then it will spawn_blocking the blocking part
-            crate::task_mgr::BACKGROUND_RUNTIME.spawn(start_evicting.instrument(span));
+            Self::spawn(start_evicting.instrument(span));
         }
     }
 
@@ -1278,7 +1278,7 @@ impl LayerInner {
         //
         // eviction completion reporting is the only thing hinging on this, and it can be just as
         // well from a spawn_blocking thread.
-        crate::task_mgr::BACKGROUND_RUNTIME.spawn_blocking(move || {
+        Self::spawn_blocking(move || {
             let _span = span.entered();
 
             let res = self.evict_blocking(&timeline, permit);

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -542,6 +542,9 @@ struct LayerInner {
     /// a shard split since the layer was originally written.
     shard: ShardIndex,
 
+    /// When the Layer was last evicted but has not been downloaded since.
+    ///
+    /// This is used solely for updating metrics. See [`LayerImplMetrics::redownload_after`].
     last_evicted_at: std::sync::Mutex<Option<std::time::Instant>>,
 
     #[cfg(test)]

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -497,7 +497,7 @@ struct LayerInner {
     last_evicted_at: std::sync::Mutex<Option<std::time::Instant>>,
 
     #[cfg(test)]
-    failpoints: std::sync::Mutex<enumset::EnumSet<failpoints::FailpointKind>>,
+    failpoints: std::sync::Mutex<Vec<failpoints::Failpoint>>,
 }
 
 impl std::fmt::Display for LayerInner {
@@ -780,7 +780,8 @@ impl LayerInner {
 
         let Some(reason) = needs_download else {
             #[cfg(test)]
-            self.failpoint(failpoints::FailpointKind::AfterDeterminingLayerNeedsNoDownload)?;
+            self.failpoint(failpoints::FailpointKind::AfterDeterminingLayerNeedsNoDownload)
+                .await?;
 
             // the file is present locally, probably by a previous but cancelled call to
             // get_or_maybe_download. alternatively we might be running without remote storage.

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -779,6 +779,9 @@ impl LayerInner {
         let needs_download = needs_download?;
 
         let Some(reason) = needs_download else {
+            #[cfg(test)]
+            self.failpoint(failpoints::FailpointKind::AfterDeterminingLayerNeedsNoDownload)?;
+
             // the file is present locally, probably by a previous but cancelled call to
             // get_or_maybe_download. alternatively we might be running without remote storage.
             LAYER_IMPL_METRICS.inc_init_needed_no_download();

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1333,6 +1333,7 @@ impl LayerInner {
         Ok(())
     }
 
+    /// This is blocking only to do just one spawn_blocking hop compared to multiple via tokio::fs.
     fn evict_blocking(
         &self,
         timeline: &Timeline,

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -956,6 +956,8 @@ impl LayerInner {
                     Some(remote_storage::DownloadError::Cancelled) => {
                         Err(DownloadError::DownloadCancelled)
                     }
+                    // FIXME: this is not embedding the error because historically it would had
+                    // been output to compute, however that is no longer the case.
                     _ => Err(DownloadError::DownloadFailed),
                 }
             }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -808,7 +808,7 @@ impl LayerInner {
                     return Ok(strong);
                 }
                 Ok(Err(guard)) => {
-                    // path to here: the evict_blocking is stuck on spawn_blocking queue.
+                    // path to here: we won the eviction, the file should still be on the disk.
                     //
                     // reset the contents, deactivating the eviction and causing a
                     // EvictionCancelled::LostToDownload or EvictionCancelled::VersionCheckFailed.

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -764,7 +764,8 @@ impl LayerInner {
 
         match &*current {
             Status::Evicted => Ok(()),
-            // it surely was evicted in between, but then there was a new access
+            // it surely was evicted in between, but then there was a new access now; we can't know
+            // if it'll succeed so lets just call it evicted
             Status::Downloading => Ok(()),
             // either the download which was started after eviction completed already, or it was
             // never evicted

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1242,7 +1242,8 @@ impl LayerInner {
 
             let waited = loop {
                 // we must race to the Downloading starting, otherwise we would have to wait until the
-                // completion of the download
+                // completion of the download. waiting for download could be long and hinder our
+                // efforts to alert on "hanging" evictions.
                 tokio::select! {
                     res = &mut wait => break res,
                     _ = rx.changed() => {

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -834,8 +834,7 @@ impl LayerInner {
             self.failpoint(failpoints::FailpointKind::AfterDeterminingLayerNeedsNoDownload)
                 .await?;
 
-            // the file is present locally, probably by a previous but cancelled call to
-            // get_or_maybe_download. alternatively we might be running without remote storage.
+            // the file is present locally because eviction has not had a chance to run yet
             LAYER_IMPL_METRICS.inc_init_needed_no_download();
 
             return Ok(self.initialize_after_layer_is_on_disk(permit));

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -512,7 +512,13 @@ struct LayerInner {
     /// `ResidentOrWantedEvicted::WantedEvicted`.
     version: AtomicUsize,
 
-    /// Allow subscribing to when the layer actually gets evicted.
+    /// Allow subscribing to when the layer actually gets evicted, a non-cancellable download
+    /// starts or completes.
+    ///
+    /// Updates must only be posted while holding the InitPermit, which is the only time we can do
+    /// state transitions.
+    ///
+    /// The sender is wrapped in an Option to facilitate moving it out on [`LayerInner::drop`].
     status: Option<tokio::sync::watch::Sender<Status>>,
 
     /// Counter for exponential backoff with the download

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -521,7 +521,10 @@ struct LayerInner {
     /// The sender is wrapped in an Option to facilitate moving it out on [`LayerInner::drop`].
     status: Option<tokio::sync::watch::Sender<Status>>,
 
-    /// Counter for exponential backoff with the download
+    /// Counter for exponential backoff with the download.
+    ///
+    /// This is atomic only for the purposes of having additional data only accessed while holding
+    /// the InitPermit.
     consecutive_failures: AtomicUsize,
 
     /// The generation of this Layer.

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -693,6 +693,7 @@ impl LayerInner {
 
     /// Cancellation safe, however dropping the future and calling this method again might result
     /// in a new attempt to evict OR join the previously started attempt.
+    #[tracing::instrument(level = tracing::Level::DEBUG, skip_all, ret, err(level = tracing::Level::DEBUG), fields(layer=%self))]
     pub(crate) async fn evict_and_wait(&self, timeout: Duration) -> Result<(), EvictionError> {
         assert!(self.have_remote_client);
 

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1400,15 +1400,7 @@ impl LayerInner {
                     .resident_physical_size_sub(self.desc.file_size);
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // this used to be an error!, but now it can always happen if there are more than
-                // one pending eviction. we must attempt evicting even if the self.inner is
-                // uninitialized. we must attempt even then, because a get_or_maybe_download was
-                // most likely cancelled.
-                //
-                // important here is not to touch any of the metrics; they've already been dealt
-                // with unless this deletion was caused by operator at filesystem level which is
-                // unsupported.
-                tracing::debug!(
+                tracing::error!(
                     layer_size = %self.desc.file_size,
                     "failed to evict layer from disk, it was already gone"
                 );

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -978,6 +978,11 @@ impl LayerInner {
                     .unwrap()
                     .send_replace(Status::Downloading);
 
+                #[cfg(test)]
+                this.failpoint(failpoints::FailpointKind::WaitBeforeDownloading)
+                    .await
+                    .unwrap();
+
                 let res = this.download_and_init(timeline, permit).await;
 
                 if let Err(res) = tx.send(res) {

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -501,7 +501,7 @@ struct LayerInner {
 
     /// Version is to make sure we will only evict a specific download of a file.
     ///
-    /// Incremented for each download, stored in `DownloadedLayer::version` or
+    /// Incremented for each initialization, stored in `DownloadedLayer::version` or
     /// `ResidentOrWantedEvicted::WantedEvicted`.
     version: AtomicUsize,
 

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1900,7 +1900,7 @@ impl LayerImplMetrics {
     }
 }
 
-#[derive(Debug, enum_map::Enum)]
+#[derive(Debug, Clone, Copy, enum_map::Enum)]
 enum EvictionCancelled {
     LayerGone,
     TimelineGone,

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -480,6 +480,9 @@ struct LayerInner {
     desc: PersistentLayerDesc,
 
     /// Timeline access is needed for remote timeline client and metrics.
+    ///
+    /// There should not be an access to timeline for any reason without entering the
+    /// [`Timeline::gate`] at the same time.
     timeline: Weak<Timeline>,
 
     /// Cached knowledge of [`Timeline::remote_client`] being `Some`.

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1080,7 +1080,7 @@ impl LayerInner {
     ) -> Arc<DownloadedLayer> {
         debug_assert_current_span_has_tenant_and_timeline_id();
 
-        // disable any scheduled but not yet running eviction deletions for this
+        // disable any scheduled but not yet running eviction deletions for this initialization
         let next_version = 1 + self.version.fetch_add(1, Ordering::Relaxed);
 
         // only reset this after we've decided we really need to download. otherwise it'd
@@ -1089,6 +1089,7 @@ impl LayerInner {
         self.wanted_evicted.store(false, Ordering::Release);
 
         // no need to make the evict_and_wait wait for the actual download to complete
+        // this also stops any pending eviction from hanging
         self.status.as_ref().unwrap().send_replace(Status::Resident);
 
         let res = Arc::new(DownloadedLayer {

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1118,14 +1118,7 @@ impl LayerInner {
 
         // disable any scheduled but not yet running eviction deletions for this initialization
         let next_version = 1 + self.version.fetch_add(1, Ordering::Relaxed);
-
-        // only reset this after we've decided we really need to download. otherwise it'd
-        // be impossible to mark cancelled downloads for eviction, like one could imagine
-        // we would like to do for prefetching which was not needed.
         self.wanted_evicted.store(false, Ordering::Release);
-
-        // no need to make the evict_and_wait wait for the actual download to complete
-        // this also stops any pending eviction from hanging
         self.status.as_ref().unwrap().send_replace(Status::Resident);
 
         let res = Arc::new(DownloadedLayer {

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -833,9 +833,6 @@ impl LayerInner {
                 }
                 Ok(Err(guard)) => {
                     // path to here: we won the eviction, the file should still be on the disk.
-                    //
-                    // reset the contents, deactivating the eviction and causing a
-                    // EvictionCancelled::LostToDownload or EvictionCancelled::VersionCheckFailed.
                     let (weak, permit) = guard.take_and_deinit();
                     (Some(weak), permit)
                 }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -573,9 +573,8 @@ enum Status {
 impl Drop for LayerInner {
     fn drop(&mut self) {
         if !*self.wanted_deleted.get_mut() {
-            // should we try to evict if the last wish was for eviction?
-            // feels like there's some hazard of overcrowding near shutdown near by, but we don't
-            // run drops during shutdown (yet)
+            // should we try to evict if the last wish was for eviction? seems more like a hazard
+            // than a clear win.
             return;
         }
 

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1555,6 +1555,7 @@ impl Drop for DownloadedLayer {
             owner.on_downloaded_layer_drop(self.version);
         } else {
             // no need to do anything, we are shutting down
+            LAYER_IMPL_METRICS.inc_eviction_cancelled(EvictionCancelled::LayerGone);
         }
     }
 }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -491,7 +491,11 @@ struct LayerInner {
     access_stats: LayerAccessStats,
 
     /// This custom OnceCell is backed by std mutex, but only held for short time periods.
-    /// Initialization and deinitialization are done while holding a permit.
+    /// Initialization and deinitialization are done while holding a permit which the
+    /// heavier_once_cell provides.
+    ///
+    /// A number of fields in `Layer` are meant to only be updated when holding the InitPermit, but
+    /// possibly read while not holding it.
     inner: heavier_once_cell::OnceCell<ResidentOrWantedEvicted>,
 
     /// Do we want to delete locally and remotely this when `LayerInner` is dropped

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -32,6 +32,9 @@ use utils::generation::Generation;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod failpoints;
+
 /// A Layer contains all data in a "rectangle" consisting of a range of keys and
 /// range of LSNs.
 ///
@@ -492,6 +495,9 @@ struct LayerInner {
     shard: ShardIndex,
 
     last_evicted_at: std::sync::Mutex<Option<std::time::Instant>>,
+
+    #[cfg(test)]
+    failpoints: std::sync::Mutex<enumset::EnumSet<failpoints::FailpointKind>>,
 }
 
 impl std::fmt::Display for LayerInner {
@@ -629,6 +635,8 @@ impl LayerInner {
             generation,
             shard,
             last_evicted_at: std::sync::Mutex::default(),
+            #[cfg(test)]
+            failpoints: Default::default(),
         }
     }
 
@@ -1254,6 +1262,10 @@ pub(crate) enum DownloadError {
     DownloadCancelled,
     #[error("pre-condition: stat before download failed")]
     PreStatFailed(#[source] std::io::Error),
+
+    #[cfg(test)]
+    #[error("failpoint: {0:?}")]
+    Failpoint(failpoints::FailpointKind),
 }
 
 #[derive(Debug, PartialEq)]

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -525,8 +525,9 @@ struct LayerInner {
     access_stats: LayerAccessStats,
 
     /// This custom OnceCell is backed by std mutex, but only held for short time periods.
-    /// Initialization and deinitialization are done while holding a permit which the
-    /// heavier_once_cell provides.
+    ///
+    /// Filesystem changes (download, evict) are only done while holding a permit which the
+    /// `heavier_once_cell` provides.
     ///
     /// A number of fields in `Layer` are meant to only be updated when holding the InitPermit, but
     /// possibly read while not holding it.

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -542,14 +542,14 @@ struct LayerInner {
     /// a task.
     wanted_evicted: AtomicBool,
 
-    /// Version is to make sure we will only evict a specific download of a file.
+    /// Version is to make sure we will only evict a specific initialization of the downloaded file.
     ///
     /// Incremented for each initialization, stored in `DownloadedLayer::version` or
     /// `ResidentOrWantedEvicted::WantedEvicted`.
     version: AtomicUsize,
 
     /// Allow subscribing to when the layer actually gets evicted, a non-cancellable download
-    /// starts or completes.
+    /// starts, or completes.
     ///
     /// Updates must only be posted while holding the InitPermit, which is the only time we can do
     /// state transitions.

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -793,6 +793,7 @@ impl LayerInner {
         let current = rx.borrow_and_update();
 
         match &*current {
+            // the easiest case
             Status::Evicted => Ok(()),
             // it surely was evicted in between, but then there was a new access now; we can't know
             // if it'll succeed so lets just call it evicted

--- a/pageserver/src/tenant/storage_layer/layer/failpoints.rs
+++ b/pageserver/src/tenant/storage_layer/layer/failpoints.rs
@@ -1,0 +1,51 @@
+//! failpoints for unit tests, implying `#[cfg(test)]`.
+//!
+//! These are not accessible over http.
+
+use super::*;
+
+impl LayerInner {
+    #[cfg(test)]
+    pub(super) fn failpoint(&self, kind: FailpointKind) -> Result<(), FailpointHit> {
+        let hit = self.failpoints.lock().unwrap().contains(kind);
+        if hit {
+            Err(FailpointHit(kind))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(super) fn enable_failpoint(&self, kind: FailpointKind) {
+        assert!(self.failpoints.lock().unwrap().insert(kind));
+    }
+}
+
+#[derive(Debug, enumset::EnumSetType)]
+#[cfg(test)]
+pub(crate) enum FailpointKind {
+    /// Failpoint acts as an accurate cancelled by drop here; see the only site of use.
+    AfterDeterminingLayerNeedsNoDownload,
+}
+
+impl std::fmt::Display for FailpointKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FailpointHit(FailpointKind);
+
+impl std::fmt::Display for FailpointHit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for FailpointHit {}
+
+impl From<FailpointHit> for DownloadError {
+    fn from(value: FailpointHit) -> Self {
+        DownloadError::Failpoint(value.0)
+    }
+}

--- a/pageserver/src/tenant/storage_layer/layer/failpoints.rs
+++ b/pageserver/src/tenant/storage_layer/layer/failpoints.rs
@@ -4,6 +4,13 @@
 
 use super::*;
 
+impl Layer {
+    /// Enable a failpoint from a unit test.
+    pub(super) fn enable_failpoint(&self, failpoint: Failpoint) {
+        self.0.failpoints.lock().unwrap().push(failpoint);
+    }
+}
+
 impl LayerInner {
     /// Query if this failpoint is enabled, as in, arrive at a failpoint.
     ///
@@ -21,11 +28,6 @@ impl LayerInner {
         };
 
         fut.await
-    }
-
-    /// Enable a failpoint from a unit test.
-    pub(super) fn enable_failpoint(&self, failpoint: Failpoint) {
-        self.failpoints.lock().unwrap().push(failpoint);
     }
 }
 

--- a/pageserver/src/tenant/storage_layer/layer/failpoints.rs
+++ b/pageserver/src/tenant/storage_layer/layer/failpoints.rs
@@ -41,7 +41,6 @@ pub(crate) enum FailpointKind {
     WaitBeforeStartingEvicting,
 }
 
-#[derive(Clone)]
 pub(crate) enum Failpoint {
     /// Failpoint acts as an accurate cancelled by drop here; see the only site of use.
     AfterDeterminingLayerNeedsNoDownload,

--- a/pageserver/src/tenant/storage_layer/layer/failpoints.rs
+++ b/pageserver/src/tenant/storage_layer/layer/failpoints.rs
@@ -18,7 +18,9 @@ impl LayerInner {
     pub(super) async fn failpoint(&self, kind: FailpointKind) -> Result<(), FailpointHit> {
         let fut = {
             let mut fps = self.failpoints.lock().unwrap();
-            let fp = fps.iter_mut().find(|x| x.kind() == kind);
+            // find the *last* failpoint for cases in which we need to use multiple for the same
+            // thing (two blocked evictions)
+            let fp = fps.iter_mut().rfind(|x| x.kind() == kind);
 
             let Some(fp) = fp else {
                 return Ok(());

--- a/pageserver/src/tenant/storage_layer/layer/failpoints.rs
+++ b/pageserver/src/tenant/storage_layer/layer/failpoints.rs
@@ -5,26 +5,64 @@
 use super::*;
 
 impl LayerInner {
-    #[cfg(test)]
-    pub(super) fn failpoint(&self, kind: FailpointKind) -> Result<(), FailpointHit> {
-        let hit = self.failpoints.lock().unwrap().contains(kind);
-        if hit {
-            Err(FailpointHit(kind))
+    /// Query if this failpoint is enabled, as in, arrive at a failpoint.
+    ///
+    /// Calls to this method need to be `#[cfg(test)]` guarded.
+    pub(super) async fn failpoint(&self, kind: FailpointKind) -> Result<(), FailpointHit> {
+        let fp = {
+            let fps = self.failpoints.lock().unwrap();
+            fps.iter().find(|x| x.kind() == kind).cloned()
+        };
+        if let Some(fp) = fp {
+            fp.hit().await
         } else {
             Ok(())
         }
     }
 
-    pub(super) fn enable_failpoint(&self, kind: FailpointKind) {
-        assert!(self.failpoints.lock().unwrap().insert(kind));
+    /// Enable a failpoint from a unit test.
+    pub(super) fn enable_failpoint(&self, failpoint: Failpoint) {
+        self.failpoints.lock().unwrap().push(failpoint);
     }
 }
 
-#[derive(Debug, enumset::EnumSetType)]
-#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum FailpointKind {
     /// Failpoint acts as an accurate cancelled by drop here; see the only site of use.
     AfterDeterminingLayerNeedsNoDownload,
+    /// Failpoint for stalling eviction starting
+    WaitBeforeStartingEvicting,
+}
+
+#[derive(Clone)]
+pub(crate) enum Failpoint {
+    /// Failpoint acts as an accurate cancelled by drop here; see the only site of use.
+    AfterDeterminingLayerNeedsNoDownload,
+    /// Failpoint for stalling eviction starting
+    WaitBeforeStartingEvicting(utils::completion::Barrier),
+}
+
+impl Failpoint {
+    fn kind(&self) -> FailpointKind {
+        match self {
+            Failpoint::AfterDeterminingLayerNeedsNoDownload => {
+                FailpointKind::AfterDeterminingLayerNeedsNoDownload
+            }
+            Failpoint::WaitBeforeStartingEvicting(_) => FailpointKind::WaitBeforeStartingEvicting,
+        }
+    }
+
+    async fn hit(&self) -> Result<(), FailpointHit> {
+        match self {
+            Failpoint::AfterDeterminingLayerNeedsNoDownload => Err(FailpointHit(self.kind())),
+            Failpoint::WaitBeforeStartingEvicting(b) => {
+                tracing::trace!("waiting on a failpoint barrier");
+                b.clone().wait().await;
+                tracing::trace!("done waiting on a failpoint barrier");
+                Ok(())
+            }
+        }
+    }
 }
 
 impl std::fmt::Display for FailpointKind {

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -432,11 +432,9 @@ fn multiple_pending_evictions_scenario(name: &'static str, in_order: bool) {
         // now the eviction cannot proceed because we are simulating arbitrary long delay for the
         // eviction task start.
         drop(resident);
-
-        // synchronize so we don't have two different possible outcomes for this test
-        arrived_at_barrier.wait().await;
-
         assert!(!layer.is_likely_resident());
+
+        arrived_at_barrier.wait().await;
 
         // because no actual eviction happened, we get to just reinitialize the DownloadedLayer
         layer

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -5,6 +5,7 @@ use utils::{
     id::TimelineId,
 };
 
+use super::failpoints::{Failpoint, FailpointKind};
 use super::*;
 use crate::context::DownloadBehavior;
 use crate::{task_mgr::TaskKind, tenant::harness::TenantHarness};
@@ -290,7 +291,7 @@ fn read_wins_pending_eviction() {
 
         let (completion, barrier) = utils::completion::channel();
         let (arrival, arrived_at_barrier) = utils::completion::channel();
-        layer.enable_failpoint(failpoints::Failpoint::WaitBeforeStartingEvicting(
+        layer.enable_failpoint(Failpoint::WaitBeforeStartingEvicting(
             Some(arrival),
             barrier,
         ));
@@ -421,7 +422,7 @@ fn multiple_pending_evictions_scenario(name: &'static str, in_order: bool) {
         let (completion1, barrier) = utils::completion::channel();
         let mut completion1 = Some(completion1);
         let (arrival, arrived_at_barrier) = utils::completion::channel();
-        layer.enable_failpoint(failpoints::Failpoint::WaitBeforeStartingEvicting(
+        layer.enable_failpoint(Failpoint::WaitBeforeStartingEvicting(
             Some(arrival),
             barrier,
         ));
@@ -470,7 +471,7 @@ fn multiple_pending_evictions_scenario(name: &'static str, in_order: bool) {
         // so now that we've reinitialized the inner, we get to run two of them at the same time.
         let (completion2, barrier) = utils::completion::channel();
         let (arrival, arrived_at_barrier) = utils::completion::channel();
-        layer.enable_failpoint(failpoints::Failpoint::WaitBeforeStartingEvicting(
+        layer.enable_failpoint(Failpoint::WaitBeforeStartingEvicting(
             Some(arrival),
             barrier,
         ));
@@ -574,12 +575,12 @@ async fn cancelled_get_or_maybe_download_does_not_cancel_eviction() {
 
     // this failpoint will simulate the `get_or_maybe_download` becoming cancelled (by returning an
     // Err) at the right time as in "during" the `LayerInner::needs_download`.
-    layer.enable_failpoint(failpoints::Failpoint::AfterDeterminingLayerNeedsNoDownload);
+    layer.enable_failpoint(Failpoint::AfterDeterminingLayerNeedsNoDownload);
 
     let (completion, barrier) = utils::completion::channel();
     let (arrival, arrived_at_barrier) = utils::completion::channel();
 
-    layer.enable_failpoint(failpoints::Failpoint::WaitBeforeStartingEvicting(
+    layer.enable_failpoint(Failpoint::WaitBeforeStartingEvicting(
         Some(arrival),
         barrier,
     ));
@@ -599,9 +600,7 @@ async fn cancelled_get_or_maybe_download_does_not_cancel_eviction() {
     assert!(
         matches!(
             e,
-            DownloadError::Failpoint(
-                failpoints::FailpointKind::AfterDeterminingLayerNeedsNoDownload
-            )
+            DownloadError::Failpoint(FailpointKind::AfterDeterminingLayerNeedsNoDownload)
         ),
         "{e:?}"
     );

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -297,10 +297,7 @@ fn read_wins_pending_eviction() {
 
         // now the eviction cannot proceed because the threads are consumed while completion exists
         drop(resident);
-
-        // synchronize so we don't have two different possible outcomes for this test
         arrived_at_barrier.wait().await;
-
         assert!(!layer.is_likely_resident());
 
         // because no actual eviction happened, we get to just reinitialize the DownloadedLayer
@@ -616,11 +613,7 @@ async fn cancelled_get_or_maybe_download_does_not_cancel_eviction() {
 
     // release the eviction task
     drop(completion);
-
-    // run pending tasks to completion, namely, to spawn blocking the eviction
     tokio::time::sleep(ADVANCE).await;
-
-    // synchronize with the spawn_blocking from eviction
     SpawnBlockingPoolHelper::consume_and_release_all_of_spawn_blocking_threads(&handle).await;
 
     // failpoint is still enabled, but it is not hit

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -432,6 +432,13 @@ async fn cancelled_get_or_maybe_download_does_not_cancel_eviction() {
     assert!(matches!(e, DownloadError::DownloadRequired), "{e:?}");
 }
 
+#[test]
+fn layer_size() {
+    assert_eq!(std::mem::size_of::<LayerAccessStats>(), 2040);
+    assert_eq!(std::mem::size_of::<PersistentLayerDesc>(), 104);
+    assert_eq!(std::mem::size_of::<LayerInner>(), 2348);
+}
+
 struct SpawnBlockingPoolHelper {
     awaited_by_spawn_blocking_tasks: Completion,
     blocking_tasks: JoinSet<()>,

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -398,19 +398,15 @@ async fn cancelled_get_or_maybe_download_does_not_cancel_eviction() {
         layers.swap_remove(0)
     };
 
-    layer
-        .0
-        .enable_failpoint(failpoints::Failpoint::AfterDeterminingLayerNeedsNoDownload);
+    layer.enable_failpoint(failpoints::Failpoint::AfterDeterminingLayerNeedsNoDownload);
 
     let (completion, barrier) = utils::completion::channel();
     let (arrival, arrived_at_barrier) = utils::completion::channel();
 
-    layer
-        .0
-        .enable_failpoint(failpoints::Failpoint::WaitBeforeStartingEvicting(
-            Some(arrival),
-            barrier,
-        ));
+    layer.enable_failpoint(failpoints::Failpoint::WaitBeforeStartingEvicting(
+        Some(arrival),
+        barrier,
+    ));
 
     tokio::time::timeout(ADVANCE, layer.evict_and_wait(FOREVER))
         .await

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -472,6 +472,8 @@ impl SpawnBlockingPoolHelper {
             rx.recv().await.unwrap();
         }
 
+        tracing::trace!("consumed all threads");
+
         SpawnBlockingPoolHelper {
             awaited_by_spawn_blocking_tasks: completion,
             blocking_tasks,
@@ -490,6 +492,8 @@ impl SpawnBlockingPoolHelper {
         while let Some(res) = blocking_tasks.join_next().await {
             res.expect("none of the tasks should had panicked");
         }
+
+        tracing::trace!("released all threads");
     }
 
     /// In the tests it is used as an easy way of making sure something scheduled on the target

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -357,7 +357,7 @@ async fn residency_check_while_evict_and_wait_on_clogged_spawn_blocking() {
 
     assert_eq!(1, LAYER_IMPL_METRICS.completed_evictions.get());
 
-    // now we finally can observe the original spawn_blocking failing
+    // now we finally can observe the original eviction failing
     // it would had been possible to observe it earlier, but here it is guaranteed to have
     // happened.
     assert_eq!(
@@ -454,7 +454,8 @@ async fn cancelled_get_or_maybe_download_does_not_cancel_eviction() {
 fn layer_size() {
     assert_eq!(std::mem::size_of::<LayerAccessStats>(), 2040);
     assert_eq!(std::mem::size_of::<PersistentLayerDesc>(), 104);
-    assert_eq!(std::mem::size_of::<LayerInner>(), 2348);
+    assert_eq!(std::mem::size_of::<LayerInner>(), 2328);
+    // it also has the utf8 path
 }
 
 struct SpawnBlockingPoolHelper {


### PR DESCRIPTION
## Problem

The current implementation of struct Layer supports canceled read requests, but those will leave the internal state such that a following `Layer::keep_resident` call will need to repair the state. In pathological cases seen during generation numbers resetting in staging or with too many in-progress on-demand downloads, this repair activity will need to wait for the download to complete, which stalls disk usage-based eviction. Similar stalls have been observed in staging near disk-full situations, where downloads failed because the disk was full.

Fixes #6028 or the "layer is present on filesystem but not evictable" problems by:
1. not canceling pending evictions by a canceled `LayerInner::get_or_maybe_download`
2. completing post-download initialization of the `LayerInner::inner` from the download task

Not canceling evictions above case (1) and always initializing (2) lead to plain `LayerInner::inner` always having the up-to-date information, which leads to the old `Layer::keep_resident` never having to wait for downloads to complete. Finally, the `Layer::keep_resident` is replaced with `Layer::is_likely_resident`. These fix #7145.

## Summary of changes

- add a new test showing that a canceled get_or_maybe_download should not cancel the eviction
- switch to using a `watch` internally rather than a `broadcast` to avoid hanging eviction while a download is ongoing
- doc changes for new semantics and cleanup
- fix `Layer::keep_resident` to use just `self.0.inner.get()` as truth as `Layer::is_likely_resident`
- remove `LayerInner::wanted_evicted` boolean as no longer needed

Builds upon: #7185. Cc: #5331.