### PR TITLE
heavier_once_cell: add detached init support

### DIFF
--- a/libs/utils/src/sync/heavier_once_cell.rs
+++ b/libs/utils/src/sync/heavier_once_cell.rs
@@ -110,7 +110,12 @@ impl<T> OnceCell<T> {
         }
     }
 
+    /// Returns a guard to an existing initialized value, or returns an unique initialization
+    /// permit which can be used to initialize this `OnceCell` using `OnceCell::set`.
     pub async fn get_or_init_detached(&self) -> Result<Guard<'_, T>, InitPermit> {
+        // It looks like OnceCell::get_or_init could be implemented using this method instead of
+        // duplication. However, that makes the future be !Send due to possibly holding on to the
+        // MutexGuard over an await point.
         loop {
             let sem = {
                 let guard = self.inner.lock().unwrap();


### PR DESCRIPTION
Aiming for the design where `heavier_once_cell::OnceCell` is initialized by a future factory lead to awkwardness with how `LayerInner::get_or_maybe_download` looks right now with the `loop`. The loop helps with two situations:

- an eviction has been scheduled but has not yet happened, and a read access should cancel the eviction
- a previous `LayerInner::get_or_maybe_download` that canceled a pending eviction was canceled leaving the `heavier_once_cell::OnceCell` uninitialized but needing repair by the next `LayerInner::get_or_maybe_download`

By instead supporting detached initialization in `heavier_once_cell::OnceCell` via an `OnceCell::get_or_detached_init`, we can fix what the monolithic #7030 does:
- spawned off download task initializes the `heavier_once_cell::OnceCell` regardless of the download starter being canceled
- a canceled `LayerInner::get_or_maybe_download` no longer stops eviction but can win it if not canceled

Split off from #7030.

Cc: #5331