### PR TITLE
tests: reinstate some syntethic size tests

### DIFF
--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -20,7 +20,6 @@ from fixtures.pg_version import PgVersion
 from fixtures.types import Lsn, TenantId, TimelineId
 
 
-@pytest.mark.repeat(50)
 def test_empty_tenant_size(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_configs()
     env.start()
@@ -151,7 +150,6 @@ def test_branched_from_many_empty_parents_size(neon_simple_env: NeonEnv, test_ou
     size_debug_file.write(size_debug)
 
 
-@pytest.mark.repeat(50)
 def test_branch_point_within_horizon(neon_simple_env: NeonEnv, test_output_dir: Path):
     """
     gc_horizon = 15
@@ -194,7 +192,6 @@ def test_branch_point_within_horizon(neon_simple_env: NeonEnv, test_output_dir: 
     size_debug_file.write(size_debug)
 
 
-@pytest.mark.repeat(50)
 def test_parent_within_horizon(neon_simple_env: NeonEnv, test_output_dir: Path):
     """
     gc_horizon = 5
@@ -243,7 +240,6 @@ def test_parent_within_horizon(neon_simple_env: NeonEnv, test_output_dir: Path):
     size_debug_file.write(size_debug)
 
 
-@pytest.mark.repeat(50)
 def test_only_heads_within_horizon(neon_simple_env: NeonEnv, test_output_dir: Path):
     """
     gc_horizon = small


### PR DESCRIPTION
## Problem

`test_empty_tenant_size` was marked `xfail` and a few other tests were skipped.

## Summary of changes

Stabilise `test_empty_tenant_size`. This test attempted to disable checkpointing for the postgres instance
and expected that the synthetic size remains stable for an empty tenant. When debugging I noticed that
postgres *was* issuing a checkpoint after the transaction in the test (perhaps something changed since the
test was introduced). Hence, I relaxed the size check to allow for the checkpoint key written on the pageserver.

Also removed the checks for synthetic size inputs since the expected values differ between postgres versions.

Closes https://github.com/neondatabase/neon/issues/7138

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
