### PR TITLE
Fix test_physical_replication test taken in acount autocommit behaviour of psycopg

### DIFF
--- a/test_runner/regress/test_physical_replication.py
+++ b/test_runner/regress/test_physical_replication.py
@@ -18,12 +18,15 @@ def test_physical_replication(neon_simple_env: NeonEnv):
                 )
         time.sleep(1)
         with env.endpoints.new_replica_start(origin=primary, endpoint_id="secondary") as secondary:
-            with primary.connect() as p_con:
-                with p_con.cursor() as p_cur:
-                    with secondary.connect() as s_con:
-                        with s_con.cursor() as s_cur:
-                            for pk in range(n_records):
-                                p_cur.execute("insert into t (pk) values (%s)", (pk,))
-                                s_cur.execute(
-                                    "select * from t where pk=%s", (random.randrange(1, n_records),)
-                                )
+            p_con = primary.connect()
+            s_con = secondary.connect()
+            count = 0
+            with p_con.cursor() as p_cur:
+                with s_con.cursor() as s_cur:
+                    for pk in range(n_records):
+                        p_cur.execute("insert into t (pk) values (%s)", (pk,))
+                        s_cur.execute(
+                            "select count(*) from t where pk=%s", (random.randrange(1, n_records),)
+                        )
+                        count += s_cur.fetchall()[0][0]
+            assert count > 0

--- a/test_runner/regress/test_physical_replication.py
+++ b/test_runner/regress/test_physical_replication.py
@@ -6,7 +6,7 @@ from fixtures.neon_fixtures import NeonEnv
 
 def test_physical_replication(neon_simple_env: NeonEnv):
     env = neon_simple_env
-    n_records = 100000
+    n_records = 10000
     with env.endpoints.create_start(
         branch_name="main",
         endpoint_id="primary",


### PR DESCRIPTION
## Problem

`with ... connect` statement implicitly starts transaction envelope if auto commit is enabled:
```
Changed in version 2.9: with connection starts a transaction also on autocommit connections.
```

This is why  `test_physical_replication.py` test which is expected to check that changes are propagated by physical replication actually doesn't properly work.

## Summary of changes

Do not use `with` clause in this case.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
