### PR TITLE
test: fix `test_pageserver_recovery` flakyness

### DIFF
--- a/control_plane/attachment_service/src/heartbeater.rs
+++ b/control_plane/attachment_service/src/heartbeater.rs
@@ -139,7 +139,7 @@ impl HeartbeaterTask {
                         .with_client_retries(
                             |client| async move { client.get_utilization().await },
                             &jwt_token,
-                            2,
+                            3,
                             3,
                             Duration::from_secs(1),
                             &cancel,

--- a/test_runner/regress/test_recovery.py
+++ b/test_runner/regress/test_recovery.py
@@ -20,6 +20,9 @@ def test_pageserver_recovery(neon_env_builder: NeonEnvBuilder):
     # We expect the pageserver to exit, which will cause storage storage controller
     # requests to fail and warn.
     env.storage_controller.allowed_errors.append(".*management API still failed.*")
+    env.storage_controller.allowed_errors.append(
+        ".*Reconcile error.*error sending request for url.*"
+    )
 
     # Create a branch for us
     env.neon_cli.create_branch("test_pageserver_recovery", "main")

--- a/test_runner/regress/test_recovery.py
+++ b/test_runner/regress/test_recovery.py
@@ -26,7 +26,7 @@ def test_pageserver_recovery(neon_env_builder: NeonEnvBuilder):
 
     endpoint = env.endpoints.create_start("test_pageserver_recovery")
 
-    with closing(endpoint.connect(options="-cstatement_timeout=300s")) as conn:
+    with closing(endpoint.connect()) as conn:
         with conn.cursor() as cur:
             with env.pageserver.http_client() as pageserver_http:
                 # Create and initialize test table

--- a/test_runner/regress/test_recovery.py
+++ b/test_runner/regress/test_recovery.py
@@ -14,6 +14,7 @@ def test_pageserver_recovery(neon_env_builder: NeonEnvBuilder):
 
     env = neon_env_builder.init_start()
     env.pageserver.is_testing_enabled_or_skip()
+    env.storage_controller.allowed_errors.append(".*management API still failed.*utilization.*")
 
     # Create a branch for us
     env.neon_cli.create_branch("test_pageserver_recovery", "main")

--- a/test_runner/regress/test_recovery.py
+++ b/test_runner/regress/test_recovery.py
@@ -1,7 +1,6 @@
 import time
 from contextlib import closing
 
-import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnvBuilder
 
@@ -9,7 +8,6 @@ from fixtures.neon_fixtures import NeonEnvBuilder
 #
 # Test pageserver recovery after crash
 #
-@pytest.mark.repeat(30)
 def test_pageserver_recovery(neon_env_builder: NeonEnvBuilder):
     # Override default checkpointer settings to run it more often
     neon_env_builder.pageserver_config_override = "tenant_config={checkpoint_distance = 1048576}"

--- a/test_runner/regress/test_recovery.py
+++ b/test_runner/regress/test_recovery.py
@@ -1,6 +1,7 @@
 import time
 from contextlib import closing
 
+import pytest
 from fixtures.log_helper import log
 from fixtures.neon_fixtures import NeonEnvBuilder
 
@@ -8,6 +9,7 @@ from fixtures.neon_fixtures import NeonEnvBuilder
 #
 # Test pageserver recovery after crash
 #
+@pytest.mark.repeat(30)
 def test_pageserver_recovery(neon_env_builder: NeonEnvBuilder):
     # Override default checkpointer settings to run it more often
     neon_env_builder.pageserver_config_override = "tenant_config={checkpoint_distance = 1048576}"


### PR DESCRIPTION
## Problem
We recently introduced log file validation for the storage controller. The heartbeater will WARN when it fails
for a node, hence the test fails.

Closes https://github.com/neondatabase/neon/issues/7159

## Summary of changes
* Warn only once for each set of heartbeat retries
* Allow list heartbeat warns

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
