### PR TITLE
neonvm: add LFC approximate working set size to metrics

### DIFF
--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -187,6 +187,13 @@ files:
         query: |
           select sum(pg_database_size(datname)) as total from pg_database;
 
+      - metric_name: lfc_approximate_working_set_size
+        type: gauge
+        help: 'Approximate working set size'
+        key_labels:
+        values: [approximate_working_set_size]
+          select approximate_working_set_size(false) as approximate_working_set_size;
+
 build: |
   # Build cgroup-tools
   #

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -189,7 +189,7 @@ files:
 
       - metric_name: lfc_approximate_working_set_size
         type: gauge
-        help: 'Approximate working set size'
+        help: 'Approximate working set size in pages of 8192 bytes'
         key_labels:
         values: [approximate_working_set_size]
         query: |

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -192,7 +192,8 @@ files:
         help: 'Approximate working set size'
         key_labels:
         values: [approximate_working_set_size]
-          select approximate_working_set_size(false) as approximate_working_set_size;
+        query: |
+          select neon.approximate_working_set_size(false) as approximate_working_set_size;
 
 build: |
   # Build cgroup-tools


### PR DESCRIPTION
## Problem

ref https://github.com/neondatabase/autoscaling/pull/878
ref https://github.com/neondatabase/autoscaling/issues/872

## Summary of changes

Add `approximate_working_set_size` to sql exporter so that autoscaling can use it in the future.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
