### PR TITLE
Force LSN order with wrapper structure

### DIFF
--- a/libs/utils/src/vec_map.rs
+++ b/libs/utils/src/vec_map.rs
@@ -10,7 +10,7 @@ pub enum VecMapOrdering {
 /// Append only - can only add keys that are larger than the
 /// current max key.
 /// Ordering can be adjusted using [`VecMapOrdering`]
-/// during VecMap construction.
+/// during `VecMap` construction.
 #[derive(Clone, Debug)]
 pub struct VecMap<K, V> {
     data: Vec<(K, V)>,

--- a/libs/utils/src/vec_map.rs
+++ b/libs/utils/src/vec_map.rs
@@ -172,6 +172,15 @@ impl<K: Ord, V> FromIterator<(K, V)> for VecMap<K, V> {
     }
 }
 
+impl<K: Ord, V> IntoIterator for VecMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<(K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 fn extract_key<K, V>(entry: &(K, V)) -> &K {
     &entry.0
 }

--- a/libs/utils/src/vec_map.rs
+++ b/libs/utils/src/vec_map.rs
@@ -24,6 +24,10 @@ impl<K: Ord, V> VecMap<K, V> {
         self.0.as_slice()
     }
 
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
     /// This function may panic if given a range where the lower bound is
     /// greater than the upper bound.
     pub fn slice_range<R: RangeBounds<K>>(&self, range: R) -> &[(K, V)] {
@@ -144,6 +148,25 @@ impl<K: Ord, V> VecMap<K, V> {
             Ordering::Equal => 0,
             Ordering::Greater => panic!("VecMap capacity shouldn't ever decrease"),
         }
+    }
+}
+
+impl<K: Ord, V> IntoIterator for VecMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<(K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<K: Ord, V> FromIterator<(K, V)> for VecMap<K, V> {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let mut vec_map = VecMap::default();
+        vec_map.0 = iter.into_iter().collect();
+        vec_map.0.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+
+        vec_map
     }
 }
 

--- a/libs/utils/src/vec_map.rs
+++ b/libs/utils/src/vec_map.rs
@@ -24,10 +24,6 @@ impl<K: Ord, V> VecMap<K, V> {
         self.0.as_slice()
     }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
     /// This function may panic if given a range where the lower bound is
     /// greater than the upper bound.
     pub fn slice_range<R: RangeBounds<K>>(&self, range: R) -> &[(K, V)] {

--- a/libs/utils/src/vec_map.rs
+++ b/libs/utils/src/vec_map.rs
@@ -151,18 +151,10 @@ impl<K: Ord, V> VecMap<K, V> {
     }
 }
 
-impl<K: Ord, V> IntoIterator for VecMap<K, V> {
-    type Item = (K, V);
-    type IntoIter = std::vec::IntoIter<(K, V)>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
 impl<K: Ord, V> FromIterator<(K, V)> for VecMap<K, V> {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let mut vec_map = VecMap::default();
+
         vec_map.0 = iter.into_iter().collect();
         vec_map.0.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
 
@@ -333,5 +325,13 @@ mod tests {
         left.extend(&mut one_map).unwrap_err();
         assert_eq!(left.as_slice(), &[(0, ()), (1, ())]);
         assert_eq!(one_map.as_slice(), &[(1, ())]);
+    }
+
+    #[test]
+    fn vec_map_from() {
+        let vec = vec![(3, ()), (1, ()), (2, ()), (6, ())];
+        let vec_map = VecMap::from_iter(vec);
+
+        assert_eq!(vec_map.as_slice(), &[(1, ()), (2, ()), (3, ()), (6, ())]);
     }
 }

--- a/libs/utils/src/vec_map.rs
+++ b/libs/utils/src/vec_map.rs
@@ -9,7 +9,7 @@ pub enum VecMapOrdering {
 /// Ordered map datastructure implemented in a Vec.
 /// Append only - can only add keys that are larger than the
 /// current max key.
-/// Ordering can be adjusted using [VecMapOrdering]
+/// Ordering can be adjusted using [`VecMapOrdering`]
 /// during VecMap construction.
 #[derive(Clone, Debug)]
 pub struct VecMap<K, V> {
@@ -203,7 +203,7 @@ impl<K: Ord, V> VecMap<K, V> {
     }
 
     /// Similar to `from_iter` defined in `FromIter` trait except
-    /// that it accepts an [VecMapOrdering]
+    /// that it accepts an [`VecMapOrdering`]
     pub fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I, ordering: VecMapOrdering) -> Self {
         let iter = iter.into_iter();
         let initial_capacity = {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4574,7 +4574,7 @@ impl<'a> TimelineWriter<'a> {
 
     /// Put a batch of keys at the specified Lsns.
     ///
-    /// The batch is sorted by Lsn (enforced by usage of [`utils::VecMap`].
+    /// The batch is sorted by Lsn (enforced by usage of [`utils::vec_map::VecMap`].
     pub(crate) async fn put_batch(
         &mut self,
         batch: VecMap<Lsn, (Key, Value)>,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4577,8 +4577,8 @@ impl<'a> TimelineWriter<'a> {
         batch: VecMap<Lsn, (Key, Value)>,
         ctx: &RequestContext,
     ) -> anyhow::Result<()> {
-        for (lsn, (key, val)) in batch.into_iter() {
-            self.put(key, lsn, &val, ctx).await?
+        for (lsn, (key, val)) in batch.as_slice() {
+            self.put(*key, *lsn, val, ctx).await?
         }
 
         Ok(())

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4580,8 +4580,8 @@ impl<'a> TimelineWriter<'a> {
         batch: VecMap<Lsn, (Key, Value)>,
         ctx: &RequestContext,
     ) -> anyhow::Result<()> {
-        for (lsn, (key, val)) in batch.as_slice() {
-            self.put(*key, *lsn, val, ctx).await?
+        for (lsn, (key, val)) in batch {
+            self.put(key, lsn, &val, ctx).await?
         }
 
         Ok(())

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4572,6 +4572,9 @@ impl<'a> TimelineWriter<'a> {
         }
     }
 
+    /// Put a batch of keys at the specified Lsns.
+    ///
+    /// The batch is sorted by Lsn (enforced by usage of [`utils::VecMap`].
     pub(crate) async fn put_batch(
         &mut self,
         batch: VecMap<Lsn, (Key, Value)>,


### PR DESCRIPTION
## Summary of changes

Add a wrapper structure 'OrderedBatchUpdates' to enforce an order of updates by LSN.

Closes https://github.com/neondatabase/neon/issues/6707

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
