### PR TITLE
compute_ctl: Auto-set dynamic_shared_memory_type

### DIFF
--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::pg_helpers::escape_conf_value;
-use crate::pg_helpers::PgOptionsSerialize;
-use compute_api::spec::{ComputeMode, ComputeSpec};
+use crate::pg_helpers::{GenericOptionExt, PgOptionsSerialize};
+use compute_api::spec::{ComputeMode, ComputeSpec, GenericOption};
 
 /// Check that `line` is inside a text file and put it there if it is not.
 /// Create file if it doesn't exist.
@@ -90,6 +90,25 @@ pub fn write_postgres_conf(
                 writeln!(file, "neon.primary_is_running={}", primary_is_running)?;
             }
         }
+    }
+
+    // Check /proc/sys/vm/overcommit_memory -- if it equals 2 (i.e. linux memory overcommit is
+    // disabled), then the control plane has enabled swap and we should set
+    // dynamic_shared_memory_type = 'mmap'.
+    //
+    // This is (maybe?) temporary - for more, see https://github.com/neondatabase/cloud/issues/12047.
+    let overcommit_memory_contents = std::fs::read_to_string("/proc/sys/vm/overcommit_memory")
+        // ignore any errors - they may be expected to occur under certain situations (e.g. when
+        // not running in Linux).
+        .unwrap_or_else(|_| String::new());
+    if overcommit_memory_contents.trim() == "2" {
+        let opt = GenericOption {
+            name: "dynamic_shared_memory_type".to_owned(),
+            value: Some("mmap".to_owned()),
+            vartype: "enum".to_owned(),
+        };
+
+        write!(file, "{}", opt.to_pg_setting())?;
     }
 
     // If there are any extra options in the 'settings' field, append those

--- a/compute_tools/src/pg_helpers.rs
+++ b/compute_tools/src/pg_helpers.rs
@@ -44,7 +44,7 @@ pub fn escape_conf_value(s: &str) -> String {
     format!("'{}'", res)
 }
 
-trait GenericOptionExt {
+pub trait GenericOptionExt {
     fn to_pg_option(&self) -> String;
     fn to_pg_setting(&self) -> String;
 }


### PR DESCRIPTION
Part of neondatabase/cloud#12047.

The basic idea is that for our VMs, we want to enable swap and disable Linux memory overcommit. Alongside these, we should set postgres' dynamic_shared_memory_type to mmap, but we want to avoid setting it to mmap if swap is not enabled.

Implementing this in the control plane would be fiddly, but it's relatively straightforward to add to compute_ctl.

## Summary of changes

Change compute_ctl's `write_postgres_conf` to inject `dynamic_shared_memory_type = mmap` iff `vm.overcommit_memory = 2` (which we can check by reading `/proc/sys/vm/overcommit_memory`).