### PR TITLE
fix(layer): metric miscalculations

### DIFF
--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -722,8 +722,6 @@ impl LayerInner {
                         .upgrade()
                         .ok_or_else(|| DownloadError::TimelineShutdown)?;
 
-                    // FIXME: grab a gate
-
                     let can_ever_evict = timeline.remote_client.as_ref().is_some();
 
                     // check if we really need to be downloaded; could have been already downloaded by a

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -710,10 +710,6 @@ impl LayerInner {
                     // disable any scheduled but not yet running eviction deletions for this
                     let next_version = 1 + self.version.fetch_add(1, Ordering::Relaxed);
 
-                    // count cancellations, which currently remain largely unexpected
-                    let init_cancelled =
-                        scopeguard::guard((), |_| LAYER_IMPL_METRICS.inc_init_cancelled());
-
                     // no need to make the evict_and_wait wait for the actual download to complete
                     drop(self.status.send(Status::Downloaded));
 
@@ -721,6 +717,10 @@ impl LayerInner {
                         .timeline
                         .upgrade()
                         .ok_or_else(|| DownloadError::TimelineShutdown)?;
+
+                    // count cancellations, which currently remain largely unexpected
+                    let init_cancelled =
+                        scopeguard::guard((), |_| LAYER_IMPL_METRICS.inc_init_cancelled());
 
                     let can_ever_evict = timeline.remote_client.as_ref().is_some();
 

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -771,7 +771,15 @@ impl LayerInner {
 
                         tracing::info!(%reason, "downloading on-demand");
 
-                        let permit = self.spawn_download_and_wait(timeline, permit).await?;
+                        let permit = self.spawn_download_and_wait(timeline, permit).await;
+
+                        let permit = match permit {
+                            Ok(permit) => permit,
+                            Err(e) => {
+                                scopeguard::ScopeGuard::into_inner(init_cancelled);
+                                return Err(e);
+                            }
+                        };
 
                         (permit, true)
                     } else {


### PR DESCRIPTION
Split off from #7030:
- each early exit is counted as canceled init, even though it most likely was just `LayerInner::keep_resident` doing the no-download repair check
- `downloaded_after` could had been accounted for multiple times, and also when repairing to match on-disk state

Cc: #5331 