### PR TITLE
fixup: PR #7319 defined workload.py `def stop()` twice

### DIFF
--- a/test_runner/fixtures/workload.py
+++ b/test_runner/fixtures/workload.py
@@ -89,11 +89,6 @@ class Workload:
     def __del__(self):
         self.stop()
 
-    def stop(self):
-        if self._endpoint is not None:
-            self._endpoint.stop()
-            self._endpoint = None
-
     def init(self, pageserver_id: Optional[int] = None):
         endpoint = self.endpoint(pageserver_id)
 


### PR DESCRIPTION
Somehow it made it through CI.