### PR TITLE
Bump vm-builder v0.23.2 -> v0.28.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -865,7 +865,7 @@ jobs:
       run:
         shell: sh -eu {0}
     env:
-      VM_BUILDER_VERSION: v0.23.2
+      VM_BUILDER_VERSION: v0.28.1
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Only one relevant change, from v0.28.0:

- neondatabase/autoscaling#887

Double-checked with `git log neonvm/tools/vm-builder`.

---

From the compute side, all that neondatabase/autoscaling#887 does is add a shell script at `/neonvm/bin/resize-swap` that may or may not work, depending on whether swap is enabled and autoscaling ≥v0.28.0 is rolled out.

This is part of neondatabase/cloud#12047, more concretely a pre-requisite of #7239.