### PR TITLE
pageserver: jitter secondary periods

### DIFF
--- a/pageserver/src/tenant/secondary/scheduler.rs
+++ b/pageserver/src/tenant/secondary/scheduler.rs
@@ -23,13 +23,21 @@ const MIN_SCHEDULING_INTERVAL: Duration = Duration::from_secs(1);
 /// Jitter a Duration by an integer percentage.  Returned values are uniform
 /// in the range 100-pct..100+pct (i.e. a 5% jitter is 5% either way: a ~10% range)
 pub(super) fn period_jitter(d: Duration, pct: u32) -> Duration {
-    rand::thread_rng().gen_range((d * (100 - pct)) / 100..(d * (100 + pct)) / 100)
+    if d == Duration::ZERO {
+        d
+    } else {
+        rand::thread_rng().gen_range((d * (100 - pct)) / 100..(d * (100 + pct)) / 100)
+    }
 }
 
 /// When a periodic task first starts, it should wait for some time in the range 0..period, so
 /// that starting many such tasks at the same time spreads them across the time range.
 pub(super) fn period_warmup(period: Duration) -> Duration {
-    rand::thread_rng().gen_range(Duration::ZERO..period)
+    if period == Duration::ZERO {
+        period
+    } else {
+        rand::thread_rng().gen_range(Duration::ZERO..period)
+    }
 }
 
 /// Scheduling helper for background work across many tenants.

--- a/pageserver/src/tenant/secondary/scheduler.rs
+++ b/pageserver/src/tenant/secondary/scheduler.rs
@@ -1,4 +1,5 @@
 use futures::Future;
+use rand::Rng;
 use std::{
     collections::HashMap,
     marker::PhantomData,
@@ -18,6 +19,18 @@ use super::{CommandRequest, CommandResponse};
 /// interval, which we will respect within these intervals.
 const MAX_SCHEDULING_INTERVAL: Duration = Duration::from_secs(10);
 const MIN_SCHEDULING_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Jitter a Duration by an integer percentage.  Returned values are uniform
+/// in the range 100-pct..100+pct (i.e. a 5% jitter is 5% either way: a ~10% range)
+pub(super) fn period_jitter(d: Duration, pct: u32) -> Duration {
+    rand::thread_rng().gen_range((d * (100 - pct)) / 100..(d * (100 + pct)) / 100)
+}
+
+/// When a periodic task first starts, it should wait for some time in the range 0..period, so
+/// that starting many such tasks at the same time spreads them across the time range.
+pub(super) fn period_warmup(period: Duration) -> Duration {
+    rand::thread_rng().gen_range(Duration::ZERO..period)
+}
 
 /// Scheduling helper for background work across many tenants.
 ///


### PR DESCRIPTION
## Problem

After some time the load from heatmap uploads gets rather spiky.  They're unintentionally synchronising.

Chart (does this make a _boing_ sound in anyone else's head?):
![image](https://github.com/neondatabase/neon/assets/944640/18829fc8-c5b7-4739-9a9b-491b5d6fcade)


## Summary of changes

- Add a helper `period_jitter` and apply a 5% jitter from downloader  and heatmap_uploader when updating the next runtime at the end of an interation.
- Refactor existing places that we pick a startup interval into `period_warmup`, so that the intent is obvious.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
