### PR TITLE
refactor(layer): use detached init

### DIFF
--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -759,8 +759,6 @@ impl LayerInner {
             // count cancellations, which currently remain largely unexpected
             let init_cancelled = scopeguard::guard((), |_| LAYER_IMPL_METRICS.inc_init_cancelled());
 
-            let can_ever_evict = timeline.remote_client.as_ref().is_some();
-
             // check if we really need to be downloaded; could have been already downloaded by a
             // cancelled previous attempt.
             let needs_download = self
@@ -797,7 +795,7 @@ impl LayerInner {
             // we would like to do for prefetching which was not needed.
             self.wanted_evicted.store(false, Ordering::Release);
 
-            if !can_ever_evict {
+            if timeline.remote_client.as_ref().is_none() {
                 scopeguard::ScopeGuard::into_inner(init_cancelled);
                 return Err(DownloadError::NoRemoteStorage);
             }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -835,15 +835,9 @@ impl LayerInner {
 
             let permit = self.spawn_download_and_wait(timeline, permit).await;
 
-            let permit = match permit {
-                Ok(permit) => permit,
-                Err(e) => {
-                    scopeguard::ScopeGuard::into_inner(init_cancelled);
-                    return Err(e);
-                }
-            };
-
             scopeguard::ScopeGuard::into_inner(init_cancelled);
+
+            let permit = permit?;
 
             let since_last_eviction = self
                 .last_evicted_at

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -775,74 +775,85 @@ impl LayerInner {
                 }
             };
 
-            let (permit, downloaded) = if let Some(reason) = needs_download {
-                if let NeedsDownload::NotFile(ft) = reason {
-                    scopeguard::ScopeGuard::into_inner(init_cancelled);
-                    return Err(DownloadError::NotFile(ft));
-                }
+            let Some(reason) = needs_download else {
+                scopeguard::ScopeGuard::into_inner(init_cancelled);
 
-                // only reset this after we've decided we really need to download. otherwise it'd
-                // be impossible to mark cancelled downloads for eviction, like one could imagine
-                // we would like to do for prefetching which was not needed.
-                self.wanted_evicted.store(false, Ordering::Release);
-
-                // no need to make the evict_and_wait wait for the actual download to complete
-                drop(self.status.send(Status::Downloaded));
-
-                if !can_ever_evict {
-                    scopeguard::ScopeGuard::into_inner(init_cancelled);
-                    return Err(DownloadError::NoRemoteStorage);
-                }
-
-                if let Some(ctx) = ctx {
-                    let res = self.check_expected_download(ctx);
-                    if let Err(e) = res {
-                        scopeguard::ScopeGuard::into_inner(init_cancelled);
-                        return Err(e);
-                    }
-                }
-
-                if !allow_download {
-                    // this does look weird, but for LayerInner the "downloading" means also changing
-                    // internal once related state ...
-                    scopeguard::ScopeGuard::into_inner(init_cancelled);
-                    return Err(DownloadError::DownloadRequired);
-                }
-
-                tracing::info!(%reason, "downloading on-demand");
-
-                let permit = self.spawn_download_and_wait(timeline, permit).await;
-
-                let permit = match permit {
-                    Ok(permit) => permit,
-                    Err(e) => {
-                        scopeguard::ScopeGuard::into_inner(init_cancelled);
-                        return Err(e);
-                    }
-                };
-
-                (permit, true)
-            } else {
                 // the file is present locally, probably by a previous but cancelled call to
                 // get_or_maybe_download. alternatively we might be running without remote storage.
                 LAYER_IMPL_METRICS.inc_init_needed_no_download();
 
-                (permit, false)
+                let res = Arc::new(DownloadedLayer {
+                    owner: Arc::downgrade(self),
+                    kind: tokio::sync::OnceCell::default(),
+                    version: next_version,
+                });
+
+                self.access_stats.record_residence_event(
+                    LayerResidenceStatus::Resident,
+                    LayerResidenceEventReason::ResidenceChange,
+                );
+
+                let waiters = self.inner.initializer_count();
+                if waiters > 0 {
+                    tracing::info!(waiters, "completing the on-demand download for other tasks");
+                }
+
+                return Ok((ResidentOrWantedEvicted::Resident(res), permit));
+            };
+
+            if let NeedsDownload::NotFile(ft) = reason {
+                scopeguard::ScopeGuard::into_inner(init_cancelled);
+                return Err(DownloadError::NotFile(ft));
+            }
+
+            // only reset this after we've decided we really need to download. otherwise it'd
+            // be impossible to mark cancelled downloads for eviction, like one could imagine
+            // we would like to do for prefetching which was not needed.
+            self.wanted_evicted.store(false, Ordering::Release);
+
+            if !can_ever_evict {
+                scopeguard::ScopeGuard::into_inner(init_cancelled);
+                return Err(DownloadError::NoRemoteStorage);
+            }
+
+            if let Some(ctx) = ctx {
+                let res = self.check_expected_download(ctx);
+                if let Err(e) = res {
+                    scopeguard::ScopeGuard::into_inner(init_cancelled);
+                    return Err(e);
+                }
+            }
+
+            if !allow_download {
+                // this does look weird, but for LayerInner the "downloading" means also changing
+                // internal once related state ...
+                scopeguard::ScopeGuard::into_inner(init_cancelled);
+                return Err(DownloadError::DownloadRequired);
+            }
+
+            tracing::info!(%reason, "downloading on-demand");
+
+            let permit = self.spawn_download_and_wait(timeline, permit).await;
+
+            let permit = match permit {
+                Ok(permit) => permit,
+                Err(e) => {
+                    scopeguard::ScopeGuard::into_inner(init_cancelled);
+                    return Err(e);
+                }
             };
 
             scopeguard::ScopeGuard::into_inner(init_cancelled);
 
-            if downloaded {
-                let since_last_eviction = self
-                    .last_evicted_at
-                    .lock()
-                    .unwrap()
-                    .take()
-                    .map(|ts| ts.elapsed());
+            let since_last_eviction = self
+                .last_evicted_at
+                .lock()
+                .unwrap()
+                .take()
+                .map(|ts| ts.elapsed());
 
-                if let Some(since_last_eviction) = since_last_eviction {
-                    LAYER_IMPL_METRICS.record_redownloaded_after(since_last_eviction);
-                }
+            if let Some(since_last_eviction) = since_last_eviction {
+                LAYER_IMPL_METRICS.record_redownloaded_after(since_last_eviction);
             }
 
             let res = Arc::new(DownloadedLayer {

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -741,6 +741,7 @@ impl LayerInner {
 
                     let (permit, downloaded) = if let Some(reason) = needs_download {
                         if let NeedsDownload::NotFile(ft) = reason {
+                            scopeguard::ScopeGuard::into_inner(init_cancelled);
                             return Err(DownloadError::NotFile(ft));
                         }
 
@@ -841,10 +842,14 @@ impl LayerInner {
             }
 
             let (weak, permit) = {
-                let mut locked = self.inner.get_or_init(download).await?;
+                let locked = self
+                    .inner
+                    .get_or_init_detached()
+                    .await
+                    .map(|mut guard| guard.get_and_upgrade().ok_or(guard));
 
-                if let Some((strong, upgraded)) = locked.get_and_upgrade() {
-                    if upgraded {
+                match locked {
+                    Ok(Ok((strong, upgraded))) if upgraded => {
                         // when upgraded back, the Arc<DownloadedLayer> is still available, but
                         // previously a `evict_and_wait` was received.
                         self.wanted_evicted.store(false, Ordering::Relaxed);
@@ -853,29 +858,31 @@ impl LayerInner {
                         drop(self.status.send(Status::Downloaded));
                         LAYER_IMPL_METRICS
                             .inc_eviction_cancelled(EvictionCancelled::UpgradedBackOnAccess);
-                    }
 
-                    return Ok(strong);
-                } else {
-                    // path to here: the evict_blocking is stuck on spawn_blocking queue.
-                    //
-                    // reset the contents, deactivating the eviction and causing a
-                    // EvictionCancelled::LostToDownload or EvictionCancelled::VersionCheckFailed.
-                    locked.take_and_deinit()
+                        return Ok(strong);
+                    }
+                    Ok(Ok((strong, _))) => return Ok(strong),
+                    Ok(Err(mut guard)) => {
+                        // path to here: the evict_blocking is stuck on spawn_blocking queue.
+                        //
+                        // reset the contents, deactivating the eviction and causing a
+                        // EvictionCancelled::LostToDownload or EvictionCancelled::VersionCheckFailed.
+                        let (weak, permit) = guard.take_and_deinit();
+                        (Some(weak), permit)
+                    }
+                    Err(permit) => (None, permit),
                 }
             };
 
-            // unlock first, then drop the weak, but because upgrade failed, we
-            // know it cannot be a problem.
-
-            assert!(
-                matches!(weak, ResidentOrWantedEvicted::WantedEvicted(..)),
-                "unexpected {weak:?}, ResidentOrWantedEvicted::get_and_upgrade has a bug"
-            );
+            if let Some(weak) = weak {
+                // only drop the weak after dropping the heavier_once_cell guard
+                assert!(
+                    matches!(weak, ResidentOrWantedEvicted::WantedEvicted(..)),
+                    "unexpected {weak:?}, ResidentOrWantedEvicted::get_and_upgrade has a bug"
+                );
+            }
 
             init_permit = Some(permit);
-
-            LAYER_IMPL_METRICS.inc_retried_get_or_maybe_download();
         }
     }
 
@@ -1690,11 +1697,6 @@ impl LayerImplMetrics {
         self.rare_counters[RareEvent::RemoveOnDropFailed].inc();
     }
 
-    /// Expected rare because requires a race with `evict_blocking` and `get_or_maybe_download`.
-    fn inc_retried_get_or_maybe_download(&self) {
-        self.rare_counters[RareEvent::RetriedGetOrMaybeDownload].inc();
-    }
-
     /// Expected rare because cancellations are unexpected, and failures are unexpected
     fn inc_download_failed_without_requester(&self) {
         self.rare_counters[RareEvent::DownloadFailedWithoutRequester].inc();
@@ -1779,7 +1781,6 @@ impl DeleteFailed {
 #[derive(enum_map::Enum)]
 enum RareEvent {
     RemoveOnDropFailed,
-    RetriedGetOrMaybeDownload,
     DownloadFailedWithoutRequester,
     UpgradedWantedEvicted,
     InitWithoutDownload,
@@ -1793,7 +1794,6 @@ impl RareEvent {
 
         match self {
             RemoveOnDropFailed => "remove_on_drop_failed",
-            RetriedGetOrMaybeDownload => "retried_gomd",
             DownloadFailedWithoutRequester => "download_failed_without",
             UpgradedWantedEvicted => "raced_wanted_evicted",
             InitWithoutDownload => "init_needed_no_download",


### PR DESCRIPTION
The second part of work towards fixing `Layer::keep_resident` so that it does not need to repair the internal state. #7135 added a nicer API for initialization. This PR uses it to remove a few indentation levels and the loop construction. The next PR #7175 will use the refactorings done in this PR, and always initialize the internal state after a download.

Split off from #7030.

Cc: #5331

Reviewing: commit by commit with whitespace hidden works.