### PR TITLE
Add downgrade scripts for neon extension.

### DIFF
--- a/pgxn/neon/Makefile
+++ b/pgxn/neon/Makefile
@@ -21,7 +21,7 @@ SHLIB_LINK_INTERNAL = $(libpq)
 SHLIB_LINK = -lcurl
 
 EXTENSION = neon
-DATA = neon--1.0.sql neon--1.0--1.1.sql neon--1.1--1.2.sql neon--1.2--1.3.sql
+DATA = neon--1.0.sql neon--1.0--1.1.sql neon--1.1--1.2.sql neon--1.2--1.3.sql neon--1.3--1.2.sql neon--1.2--1.1.sql neon--1.1--1.0.sql
 PGFILEDESC = "neon - cloud storage for PostgreSQL"
 
 EXTRA_CLEAN = \

--- a/pgxn/neon/neon--1.1--1.0.sql
+++ b/pgxn/neon/neon--1.1--1.0.sql
@@ -3,4 +3,4 @@
 
 DROP VIEW IF EXISTS neon_lfc_stats CASCADE;
 
-DROP FUNCTION IF EXISTS neon_get_lfc_stats() CASCADE;
+DROP FUNCTION IF EXISTS neon_get_lfc_stats CASCADE;

--- a/pgxn/neon/neon--1.1-1.0.sql
+++ b/pgxn/neon/neon--1.1-1.0.sql
@@ -1,0 +1,6 @@
+-- the order of operations is important here
+-- because the view depends on the function
+
+DROP VIEW IF EXISTS neon_lfc_stats CASCADE;
+
+DROP FUNCTION IF EXISTS neon_get_lfc_stats() CASCADE;

--- a/pgxn/neon/neon--1.2--1.1.sql
+++ b/pgxn/neon/neon--1.2--1.1.sql
@@ -1,0 +1,6 @@
+-- the order of operations is important here
+-- because the view depends on the function
+
+DROP VIEW IF EXISTS neon_stat_file_cache CASCADE;
+
+DROP FUNCTION IF EXISTS neon_get_lfc_stats CASCADE;

--- a/pgxn/neon/neon--1.2--1.1.sql
+++ b/pgxn/neon/neon--1.2--1.1.sql
@@ -1,6 +1,1 @@
--- the order of operations is important here
--- because the view depends on the function
-
-DROP VIEW IF EXISTS neon_stat_file_cache CASCADE;
-
-DROP FUNCTION IF EXISTS neon_get_lfc_stats CASCADE;
+DROP VIEW IF EXISTS NEON_STAT_FILE_CACHE CASCADE;

--- a/pgxn/neon/neon--1.3--1.2.sql
+++ b/pgxn/neon/neon--1.3--1.2.sql
@@ -1,2 +1,1 @@
-
 DROP FUNCTION IF EXISTS approximate_working_set_size(bool) CASCADE;

--- a/pgxn/neon/neon--1.3--1.2.sql
+++ b/pgxn/neon/neon--1.3--1.2.sql
@@ -1,0 +1,2 @@
+
+DROP FUNCTION IF EXISTS approximate_working_set_size(bool) CASCADE;

--- a/test_runner/regress/test_neon_extension.py
+++ b/test_runner/regress/test_neon_extension.py
@@ -29,3 +29,34 @@ def test_neon_extension(neon_env_builder: NeonEnvBuilder):
             log.info(res)
             assert len(res) == 1
             assert len(res[0]) == 5
+
+
+# Verify that the neon extension can be upgraded/downgraded.
+def test_neon_extension_compatibility(neon_env_builder: NeonEnvBuilder):
+    env = neon_env_builder.init_start()
+    env.neon_cli.create_branch("test_neon_extension_compatibility")
+
+    endpoint_main = env.endpoints.create("test_neon_extension_compatibility")
+    # don't skip pg_catalog updates - it runs CREATE EXTENSION neon
+    endpoint_main.respec(skip_pg_catalog_updates=False)
+    endpoint_main.start()
+
+    with closing(endpoint_main.connect()) as conn:
+        with conn.cursor() as cur:
+            all_versions = ["1.3", "1.2", "1.1", "1.0"]
+            current_version = "1.3"
+            for idx, begin_version in enumerate(all_versions):
+                for target_version in all_versions[idx + 1 :]:
+                    if current_version != begin_version:
+                        cur.execute(
+                            f"ALTER EXTENSION neon UPDATE TO '{begin_version}'; -- {current_version}->{begin_version}"
+                        )
+                        current_version = begin_version
+                    # downgrade
+                    cur.execute(
+                        f"ALTER EXTENSION neon UPDATE TO '{target_version}'; -- {begin_version}->{target_version}"
+                    )
+                    # upgrade
+                    cur.execute(
+                        f"ALTER EXTENSION neon UPDATE TO '{begin_version}'; -- {target_version}->{begin_version}"
+                    )


### PR DESCRIPTION
Follow-up for https://app.incident.io/neondb/incidents/167?tab=follow-ups

## Problem

When we start compute with newer version of extension (i.e. 1.2) and then rollback the release, downgrading the compute version, next compute start will try to update extension to the latest version available in neon.control (i.e. 1.1).

Thus we need to provide downgrade scripts like neon--1.2--1.1.sql

These scripts must revert the changes made by the upgrade scripts in the reverse order. This is necessary to ensure that the next upgrade will work correctly.

In general, we need to write upgrade and downgrade scripts to be more robust and add IF EXISTS / CREATE OR REPLACE clauses to all statements (where applicable).

## Questions to reviewers

1. Do I need to add IF EXISTS / CREATE OR REPLACE  to existing upgrade scripts? 

2. Are CASCADE deletions ok? Do we have any other objects depending on extension objects?

3. These scripts are necessary to make compute image changes robust and rollback-safe for existing computes and upcoming release.
Is there any way to improve `ALTER EXTENSION neon UPDATE` flow for the future? I.e. pass flag from control plane that will point, if it is an upgrade or downgrade of compute.
See also this discussion: 
https://neondb.slack.com/archives/C04DGM6SMTM/p1709559918439189?thread_ts=1709552427.964049&cid=C04DGM6SMTM

## TODO

- [ ] test downgrade scripts
- [ ] add tests for compute downgrade
- [ ] add some automated check to ensure that both upgrade and downgrade scripts are present for every neon extension version