### PR TITLE
Fix flaky test_gc_of_remote_layers

### DIFF
--- a/test_runner/regress/test_layer_eviction.py
+++ b/test_runner/regress/test_layer_eviction.py
@@ -159,6 +159,11 @@ def test_basic_eviction(
 def test_gc_of_remote_layers(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
+    # Disable GC for all tenants, because we want to control when it runs.
+    # Without this, GC can sometimes run for initial tenant and fail the test.
+    # The test can fail because of unexpected "gc_loop{...}: Nothing to GC" log line.
+    neon_env_builder.pageserver_config_override = "tenant_config={gc_period='0s'}"
+
     env = neon_env_builder.init_start()
 
     tenant_config = {

--- a/test_runner/regress/test_layer_eviction.py
+++ b/test_runner/regress/test_layer_eviction.py
@@ -159,12 +159,9 @@ def test_basic_eviction(
 def test_gc_of_remote_layers(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.enable_pageserver_remote_storage(RemoteStorageKind.LOCAL_FS)
 
-    # Disable GC for all tenants, because we want to control when it runs.
-    # Without this, GC can sometimes run for initial tenant and fail the test.
-    # The test can fail because of unexpected "gc_loop{...}: Nothing to GC" log line.
-    neon_env_builder.pageserver_config_override = "tenant_config={gc_period='0s'}"
-
-    env = neon_env_builder.init_start()
+    # don't create initial tenant, we'll create it manually with custom config
+    env = neon_env_builder.init_configs()
+    env.start()
 
     tenant_config = {
         "pitr_interval": "1s",  # set to non-zero, so GC actually does something


### PR DESCRIPTION
Fixes flaky test `test_gc_of_remote_layers`, which was failing because of the `Nothing to GC` pageserver log.
I looked into the fails, it seems that backround `gc_loop` sometimes started GC for initial tenant, which wasn't
configured to disable GC. The fix is to not create initial tenant with enabled gc at all.

Fixes #7538