### PR TITLE
pageserver: fix unlogged relations with sharding

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -13,7 +13,7 @@
 use anyhow::{anyhow, bail, ensure, Context};
 use bytes::{BufMut, Bytes, BytesMut};
 use fail::fail_point;
-use pageserver_api::key::{key_to_slru_block, Key};
+use pageserver_api::key::{key_to_slru_block, rel_block_to_key, Key};
 use postgres_ffi::pg_constants;
 use std::fmt::Write as FmtWrite;
 use std::time::SystemTime;
@@ -295,6 +295,19 @@ where
                 // contents of UNLOGGED relations. Postgres copies it in
                 // `reinit.c` during recovery.
                 if rel.forknum == INIT_FORKNUM {
+                    // Workaround https://github.com/neondatabase/neon/issues/7451 -- if we have an unlogged relation
+                    // whose INIT_FORKNUM is not correctly on shard zero, then omit it in the basebackup.  This allows
+                    // postgres to start up.  The relation won't work, but it will be possible to DROP TABLE on it and
+                    // recreate.
+                    if !self
+                        .timeline
+                        .get_shard_identity()
+                        .is_key_local(&rel_block_to_key(rel, 0x0))
+                    {
+                        tracing::warn!("Omitting relation {rel} for issue #7451: drop and recreate this unlogged relation");
+                        continue;
+                    }
+
                     // I doubt we need _init fork itself, but having it at least
                     // serves as a marker relation is unlogged.
                     self.add_rel(rel, rel).await?;


### PR DESCRIPTION
## Problem

- #7451 

INIT_FORKNUM blocks must be stored on shard 0 to enable including them in basebackup.

This issue can be missed in simple tests because creating an unlogged table isn't sufficient -- to repro I had to create an _index_ on an unlogged table (then restart the endpoint).

Closes: #7451 

## Summary of changes

- Add a reproducer for the issue.
- Tweak the condition for `key_is_shard0` to include anything that isn't a normal relation block _and_ any normal relation block whose forknum is INIT_FORKNUM.
- To enable existing databases to recover from the issue, add a special case that omits relations if they were stored on the wrong INITFORK.  This enables postgres to start and the user to drop the table and recreate it.


## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
