### PR TITLE
openapi: document timeline ancestor detach

### DIFF
--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -641,22 +641,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AncestorDetached"
+
         "400":
           description: |
             Number of early checks meaning the timeline cannot be detached now:
               - timeline ancestor has an ancestor: not supported, see RFC
-              - another timeline detach for the same tenant is underway, please retry later
+
         "404":
           description: |
             No such tenant or timeline exists.
+
         "409":
           description: |
             The timeline can never be detached:
               - timeline has no ancestor:
                   - implies that the timeline has not been detached before
+
         "500":
           description: |
             Transient error, for example, pageserver restart happened while processing the request.
+
+        "503":
+          description: |
+            Temporarily unavailable, please retry. Possible reasons:
+              - another timeline detach for the same tenant is underway, please retry later
+
 
   /v1/tenant/:
     get:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -612,6 +612,49 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /v1/tenant/{tenant_id}/timeline/{timeline_id}/detach_ancestor:
+    parameters:
+      - name: tenant_id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: timeline_id
+        in: path
+        ŕequired: true
+        schema:
+          type: string
+
+    put:
+      description: |
+        Detach a timeline from its ancestor and reparent all ancestors timelines with lower `ancestor_lsn`.
+
+        Current implementation is not retryable across failure cases, but will be enhanced in future.
+
+        Detaching should be expected to be expensive operation. Timeouts should be retried.
+      responses:
+        "200":
+          description: |
+            The timeline has been detached from it's ancestor (now or earlier), and at least the returned timelines have been reparented.
+            If any timelines were deleted after reparenting, they might not be on this list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AncestorDetached"
+        "400":
+          description: |
+            Number of early checks meaning the timeline cannot be detached now:
+              - timeline ancestor has an ancestor: not supported, see RFC
+              - another timeline detach for the same tenant is underway
+        "409":
+          description: |
+            The timeline can never be detached:
+              - timeline has no ancestor:
+                  - implies that the timeline has not been detached before
+        "500":
+          description: |
+            Transient error, for example, pageserver restart happened while processing the request.
+
   /v1/tenant/:
     get:
       description: Get tenants list
@@ -1076,6 +1119,19 @@ components:
           type: integer
           format: int64
           description: How many bytes of layer content were in the latest layer heatmap
+
+    AncestorDetached:
+      type: object
+      required:
+        - reparented_timelines
+      properties:
+        reparented_timelines:
+          type: array
+          description: Set of reparented timeline ids
+          properties:
+            type: string
+            format: hex
+            description: TimelineId
 
 
     Error:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -628,9 +628,7 @@ paths:
     put:
       description: |
         Detach a timeline from its ancestor and reparent all ancestors timelines with lower `ancestor_lsn`.
-
-        Current implementation is not retryable across failure cases, but will be enhanced in future.
-
+        Current implementation might not be retryable across failure cases, but will be enhanced in future.
         Detaching should be expected to be expensive operation. Timeouts should be retried.
       responses:
         "200":
@@ -645,7 +643,7 @@ paths:
         "400":
           description: |
             Number of early checks meaning the timeline cannot be detached now:
-              - timeline ancestor has an ancestor: not supported, see RFC
+              - the ancestor of timeline has an ancestor: not supported, see RFC
           content:
             application/json:
               schema:
@@ -661,8 +659,7 @@ paths:
         "409":
           description: |
             The timeline can never be detached:
-              - timeline has no ancestor:
-                  - implies that the timeline has not been detached before
+              - timeline has no ancestor, implying that the timeline has never had an ancestor
           content:
             application/json:
               schema:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -645,7 +645,10 @@ paths:
           description: |
             Number of early checks meaning the timeline cannot be detached now:
               - timeline ancestor has an ancestor: not supported, see RFC
-              - another timeline detach for the same tenant is underway
+              - another timeline detach for the same tenant is underway, please retry later
+        "404":
+          description: |
+            No such tenant or timeline exists.
         "409":
           description: |
             The timeline can never be detached:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -646,25 +646,44 @@ paths:
           description: |
             Number of early checks meaning the timeline cannot be detached now:
               - timeline ancestor has an ancestor: not supported, see RFC
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
         "404":
-          description: |
-            No such tenant or timeline exists.
+          description: Tenant or timeline not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
 
         "409":
           description: |
             The timeline can never be detached:
               - timeline has no ancestor:
                   - implies that the timeline has not been detached before
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictError"
 
         "500":
           description: |
             Transient error, for example, pageserver restart happened while processing the request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
         "503":
           description: |
             Temporarily unavailable, please retry. Possible reasons:
               - another timeline detach for the same tenant is underway, please retry later
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ServiceUnavailableError"
 
 
   /v1/tenant/:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -612,9 +612,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /v1/tenant/{tenant_id}/timeline/{timeline_id}/detach_ancestor:
+  /v1/tenant/{tenant_shard_id}/timeline/{timeline_id}/detach_ancestor:
     parameters:
-      - name: tenant_id
+      - name: tenant_shard_id
         in: path
         required: true
         schema:
@@ -670,7 +670,8 @@ paths:
 
         "500":
           description: |
-            Transient error, for example, pageserver restart happened while processing the request.
+            Transient error, for example, pageserver shutdown happened while processing the request.
+            Must be retried.
           content:
             application/json:
               schema:

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -667,8 +667,9 @@ paths:
 
         "500":
           description: |
-            Transient error, for example, pageserver shutdown happened while processing the request.
-            Must be retried.
+            Transient error, for example, pageserver shutdown happened while
+            processing the request but we were unable to distinguish that. Must
+            be retried.
           content:
             application/json:
               schema:
@@ -678,6 +679,7 @@ paths:
           description: |
             Temporarily unavailable, please retry. Possible reasons:
               - another timeline detach for the same tenant is underway, please retry later
+              - detected shutdown error
           content:
             application/json:
               schema:

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1901,14 +1901,14 @@ async fn timeline_detach_ancestor_handler(
         let ctx = RequestContext::new(TaskKind::DetachAncestor, DownloadBehavior::Download);
         let ctx = &ctx;
 
+        // FIXME: why is there no conversion?
         let timeline = tenant
             .get_timeline(timeline_id, true)
             .map_err(|e| ApiError::NotFound(e.into()))?;
 
         let (_guard, prepared) = timeline
             .prepare_to_detach_from_ancestor(&tenant, options, ctx)
-            .await
-            .map_err(|e| ApiError::InternalServerError(e.into()))?;
+            .await?;
 
         let res = state
             .tenant_manager

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -47,7 +47,7 @@ impl From<Error> for ApiError {
             e @ Error::NoAncestor => ApiError::Conflict(e.to_string()),
             // TODO: ApiError converts the anyhow using debug formatting ... just stop using ApiError?
             e @ Error::TooManyAncestors => ApiError::BadRequest(anyhow::anyhow!("{}", e)),
-            e @ Error::ShuttingDown => ApiError::InternalServerError(e.into()),
+            Error::ShuttingDown => ApiError::ShuttingDown,
             Error::OtherTimelineDetachOngoing(_) => {
                 ApiError::ResourceUnavailable("other timeline detach is already ongoing".into())
             }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -45,7 +45,8 @@ impl From<Error> for ApiError {
     fn from(value: Error) -> Self {
         match value {
             e @ Error::NoAncestor => ApiError::Conflict(e.to_string()),
-            e @ Error::TooManyAncestors => ApiError::BadRequest(e.into()),
+            // TODO: ApiError converts the anyhow using debug formatting ... just stop using ApiError?
+            e @ Error::TooManyAncestors => ApiError::BadRequest(anyhow::anyhow!("{}", e)),
             e @ Error::ShuttingDown => ApiError::InternalServerError(e.into()),
             Error::OtherTimelineDetachOngoing(_) => {
                 ApiError::ResourceUnavailable("other timeline detach is already ongoing".into())

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -51,6 +51,7 @@ impl From<Error> for ApiError {
             Error::OtherTimelineDetachOngoing(_) => {
                 ApiError::ResourceUnavailable("other timeline detach is already ongoing".into())
             }
+            // All of these contain shutdown errors, in fact, it's the most common
             e @ Error::FlushAncestor(_)
             | e @ Error::RewrittenDeltaDownloadFailed(_)
             | e @ Error::CopyDeltaPrefix(_)

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -95,6 +95,11 @@ pub(super) async fn prepare(
         .as_ref()
         .map(|tl| (tl.clone(), detached.ancestor_lsn))
     else {
+        // TODO: check if we have already been detached; for this we need to read the stored data
+        // on remote client, for that we need a follow-up which makes uploads cheaper and maintains
+        // a projection of the commited data.
+        //
+        // the error is wrong per openapi
         return Err(NoAncestor);
     };
 
@@ -104,7 +109,7 @@ pub(super) async fn prepare(
 
     if ancestor.ancestor_timeline.is_some() {
         // non-technical requirement; we could flatten N ancestors just as easily but we chose
-        // not to
+        // not to, at least initially
         return Err(TooManyAncestors);
     }
 


### PR DESCRIPTION
The openapi description with the error descriptions:

- 200 is used for "detached or has been detached previously"
- 400 is used for "cannot be detached right now" -- it's an odd thing, but good enough
- 404 is used for tenant or timeline not found
- 409 is used for "can never be detached" (root timeline)
- 500 is used for transient errors (basically ill-defined shutdown errors)
- 503 is used for busy (other tenant ancestor detach underway, pageserver shutdown)

Cc: #6994 