### PR TITLE
CI(deploy): Cleanup deploy job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1091,104 +1091,83 @@ jobs:
   deploy:
     needs: [ check-permissions, promote-images, tag, regress-tests, trigger-custom-extensions-build-and-wait ]
     if: github.ref_name == 'main' || github.ref_name == 'release'|| github.ref_name == 'release-proxy'
-
-    runs-on: [ self-hosted, gen3, small ]
-    container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/ansible:latest
+    runs-on: ubuntu-latest
+    env:
+      BUILD_TAG: ${{ needs.tag.outputs.build-tag }}
     steps:
-      - name: Fix git ownership
-        run: |
-          # Workaround for `fatal: detected dubious ownership in repository at ...`
-          #
-          # Use both ${{ github.workspace }} and ${GITHUB_WORKSPACE} because they're different on host and in containers
-          #   Ref https://github.com/actions/checkout/issues/785
-          #
-          git config --global --add safe.directory ${{ github.workspace }}
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          for r in 14 15 16; do
-            git config --global --add safe.directory "${{ github.workspace }}/vendor/postgres-v$r"
-            git config --global --add safe.directory "${GITHUB_WORKSPACE}/vendor/postgres-v$r"
-          done
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-          fetch-depth: 0
-
-      - name: Trigger deploy workflow
+      - name: Trigger deploy workflow for `main` branch
+        if: github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
         run: |
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            gh workflow --repo neondatabase/aws run deploy-dev.yml --ref main -f branch=main -f dockerTag=${{needs.tag.outputs.build-tag}} -f deployPreprodRegion=false
-          elif [[ "$GITHUB_REF_NAME" == "release" ]]; then
-            gh workflow --repo neondatabase/aws run deploy-dev.yml --ref main \
-              -f deployPgSniRouter=false \
-              -f deployProxy=false \
-              -f deployStorage=true \
-              -f deployStorageBroker=true \
-              -f deployStorageController=true \
-              -f branch=main \
-              -f dockerTag=${{needs.tag.outputs.build-tag}} \
-              -f deployPreprodRegion=true
+          gh workflow --repo neondatabase/aws run deploy-dev.yml \
+            --ref main \
+            -f branch=main \
+            -f dockerTag=${BUILD_TAG} \
+            -f deployPreprodRegion=false
 
-            gh workflow --repo neondatabase/aws run deploy-prod.yml --ref main \
-              -f deployPgSniRouter=false \
-              -f deployProxy=false \
-              -f deployStorage=true \
-              -f deployStorageBroker=true \
-              -f deployStorageController=true \
-              -f branch=main \
-              -f dockerTag=${{needs.tag.outputs.build-tag}}
-          elif [[ "$GITHUB_REF_NAME" == "release-proxy" ]]; then
-            gh workflow --repo neondatabase/aws run deploy-dev.yml --ref main \
-              -f deployPgSniRouter=true \
-              -f deployProxy=true \
-              -f deployStorage=false \
-              -f deployStorageBroker=false \
-              -f deployStorageController=false \
-              -f branch=main \
-              -f dockerTag=${{needs.tag.outputs.build-tag}} \
-              -f deployPreprodRegion=true
-
-            gh workflow --repo neondatabase/aws run deploy-proxy-prod.yml --ref main \
-              -f deployPgSniRouter=true \
-              -f deployProxy=true \
-              -f branch=main \
-              -f dockerTag=${{needs.tag.outputs.build-tag}}
-          else
-            echo "GITHUB_REF_NAME (value '$GITHUB_REF_NAME') is not set to either 'main' or 'release'"
-            exit 1
-          fi
-
-      - name: Create git tag
-        if: github.ref_name == 'release' || github.ref_name == 'release-proxy'
-        uses: actions/github-script@v7
-        with:
-          # Retry script for 5XX server errors: https://github.com/actions/github-script#retries
-          retries: 5
-          script: |
-            await github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: "refs/tags/${{ needs.tag.outputs.build-tag }}",
-              sha: context.sha,
-            })
-
-      # TODO: check how GitHub releases looks for proxy releases and enable it if it's ok
-      - name: Create GitHub release
+      - name: Trigger deploy workflow for `release` branch
         if: github.ref_name == 'release'
-        uses: actions/github-script@v7
-        with:
-          # Retry script for 5XX server errors: https://github.com/actions/github-script#retries
-          retries: 5
-          script: |
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: "${{ needs.tag.outputs.build-tag }}",
-              generate_release_notes: true,
-            })
+        env:
+          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
+        run: |
+          gh workflow --repo neondatabase/aws run deploy-dev.yml \
+            --ref main \
+            -f deployPgSniRouter=false \
+            -f deployProxy=false \
+            -f deployStorage=true \
+            -f deployStorageBroker=true \
+            -f deployStorageController=true \
+            -f branch=main \
+            -f dockerTag=${BUILD_TAG} \
+            -f deployPreprodRegion=true
+
+          gh workflow --repo neondatabase/aws run deploy-prod.yml \
+            --ref main \
+            -f deployPgSniRouter=false \
+            -f deployProxy=false \
+            -f deployStorage=true \
+            -f deployStorageBroker=true \
+            -f deployStorageController=true \
+            -f branch=main \
+            -f dockerTag=${BUILD_TAG}
+
+      - name: Trigger deploy workflow for `release-proxy` branch
+        if: github.ref_name == 'release-proxy'
+        env:
+          GH_TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
+        run: |
+          gh workflow --repo neondatabase/aws run deploy-dev.yml \
+            --ref main \
+            -f deployPgSniRouter=true \
+            -f deployProxy=true \
+            -f deployStorage=false \
+            -f deployStorageBroker=false \
+            -f deployStorageController=false \
+            -f branch=main \
+            -f dockerTag=${BUILD_TAG} \
+            -f deployPreprodRegion=true
+
+          gh workflow --repo neondatabase/aws run deploy-proxy-prod.yml \
+            --ref main \
+            -f deployPgSniRouter=true \
+            -f deployProxy=true \
+            -f branch=main \
+            -f dockerTag=${BUILD_TAG}
+
+      - name: Create GitHub Release
+        if: github.ref_name == 'release' || github.ref_name == 'release-proxy'
+        run: |
+          previous_release_tag=$(gh release list --repo neondatabase/neon \
+            --json name \
+            | jq --arg tag_prefix ${GITHUB_REF_NAME} --raw-output '.[].name | select(test($tag_prefix + "-[0-9]"))' | head -1)
+
+          gh release create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${GITHUB_SHA}" \
+            --generate-notes \
+            --notes-start-tag "${previous_release_tag}" \
+            --title "${BUILD_TAG}"
 
   promote-compatibility-data:
     needs: [ check-permissions, promote-images, tag, regress-tests ]


### PR DESCRIPTION
Should be merged after https://github.com/neondatabase/neon/pull/7269

## Summary of changes
- Run deploy job on ubuntu-latest and do not clone the repo
- Split `Trigger deploy workflow` step  into several steps (for main/release/release-proxy branches)
- Use GitHub CLI instead of `actions/github-script` action
- Create GitHub Release for release-proxy as well as for storage release

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
