### PR TITLE
refactor: composite ancestor branchpoint

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1452,11 +1452,8 @@ impl Tenant {
                 debug!("timeline {new_timeline_id} already exists");
 
                 {
-                    let branchpoint = existing.ancestor_branchpoint.read().unwrap();
-                    let branchpoint = branchpoint.as_ref();
-
-                    let ancestor_id = branchpoint.map(|(tl, _)| tl.timeline_id);
-                    let ancestor_lsn = branchpoint.map(|(_, lsn)| *lsn);
+                    let (ancestor_id, ancestor_lsn) =
+                        existing.ancestor_branchpoint.as_id_lsn_pair();
 
                     // Idempotency: creating the same timeline twice is not an error, unless
                     // the second creation has different parameters.

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -2824,27 +2824,20 @@ impl Tenant {
                         if let Some(ancestor_timeline_id) =
                             &timeline_entry.get_ancestor_timeline_id()
                         {
-                            // If target_timeline is specified, we only need to know branchpoints of its children
-                            if let Some(timeline_id) = target_timeline_id {
-                                if ancestor_timeline_id == &timeline_id {
-                                    all_branchpoints.insert((
-                                        *ancestor_timeline_id,
-                                        timeline_entry.get_ancestor_lsn(),
-                                    ));
-                                }
-                            }
-                            // Collect branchpoints for all timelines
-                            else {
-                                all_branchpoints.insert((
-                                    *ancestor_timeline_id,
-                                    timeline_entry.get_ancestor_lsn(),
-                                ));
-                            }
+                            all_branchpoints
+                                .insert((*ancestor_timeline_id, timeline_entry.get_ancestor_lsn()));
                         }
                     })
                     .map(|(timeline_id, _)| *timeline_id)
                     .collect::<Vec<_>>()
             };
+
+            if let Some(timeline_id) = target_timeline_id.as_ref() {
+                // if we only want to gc a single timeline, we need to know the branchpoints
+                // we've recorded through it's children
+                all_branchpoints.retain(|(id, _lsn)| id == timeline_id);
+            }
+
             (all_branchpoints, timeline_ids)
         };
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -2828,17 +2828,13 @@ impl Tenant {
                 timelines
                     .iter()
                     .inspect(|(_, timeline)| {
-                        let (ancestor_timeline_id, ancestor_lsn) = {
-                            let bp = timeline.ancestor_branchpoint.read().unwrap();
-
-                            let Some((ancestor, ancestor_lsn)) = bp.as_ref() else {
-                                return;
-                            };
-
-                            (ancestor.timeline_id, *ancestor_lsn)
+                        let Some((ancestor_id, ancestor_lsn)) =
+                            timeline.ancestor_branchpoint.as_id_lsn()
+                        else {
+                            return;
                         };
 
-                        all_branchpoints.insert((ancestor_timeline_id, ancestor_lsn));
+                        all_branchpoints.insert((ancestor_id, ancestor_lsn));
                     })
                     .map(|(timeline_id, _)| *timeline_id)
                     .collect::<Vec<_>>()

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -2820,7 +2820,7 @@ impl Tenant {
 
                 timelines
                     .iter()
-                    .map(|(timeline_id, timeline_entry)| {
+                    .inspect(|(_, timeline_entry)| {
                         if let Some(ancestor_timeline_id) =
                             &timeline_entry.get_ancestor_timeline_id()
                         {
@@ -2841,9 +2841,8 @@ impl Tenant {
                                 ));
                             }
                         }
-
-                        *timeline_id
                     })
+                    .map(|(timeline_id, _)| *timeline_id)
                     .collect::<Vec<_>>()
             };
             (all_branchpoints, timeline_ids)

--- a/pageserver/src/tenant/size.rs
+++ b/pageserver/src/tenant/size.rs
@@ -179,6 +179,9 @@ pub(super) async fn gather_inputs(
         // might not be an issue, because it's not for Timeline::gc
         let gc_info = timeline.gc_info.read().unwrap();
 
+        let pitr_cutoff = gc_info.pitr_cutoff;
+        let horizon_cutoff = gc_info.horizon_cutoff;
+
         // similar to gc, but Timeline::get_latest_gc_cutoff_lsn() will not be updated before a
         // new gc run, which we have no control over. however differently from `Timeline::gc`
         // we don't consider the `Timeline::disk_consistent_lsn` at all, because we are not
@@ -189,7 +192,7 @@ pub(super) async fn gather_inputs(
         // than a space bound (horizon cutoff).  This means that if someone drops a database and waits for their
         // PITR interval, they will see synthetic size decrease, even if we are still storing data inside
         // horizon_cutoff.
-        let mut next_gc_cutoff = gc_info.pitr_cutoff;
+        let mut next_gc_cutoff = pitr_cutoff;
 
         // If the caller provided a shorter retention period, use that instead of the GC cutoff.
         let retention_param_cutoff = if let Some(max_retention_period) = max_retention_period {
@@ -215,6 +218,8 @@ pub(super) async fn gather_inputs(
             // this assumes there are no other retain_lsns than the branchpoints
             .map(|lsn| (lsn, LsnKind::BranchPoint))
             .collect::<Vec<_>>();
+
+        drop(gc_info);
 
         // Add branch points we collected earlier, just in case there were any that were
         // not present in retain_lsns. We will remove any duplicates below later.
@@ -294,8 +299,8 @@ pub(super) async fn gather_inputs(
             last_record: last_record_lsn,
             // this is not used above, because it might not have updated recently enough
             latest_gc_cutoff: *timeline.get_latest_gc_cutoff_lsn(),
-            horizon_cutoff: gc_info.horizon_cutoff,
-            pitr_cutoff: gc_info.pitr_cutoff,
+            horizon_cutoff,
+            pitr_cutoff,
             next_gc_cutoff,
             retention_param_cutoff,
         });

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2688,7 +2688,7 @@ impl Timeline {
         // Start from the current timeline.
         let mut timeline_owned;
         let mut timeline = self;
-        let mut ancestor_branchpoint = self.ancestor_branchpoint.read().unwrap().clone();
+        let mut ancestor_branchpoint = self.ancestor_branchpoint.snapshot();
 
         let mut read_count = scopeguard::guard(0, |cnt| {
             crate::metrics::READ_NUM_FS_LAYERS.observe(cnt as f64)
@@ -2774,7 +2774,7 @@ impl Timeline {
                     ancestor.ready_ancestor_for_lsn(*ancestor_lsn, ctx).await?;
                     timeline_owned = ancestor.clone();
                     timeline = &*timeline_owned;
-                    ancestor_branchpoint = timeline.ancestor_branchpoint.read().unwrap().clone();
+                    ancestor_branchpoint = timeline.ancestor_branchpoint.snapshot();
                     prev_lsn = None;
                     continue 'outer;
                 }
@@ -2907,7 +2907,7 @@ impl Timeline {
     ) -> Result<(), GetVectoredError> {
         let mut timeline_owned: Arc<Timeline>;
         let mut timeline = self;
-        let mut ancestor_branchpoint = timeline.ancestor_branchpoint.read().unwrap().clone();
+        let mut ancestor_branchpoint = timeline.ancestor_branchpoint.snapshot();
 
         let mut cont_lsn = Lsn(request_lsn.0 + 1);
 
@@ -2943,7 +2943,7 @@ impl Timeline {
                 .map_err(GetVectoredError::GetReadyAncestorError)?;
             timeline_owned = ancestor;
             timeline = &*timeline_owned;
-            ancestor_branchpoint = timeline.ancestor_branchpoint.read().unwrap().clone();
+            ancestor_branchpoint = timeline.ancestor_branchpoint.snapshot();
         }
 
         if keyspace.total_size() != 0 {
@@ -3432,18 +3432,13 @@ impl Timeline {
             None
         };
 
-        let ancestor_branchpoint = self
-            .ancestor_branchpoint
-            .read()
-            .unwrap()
-            .as_ref()
-            .map(|(a, lsn)| (a.timeline_id, *lsn));
+        let (ancestor_id, ancestor_lsn) = self.ancestor_branchpoint.as_id_lsn_pair();
 
         let metadata = TimelineMetadata::new(
             disk_consistent_lsn,
             ondisk_prev_record_lsn,
-            ancestor_branchpoint.map(|x| x.0),
-            ancestor_branchpoint.map(|x| x.1).unwrap_or(Lsn::INVALID),
+            ancestor_id,
+            ancestor_lsn.unwrap_or(Lsn::INVALID),
             *self.latest_gc_cutoff_lsn.read(),
             self.initdb_lsn,
             self.pg_version,


### PR DESCRIPTION
## Problem

Currently, we have two fields for one thing: `Timeline::{ancestor,ancestor_lsn}`. The #6994 will need to make the ancestor branchpoint mutable.

## Summary of changes

First move the fields behind one field, adjusting all callers which had previously done two accesses. Then move it behind an `struct Branchpoint(RwLock<Option<(Arc<Timeline>, Lsn)>>);`.

There are some bonus refactorings (3 first commits):
- drop gc_info lock earlier
- stop using map for what inspect can do

Notable internal changes:

Instead of `Timeline::get_ready_ancestor_timeline`, we now need `Timeline::ready_ancestor_for_lsn`. We can shed the additional now unused getter, because we always take a snapshot of the ancestor at the beginning of ancestor looping get value reconstruct methods and re-snapshot after acquiring the ancestor. This is done because our search might yield that we need to walk to an ancestor, but if there is an already ongoing `Timeline::detach_ancestor` then the ancestor could have been mutated away after we complete the search. Obtaining the ancestor at the same time as the timeline avoids this problem.