### PR TITLE
pageserver/config: disable image layer creation check threshold

### DIFF
--- a/pageserver/src/tenant/config.rs
+++ b/pageserver/src/tenant/config.rs
@@ -59,7 +59,7 @@ pub mod defaults {
     pub const DEFAULT_EVICTIONS_LOW_RESIDENCE_DURATION_METRIC_THRESHOLD: &str = "24 hour";
     // By default ingest enough WAL for two new L0 layers before checking if new image
     // image layers should be created.
-    pub const DEFAULT_IMAGE_LAYER_CREATION_CHECK_THRESHOLD: u8 = 2;
+    pub const DEFAULT_IMAGE_LAYER_CREATION_CHECK_THRESHOLD: u8 = 0;
 
     pub const DEFAULT_INGEST_BATCH_SIZE: u64 = 100;
 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1742,15 +1742,13 @@ impl Timeline {
     }
 
     fn get_image_layer_creation_check_threshold(&self) -> u8 {
-        let tenant_conf = self.tenant_conf.load();
-        tenant_conf
-            .tenant_conf
+        // Ignore the tenant config override and use the default.
+        // This was done as a quick fix to resolve a perf degrdation.
+        // TODO: figure out if we wish to keep this config and related functionality
+        // If not, deprecate the config gracefully.
+        self.conf
+            .default_tenant_conf
             .image_layer_creation_check_threshold
-            .unwrap_or(
-                self.conf
-                    .default_tenant_conf
-                    .image_layer_creation_check_threshold,
-            )
     }
 
     pub(super) fn tenant_conf_updated(&self, new_conf: &TenantConfOpt) {


### PR DESCRIPTION
## Problem
Christian diagnosed the compaction change in https://github.com/neondatabase/neon/pull/7230 as the root cause for slow `find_lsn_for_timestamp` in prod.

The essence of the problem is that `Timeline::last_image_layer_creation_check_at` is updated after the first partition, causing all remaining ones to skip image layer creation.

Details: https://neondb.slack.com/archives/C06UEMLK7FE/p1713380092262789

## Summary of changes

As a quick fix, we effectively disable this check while we figure out how to inhibit image layer creation check
more gracefully. If it turns out that the solution shouldn't be wal based, we'll gracefully deprecate the config.