### PR TITLE
proxy: http conn pool overhaul (WIP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3939,6 +3939,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-list"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe91484d5a948b56f858ff2b92fd5b20b97d21b11d2d41041db8e5ec12d56c5e"
+dependencies = [
+ "pin-project-lite",
+ "pinned-aliasable",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +3979,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pinned-aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0f9ae89bf0ed03b69ac1f3f7ea2e6e09b4fa5448011df2e67d581c2b850b7b"
 
 [[package]]
 name = "pkcs8"
@@ -4349,6 +4365,7 @@ dependencies = [
  "parquet",
  "parquet_derive",
  "pbkdf2",
+ "pin-list",
  "pin-project-lite",
  "postgres-native-tls",
  "postgres-protocol",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -100,6 +100,7 @@ postgres-protocol.workspace = true
 redis.workspace = true
 
 workspace_hack.workspace = true
+pin-list = { version = "0.1.0", features = ["std"] }
 
 [dev-dependencies]
 camino-tempfile.workspace = true

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -192,7 +192,8 @@ impl ConnectMechanism for TokioMechanism {
             connection,
             self.conn_id,
             node_info.aux.clone(),
-        ))
+        )
+        .await)
     }
 
     fn update_connect_config(&self, _config: &mut compute::ConnCfg) {}

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -192,8 +192,7 @@ impl ConnectMechanism for TokioMechanism {
             connection,
             self.conn_id,
             node_info.aux.clone(),
-        )
-        .await)
+        ))
     }
 
     fn update_connect_config(&self, _config: &mut compute::ConnCfg) {}

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -187,7 +187,7 @@ impl ConnectMechanism for TokioMechanism {
         Ok(poll_tokio_client(
             self.pool.clone(),
             ctx,
-            self.conn_info.clone(),
+            &self.conn_info,
             client,
             connection,
             self.conn_id,

--- a/proxy/src/serverless/conn_pool.rs
+++ b/proxy/src/serverless/conn_pool.rs
@@ -140,7 +140,7 @@ impl<C: ClientInnerExt> EndpointConnPool<C> {
 
     fn put(
         pool: &RwLock<Self>,
-        mut node: Pin<&mut Node<ConnTypes<C>>>,
+        node: Pin<&mut Node<ConnTypes<C>>>,
         db_user: &(DbName, RoleName),
         client: ClientInner<C>,
         conn_info: ConnInfo,
@@ -168,11 +168,6 @@ impl<C: ClientInnerExt> EndpointConnPool<C> {
             if pool.total_conns < pool.max_conns {
                 let pool_entries = pool.pools.entry(db_user.clone()).or_default();
 
-                if let Some(node) = node.as_mut().initialized_mut() {
-                    if node.take_removed(&pool_entries.conns).is_err() {
-                        panic!("client is already in the pool")
-                    };
-                }
                 pool_entries.conns.cursor_front_mut().insert_after(
                     node,
                     ConnPoolEntry {
@@ -457,7 +452,6 @@ impl<C: ClientInnerExt> GlobalConnPool<C> {
                     cold_start_info = ColdStartInfo::HttpPoolHit.as_str(),
                     "pool: reusing connection '{conn_info}'"
                 );
-                client.session.send(ctx.session_id)?;
                 ctx.set_cold_start_info(ColdStartInfo::HttpPoolHit);
                 ctx.latency_timer.success();
                 return Ok(Some(Client::new(client, conn_info.clone(), endpoint_pool)));
@@ -520,7 +514,7 @@ type ConnTypes<C> = dyn pin_list::Types<
     Unprotected = (),
 >;
 
-pub async fn poll_tokio_client(
+pub fn poll_tokio_client(
     global_pool: Arc<GlobalConnPool<tokio_postgres::Client>>,
     ctx: &mut RequestMonitoring,
     conn_info: ConnInfo,
@@ -580,7 +574,6 @@ pub fn poll_client<C: ClientInnerExt, I: Future<Output = ()> + Send + 'static>(
 ) -> Client<C> {
     let conn_gauge = Metrics::get().proxy.db_connections.guard(ctx.protocol);
     let session_id = ctx.session_id;
-    let (tx, rx) = tokio::sync::watch::channel(session_id);
 
     let span = info_span!(parent: None, "connection", %conn_id);
     let cold_start_info = ctx.cold_start_info;
@@ -609,7 +602,6 @@ pub fn poll_client<C: ClientInnerExt, I: Future<Output = ()> + Send + 'static>(
         pool: pool.clone(),
 
         session_span,
-        session_rx: rx,
 
         conn_gauge,
         conn_id,
@@ -620,7 +612,6 @@ pub fn poll_client<C: ClientInnerExt, I: Future<Output = ()> + Send + 'static>(
 
     let inner = ClientInner {
         inner: client,
-        session: tx,
         pool: send_client,
         cancel,
         aux,
@@ -649,7 +640,6 @@ pin_project! {
 
         // Used for reporting the current session the conn is attached to
         session_span: tracing::Span,
-        session_rx: tokio::sync::watch::Receiver<uuid::Uuid>,
 
         // Static connection state
         conn_gauge: NumDbConnectionsGuard<'static>,
@@ -670,14 +660,29 @@ impl<C: ClientInnerExt, I: Future<Output = ()>> Future for DbConnection<C, I> {
             return Poll::Ready(());
         }
 
+        // if there's no pool, then this client will be closed.
+        let Some(pool) = this.pool.upgrade() else {
+            info!("connection dropped");
+            return Poll::Ready(());
+        };
+
+        if let Some(init) = this.node.as_mut().initialized_mut() {
+            if let Some(entry) = pool.read().pools.get(this.db_user) {
+                if let Ok((session_id, _)) = init.take_removed(&entry.conns) {
+                    *this.session_span = info_span!("", %session_id);
+                    let _span = this.session_span.enter();
+                    info!("changed session");
+                    this.idle_timeout
+                        .as_mut()
+                        .reset(Instant::now() + *this.idle);
+                };
+            }
+        }
+
         if let Poll::Ready(client) = this.recv_client.poll_recv(cx) {
             // if the send_client is dropped, then the client is dropped
             let Some((span, client, conn_info)) = client else {
-                info!("connection dropped");
-                return Poll::Ready(());
-            };
-            // if there's no pool, then this client will be closed.
-            let Some(pool) = this.pool.upgrade() else {
+                let _span = this.session_span.enter();
                 info!("connection dropped");
                 return Poll::Ready(());
             };
@@ -686,24 +691,6 @@ impl<C: ClientInnerExt, I: Future<Output = ()>> Future for DbConnection<C, I> {
             if !EndpointConnPool::put(&*pool, this.node.as_mut(), this.db_user, client, conn_info) {
                 return Poll::Ready(());
             }
-        }
-
-        match this.session_rx.has_changed() {
-            Ok(true) => {
-                let session_id = *this.session_rx.borrow_and_update();
-                *this.session_span = info_span!("", %session_id);
-                let _span = this.session_span.enter();
-                info!("changed session");
-                this.idle_timeout
-                    .as_mut()
-                    .reset(Instant::now() + *this.idle);
-            }
-            Err(_) => {
-                let _span = this.session_span.enter();
-                info!("connection dropped");
-                return Poll::Ready(());
-            }
-            _ => {}
         }
 
         let _span = this.session_span.enter();
@@ -729,13 +716,11 @@ impl<C: ClientInnerExt, I: Future<Output = ()>> Future for DbConnection<C, I> {
         ready!(this.connection.poll(cx));
 
         // remove from connection pool
-        if let Some(pool) = this.pool.upgrade() {
-            if pool
-                .write()
-                .remove_client(this.db_user.clone(), *this.conn_id)
-            {
-                info!("closed connection removed");
-            }
+        if pool
+            .write()
+            .remove_client(this.db_user.clone(), *this.conn_id)
+        {
+            info!("closed connection removed");
         }
 
         Poll::Ready(())
@@ -744,7 +729,6 @@ impl<C: ClientInnerExt, I: Future<Output = ()>> Future for DbConnection<C, I> {
 
 struct ClientInner<C: ClientInnerExt> {
     inner: C,
-    session: tokio::sync::watch::Sender<uuid::Uuid>,
     pool: tokio::sync::mpsc::Sender<(tracing::Span, ClientInner<C>, ConnInfo)>,
     cancel: CancellationToken,
     aux: MetricsAuxInfo,


### PR DESCRIPTION
## Problem

The `HashMap<Endpoint, HashMap<DbUser, Vec<Client>>>` has always upset me a bit.

## Summary of changes

Since the `Connection` is allocated as a task, we can make it an intrusive linked node and make the pool a `HashMap<Endpoint, HashMap<DbUser, LinkedList<Client>>>`

Unsure if this is better but I wanted to play.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
