### PR TITLE
Expose LSN and replication delay as metrics

### DIFF
--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -251,15 +251,42 @@ files:
         key_labels:
         values: [lsn]
         query: |
-          select pg_current_wal_lsn() as lsn;
+          select
+            case
+              when pg_catalog.pg_is_in_recovery()
+              then pg_last_wal_replay_lsn()
+              else pg_current_wal_lsn()
+            end as lsn;
 
-      - metric_name: replication_lag
+      - metric_name: replication_delay_seconds
+        type: gauge
+        help: 'Bytes between received and replayed LSN'
+        key_labels:
+        values: [replication_delay_bytes]
+        query: |
+          SELECT abs(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())) AS replication_delay_bytes;
+
+      - metric_name: replication_delay_seconds
         type: gauge
         help: 'Time since last LSN was replayed'
         key_labels:
-        values: [replication_lag]
+        values: [replication_delay_seconds]
         query: |
-          select now()-pg_last_xact_replay_timestamp() as replication_lag
+          SELECT
+            CASE
+              WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0
+              ELSE GREATEST (0, EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()))
+            END AS replication_delay_seconds;
+
+      - metric_name: replication_delay_seconds
+        type: gauge
+        help: 'Time since last LSN was replayed'
+        key_labels:
+        values:
+          - checkpoints_req
+          - checkpoints_timed
+        query: |
+          SELECT checkpoints_req, checkpoints_timed FROM pg_stat_bgwriter;
   - filename: neon_collector_autoscaling.yml
     content: |
       collector_name: neon_collector_autoscaling
@@ -311,22 +338,6 @@ files:
         values: [approximate_working_set_size]
         query: |
           select neon.approximate_working_set_size(false) as approximate_working_set_size;
-
-      - metric_name: current_lsn
-        type: gauge
-        help: 'Current LSN of the database'
-        key_labels:
-        values: [lsn]
-        query: |
-          select pg_current_wal_lsn() as lsn;
-
-      - metric_name: replication_lag
-        type: gauge
-        help: 'Time since last LSN was replayed'
-        key_labels:
-        values: [replication_lag]
-        query: |
-          select now()-pg_last_xact_replay_timestamp() as replication_lag
 build: |
   # Build cgroup-tools
   #

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -258,13 +258,13 @@ files:
               else pg_current_wal_lsn()
             end as lsn;
 
-      - metric_name: replication_delay_seconds
+      - metric_name: replication_delay_bytes
         type: gauge
         help: 'Bytes between received and replayed LSN'
         key_labels:
         values: [replication_delay_bytes]
         query: |
-          SELECT abs(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn())) AS replication_delay_bytes;
+          SELECT pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()) AS replication_delay_bytes;
 
       - metric_name: replication_delay_seconds
         type: gauge

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -244,6 +244,22 @@ files:
         values: [approximate_working_set_size]
         query: |
           select neon.approximate_working_set_size(false) as approximate_working_set_size;
+
+      - metric_name: current_lsn
+        type: gauge
+        help: 'Current LSN of the database'
+        key_labels:
+        values: [lsn]
+        query: |
+          select pg_current_wal_lsn() as lsn;
+
+      - metric_name: replication_lag
+        type: gauge
+        help: 'Time since last LSN was replayed'
+        key_labels:
+        values: [replication_lag]
+        query: |
+          select now()-pg_last_xact_replay_timestamp() as replication_lag
   - filename: neon_collector_autoscaling.yml
     content: |
       collector_name: neon_collector_autoscaling
@@ -296,6 +312,21 @@ files:
         query: |
           select neon.approximate_working_set_size(false) as approximate_working_set_size;
 
+      - metric_name: current_lsn
+        type: gauge
+        help: 'Current LSN of the database'
+        key_labels:
+        values: [lsn]
+        query: |
+          select pg_current_wal_lsn() as lsn;
+
+      - metric_name: replication_lag
+        type: gauge
+        help: 'Time since last LSN was replayed'
+        key_labels:
+        values: [replication_lag]
+        query: |
+          select now()-pg_last_xact_replay_timestamp() as replication_lag
 build: |
   # Build cgroup-tools
   #

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -278,9 +278,9 @@ files:
               ELSE GREATEST (0, EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()))
             END AS replication_delay_seconds;
 
-      - metric_name: replication_delay_seconds
+      - metric_name: checkpoint_stats
         type: gauge
-        help: 'Time since last LSN was replayed'
+        help: 'Number of requested and scheduled checkpoints'
         key_labels:
         values:
           - checkpoints_req


### PR DESCRIPTION
## Problem
We currently have no way to see what the current LSN of a compute its, and in case of read replicas, we don't know what the difference in LSNs is. 

## Summary of changes
Adds these metrics