### PR TITLE
compute_ctl: Fix unused variable on non-Linux

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -378,7 +378,8 @@ struct WaitSpecResult {
 }
 
 fn start_postgres(
-    matches: &clap::ArgMatches,
+    // need to allow unused because `matches` is only used if target_os = "linux"
+    #[allow(unused_variables)] matches: &clap::ArgMatches,
     WaitSpecResult {
         compute,
         http_port,


### PR DESCRIPTION
## Problem

`./run_clippy` now fails on non-Linux from an unused variable introduced by #7577.

See an example `check-macos-build` failure here: https://github.com/neondatabase/neon/actions/runs/8992211409/job/24701531264

## Summary of changes

Add `#[allow(unused_variables)]` to the relevant function argument.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
