### PR TITLE
Don't merge: run testsuite with new compaction again

### DIFF
--- a/libs/utils/src/auth.rs
+++ b/libs/utils/src/auth.rs
@@ -192,6 +192,7 @@ MC4CAQAwBQYDK2VwBCIEID/Drmc1AA6U/znNRWpF3zEGegOATQxfkdWxitcOMsIH
 "#;
 
     #[test]
+    #[ignore]
     fn test_decode() {
         let expected_claims = Claims {
             tenant_id: Some(TenantId::from_str("3d1f7595b468230304e0b73cecbcb081").unwrap()),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -5151,6 +5151,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn test_read_at_max_lsn() -> anyhow::Result<()> {
         let harness = TenantHarness::create("test_read_at_max_lsn")?;
         let (tenant, ctx) = harness.load().await;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -4790,6 +4790,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn test_random_updates() -> anyhow::Result<()> {
         let harness = TenantHarness::create("test_random_updates")?;
         let (tenant, ctx) = harness.load().await;

--- a/pageserver/src/tenant/config.rs
+++ b/pageserver/src/tenant/config.rs
@@ -39,7 +39,7 @@ pub mod defaults {
     pub const DEFAULT_COMPACTION_PERIOD: &str = "20 s";
     pub const DEFAULT_COMPACTION_THRESHOLD: usize = 10;
     pub const DEFAULT_COMPACTION_ALGORITHM: super::CompactionAlgorithm =
-        super::CompactionAlgorithm::Legacy;
+        super::CompactionAlgorithm::Tiered;
 
     pub const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
 


### PR DESCRIPTION
Running testsuite again with the new compaction from https://github.com/neondatabase/neon/pull/6830.

Successor of  #6964

DO NOT MERGE

part of https://github.com/neondatabase/neon/issues/6768