### PR TITLE
Add state diagram for compute

### DIFF
--- a/compute_tools/README.md
+++ b/compute_tools/README.md
@@ -32,6 +32,29 @@ compute_ctl -D /var/db/postgres/compute \
             -b /usr/local/bin/postgres
 ```
 
+## State Diagram
+
+Computes can be in various states. Below is a diagram that details how a
+compute moves between states.
+
+```mermaid
+%% https://mermaid.js.org/syntax/stateDiagram.html
+stateDiagram-v2
+  [*] --> Empty : Compute spawned
+  Empty --> ConfigurationPending : Waiting for compute spec
+  ConfigurationPending --> Configuration : Received compute spec
+  Configuration --> Failed : Failed to configure the compute
+  Configuration --> Running : Compute has been configured
+  Empty --> Init : Compute spec is immediately available
+  Empty --> TerminationPending : Requested termination
+  Init --> Failed : Failed to start Postgres
+  Init --> Running : Started Postgres
+  Running --> TerminationPending : Requested termination
+  TerminationPending --> Terminated : Terminated compute
+  Failed --> [*] : Compute exited
+  Terminated --> [*] : Compute exited
+```
+
 ## Tests
 
 Cargo formatter:


### PR DESCRIPTION
Models a compute's lifetime.

Here is a [link](https://mermaid.ink/img/pako:eNqVklFPwjAQx79Kc49mkLGNufXBF9TENwImJjofynZAI23n1iGT8N1twbmBYOLbtff7_3t3vS2kKkOgUGqm8ZazRcFEb-0lkpCXq1fS692QO5HrmlAyUiKvNJIyZx8SM4scUhYaKTnni6pgmis5RplxuTCaJ8a1jeaqIOmPHlMrPiv55WVMJpgiX2P2t8Nees_4yoC0CbQyogOERC-xsTivnlRSHupuel2ykswQZety0veD5PpoNpgSXhIuBGbcjHRVE7Y2tbDZCo-Vj1gILk_mNcH3CkttK2_TVrd_50KH5u8KTcaq1IsCyyO67WhqIcN3sSb7_3LO0F2TfYGdQ2fq32Vb2i5YOzrccH2Ybkd4GQMHhOEYz8z2bq0sAfPBAhOgJsxY8ZZAIneGY5VW01qmQHVRoQNVnrXLDnTOVqW5zZl8Vko0kDkC3cIGaG8Q969dfxB5nucGwyiOAgdqoAM36rtx4AXDeOCGQTD0dw587i3cvrkfer4fB6EfuNdhuPsCwrQllA?type=png) to what it looks like rendered. Or use the "Rich Diff" on GitHub for viewing the diagram