### PR TITLE
chore(pageserver): use sha256 for aux file encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3692,6 +3692,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_with",
+ "sha2",
  "signal-hook",
  "smallvec",
  "storage_broker",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -88,6 +88,7 @@ reqwest.workspace = true
 rpds.workspace = true
 enum-map.workspace = true
 enumset = { workspace = true, features = ["serde"]}
+sha2.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 

--- a/pageserver/src/aux_file.rs
+++ b/pageserver/src/aux_file.rs
@@ -7,7 +7,7 @@ fn hash256(data: &[u8]) -> [u8; 32] {
     sha2::Sha256::digest(data).into()
 }
 
-/// Create a metadata key from a hash, encoded as [AUX_KEY_PREFIX, 2B directory prefix, first 13B of 128b xxhash].
+/// Create a metadata key from a hash, encoded as [AUX_KEY_PREFIX, 2B directory prefix, first 13B of 128b sha256].
 fn aux_hash_to_metadata_key(dir_level1: u8, dir_level2: u8, data: &[u8]) -> Key {
     let mut key = [0; METADATA_KEY_SIZE];
     let hash = hash256(data);

--- a/pageserver/src/aux_file.rs
+++ b/pageserver/src/aux_file.rs
@@ -4,9 +4,7 @@ use sha2::Digest;
 use tracing::warn;
 
 fn hash256(data: &[u8]) -> [u8; 32] {
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(data);
-    hasher.finalize().into()
+    sha2::Sha256::digest(data).into()
 }
 
 /// Create a metadata key from a hash, encoded as [AUX_KEY_PREFIX, 2B directory prefix, first 13B of 128b xxhash].


### PR DESCRIPTION
## Problem

ref https://github.com/neondatabase/neon/issues/7462

We need a stable + portable hashing algorithm. SHA256 turns out to be a better choice b/c xxhash did not guarantee producing a stable hash across different versions.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
