### PR TITLE
pageserver: drop the layer map lock after planning reads

### DIFF
--- a/pageserver/src/tenant/ephemeral_file.rs
+++ b/pageserver/src/tenant/ephemeral_file.rs
@@ -72,8 +72,8 @@ impl EphemeralFile {
         self.len
     }
 
-    pub(crate) fn path(&self) -> Utf8PathBuf {
-        self.file.path.clone()
+    pub(crate) fn id(&self) -> page_cache::FileId {
+        self.page_cache_file_id
     }
 
     pub(crate) async fn read_blk(

--- a/pageserver/src/tenant/ephemeral_file.rs
+++ b/pageserver/src/tenant/ephemeral_file.rs
@@ -72,6 +72,10 @@ impl EphemeralFile {
         self.len
     }
 
+    pub(crate) fn path(&self) -> Utf8PathBuf {
+        self.file.path.clone()
+    }
+
     pub(crate) async fn read_blk(
         &self,
         blknum: u32,

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -346,35 +346,6 @@ where
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Debug, Clone)]
-pub enum InMemoryLayerHandle {
-    Open {
-        lsn_floor: Lsn,
-        end_lsn: Lsn,
-    },
-    Frozen {
-        idx: usize,
-        lsn_floor: Lsn,
-        end_lsn: Lsn,
-    },
-}
-
-impl InMemoryLayerHandle {
-    pub fn get_lsn_floor(&self) -> Lsn {
-        match self {
-            InMemoryLayerHandle::Open { lsn_floor, .. } => *lsn_floor,
-            InMemoryLayerHandle::Frozen { lsn_floor, .. } => *lsn_floor,
-        }
-    }
-
-    pub fn get_end_lsn(&self) -> Lsn {
-        match self {
-            InMemoryLayerHandle::Open { end_lsn, .. } => *end_lsn,
-            InMemoryLayerHandle::Frozen { end_lsn, .. } => *end_lsn,
-        }
-    }
-}
-
 impl LayerMap {
     ///
     /// Find the latest layer (by lsn.end) that covers the given

--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -576,41 +576,18 @@ impl LayerMap {
         self.historic.iter()
     }
 
-    /// Get a handle for the first in memory layer that matches the provided predicate.
-    /// The handle should be used with [`Self::get_in_memory_layer`] to retrieve the actual layer.
-    ///
-    /// Note: [`Self::find_in_memory_layer`] and [`Self::get_in_memory_layer`] should be called during
-    /// the same exclusive region established by holding the layer manager lock.
-    pub fn find_in_memory_layer<Pred>(&self, mut pred: Pred) -> Option<InMemoryLayerHandle>
+    /// Get a ref counted pointer for the first in memory layer that matches the provided predicate.
+    pub fn find_in_memory_layer<Pred>(&self, mut pred: Pred) -> Option<Arc<InMemoryLayer>>
     where
         Pred: FnMut(&Arc<InMemoryLayer>) -> bool,
     {
         if let Some(open) = &self.open_layer {
             if pred(open) {
-                return Some(InMemoryLayerHandle::Open {
-                    lsn_floor: open.get_lsn_range().start,
-                    end_lsn: open.get_lsn_range().end,
-                });
+                return Some(open.clone());
             }
         }
 
-        let pos = self.frozen_layers.iter().rev().position(pred);
-        pos.map(|rev_idx| {
-            let idx = self.frozen_layers.len() - 1 - rev_idx;
-            InMemoryLayerHandle::Frozen {
-                idx,
-                lsn_floor: self.frozen_layers[idx].get_lsn_range().start,
-                end_lsn: self.frozen_layers[idx].get_lsn_range().end,
-            }
-        })
-    }
-
-    /// Get the layer pointed to by the provided handle.
-    pub fn get_in_memory_layer(&self, handle: &InMemoryLayerHandle) -> Option<Arc<InMemoryLayer>> {
-        match handle {
-            InMemoryLayerHandle::Open { .. } => self.open_layer.clone(),
-            InMemoryLayerHandle::Frozen { idx, .. } => self.frozen_layers.get(*idx).cloned(),
-        }
+        self.frozen_layers.iter().rfind(|l| pred(l)).cloned()
     }
 
     ///

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -226,31 +226,6 @@ struct ReadDesc {
     lsn_range: Range<Lsn>,
 }
 
-impl Ord for ReadDesc {
-    fn cmp(&self, other: &Self) -> Ordering {
-        let ord = self.lsn_range.end.cmp(&other.lsn_range.end);
-        if ord == std::cmp::Ordering::Equal {
-            self.lsn_range.start.cmp(&other.lsn_range.start).reverse()
-        } else {
-            ord
-        }
-    }
-}
-
-impl PartialOrd for ReadDesc {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for ReadDesc {
-    fn eq(&self, other: &Self) -> bool {
-        self.lsn_range == other.lsn_range
-    }
-}
-
-impl Eq for ReadDesc {}
-
 /// Data structure which maintains a fringe of layers for the
 /// read path. The fringe is the set of layers which intersects
 /// the current keyspace that the search is descending on.
@@ -313,6 +288,31 @@ impl Default for LayerFringe {
         Self::new()
     }
 }
+
+impl Ord for ReadDesc {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let ord = self.lsn_range.end.cmp(&other.lsn_range.end);
+        if ord == std::cmp::Ordering::Equal {
+            self.lsn_range.start.cmp(&other.lsn_range.start).reverse()
+        } else {
+            ord
+        }
+    }
+}
+
+impl PartialOrd for ReadDesc {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for ReadDesc {
+    fn eq(&self, other: &Self) -> bool {
+        self.lsn_range == other.lsn_range
+    }
+}
+
+impl Eq for ReadDesc {}
 
 impl ReadableLayer {
     pub(crate) fn key(&self) -> LayerKey {

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -221,7 +221,7 @@ pub(crate) enum ReadableLayer {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ReadDesc {
+struct ReadDesc {
     layer_key: LayerKey,
     lsn_range: Range<Lsn>,
 }

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -41,7 +41,7 @@ pub use layer_desc::{PersistentLayerDesc, PersistentLayerKey};
 
 pub(crate) use layer::{EvictionError, Layer, ResidentLayer};
 
-use self::inmemory_layer::InMemoryLayerKey;
+use self::inmemory_layer::InMemoryLayerFileId;
 
 use super::timeline::GetVectoredError;
 use super::PageReconstructError;
@@ -206,9 +206,9 @@ impl Default for ValuesReconstructState {
 
 /// A key that uniquely identifies a layer in a timeline
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub(crate) enum LayerKey {
-    PersitentLayerKey(PersistentLayerKey),
-    InMemoryLayerKey(InMemoryLayerKey),
+pub(crate) enum LayerId {
+    PersitentLayerId(PersistentLayerKey),
+    InMemoryLayerId(InMemoryLayerFileId),
 }
 
 /// Layer wrapper for the read path. Note that it is valid
@@ -222,7 +222,7 @@ pub(crate) enum ReadableLayer {
 
 #[derive(Debug, Clone)]
 struct ReadDesc {
-    layer_key: LayerKey,
+    layer_key: LayerId,
     lsn_range: Range<Lsn>,
 }
 
@@ -236,7 +236,7 @@ struct ReadDesc {
 #[derive(Debug)]
 pub(crate) struct LayerFringe {
     planned_reads_by_lsn: BinaryHeap<ReadDesc>,
-    layers: HashMap<LayerKey, (ReadableLayer, KeySpace)>,
+    layers: HashMap<LayerId, (ReadableLayer, KeySpace)>,
 }
 
 impl LayerFringe {
@@ -315,10 +315,10 @@ impl PartialEq for ReadDesc {
 impl Eq for ReadDesc {}
 
 impl ReadableLayer {
-    pub(crate) fn key(&self) -> LayerKey {
+    pub(crate) fn key(&self) -> LayerId {
         match self {
-            Self::PersistentLayer(layer) => LayerKey::PersitentLayerKey(layer.layer_desc().key()),
-            Self::InMemoryLayer(layer) => LayerKey::InMemoryLayerKey(layer.key()),
+            Self::PersistentLayer(layer) => LayerId::PersitentLayerId(layer.layer_desc().key()),
+            Self::InMemoryLayer(layer) => LayerId::InMemoryLayerId(layer.key()),
         }
     }
 

--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -39,7 +39,7 @@ pub struct InMemoryLayer {
     conf: &'static PageServerConf,
     tenant_shard_id: TenantShardId,
     timeline_id: TimelineId,
-    key: InMemoryLayerFileId,
+    file_id: InMemoryLayerFileId,
 
     /// This layer contains all the changes from 'start_lsn'. The
     /// start is inclusive.
@@ -83,8 +83,8 @@ impl std::fmt::Debug for InMemoryLayerInner {
 }
 
 impl InMemoryLayer {
-    pub(crate) fn key(&self) -> InMemoryLayerFileId {
-        self.key
+    pub(crate) fn file_id(&self) -> InMemoryLayerFileId {
+        self.file_id
     }
 
     pub(crate) fn get_timeline_id(&self) -> TimelineId {
@@ -329,7 +329,7 @@ impl InMemoryLayer {
         let key = InMemoryLayerFileId(file.id());
 
         Ok(InMemoryLayer {
-            key,
+            file_id: key,
             conf,
             timeline_id,
             tenant_shard_id,

--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -33,13 +33,13 @@ use super::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub(crate) struct InMemoryLayerKey(page_cache::FileId);
+pub(crate) struct InMemoryLayerFileId(page_cache::FileId);
 
 pub struct InMemoryLayer {
     conf: &'static PageServerConf,
     tenant_shard_id: TenantShardId,
     timeline_id: TimelineId,
-    key: InMemoryLayerKey,
+    key: InMemoryLayerFileId,
 
     /// This layer contains all the changes from 'start_lsn'. The
     /// start is inclusive.
@@ -83,7 +83,7 @@ impl std::fmt::Debug for InMemoryLayerInner {
 }
 
 impl InMemoryLayer {
-    pub(crate) fn key(&self) -> InMemoryLayerKey {
+    pub(crate) fn key(&self) -> InMemoryLayerFileId {
         self.key
     }
 
@@ -326,7 +326,7 @@ impl InMemoryLayer {
         trace!("initializing new empty InMemoryLayer for writing on timeline {timeline_id} at {start_lsn}");
 
         let file = EphemeralFile::create(conf, tenant_shard_id, timeline_id).await?;
-        let key = InMemoryLayerKey(file.id());
+        let key = InMemoryLayerFileId(file.id());
 
         Ok(InMemoryLayer {
             key,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2825,6 +2825,13 @@ impl Timeline {
             // It's safe to drop the layer map lock after planning the next round of reads.
             // The fringe keeps readable handles for the layers which are safe to read even
             // if layers were compacted or flushed.
+            //
+            // The more interesting consideration is: "Why is the read algorithm still correct
+            // if the layer map changes while it is operating?". Doing a vectored read on a
+            // timeline boils down to pushing an imaginary lsn boundary downwards for each range
+            // covered by the read. The layer map tells us how to move the lsn downwards for a
+            // range at *a particular point in time*. It is fine for the answer to be different
+            // at two different time points.
             drop(guard);
 
             if let Some((layer_to_read, keyspace_to_read, lsn_range)) = fringe.next_layer() {


### PR DESCRIPTION
## Problem
The vectored read path holds the layer map lock while visiting a timeline.

## Summary of changes
* Rework the fringe order to hold `Layer` on `Arc<InMemoryLayer>` handles instead of descriptions that are resolved by the layer map at the time of read. Note that previously `get_values_reconstruct_data` was implemented for the layer description which already knew the lsn range for the read. Now it is implemented on the new `ReadableLayer` handle and needs to get the lsn range as an argument.
* Drop the layer map lock after updating the fringe.

Related https://github.com/neondatabase/neon/issues/6833

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
