### PR TITLE
pageserver: finish vectored get early

### DIFF
--- a/libs/pageserver_api/src/keyspace.rs
+++ b/libs/pageserver_api/src/keyspace.rs
@@ -162,6 +162,10 @@ impl KeySpace {
             .sum()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.total_size() == 0
+    }
+
     fn overlaps_at(&self, range: &Range<Key>) -> Option<usize> {
         match self.ranges.binary_search_by_key(&range.end, |r| r.start) {
             Ok(0) => None,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3127,7 +3127,11 @@ impl Timeline {
             unmapped_keyspace.remove_overlapping_with(&keys_done_last_step);
             completed_keyspace.merge(&keys_done_last_step);
 
-            if unmapped_keyspace.start().is_some() {
+            // Do not descent any further if the last layer we visited
+            // completed all keys in the keyspace it inspected. This is not
+            // required for correctness, but avoids visiting extra layers
+            // which turns out to be a perf bottleneck in some cases.
+            if !unmapped_keyspace.is_empty() {
                 let guard = timeline.layers.read().await;
                 let layers = guard.layer_map();
 


### PR DESCRIPTION
## Problem
If the previous step of the vectored left no further keyspace to investigate
(i.e. keyspace remains empty after removing keys completed in the previous step),
then we'd still grab the layers lock, potentially add an in-mem layer to the fringe and
at some further point read its index without reading any values from it.

## Summary of changes
If there's nothing left in the current keyspace, then skip the search and just select
the next item from the fringe as usual.

When running `test_pg_regress[release-pg16]` with the vectored read path for singular
gets this improved perf drastically:

![skip_vs_no_skip_pg_regress](https://github.com/neondatabase/neon/assets/20340401/625616d3-5d0b-4ba5-b7a3-e0d1dd30ce9d)

Legend:
blue - without this patch 
orange - with this patch

## Correctness
Since no keys remained from the previous range (i.e. we are on a leaf node) there's nothing
that search can find in deeper nodes.

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
