### PR TITLE
fix(Layer): always init after downloading in the spawned task

### DIFF
--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -745,12 +745,6 @@ impl LayerInner {
         }
 
         async move {
-            // disable any scheduled but not yet running eviction deletions for this
-            let next_version = 1 + self.version.fetch_add(1, Ordering::Relaxed);
-
-            // no need to make the evict_and_wait wait for the actual download to complete
-            drop(self.status.send(Status::Downloaded));
-
             let timeline = self
                 .timeline
                 .upgrade()
@@ -781,7 +775,7 @@ impl LayerInner {
                 // get_or_maybe_download. alternatively we might be running without remote storage.
                 LAYER_IMPL_METRICS.inc_init_needed_no_download();
 
-                let res = self.initialize_after_layer_is_on_disk(next_version, permit, false);
+                let res = self.initialize_after_layer_is_on_disk(permit, false);
                 return Ok(res);
             };
 
@@ -789,11 +783,6 @@ impl LayerInner {
                 scopeguard::ScopeGuard::into_inner(init_cancelled);
                 return Err(DownloadError::NotFile(ft));
             }
-
-            // only reset this after we've decided we really need to download. otherwise it'd
-            // be impossible to mark cancelled downloads for eviction, like one could imagine
-            // we would like to do for prefetching which was not needed.
-            self.wanted_evicted.store(false, Ordering::Release);
 
             if timeline.remote_client.as_ref().is_none() {
                 scopeguard::ScopeGuard::into_inner(init_cancelled);
@@ -823,7 +812,7 @@ impl LayerInner {
 
             let permit = permit?;
 
-            let res = self.initialize_after_layer_is_on_disk(next_version, permit, true);
+            let res = self.initialize_after_layer_is_on_disk(permit, true);
             Ok(res)
         }
         .instrument(tracing::info_span!("get_or_maybe_download", layer=%self))
@@ -986,11 +975,21 @@ impl LayerInner {
     /// changes are made before we can write to the OnceCell in non-cancellable fashion.
     fn initialize_after_layer_is_on_disk(
         self: &Arc<LayerInner>,
-        next_version: usize,
         permit: heavier_once_cell::InitPermit,
         downloaded: bool,
     ) -> Arc<DownloadedLayer> {
         debug_assert_current_span_has_tenant_and_timeline_id();
+
+        // disable any scheduled but not yet running eviction deletions for this
+        let next_version = 1 + self.version.fetch_add(1, Ordering::Relaxed);
+
+        // only reset this after we've decided we really need to download. otherwise it'd
+        // be impossible to mark cancelled downloads for eviction, like one could imagine
+        // we would like to do for prefetching which was not needed.
+        self.wanted_evicted.store(false, Ordering::Release);
+
+        // no need to make the evict_and_wait wait for the actual download to complete
+        drop(self.status.send(Status::Downloaded));
 
         if downloaded {
             let since_last_eviction = self
@@ -1000,8 +999,6 @@ impl LayerInner {
                 .take()
                 .map(|ts| ts.elapsed());
             if let Some(since_last_eviction) = since_last_eviction {
-                // FIXME: this will not always be recorded correctly until #6028 (the no
-                // download needed branch above)
                 LAYER_IMPL_METRICS.record_redownloaded_after(since_last_eviction);
             }
         }

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1009,7 +1009,7 @@ impl LayerInner {
 
         let waiters = self.inner.initializer_count();
         if waiters > 0 {
-            tracing::info!(waiters, "completing the on-demand download for other tasks");
+            tracing::info!(waiters, "completing layer init for other tasks");
         }
 
         let value = ResidentOrWantedEvicted::Resident(res.clone());

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -912,6 +912,8 @@ impl LayerInner {
 
         match result {
             Ok(size) => {
+                assert_eq!(size, self.desc.file_size);
+
                 match self.needs_download().await {
                     Ok(Some(reason)) => {
                         // this is really a bug in needs_download or remote timeline client
@@ -926,7 +928,9 @@ impl LayerInner {
                 }
 
                 tracing::info!(size=%self.desc.file_size, "on-demand download successful");
-                timeline.metrics.resident_physical_size_add(size);
+                timeline
+                    .metrics
+                    .resident_physical_size_add(self.desc.file_size);
                 self.consecutive_failures.store(0, Ordering::Relaxed);
 
                 let since_last_eviction = self

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -775,8 +775,7 @@ impl LayerInner {
             // get_or_maybe_download. alternatively we might be running without remote storage.
             LAYER_IMPL_METRICS.inc_init_needed_no_download();
 
-            let res = self.initialize_after_layer_is_on_disk(permit);
-            return Ok(res);
+            return Ok(self.initialize_after_layer_is_on_disk(permit));
         };
 
         if let NeedsDownload::NotFile(ft) = reason {
@@ -945,8 +944,7 @@ impl LayerInner {
                     LayerResidenceEventReason::ResidenceChange,
                 );
 
-                let res = self.initialize_after_layer_is_on_disk(permit);
-                Ok(res)
+                Ok(self.initialize_after_layer_is_on_disk(permit))
             }
             Err(e) => {
                 let consecutive_failures =

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -953,7 +953,7 @@ impl LayerInner {
             }
             Err(e) => {
                 let consecutive_failures =
-                    self.consecutive_failures.fetch_add(1, Ordering::Relaxed);
+                    1 + self.consecutive_failures.fetch_add(1, Ordering::Relaxed);
 
                 tracing::error!(consecutive_failures, "layer file download failed: {e:#}");
 

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -806,13 +806,8 @@ impl LayerInner {
 
             tracing::info!(%reason, "downloading on-demand");
 
-            let permit = self.spawn_download_and_wait(timeline, permit).await;
-
+            let res = self.download_init_and_wait(timeline, permit).await?;
             scopeguard::ScopeGuard::into_inner(init_cancelled);
-
-            let permit = permit?;
-
-            let res = self.initialize_after_layer_is_on_disk(permit, true);
             Ok(res)
         }
         .instrument(tracing::info_span!("get_or_maybe_download", layer=%self))
@@ -846,11 +841,11 @@ impl LayerInner {
     }
 
     /// Actual download, at most one is executed at the time.
-    async fn spawn_download_and_wait(
+    async fn download_init_and_wait(
         self: &Arc<Self>,
         timeline: Arc<Timeline>,
         permit: heavier_once_cell::InitPermit,
-    ) -> Result<heavier_once_cell::InitPermit, DownloadError> {
+    ) -> Result<Arc<DownloadedLayer>, DownloadError> {
         debug_assert_current_span_has_tenant_and_timeline_id();
 
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -880,12 +875,24 @@ impl LayerInner {
 
                 let result = match result {
                     Ok(size) => {
+                        match this.needs_download().await {
+                            Ok(Some(reason)) => panic!("post-condition failed: needs_download returned {reason:?}"),
+                            Ok(None) => { /* good */ },
+                            Err(e) => panic!("post-condition failed needs_download errored: {e:?}"),
+                        }
+
+                        tracing::info!(size=%this.desc.file_size, "on-demand download successful");
                         timeline.metrics.resident_physical_size_add(size);
-                        Ok(())
+                        this.consecutive_failures.store(0, Ordering::Relaxed);
+
+                        let res = this.initialize_after_layer_is_on_disk(permit, true);
+                        Ok(res)
                     }
                     Err(e) => {
                         let consecutive_failures =
                             this.consecutive_failures.fetch_add(1, Ordering::Relaxed);
+
+                        tracing::error!(consecutive_failures, "layer file download failed: {e:#}");
 
                         let backoff = utils::backoff::exponential_backoff_duration_seconds(
                             consecutive_failures.min(u32::MAX as usize) as u32,
@@ -904,23 +911,13 @@ impl LayerInner {
                     }
                 };
 
-                if let Err(res) = tx.send((result, permit)) {
+                if let Err(res) = tx.send(result) {
                     match res {
-                        (Ok(()), _) => {
-                            // our caller is cancellation safe so this is fine; if someone
-                            // else requests the layer, they'll find it already downloaded.
-                            //
-                            // See counter [`LayerImplMetrics::inc_init_needed_no_download`]
-                            //
-                            // FIXME(#6028): however, could be that we should consider marking the
-                            // layer for eviction? alas, cannot: because only DownloadedLayer will
-                            // handle that.
+                        Ok(_res) => {
+                            // our caller has been cancelled. regardless, the layer is now
+                            // initialized for any next read request.
                         },
-                        (Err(e), _) => {
-                            // our caller is cancellation safe, but we might be racing with
-                            // another attempt to initialize. before we have cancellation
-                            // token support: these attempts should converge regardless of
-                            // their completion order.
+                        Err(e) => {
                             tracing::error!("layer file download failed, and additionally failed to communicate this to caller: {e:?}");
                             LAYER_IMPL_METRICS.inc_download_failed_without_requester();
                         }
@@ -931,35 +928,16 @@ impl LayerInner {
         );
 
         match rx.await {
-            Ok((Ok(()), permit)) => {
-                if let Some(reason) = self
-                    .needs_download()
-                    .await
-                    .map_err(DownloadError::PostStatFailed)?
-                {
-                    // this is really a bug in needs_download or remote timeline client
-                    panic!("post-condition failed: needs_download returned {reason:?}");
-                }
-
-                self.consecutive_failures.store(0, Ordering::Relaxed);
-                tracing::info!(size=%self.desc.file_size, "on-demand download successful");
-
-                Ok(permit)
-            }
-            Ok((Err(e), _permit)) => {
+            Ok(Ok(res)) => Ok(res),
+            Ok(Err(e)) => {
                 // sleep already happened in the spawned task, if it was not cancelled
-                let consecutive_failures = self.consecutive_failures.load(Ordering::Relaxed);
-
                 match e.downcast_ref::<remote_storage::DownloadError>() {
                     // If the download failed due to its cancellation token,
                     // propagate the cancellation error upstream.
                     Some(remote_storage::DownloadError::Cancelled) => {
                         Err(DownloadError::DownloadCancelled)
                     }
-                    _ => {
-                        tracing::error!(consecutive_failures, "layer file download failed: {e:#}");
-                        Err(DownloadError::DownloadFailed)
-                    }
+                    _ => Err(DownloadError::DownloadFailed),
                 }
             }
             Err(_gone) => Err(DownloadError::DownloadCancelled),
@@ -1265,8 +1243,6 @@ pub(crate) enum DownloadError {
     DownloadCancelled,
     #[error("pre-condition: stat before download failed")]
     PreStatFailed(#[source] std::io::Error),
-    #[error("post-condition: stat after download failed")]
-    PostStatFailed(#[source] std::io::Error),
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Before this PR, cancellation for `LayerInner::get_or_maybe_download` could occur so that we have downloaded the layer file in the filesystem, but because of the cancellation chance, we have not set the internal `LayerInner::inner` or initialized the state. With the detached init support introduced in #7135  and in place in #7152, we can now initialize the internal state after successfully downloading in the spawned task.

The next PR will fix the remaining problems that this PR leaves:
- `Layer::keep_resident` is still used because
- `Layer::get_or_maybe_download` always cancels an eviction, even when canceled

Split off from #7030. Stacked on top of #7152. Cc: #5331.