### PR TITLE
throttling: fixup interactions with Timeline::get_vectored

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "300"]
+
 //! Main entry point for the Page Server executable.
 
 use std::env::{var, VarError};

--- a/pageserver/src/context/optional_counter.rs
+++ b/pageserver/src/context/optional_counter.rs
@@ -31,6 +31,13 @@ impl CounterU32 {
         }
     }
 
+    pub fn get(&self) -> Result<u32, &'static str> {
+        match self.inner.fetch(Ordering::Relaxed) {
+            u32::MAX => Err("get() called on closed state"),
+            x => Ok(x),
+        }
+    }
+
     pub fn add(&self, count: u32) -> Result<(), &'static str> {
         if count == 0 {
             return Ok(());
@@ -71,6 +78,10 @@ impl MicroSecondsCounterU32 {
             Ok(x) => self.inner.add(x),
             Err(_) => Err("add(): duration conversion error"),
         }
+    }
+    pub fn get_and_checked_sub_from(&self, from: Duration) -> Result<Duration, &'static str> {
+        let val = self.inner.get()?;
+        Ok(Duration::from_micros(val as u64))
     }
     pub fn close_and_checked_sub_from(&self, from: Duration) -> Result<Duration, &'static str> {
         let val = self.inner.close()?;

--- a/pageserver/src/context/optional_counter.rs
+++ b/pageserver/src/context/optional_counter.rs
@@ -31,13 +31,6 @@ impl CounterU32 {
         }
     }
 
-    pub fn get(&self) -> Result<u32, &'static str> {
-        match self.inner.fetch(Ordering::Relaxed) {
-            u32::MAX => Err("get() called on closed state"),
-            x => Ok(x),
-        }
-    }
-
     pub fn add(&self, count: u32) -> Result<(), &'static str> {
         if count == 0 {
             return Ok(());
@@ -78,10 +71,6 @@ impl MicroSecondsCounterU32 {
             Ok(x) => self.inner.add(x),
             Err(_) => Err("add(): duration conversion error"),
         }
-    }
-    pub fn get_and_checked_sub_from(&self, from: Duration) -> Result<Duration, &'static str> {
-        let val = self.inner.get()?;
-        Ok(Duration::from_micros(val as u64))
     }
     pub fn close_and_checked_sub_from(&self, from: Duration) -> Result<Duration, &'static str> {
         let val = self.inner.close()?;

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -154,73 +154,13 @@ pub(crate) struct GetVectoredLatency {
     map: EnumMap<TaskKind, Option<Histogram>>,
 }
 
-#[must_use]
-pub(crate) enum GetVectoredLatencyOngoingRecording<'a, 'c> {
-    Ignored,
-    Started {
-        histo: Histogram,
-        ctx: &'c RequestContext,
-        start: std::time::Instant,
-    },
-}
-
 impl GetVectoredLatency {
     // Only these task types perform vectored gets. Filter all other tasks out to reduce total
     // cardinality of the metric.
     const TRACKED_TASK_KINDS: [TaskKind; 2] = [TaskKind::Compaction, TaskKind::PageRequestHandler];
 
-    pub(crate) fn start_recording<'c: 'a, 'a>(
-        &'a self,
-        ctx: &'c RequestContext,
-    ) -> GetVectoredLatencyOngoingRecording<'a, 'c> {
-        let Some(histo) = self.map[task_kind].as_ref() else {
-            return GetVectoredLatencyOngoingRecording::Ignored;
-        };
-        let start = Instant::now();
-        match ctx.micros_spent_throttled.open() {
-            Ok(()) => (),
-            Err(error) => {
-                use utils::rate_limit::RateLimit;
-                static LOGGED: Lazy<Mutex<RateLimit>> =
-                    Lazy::new(|| Mutex::new(RateLimit::new(Duration::from_secs(10))));
-                let mut rate_limit = LOGGED.lock().unwrap();
-                rate_limit.call(|| {
-                    warn!(error, "error opening micros_spent_throttled; this message is logged at a global rate limit");
-                });
-            }
-        }
-        Some(GetVectoredLatencyOngoingRecording { histo, ctx, start })
-    }
-}
-
-impl<'a, 'c> GetVectoredLatencyOngoingRecording<'a, 'c> {
-    pub(crate) fn observe<T, E>(self) {
-        match self {
-            GetVectoredLatencyOngoingRecording::Ignored => (),
-            GetVectoredLatencyOngoingRecording::Started { histo, ctx, start } => {
-                let elapsed = start.elapsed();
-                let ex_throttled = ctx
-                    .micros_spent_throttled
-                    // NB: unlike the other two similar patterns of code in this file,
-                    // we don't use close_... here, but get_... because Self is used
-                    // nested within the basebackup handler.
-                    .get_and_checked_sub_from(elapsed);
-                let ex_throttled = match ex_throttled {
-                    Ok(ex_throttled) => ex_throttled,
-                    Err(error) => {
-                        use utils::rate_limit::RateLimit;
-                        static LOGGED: Lazy<Mutex<RateLimit>> =
-                            Lazy::new(|| Mutex::new(RateLimit::new(Duration::from_secs(10))));
-                        let mut rate_limit = LOGGED.lock().unwrap();
-                        rate_limit.call(|| {
-                            warn!(error, "error deducting time spent throttled; this message is logged at a global rate limit");
-                        });
-                        elapsed
-                    }
-                };
-                histo.observe(ex_throttled.as_secs_f64());
-            }
-        }
+    pub(crate) fn for_task_kind(&self, task_kind: TaskKind) -> Option<&Histogram> {
+        self.map[task_kind].as_ref()
     }
 }
 

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -167,7 +167,7 @@ impl GetVectoredLatency {
 pub(crate) static GET_VECTORED_LATENCY: Lazy<GetVectoredLatency> = Lazy::new(|| {
     let inner = register_histogram_vec!(
         "pageserver_get_vectored_seconds",
-        "Time spent in get_vectored",
+        "Time spent in get_vectored, excluding time spent in timeline_get_throttle.",
         &["task_kind"],
         CRITICAL_OP_BUCKETS.into(),
     )
@@ -1282,7 +1282,6 @@ pub(crate) static BASEBACKUP_QUERY_TIME: Lazy<BasebackupQueryTime> = Lazy::new(|
     })
 });
 
-#[must_use]
 pub(crate) struct BasebackupQueryTimeOngoingRecording<'a, 'c> {
     parent: &'a BasebackupQueryTime,
     ctx: &'c RequestContext,

--- a/pageserver/src/tenant/throttle.rs
+++ b/pageserver/src/tenant/throttle.rs
@@ -130,10 +130,10 @@ where
         self.inner.load().config.steady_rps()
     }
 
-    pub async fn throttle(&self, ctx: &RequestContext, key_count: usize) {
+    pub async fn throttle(&self, ctx: &RequestContext, key_count: usize) -> Option<Duration> {
         let inner = self.inner.load_full(); // clones the `Inner` Arc
         if !inner.task_kinds.contains(ctx.task_kind()) {
-            return;
+            return None;
         };
         let start = std::time::Instant::now();
         let mut did_throttle = false;
@@ -170,6 +170,9 @@ where
                     });
                 }
             }
+            Some(wait_time)
+        } else {
+            None
         }
     }
 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -654,10 +654,10 @@ impl Timeline {
         ctx: &RequestContext,
     ) -> Result<Bytes, PageReconstructError> {
         self.timeline_get_throttle.throttle(ctx, 1).await;
-        self.get0(key, lsn, ctx).await
+        self.get_impl(key, lsn, ctx).await
     }
     /// Not subject to [`Self::timeline_get_throttle`].
-    async fn get0(
+    async fn get_impl(
         &self,
         key: Key,
         lsn: Lsn,
@@ -841,7 +841,7 @@ impl Timeline {
         for range in keyspace.ranges {
             let mut key = range.start;
             while key != range.end {
-                let block = self.get0(key, lsn, ctx).await;
+                let block = self.get_impl(key, lsn, ctx).await;
 
                 use PageReconstructError::*;
                 match block {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -646,6 +646,7 @@ impl Timeline {
     /// # Cancel-Safety
     ///
     /// This method is cancellation-safe.
+    #[inline(always)]
     pub(crate) async fn get(
         &self,
         key: Key,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -890,6 +890,7 @@ impl Timeline {
         Ok(results)
     }
 
+    /// Not subject to [`Self::timeline_get_throttle`].
     pub(super) async fn validate_get_vectored_impl(
         &self,
         vectored_res: &Result<BTreeMap<Key, Result<Bytes, PageReconstructError>>, GetVectoredError>,


### PR DESCRIPTION
## Problem

Before this PR, `Timeline::get_vectored` would be throttled twice if the sequential option was enabled or if validation was enabled.

Also, `pageserver_get_vectored_seconds` included the time spent in the throttle, which turns out to be undesirable for what we use that metric for.

## Summary of changes

Double-throttle:

* Add `Timeline::get0` method which is unthrottled.
* Use that method from within the `Timeline::get_vectored` code path.

Metric:

* return throttled time from `throttle()` method
* deduct the value from the observed time
* globally rate-limited logging of duration subtraction errors, like in all other places that do the throttled-time deduction from observations
