### PR TITLE
fixup(#7168): neon_local: use pageserver defaults for known but unspecified config overrides

### DIFF
--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -127,7 +127,7 @@ pub struct PageServerConf {
     pub pg_auth_type: AuthType,
     pub http_auth_type: AuthType,
 
-    pub(crate) virtual_file_io_engine: String,
+    pub(crate) virtual_file_io_engine: Option<String>,
     pub(crate) get_vectored_impl: String,
 }
 
@@ -139,8 +139,7 @@ impl Default for PageServerConf {
             listen_http_addr: String::new(),
             pg_auth_type: AuthType::Trust,
             http_auth_type: AuthType::Trust,
-            // FIXME: use the ones exposed by pageserver crate
-            virtual_file_io_engine: "tokio-epoll-uring".to_owned(),
+            virtual_file_io_engine: None,
             get_vectored_impl: "sequential".to_owned(),
         }
     }

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -128,7 +128,7 @@ pub struct PageServerConf {
     pub http_auth_type: AuthType,
 
     pub(crate) virtual_file_io_engine: Option<String>,
-    pub(crate) get_vectored_impl: String,
+    pub(crate) get_vectored_impl: Option<String>,
 }
 
 impl Default for PageServerConf {
@@ -140,7 +140,7 @@ impl Default for PageServerConf {
             pg_auth_type: AuthType::Trust,
             http_auth_type: AuthType::Trust,
             virtual_file_io_engine: None,
-            get_vectored_impl: "sequential".to_owned(),
+            get_vectored_impl: None,
         }
     }
 }

--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -101,7 +101,11 @@ impl PageServerNode {
 
         let pg_auth_type_param = format!("pg_auth_type='{}'", pg_auth_type);
         let listen_pg_addr_param = format!("listen_pg_addr='{}'", listen_pg_addr);
-        let virtual_file_io_engine = format!("virtual_file_io_engine='{virtual_file_io_engine}'");
+        let virtual_file_io_engine = if let Some(virtual_file_io_engine) = virtual_file_io_engine {
+            format!("virtual_file_io_engine='{virtual_file_io_engine}'")
+        } else {
+            String::new()
+        };
         let get_vectored_impl = format!("get_vectored_impl='{get_vectored_impl}'");
 
         let broker_endpoint_param = format!("broker_endpoint='{}'", self.env.broker.client_url());

--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -106,7 +106,11 @@ impl PageServerNode {
         } else {
             String::new()
         };
-        let get_vectored_impl = format!("get_vectored_impl='{get_vectored_impl}'");
+        let get_vectored_impl = if let Some(get_vectored_impl) = get_vectored_impl {
+            format!("get_vectored_impl='{get_vectored_impl}'")
+        } else {
+            String::new()
+        };
 
         let broker_endpoint_param = format!("broker_endpoint='{}'", self.env.broker.client_url());
 


### PR DESCRIPTION
## Problem

e2e tests cannot run on macOS unless the file engine env var is supplied.

```
./scripts/pytest test_runner/regress/test_neon_superuser.py -s
```

will fail with tokio-epoll-uring not supported.

This is because we persist the file engine config by default. In this pull request, we only persist when someone specifies it, so that it can use the default platform-variant config in the page server.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
