### PR TITLE
tests: allow restarting storage broker

### DIFF
--- a/test_runner/fixtures/broker.py
+++ b/test_runner/fixtures/broker.py
@@ -61,3 +61,4 @@ class NeonBroker:
             else:
                 self.handle.terminate()
             self.handle.wait()
+            self.handle = None


### PR DESCRIPTION
Currently storage broker will not be restarted by a test doing:

```
env.stop()
env.start()
```

Yet other components will be restarted. Restart storage broker as well.