### PR TITLE
pageserver: on-demand activation of tenant on GET tenant status

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -994,14 +994,16 @@ async fn tenant_status(
     let state = get_state(&request);
 
     // In tests, sometimes we want to query the state of a tenant without auto-activating it if it's currently waiting.
-    let no_activate = parse_query_param(&request, "no_activate")?.unwrap_or(false);
+    let activate = true;
+    #[cfg(feature = "testing")]
+    let activate = parse_query_param(&request, "activate")?.unwrap_or(activate);
 
     let tenant_info = async {
         let tenant = state
             .tenant_manager
             .get_attached_tenant_shard(tenant_shard_id)?;
 
-        if !no_activate {
+        if activate {
             // This is advisory: we prefer to let the tenant activate on-demand when this function is
             // called, but it is still valid to return 200 and describe the current state of the tenant
             // if it doesn't make it into an active state.

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -993,10 +993,23 @@ async fn tenant_status(
     check_permission(&request, Some(tenant_shard_id.tenant_id))?;
     let state = get_state(&request);
 
+    // In tests, sometimes we want to query the state of a tenant without auto-activating it if it's currently waiting.
+    let no_activate = parse_query_param(&request, "no_activate")?.unwrap_or(false);
+
     let tenant_info = async {
         let tenant = state
             .tenant_manager
             .get_attached_tenant_shard(tenant_shard_id)?;
+
+        if !no_activate {
+            // This is advisory: we prefer to let the tenant activate on-demand when this function is
+            // called, but it is still valid to return 200 and describe the current state of the tenant
+            // if it doesn't make it into an active state.
+            tenant
+                .wait_to_become_active(ACTIVE_TENANT_TIMEOUT)
+                .await
+                .ok();
+        }
 
         // Calculate total physical size of all timelines
         let mut current_physical_size = 0;

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -341,8 +341,20 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         res = self.post(f"http://localhost:{self.port}/v1/tenant/{tenant_id}/ignore")
         self.verbose_error(res)
 
-    def tenant_status(self, tenant_id: Union[TenantId, TenantShardId]) -> Dict[Any, Any]:
-        res = self.get(f"http://localhost:{self.port}/v1/tenant/{tenant_id}")
+    def tenant_status(
+        self, tenant_id: Union[TenantId, TenantShardId], no_activate: bool = True
+    ) -> Dict[Any, Any]:
+        """
+        :no_activate: hint the server not to accelerate activation of this tenant in response
+        to this query.  True by default for tests, because they generally want to observed the
+        system rather than interfering with it.  This is false  by default on the server side,
+        because in the field if the control plane is GET'ing a tenant it's a sign that it wants
+        to do something with it.
+        """
+        params = {}
+        if no_activate:
+            params["no_activate"] = "true"
+        res = self.get(f"http://localhost:{self.port}/v1/tenant/{tenant_id}", params=params)
         self.verbose_error(res)
         res_json = res.json()
         assert isinstance(res_json, dict)

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -342,18 +342,19 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         self.verbose_error(res)
 
     def tenant_status(
-        self, tenant_id: Union[TenantId, TenantShardId], no_activate: bool = True
+        self, tenant_id: Union[TenantId, TenantShardId], activate: bool = False
     ) -> Dict[Any, Any]:
         """
-        :no_activate: hint the server not to accelerate activation of this tenant in response
-        to this query.  True by default for tests, because they generally want to observed the
-        system rather than interfering with it.  This is false  by default on the server side,
+        :activate: hint the server not to accelerate activation of this tenant in response
+        to this query.  False by default for tests, because they generally want to observed the
+        system rather than interfering with it.  This is true  by default on the server side,
         because in the field if the control plane is GET'ing a tenant it's a sign that it wants
         to do something with it.
         """
         params = {}
-        if no_activate:
-            params["no_activate"] = "true"
+        if not activate:
+            params["activate"] = "false"
+
         res = self.get(f"http://localhost:{self.port}/v1/tenant/{tenant_id}", params=params)
         self.verbose_error(res)
         res_json = res.json()

--- a/test_runner/regress/test_timeline_size.py
+++ b/test_runner/regress/test_timeline_size.py
@@ -727,7 +727,7 @@ def test_ondemand_activation(neon_env_builder: NeonEnvBuilder):
         states = {}
         log.info(f"Tenant ids: {tenant_ids}")
         for tenant_id in tenant_ids:
-            tenant = pageserver_http.tenant_status(tenant_id=tenant_id)
+            tenant = pageserver_http.tenant_status(tenant_id=tenant_id, no_activate=True)
             states[tenant_id] = tenant["state"]["slug"]
         log.info(f"Tenant states: {states}")
         return states
@@ -774,7 +774,10 @@ def test_ondemand_activation(neon_env_builder: NeonEnvBuilder):
 
     # That one that we successfully accessed is now Active
     expect_activated += 1
-    assert pageserver_http.tenant_status(tenant_id=stuck_tenant_id)["state"]["slug"] == "Active"
+    assert (
+        pageserver_http.tenant_status(tenant_id=stuck_tenant_id, no_activate=True)["state"]["slug"]
+        == "Active"
+    )
     wait_for_tenant_startup_completions(pageserver_http, count=expect_activated - 1)
 
     # The ones we didn't touch are still in Attaching
@@ -789,7 +792,10 @@ def test_ondemand_activation(neon_env_builder: NeonEnvBuilder):
     )[0][0]
     pageserver_http.timeline_create(env.pg_version, stuck_tenant_id, TimelineId.generate())
     expect_activated += 1
-    assert pageserver_http.tenant_status(tenant_id=stuck_tenant_id)["state"]["slug"] == "Active"
+    assert (
+        pageserver_http.tenant_status(tenant_id=stuck_tenant_id, no_activate=True)["state"]["slug"]
+        == "Active"
+    )
     assert (
         len([s for s in get_tenant_states().values() if s == "Attaching"])
         == n_tenants - expect_activated

--- a/test_runner/regress/test_timeline_size.py
+++ b/test_runner/regress/test_timeline_size.py
@@ -727,7 +727,7 @@ def test_ondemand_activation(neon_env_builder: NeonEnvBuilder):
         states = {}
         log.info(f"Tenant ids: {tenant_ids}")
         for tenant_id in tenant_ids:
-            tenant = pageserver_http.tenant_status(tenant_id=tenant_id, no_activate=True)
+            tenant = pageserver_http.tenant_status(tenant_id=tenant_id)
             states[tenant_id] = tenant["state"]["slug"]
         log.info(f"Tenant states: {states}")
         return states
@@ -774,10 +774,7 @@ def test_ondemand_activation(neon_env_builder: NeonEnvBuilder):
 
     # That one that we successfully accessed is now Active
     expect_activated += 1
-    assert (
-        pageserver_http.tenant_status(tenant_id=stuck_tenant_id, no_activate=True)["state"]["slug"]
-        == "Active"
-    )
+    assert pageserver_http.tenant_status(tenant_id=stuck_tenant_id)["state"]["slug"] == "Active"
     wait_for_tenant_startup_completions(pageserver_http, count=expect_activated - 1)
 
     # The ones we didn't touch are still in Attaching
@@ -792,10 +789,7 @@ def test_ondemand_activation(neon_env_builder: NeonEnvBuilder):
     )[0][0]
     pageserver_http.timeline_create(env.pg_version, stuck_tenant_id, TimelineId.generate())
     expect_activated += 1
-    assert (
-        pageserver_http.tenant_status(tenant_id=stuck_tenant_id, no_activate=True)["state"]["slug"]
-        == "Active"
-    )
+    assert pageserver_http.tenant_status(tenant_id=stuck_tenant_id)["state"]["slug"] == "Active"
     assert (
         len([s for s in get_tenant_states().values() if s == "Attaching"])
         == n_tenants - expect_activated


### PR DESCRIPTION
## Problem

(Follows https://github.com/neondatabase/neon/pull/7237)

Some API users will query a tenant to wait for it to activate.  Currently, we return the current status of the tenant, whatever that may be.  Under heavy load, a pageserver starting up might take a long time to activate such a tenant.

## Summary of changes

- In `tenant_status` handler, call wait_to_become_active on the tenant.  If the tenant is currently waiting for activation, this causes it to skip the queue, similiar to other API handlers that require an active tenant, like timeline creation.  This avoids external services waiting a long time for activation when polling GET /v1/tenant/<id>.
