### PR TITLE
Store logical replication origin in KV storage

### DIFF
--- a/libs/pageserver_api/src/key.rs
+++ b/libs/pageserver_api/src/key.rs
@@ -40,7 +40,7 @@ pub const RELATION_SIZE_PREFIX: u8 = 0x61;
 pub const AUX_KEY_PREFIX: u8 = 0x62;
 
 /// The key prefix of ReplOrigin keys.
-pub const REPL_ORIGIN_KEY: u8 = 0x4;
+pub const REPL_ORIGIN_KEY_PREFIX: u8 = 0x63;
 
 /// Check if the key falls in the range of metadata keys.
 pub const fn is_metadata_key_slice(key: &[u8]) -> bool {
@@ -309,9 +309,6 @@ impl Key {
 //
 // AuxFiles:
 // 03 00000000 00000000 00000000 00   00000002
-//
-// ReplOrigin:
-// 04 00000000 00000000 00000000 00   ORIGIN_ID
 //
 
 //-- Section 01: relation data and metadata
@@ -597,7 +594,7 @@ pub const AUX_FILES_KEY: Key = Key {
 #[inline(always)]
 pub fn repl_origin_key(origin_id: RepOriginId) -> Key {
     Key {
-        field1: REPL_ORIGIN_KEY,
+        field1: REPL_ORIGIN_KEY_PREFIX,
         field2: 0,
         field3: 0,
         field4: 0,
@@ -609,19 +606,19 @@ pub fn repl_origin_key(origin_id: RepOriginId) -> Key {
 /// Get the range of replorigin keys.
 pub fn repl_origin_key_range() -> Range<Key> {
     Key {
-        field1: REPL_ORIGIN_KEY,
+        field1: REPL_ORIGIN_KEY_PREFIX,
         field2: 0,
         field3: 0,
         field4: 0,
         field5: 0,
         field6: 0,
     }..Key {
-        field1: REPL_ORIGIN_KEY + 1,
+        field1: REPL_ORIGIN_KEY_PREFIX,
         field2: 0,
         field3: 0,
         field4: 0,
         field5: 0,
-        field6: 0,
+        field6: 0x10000,
     }
 }
 

--- a/libs/pageserver_api/src/key.rs
+++ b/libs/pageserver_api/src/key.rs
@@ -306,6 +306,9 @@ impl Key {
 // AuxFiles:
 // 03 00000000 00000000 00000000 00   00000002
 //
+// ReplOrigin:
+// 04 00000000 00000000 00000000 00   ORIGIN_ID
+//
 
 //-- Section 01: relation data and metadata
 
@@ -586,6 +589,20 @@ pub const AUX_FILES_KEY: Key = Key {
     field5: 0,
     field6: 2,
 };
+
+//-- Section 04: Replication origin
+
+#[inline(always)]
+pub fn replorigin_key(origin_id: u16) -> Key {
+    Key {
+        field1: 0x04,
+        field2: 0,
+        field3: 0,
+        field4: 0,
+        field5: 0,
+        field6: origin_id as u32,
+    }
+}
 
 // Reverse mappings for a few Keys.
 // These are needed by WAL redo manager.

--- a/libs/pageserver_api/src/key.rs
+++ b/libs/pageserver_api/src/key.rs
@@ -307,7 +307,7 @@ impl Key {
 // 03 00000000 00000000 00000000 00   00000002
 //
 // ReplOrigin:
-// 04 00000000 00000000 00000000 00   ORIGIN_ID
+// 03 00000000 00000000 00000000 00   00000003
 //
 
 //-- Section 01: relation data and metadata
@@ -590,19 +590,14 @@ pub const AUX_FILES_KEY: Key = Key {
     field6: 2,
 };
 
-//-- Section 04: Replication origin
-
-#[inline(always)]
-pub fn replorigin_key(origin_id: u16) -> Key {
-    Key {
-        field1: 0x04,
-        field2: 0,
-        field3: 0,
-        field4: 0,
-        field5: 0,
-        field6: origin_id as u32,
-    }
-}
+pub const REPL_ORIGIN_KEY: Key = Key {
+    field1: 0x03,
+    field2: 0,
+    field3: 0,
+    field4: 0,
+    field5: 0,
+    field6: 3,
+};
 
 // Reverse mappings for a few Keys.
 // These are needed by WAL redo manager.

--- a/libs/pageserver_api/src/key.rs
+++ b/libs/pageserver_api/src/key.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use byteorder::{ByteOrder, BE};
 use postgres_ffi::relfile_utils::{FSM_FORKNUM, VISIBILITYMAP_FORKNUM};
+use postgres_ffi::RepOriginId;
 use postgres_ffi::{Oid, TransactionId};
 use serde::{Deserialize, Serialize};
 use std::{fmt, ops::Range};
@@ -37,6 +38,9 @@ pub const RELATION_SIZE_PREFIX: u8 = 0x61;
 
 /// The key prefix of AUX file keys.
 pub const AUX_KEY_PREFIX: u8 = 0x62;
+
+/// The key prefix of ReplOrigin keys.
+pub const REPL_ORIGIN_KEY: u8 = 0x4;
 
 /// Check if the key falls in the range of metadata keys.
 pub const fn is_metadata_key_slice(key: &[u8]) -> bool {
@@ -307,7 +311,7 @@ impl Key {
 // 03 00000000 00000000 00000000 00   00000002
 //
 // ReplOrigin:
-// 03 00000000 00000000 00000000 00   00000003
+// 04 00000000 00000000 00000000 00   ORIGIN_ID
 //
 
 //-- Section 01: relation data and metadata
@@ -590,14 +594,36 @@ pub const AUX_FILES_KEY: Key = Key {
     field6: 2,
 };
 
-pub const REPL_ORIGIN_KEY: Key = Key {
-    field1: 0x03,
-    field2: 0,
-    field3: 0,
-    field4: 0,
-    field5: 0,
-    field6: 3,
-};
+#[inline(always)]
+pub fn repl_origin_key(origin_id: RepOriginId) -> Key {
+    Key {
+        field1: REPL_ORIGIN_KEY,
+        field2: 0,
+        field3: 0,
+        field4: 0,
+        field5: 0,
+        field6: origin_id as u32,
+    }
+}
+
+/// Get the range of replorigin keys.
+pub fn repl_origin_key_range() -> Range<Key> {
+    Key {
+        field1: REPL_ORIGIN_KEY,
+        field2: 0,
+        field3: 0,
+        field4: 0,
+        field5: 0,
+        field6: 0,
+    }..Key {
+        field1: REPL_ORIGIN_KEY + 1,
+        field2: 0,
+        field3: 0,
+        field4: 0,
+        field5: 0,
+        field6: 0,
+    }
+}
 
 // Reverse mappings for a few Keys.
 // These are needed by WAL redo manager.

--- a/libs/postgres_ffi/build.rs
+++ b/libs/postgres_ffi/build.rs
@@ -126,6 +126,7 @@ fn main() -> anyhow::Result<()> {
             .allowlist_type("PageHeaderData")
             .allowlist_type("DBState")
             .allowlist_type("RelMapFile")
+            .allowlist_type("RepOriginId")
             // Because structs are used for serialization, tell bindgen to emit
             // explicit padding fields.
             .explicit_padding(true)

--- a/libs/postgres_ffi/src/lib.rs
+++ b/libs/postgres_ffi/src/lib.rs
@@ -110,6 +110,7 @@ pub mod pg_constants;
 pub mod relfile_utils;
 
 // Export some widely used datatypes that are unlikely to change across Postgres versions
+pub use v14::bindings::RepOriginId;
 pub use v14::bindings::{uint32, uint64, Oid};
 pub use v14::bindings::{BlockNumber, OffsetNumber};
 pub use v14::bindings::{MultiXactId, TransactionId};

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -167,6 +167,7 @@ pub const RM_RELMAP_ID: u8 = 7;
 pub const RM_STANDBY_ID: u8 = 8;
 pub const RM_HEAP2_ID: u8 = 9;
 pub const RM_HEAP_ID: u8 = 10;
+pub const RM_REPLORIGIN_ID: u8 = 19;
 pub const RM_LOGICALMSG_ID: u8 = 21;
 
 // from neon_rmgr.h
@@ -223,6 +224,10 @@ pub const XLOG_CHECKPOINT_ONLINE: u8 = 0x10;
 pub const XLP_FIRST_IS_CONTRECORD: u16 = 0x0001;
 pub const XLP_LONG_HEADER: u16 = 0x0002;
 
+/* From xlog.h */
+pub const XLOG_REPLORIGIN_SET: u8 = 0x00;
+pub const XLOG_REPLORIGIN_DROP: u8 = 0x10;
+
 /* From replication/slot.h */
 pub const REPL_SLOT_ON_DISK_OFFSETOF_RESTART_LSN: usize = 4*4  /* offset of `slotdata` in ReplicationSlotOnDisk  */
    + 64 /* NameData */  + 4*4;
@@ -236,6 +241,9 @@ pub const SLOTS_PER_FSM_PAGE: u32 = FSM_LEAF_NODES_PER_PAGE as u32;
 /* From visibilitymap.c */
 pub const VM_HEAPBLOCKS_PER_PAGE: u32 =
     (BLCKSZ as usize - SIZEOF_PAGE_HEADER_DATA) as u32 * (8 / 2); // MAPSIZE * (BITS_PER_BYTE / BITS_PER_HEAPBLOCK)
+
+/* From origin.c */
+pub const REPLICATION_STATE_MAGIC: u32 = 0x1257DADE;
 
 // List of subdirectories inside pgdata.
 // Copied from src/bin/initdb/initdb.c

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -102,7 +102,7 @@ pub const XACT_XINFO_HAS_SUBXACTS: u32 = 1u32 << 1;
 pub const XACT_XINFO_HAS_RELFILENODES: u32 = 1u32 << 2;
 pub const XACT_XINFO_HAS_INVALS: u32 = 1u32 << 3;
 pub const XACT_XINFO_HAS_TWOPHASE: u32 = 1u32 << 4;
-// pub const XACT_XINFO_HAS_ORIGIN: u32 = 1u32 << 5;
+pub const XACT_XINFO_HAS_ORIGIN: u32 = 1u32 << 5;
 // pub const XACT_XINFO_HAS_AE_LOCKS: u32 = 1u32 << 6;
 // pub const XACT_XINFO_HAS_GID: u32 = 1u32 << 7;
 

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -13,7 +13,7 @@
 use anyhow::{anyhow, Context};
 use bytes::{BufMut, Bytes, BytesMut};
 use fail::fail_point;
-use pageserver_api::key::{replorigin_key, Key};
+use pageserver_api::key::Key;
 use postgres_ffi::pg_constants;
 use std::fmt::Write as FmtWrite;
 use std::time::SystemTime;

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -355,7 +355,6 @@ where
                 .await
                 .map_err(|e| BasebackupError::Server(e.into()))?
             {
-                let header = new_tar_header(&path, content.len() as u64)?;
                 if path.starts_with("pg_replslot") {
                     let offs = pg_constants::REPL_SLOT_ON_DISK_OFFSETOF_RESTART_LSN;
                     let restart_lsn = Lsn(u64::from_le_bytes(
@@ -398,7 +397,11 @@ where
         {
             self.add_twophase_file(xid).await?;
         }
-        let repl_origins = self.timeline.get_replorigins(self.lsn, self.ctx).await?;
+        let repl_origins = self
+            .timeline
+            .get_replorigins(self.lsn, self.ctx)
+            .await
+            .map_err(|e| BasebackupError::Server(e.into()))?;
         let n_origins = repl_origins.len();
         if n_origins != 0 {
             //

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -13,7 +13,7 @@
 use anyhow::{anyhow, Context};
 use bytes::{BufMut, Bytes, BytesMut};
 use fail::fail_point;
-use pageserver_api::key::Key;
+use pageserver_api::key::{replorigin_key, Key};
 use postgres_ffi::pg_constants;
 use std::fmt::Write as FmtWrite;
 use std::time::SystemTime;
@@ -355,6 +355,7 @@ where
                 .await
                 .map_err(|e| BasebackupError::Server(e.into()))?
             {
+                let header = new_tar_header(&path, content.len() as u64)?;
                 if path.starts_with("pg_replslot") {
                     let offs = pg_constants::REPL_SLOT_ON_DISK_OFFSETOF_RESTART_LSN;
                     let restart_lsn = Lsn(u64::from_le_bytes(
@@ -362,8 +363,37 @@ where
                     ));
                     info!("Replication slot {} restart LSN={}", path, restart_lsn);
                     min_restart_lsn = Lsn::min(min_restart_lsn, restart_lsn);
+                } else if path.starts_with("pg_logical/replorigin_checkpoint") {
+                    let n_origins = (content.len() - 4 /* magic */ - 4 /* crc32 */) / 16 /* sizeof(ReplicationStateOnDisk) */;
+                    let mut new_content = Vec::with_capacity(content.len());
+                    new_content.extend_from_slice(&content[0..4]); // magic
+                    for i in 0..n_origins {
+                        let offs = 4 + i * 16;
+                        let origin_id =
+                            u16::from_le_bytes(content[offs..offs + 2].try_into().unwrap());
+                        let origin_lsn =
+                            u64::from_le_bytes(content[offs + 8..offs + 16].try_into().unwrap());
+                        new_content.extend_from_slice(&content[offs..offs + 8]); // aligned origin id
+
+                        // Try to get orgin_lsn for this origin_id at the moment of basebackup
+                        let key = replorigin_key(origin_id);
+                        if let Ok(buf) = self.timeline.get(key, self.lsn, self.ctx).await {
+                            let tx_origin_lsn = u64::from_le_bytes(buf[0..8].try_into().unwrap());
+                            if tx_origin_lsn > origin_lsn {
+                                new_content.extend_from_slice(&buf[0..8]);
+                            } else {
+                                new_content.extend_from_slice(&content[offs + 8..offs + 16]);
+                            }
+                        }
+                    }
+                    let crc32 = crc32c::crc32c(&new_content);
+                    new_content.extend_from_slice(&crc32.to_le_bytes());
+                    self.ar
+                        .append(&header, &*new_content)
+                        .await
+                        .context("could not add aux file to basebackup tarball")?;
+                    continue;
                 }
-                let header = new_tar_header(&path, content.len() as u64)?;
                 self.ar
                     .append(&header, &*content)
                     .await

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -363,37 +363,10 @@ where
                     ));
                     info!("Replication slot {} restart LSN={}", path, restart_lsn);
                     min_restart_lsn = Lsn::min(min_restart_lsn, restart_lsn);
-                } else if path.starts_with("pg_logical/replorigin_checkpoint") {
-                    let n_origins = (content.len() - 4 /* magic */ - 4 /* crc32 */) / 16 /* sizeof(ReplicationStateOnDisk) */;
-                    let mut new_content = Vec::with_capacity(content.len());
-                    new_content.extend_from_slice(&content[0..4]); // magic
-                    for i in 0..n_origins {
-                        let offs = 4 + i * 16;
-                        let origin_id =
-                            u16::from_le_bytes(content[offs..offs + 2].try_into().unwrap());
-                        let origin_lsn =
-                            u64::from_le_bytes(content[offs + 8..offs + 16].try_into().unwrap());
-                        new_content.extend_from_slice(&content[offs..offs + 8]); // aligned origin id
-
-                        // Try to get orgin_lsn for this origin_id at the moment of basebackup
-                        let key = replorigin_key(origin_id);
-                        if let Ok(buf) = self.timeline.get(key, self.lsn, self.ctx).await {
-                            let tx_origin_lsn = u64::from_le_bytes(buf[0..8].try_into().unwrap());
-                            if tx_origin_lsn > origin_lsn {
-                                new_content.extend_from_slice(&buf[0..8]);
-                            } else {
-                                new_content.extend_from_slice(&content[offs + 8..offs + 16]);
-                            }
-                        }
-                    }
-                    let crc32 = crc32c::crc32c(&new_content);
-                    new_content.extend_from_slice(&crc32.to_le_bytes());
-                    self.ar
-                        .append(&header, &*new_content)
-                        .await
-                        .context("could not add aux file to basebackup tarball")?;
-                    continue;
+                } else if path == "pg_logical/replorigin_checkpoint" {
+                    continue; // skip repliction origin fiel because we will generate new one
                 }
+                let header = new_tar_header(&path, content.len() as u64)?;
                 self.ar
                     .append(&header, &*content)
                     .await
@@ -419,6 +392,23 @@ where
             .map_err(|e| BasebackupError::Server(e.into()))?
         {
             self.add_twophase_file(xid).await?;
+        }
+        let repl_origins = self.timeline.get_replorigins(self.lsn, self.ctx).await?;
+        let n_origins = repl_origins.len();
+        if n_origins != 0 {
+            let mut content = Vec::with_capacity(n_origins * 16 + 8);
+            content.extend_from_slice(&pg_constants::REPLICATION_STATE_MAGIC.to_le_bytes());
+            for (origin_id, origin_lsn) in repl_origins {
+                content.extend_from_slice(&origin_id.to_le_bytes());
+                content.extend_from_slice(&[0u8; 6]); // align to 8 bytes
+                content.extend_from_slice(&origin_lsn.0.to_le_bytes());
+            }
+            let crc32 = crc32c::crc32c(&content);
+            content.extend_from_slice(&crc32.to_le_bytes());
+            let header = new_tar_header("pg_logical/replorigin_checkpoint", content.len() as u64)?;
+            self.ar.append(&header, &*content).await.context(
+                "could not add pg_logical/replorigin_checkpoint file to basebackup tarball",
+            )?;
         }
 
         fail_point!("basebackup-before-control-file", |_| {

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -17,10 +17,10 @@ use bytes::{Buf, Bytes, BytesMut};
 use enum_map::Enum;
 use itertools::Itertools;
 use pageserver_api::key::{
-    dbdir_key_range, rel_block_to_key, rel_dir_to_key, rel_key_range, rel_size_to_key,
-    relmap_file_key, slru_block_to_key, slru_dir_to_key, slru_segment_key_range,
-    slru_segment_size_to_key, twophase_file_key, twophase_key_range, AUX_FILES_KEY, CHECKPOINT_KEY,
-    CONTROLFILE_KEY, DBDIR_KEY, TWOPHASEDIR_KEY,
+    dbdir_key_range, is_rel_block_key, is_slru_block_key, rel_block_to_key, rel_dir_to_key,
+    rel_key_range, rel_size_to_key, relmap_file_key, replorigin_key, slru_block_to_key,
+    slru_dir_to_key, slru_segment_key_range, slru_segment_size_to_key, twophase_file_key,
+    twophase_key_range, AUX_FILES_KEY, CHECKPOINT_KEY, CONTROLFILE_KEY, DBDIR_KEY, TWOPHASEDIR_KEY,
 };
 use pageserver_api::keyspace::SparseKeySpace;
 use pageserver_api::models::AuxFilePolicy;
@@ -1151,6 +1151,12 @@ impl<'a> DatadirModification<'a> {
         );
 
         self.put(twophase_file_key(xid), Value::Image(img));
+        Ok(())
+    }
+
+    pub fn put_replorigin(&mut self, origin_id: u16, origin_lsn: Lsn) -> anyhow::Result<()> {
+        let key = replorigin_key(origin_id);
+        self.put(key, Value::Image(Bytes::from(origin_lsn.ser().unwrap())));
         Ok(())
     }
 

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -907,7 +907,7 @@ impl Timeline {
         Ok((
             result.to_keyspace(),
             /* AUX sparse key space */
-            SparseKeySpace(KeySpace::single(Key::metadata_aux_key_range())),
+            SparseKeySpace(KeySpace { ranges: vec![repl_origin_key_range(), Key::metadata_aux_key_range()] }),
         ))
     }
 

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -17,11 +17,10 @@ use bytes::{Buf, Bytes, BytesMut};
 use enum_map::Enum;
 use itertools::Itertools;
 use pageserver_api::key::{
-    dbdir_key_range, is_rel_block_key, is_slru_block_key, rel_block_to_key, rel_dir_to_key,
-    rel_key_range, rel_size_to_key, relmap_file_key, repl_origin_key, repl_origin_key_range,
-    slru_block_to_key, slru_dir_to_key, slru_segment_key_range, slru_segment_size_to_key,
-    twophase_file_key, twophase_key_range, AUX_FILES_KEY, CHECKPOINT_KEY, CONTROLFILE_KEY,
-    DBDIR_KEY, TWOPHASEDIR_KEY,
+    dbdir_key_range, rel_block_to_key, rel_dir_to_key, rel_key_range, rel_size_to_key,
+    relmap_file_key, repl_origin_key, repl_origin_key_range, slru_block_to_key, slru_dir_to_key,
+    slru_segment_key_range, slru_segment_size_to_key, twophase_file_key, twophase_key_range,
+    AUX_FILES_KEY, CHECKPOINT_KEY, CONTROLFILE_KEY, DBDIR_KEY, TWOPHASEDIR_KEY,
 };
 use pageserver_api::keyspace::SparseKeySpace;
 use pageserver_api::models::AuxFilePolicy;

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -907,7 +907,9 @@ impl Timeline {
         Ok((
             result.to_keyspace(),
             /* AUX sparse key space */
-            SparseKeySpace(KeySpace { ranges: vec![repl_origin_key_range(), Key::metadata_aux_key_range()] }),
+            SparseKeySpace(KeySpace {
+                ranges: vec![repl_origin_key_range(), Key::metadata_aux_key_range()],
+            }),
         ))
     }
 

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -1187,18 +1187,18 @@ impl<'a> DatadirModification<'a> {
         origin_lsn: Lsn,
     ) -> anyhow::Result<()> {
         let mut repl_origins = self.tline.repl_origins.lock().await;
-        let origins = repl_origins.get_or_insert_with(|| ReplOrigins::default());
+        let origins = repl_origins.get_or_insert_with(ReplOrigins::default);
         origins.map.insert(origin_id, origin_lsn);
-        let buf = ReplOrigins::ser(&origins)?;
+        let buf = ReplOrigins::ser(origins)?;
         self.put(REPL_ORIGIN_KEY, Value::Image(Bytes::from(buf)));
         Ok(())
     }
 
     pub async fn drop_replorigin(&mut self, origin_id: RepOriginId) -> anyhow::Result<()> {
         let mut repl_origins = self.tline.repl_origins.lock().await;
-        let origins = repl_origins.get_or_insert_with(|| ReplOrigins::default());
+        let origins = repl_origins.get_or_insert_with(ReplOrigins::default);
         origins.map.remove(&origin_id);
-        let buf = ReplOrigins::ser(&origins)?;
+        let buf = ReplOrigins::ser(origins)?;
         self.put(REPL_ORIGIN_KEY, Value::Image(Bytes::from(buf)));
         Ok(())
     }

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -816,9 +816,9 @@ async fn eviction_cancellation_on_drop() {
 /// below if it is really necessary to add more fields to the structures.
 #[test]
 fn layer_size() {
-    assert_eq!(std::mem::size_of::<LayerAccessStats>(), 2048);
+    assert_eq!(std::mem::size_of::<LayerAccessStats>(), 2040);
     assert_eq!(std::mem::size_of::<PersistentLayerDesc>(), 104);
-    assert_eq!(std::mem::size_of::<LayerInner>(), 2376);
+    assert_eq!(std::mem::size_of::<LayerInner>(), 2344);
     // it also has the utf8 path
 }
 

--- a/pageserver/src/tenant/storage_layer/layer/tests.rs
+++ b/pageserver/src/tenant/storage_layer/layer/tests.rs
@@ -816,9 +816,9 @@ async fn eviction_cancellation_on_drop() {
 /// below if it is really necessary to add more fields to the structures.
 #[test]
 fn layer_size() {
-    assert_eq!(std::mem::size_of::<LayerAccessStats>(), 2040);
+    assert_eq!(std::mem::size_of::<LayerAccessStats>(), 2048);
     assert_eq!(std::mem::size_of::<PersistentLayerDesc>(), 104);
-    assert_eq!(std::mem::size_of::<LayerInner>(), 2344);
+    assert_eq!(std::mem::size_of::<LayerInner>(), 2376);
     // it also has the utf8 path
 }
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -91,7 +91,7 @@ use crate::{
 };
 use crate::{pgdatadir_mapping::LsnForTimestamp, tenant::tasks::BackgroundLoopKind};
 use crate::{
-    pgdatadir_mapping::{AuxFilesDirectory, DirectoryKind, ReplOrigins},
+    pgdatadir_mapping::{AuxFilesDirectory, DirectoryKind},
     virtual_file::{MaybeFatalIo, VirtualFile},
 };
 
@@ -418,15 +418,11 @@ pub struct Timeline {
     /// Keep aux directory cache to avoid it's reconstruction on each update
     pub(crate) aux_files: tokio::sync::Mutex<AuxFilesState>,
 
-<<<<<<< HEAD
     /// Size estimator for aux file v2
     pub(crate) aux_file_size_estimator: AuxFileSizeEstimator,
 
     /// Indicate whether aux file v2 storage is enabled.
     pub(crate) last_aux_file_policy: AtomicAuxFilePolicy,
-=======
-    pub(crate) repl_origins: tokio::sync::Mutex<Option<ReplOrigins>>,
->>>>>>> 2280d128a (Handle replorigin_set and replorigin_drop WAL records, ignore pg_logical/replorigin_checkpoint file)
 }
 
 pub struct WalReceiverInfo {
@@ -2322,10 +2318,13 @@ impl Timeline {
                     dir: None,
                     n_deltas: 0,
                 }),
+<<<<<<< HEAD
 
                 aux_file_size_estimator: AuxFileSizeEstimator::new(aux_file_metrics),
 
                 last_aux_file_policy: AtomicAuxFilePolicy::new(aux_file_policy),
+=======
+>>>>>>> b57518599 (Store repl origins as individual entries)
             };
             result.repartition_threshold =
                 result.get_checkpoint_distance() / REPARTITION_FREQ_IN_CHECKPOINT_DISTANCE;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3879,6 +3879,11 @@ impl Timeline {
                 return Err(FlushLayerError::Cancelled);
             }
 
+            // FIXME(auxfilesv2): support multiple metadata key partitions might need initdb support as well?
+            // This code path will not be hit during regression tests. After #7099 we have a single partition
+            // with two key ranges. If someone wants to fix initdb optimization in the future, this might need
+            // to be fixed.
+
             // For metadata, always create delta layers.
             let delta_layer = if !metadata_partition.parts.is_empty() {
                 assert_eq!(

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -91,7 +91,7 @@ use crate::{
 };
 use crate::{pgdatadir_mapping::LsnForTimestamp, tenant::tasks::BackgroundLoopKind};
 use crate::{
-    pgdatadir_mapping::{AuxFilesDirectory, DirectoryKind},
+    pgdatadir_mapping::{AuxFilesDirectory, DirectoryKind, ReplOrigins},
     virtual_file::{MaybeFatalIo, VirtualFile},
 };
 
@@ -418,11 +418,15 @@ pub struct Timeline {
     /// Keep aux directory cache to avoid it's reconstruction on each update
     pub(crate) aux_files: tokio::sync::Mutex<AuxFilesState>,
 
+<<<<<<< HEAD
     /// Size estimator for aux file v2
     pub(crate) aux_file_size_estimator: AuxFileSizeEstimator,
 
     /// Indicate whether aux file v2 storage is enabled.
     pub(crate) last_aux_file_policy: AtomicAuxFilePolicy,
+=======
+    pub(crate) repl_origins: tokio::sync::Mutex<Option<ReplOrigins>>,
+>>>>>>> 2280d128a (Handle replorigin_set and replorigin_drop WAL records, ignore pg_logical/replorigin_checkpoint file)
 }
 
 pub struct WalReceiverInfo {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2318,13 +2318,10 @@ impl Timeline {
                     dir: None,
                     n_deltas: 0,
                 }),
-<<<<<<< HEAD
 
                 aux_file_size_estimator: AuxFileSizeEstimator::new(aux_file_metrics),
 
                 last_aux_file_policy: AtomicAuxFilePolicy::new(aux_file_policy),
-=======
->>>>>>> b57518599 (Store repl origins as individual entries)
             };
             result.repartition_threshold =
                 result.get_checkpoint_distance() / REPARTITION_FREQ_IN_CHECKPOINT_DISTANCE;
@@ -3887,18 +3884,21 @@ impl Timeline {
                 assert_eq!(
                     metadata_partition.parts.len(),
                     1,
-                    "currently sparse keyspace should only contain a single aux file keyspace"
+                    "currently sparse keyspace should only contain a single metadata keyspace"
                 );
                 let metadata_keyspace = &metadata_partition.parts[0];
-                assert_eq!(
-                    metadata_keyspace.0.ranges.len(),
-                    1,
-                    "aux file keyspace should be a single range"
-                );
                 self.create_delta_layer(
                     &frozen_layer,
+<<<<<<< HEAD
                     Some(metadata_keyspace.0.ranges[0].clone()),
                     ctx,
+=======
+                    ctx,
+                    Some(
+                        metadata_keyspace.0.ranges.first().unwrap().start
+                            ..metadata_keyspace.0.ranges.last().unwrap().end,
+                    ),
+>>>>>>> 10b1208f9 (Fix unit tests)
                 )
                 .await
                 .map_err(|e| FlushLayerError::from_anyhow(self, e))?

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3894,16 +3894,11 @@ impl Timeline {
                 let metadata_keyspace = &metadata_partition.parts[0];
                 self.create_delta_layer(
                     &frozen_layer,
-<<<<<<< HEAD
-                    Some(metadata_keyspace.0.ranges[0].clone()),
-                    ctx,
-=======
-                    ctx,
                     Some(
                         metadata_keyspace.0.ranges.first().unwrap().start
                             ..metadata_keyspace.0.ranges.last().unwrap().end,
                     ),
->>>>>>> 10b1208f9 (Fix unit tests)
+                    ctx,
                 )
                 .await
                 .map_err(|e| FlushLayerError::from_anyhow(self, e))?

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -234,6 +234,7 @@ impl WalIngest {
                         modification,
                         &parsed_xact,
                         info == pg_constants::XLOG_XACT_COMMIT,
+                        decoded.origin_id,
                         ctx,
                     )
                     .await?;
@@ -246,6 +247,7 @@ impl WalIngest {
                         modification,
                         &parsed_xact,
                         info == pg_constants::XLOG_XACT_COMMIT_PREPARED,
+                        decoded.origin_id,
                         ctx,
                     )
                     .await?;
@@ -1178,6 +1180,7 @@ impl WalIngest {
         modification: &mut DatadirModification<'_>,
         parsed: &XlXactParsedRecord,
         is_commit: bool,
+        origin_id: u16,
         ctx: &RequestContext,
     ) -> anyhow::Result<()> {
         // Record update of CLOG pages
@@ -1242,6 +1245,9 @@ impl WalIngest {
                     self.put_rel_drop(modification, rel, ctx).await?;
                 }
             }
+        }
+        if origin_id != 0 {
+            modification.put_replorigin(origin_id, parsed.origin_lsn)?;
         }
         Ok(())
     }

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -9,7 +9,7 @@ use postgres_ffi::pg_constants;
 use postgres_ffi::BLCKSZ;
 use postgres_ffi::{BlockNumber, TimestampTz};
 use postgres_ffi::{MultiXactId, MultiXactOffset, MultiXactStatus, Oid, TransactionId};
-use postgres_ffi::{XLogRecord, XLOG_SIZE_OF_XLOG_RECORD};
+use postgres_ffi::{RepOriginId, XLogRecord, XLOG_SIZE_OF_XLOG_RECORD};
 use serde::{Deserialize, Serialize};
 use tracing::*;
 use utils::{bin_ser::DeserializeError, lsn::Lsn};
@@ -814,6 +814,36 @@ impl XlRunningXacts {
             oldest_running_xid,
             latest_completed_xid,
             xids,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct XlReploriginDrop {
+    pub node_id: RepOriginId,
+}
+
+impl XlReploriginDrop {
+    pub fn decode(buf: &mut Bytes) -> XlReploriginDrop {
+        XlReploriginDrop {
+            node_id: buf.get_u16_le(),
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct XlReploriginSet {
+    pub remote_lsn: Lsn,
+    pub node_id: RepOriginId,
+}
+
+impl XlReploriginSet {
+    pub fn decode(buf: &mut Bytes) -> XlReploriginSet {
+        XlReploriginSet {
+            remote_lsn: Lsn(buf.get_u64_le()),
+            node_id: buf.get_u16_le(),
         }
     }
 }

--- a/test_runner/regress/test_compaction.py
+++ b/test_runner/regress/test_compaction.py
@@ -81,8 +81,10 @@ page_cache_size=10
 
     non_vectored_sum = metrics.query_one("pageserver_layers_visited_per_read_global_sum")
     non_vectored_count = metrics.query_one("pageserver_layers_visited_per_read_global_count")
-    non_vectored_average = non_vectored_sum.value / non_vectored_count.value
-
+    if non_vectored_count.value != 0:
+        non_vectored_average = non_vectored_sum.value / non_vectored_count.value
+    else:
+        non_vectored_average = 0
     vectored_sum = metrics.query_one("pageserver_layers_visited_per_vectored_read_global_sum")
     vectored_count = metrics.query_one("pageserver_layers_visited_per_vectored_read_global_count")
     if vectored_count.value > 0:

--- a/test_runner/regress/test_subscriber_restart.py
+++ b/test_runner/regress/test_subscriber_restart.py
@@ -1,0 +1,38 @@
+from fixtures.neon_fixtures import NeonEnv
+from fixtures.utils import wait_until
+
+
+def test_subscriber_restart(neon_simple_env: NeonEnv):
+    env = neon_simple_env
+    env.neon_cli.create_branch("publisher")
+    pub = env.endpoints.create("publisher")
+    pub.start()
+
+    env.neon_cli.create_branch("subscriber")
+    sub = env.endpoints.create("subscriber")
+    sub.start()
+
+    n_records = 1000
+    with pub.cursor() as pcur:
+        with sub.cursor() as scur:
+            pcur.execute("CREATE TABLE t (pk integer primary key)")
+            pcur.execute("CREATE PUBLICATION pub FOR TABLE t")
+            scur.execute("CREATE TABLE t (pk integer primary key)")
+            pub_conn = f"host=localhost port={pub.pg_port} dbname=postgres user=cloud_admin"
+            query = f"CREATE SUBSCRIPTION sub CONNECTION '{pub_conn}' PUBLICATION pub"
+            scur.execute(query)
+            for i in range(0, n_records):
+                pcur.execute("INSERT into t values (%s)", (i,))
+
+            def check_that_changes_propagated():
+                scur.execute("SELECT count(*) FROM t")
+                res = scur.fetchall()
+                assert res[0][0] == n_records
+
+        # restart subscriber
+        sub.stop()
+        sub.start()
+        pcur.execute("INSERT into t values (1000)")
+        n_records += 1
+        with sub.cursor() as scur:
+            wait_until(10, 0.5, check_that_changes_propagated)

--- a/test_runner/regress/test_subscriber_restart.py
+++ b/test_runner/regress/test_subscriber_restart.py
@@ -1,5 +1,4 @@
 import threading
-import time
 
 from fixtures.neon_fixtures import NeonEnv
 from fixtures.utils import wait_until
@@ -44,11 +43,10 @@ def test_subscriber_restart(neon_simple_env: NeonEnv):
         for _ in range(n_restarts):
             # restart subscriber
             # time.sleep(2)
-            sub.stop('immediate')
+            sub.stop("immediate")
             sub.start()
 
-        thread.join();
-
+        thread.join()
         pcur.execute(f"INSERT into t values ({n_records}, 0)")
         n_records += 1
         with sub.cursor() as scur:

--- a/test_runner/regress/test_subscriber_restart.py
+++ b/test_runner/regress/test_subscriber_restart.py
@@ -4,6 +4,8 @@ from fixtures.neon_fixtures import NeonEnv
 from fixtures.utils import wait_until
 
 
+# This test checks of logical replication subscriber is able to correctly restart replication without receiving duplicates.
+# It requires tracking information about replication origins at page server side
 def test_subscriber_restart(neon_simple_env: NeonEnv):
     env = neon_simple_env
     env.neon_cli.create_branch("publisher")

--- a/test_runner/regress/test_subscriber_restart.py
+++ b/test_runner/regress/test_subscriber_restart.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 from fixtures.neon_fixtures import NeonEnv
 from fixtures.utils import wait_until
@@ -38,6 +39,7 @@ def test_subscriber_restart(neon_simple_env: NeonEnv):
             pub_conn = f"host=localhost port={pub.pg_port} dbname=postgres user=cloud_admin"
             query = f"CREATE SUBSCRIPTION sub CONNECTION '{pub_conn}' PUBLICATION pub"
             scur.execute(query)
+            time.sleep(2)  # let initial table sync complete
 
         thread = threading.Thread(target=insert_data, args=(pub,), daemon=True)
         thread.start()


### PR DESCRIPTION
Store logical replication origin in KV storage

## Problem

See  #6977

## Summary of changes

* Extract origin_lsn from commit WAl record
* Add ReplOrigin key to KV storage and store origin_lsn
* In basebackup replace snapshot origin_lsn with last committed origin_lsn at basebackup LSN

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
