### PR TITLE
build: bump h2 for rustsec-2024-0332

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2024-0332.html fails the build, https://seanmonstar.com/blog/hyper-http2-continuation-flood/ has the backstory. The solution is to update h2.