### PR TITLE
fix(utilization): return used as does df

### DIFF
--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -1629,7 +1629,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          description: The amount of disk space currently utilized by layer files.
+          description: The amount of disk space currently used.
         free_space_bytes:
           type: integer
           format: int64

--- a/pageserver/src/utilization.rs
+++ b/pageserver/src/utilization.rs
@@ -29,8 +29,7 @@ pub(crate) fn regenerate(tenants_path: &Path) -> anyhow::Result<PageserverUtiliz
     let used = statvfs
         .blocks()
         // use blocks_free instead of available here to match df in case someone compares
-        .checked_sub(statvfs.blocks_free())
-        .unwrap_or(0) as u64
+        .saturating_sub(statvfs.blocks_free()) as u64
         * blocksz;
 
     let captured_at = std::time::SystemTime::now();

--- a/pageserver/src/utilization.rs
+++ b/pageserver/src/utilization.rs
@@ -15,7 +15,12 @@ pub(crate) fn regenerate(tenants_path: &Path) -> anyhow::Result<PageserverUtiliz
         .map_err(std::io::Error::from)
         .context("statvfs tenants directory")?;
 
-    let blocksz = statvfs.block_size();
+    // https://unix.stackexchange.com/a/703650
+    let blocksz = if statvfs.fragment_size() > 0 {
+        statvfs.fragment_size()
+    } else {
+        statvfs.block_size()
+    };
 
     #[cfg_attr(not(target_os = "macos"), allow(clippy::unnecessary_cast))]
     let free = statvfs.blocks_available() as u64 * blocksz;


### PR DESCRIPTION
We can currently underflow `pageserver_resident_physical_size_global`, so the used disk bytes would show `u63::MAX` by mistake. The assumption of the API (and the documented behavior) was to give the layer files disk usage.

Switch to reporting numbers that match `df` output.

Fixes: #7336 