### PR TITLE
pageserver: post-split layer trimming (1/2)

### DIFF
--- a/libs/pageserver_api/src/keyspace.rs
+++ b/libs/pageserver_api/src/keyspace.rs
@@ -240,7 +240,7 @@ impl<'a> ShardedRange<'a> {
     /// pages that would not actually be stored on this node.
     ///
     /// Don't use this function in code that works with physical entities like layer files.
-    fn raw_size(range: &Range<Key>) -> u32 {
+    pub fn raw_size(range: &Range<Key>) -> u32 {
         if is_contiguous_range(range) {
             contiguous_range_len(range)
         } else {

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -200,7 +200,34 @@ impl LayerManager {
             metrics.record_new_file_metrics(l.layer_desc().file_size);
         }
         for l in compact_from {
-            Self::delete_historic_layer(l, &mut updates, &mut self.layer_fmgr);
+            Self::delete_historic_layer(l, &mut updates, &mut self.layer_fmgr, true);
+        }
+        updates.flush();
+    }
+
+    /// Called when compaction is completed.
+    pub(crate) fn rewrite_layers(
+        &mut self,
+        rewrite_layers: &[(Layer, ResidentLayer)],
+        drop_layers: &[Layer],
+        metrics: &TimelineMetrics,
+    ) {
+        let mut updates = self.layer_map.batch_update();
+        for (old_layer, new_layer) in rewrite_layers {
+            debug_assert!(old_layer.layer_desc().key_range == new_layer.layer_desc().key_range);
+            debug_assert!(old_layer.layer_desc().lsn_range == new_layer.layer_desc().lsn_range);
+
+            Self::delete_historic_layer(old_layer, &mut updates, &mut self.layer_fmgr, false);
+            Self::insert_historic_layer(
+                new_layer.as_ref().clone(),
+                &mut updates,
+                &mut self.layer_fmgr,
+            );
+            // TODO: update metrics to subtract the one we're over-writing
+            metrics.record_new_file_metrics(new_layer.layer_desc().file_size);
+        }
+        for l in drop_layers {
+            Self::delete_historic_layer(l, &mut updates, &mut self.layer_fmgr, true);
         }
         updates.flush();
     }
@@ -209,7 +236,7 @@ impl LayerManager {
     pub(crate) fn finish_gc_timeline(&mut self, gc_layers: &[Layer]) {
         let mut updates = self.layer_map.batch_update();
         for doomed_layer in gc_layers {
-            Self::delete_historic_layer(doomed_layer, &mut updates, &mut self.layer_fmgr);
+            Self::delete_historic_layer(doomed_layer, &mut updates, &mut self.layer_fmgr, true);
         }
         updates.flush()
     }
@@ -231,6 +258,7 @@ impl LayerManager {
         layer: &Layer,
         updates: &mut BatchedUpdates<'_>,
         mapping: &mut LayerFileManager<Layer>,
+        physical: bool,
     ) {
         let desc = layer.layer_desc();
 
@@ -241,7 +269,9 @@ impl LayerManager {
         //      map index without actually rebuilding the index.
         updates.remove_historic(desc);
         mapping.remove(layer);
-        layer.delete_on_drop();
+        if physical {
+            layer.delete_on_drop();
+        }
     }
 
     pub(crate) fn likely_resident_layers(&self) -> impl Iterator<Item = Layer> + '_ {


### PR DESCRIPTION
## Problem

- After a shard split of a large existing tenant, child tenants can end up with oversized historic layers indefinitely, if those layers are prevented from being GC'd by branchpoints.

This PR is followed by https://github.com/neondatabase/neon/pull/7531

Related: https://github.com/neondatabase/neon/issues/7504

## Summary of changes

- [ ] Add a new compaction phase `compact_shard_ancestors`, which identifies layers that are no longer needed after a shard split.
- [ ] Add a Timeline->LayerMap code path called `rewrite_layers` , which is currently only used to drop layers, but will later be used to rewrite them as well in https://github.com/neondatabase/neon/pull/7531

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
