### PR TITLE
libs/http: include path when logging auth failures

### DIFF
--- a/libs/utils/src/http/endpoint.rs
+++ b/libs/utils/src/http/endpoint.rs
@@ -84,6 +84,9 @@ where
             info!("Handling request");
         }
 
+        // Take a copy of the path for error logging
+        let path = request.uri().path().to_string();
+
         // No special handling for panics here. There's a `tracing_panic_hook` from another
         // module to do that globally.
         let res = handler(request).await;
@@ -110,7 +113,7 @@ where
                 }
                 Ok(response)
             }
-            Err(err) => Ok(api_error_handler(err)),
+            Err(err) => Ok(api_error_handler(err, Some(&path))),
         }
     }
     .instrument(request_span)

--- a/libs/utils/src/http/error.rs
+++ b/libs/utils/src/http/error.rs
@@ -108,7 +108,7 @@ impl HttpErrorBody {
 
 pub async fn route_error_handler(err: routerify::RouteError) -> Response<Body> {
     match err.downcast::<ApiError>() {
-        Ok(api_error) => api_error_handler(*api_error),
+        Ok(api_error) => api_error_handler(*api_error, None),
         Err(other_error) => {
             // We expect all the request handlers to return an ApiError, so this should
             // not be reached. But just in case.
@@ -121,12 +121,16 @@ pub async fn route_error_handler(err: routerify::RouteError) -> Response<Body> {
     }
 }
 
-pub fn api_error_handler(api_error: ApiError) -> Response<Body> {
+pub fn api_error_handler(api_error: ApiError, path: Option<&str>) -> Response<Body> {
     // Print a stack trace for Internal Server errors
 
     match api_error {
         ApiError::Forbidden(_) | ApiError::Unauthorized(_) => {
-            warn!("Error processing HTTP request: {api_error:#}")
+            warn!(
+                "Error processing HTTP request: {api_error:#} {}{}",
+                path.as_ref().map(|_| "at").unwrap_or(""),
+                path.unwrap_or("")
+            )
         }
         ApiError::ResourceUnavailable(_) => info!("Error processing HTTP request: {api_error:#}"),
         ApiError::NotFound(_) => info!("Error processing HTTP request: {api_error:#}"),


### PR DESCRIPTION
## Problem

Currently, if a client sends a GET request that fails auth, we have no information about the request.

## Summary of changes

- Include path in messages logged on API auth errors

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
