### PR TITLE
Fix tiered compaction k-merge bugs and use in-memory alternative

### DIFF
--- a/pageserver/compaction/src/compact_tiered.rs
+++ b/pageserver/compaction/src/compact_tiered.rs
@@ -540,7 +540,7 @@ where
         let key_value_stream =
             std::pin::pin!(merge_delta_keys_buffered::<E>(deltas.as_slice(), ctx)
                 .await?
-                .map(|k| Result::<_, anyhow::Error>::Ok(k)));
+                .map(Result::<_, anyhow::Error>::Ok));
         let mut new_jobs = Vec::new();
 
         // Slide a window through the keyspace

--- a/pageserver/compaction/src/compact_tiered.rs
+++ b/pageserver/compaction/src/compact_tiered.rs
@@ -24,7 +24,9 @@ use tracing::{debug, info};
 use std::collections::{HashSet, VecDeque};
 use std::ops::Range;
 
-use crate::helpers::{accum_key_values, keyspace_total_size, merge_delta_keys, overlaps_with};
+use crate::helpers::{
+    accum_key_values, keyspace_total_size, merge_delta_keys_buffered, overlaps_with,
+};
 use crate::interface::*;
 use utils::lsn::Lsn;
 
@@ -535,7 +537,10 @@ where
             }
         }
         // Open stream
-        let key_value_stream = std::pin::pin!(merge_delta_keys::<E>(deltas.as_slice(), ctx));
+        let key_value_stream =
+            std::pin::pin!(merge_delta_keys_buffered::<E>(deltas.as_slice(), ctx)
+                .await?
+                .map(|k| Result::<_, anyhow::Error>::Ok(k)));
         let mut new_jobs = Vec::new();
 
         // Slide a window through the keyspace

--- a/pageserver/compaction/src/helpers.rs
+++ b/pageserver/compaction/src/helpers.rs
@@ -132,13 +132,13 @@ enum LazyLoadLayer<'a, E: CompactionJobExecutor> {
     Unloaded(&'a E::DeltaLayer),
 }
 impl<'a, E: CompactionJobExecutor> LazyLoadLayer<'a, E> {
-    fn key(&self) -> E::Key {
+    fn min_key(&self) -> E::Key {
         match self {
             Self::Loaded(entries) => entries.front().unwrap().key(),
             Self::Unloaded(dl) => dl.key_range().start,
         }
     }
-    fn lsn(&self) -> Lsn {
+    fn min_lsn(&self) -> Lsn {
         match self {
             Self::Loaded(entries) => entries.front().unwrap().lsn(),
             Self::Unloaded(dl) => dl.lsn_range().start,
@@ -153,7 +153,7 @@ impl<'a, E: CompactionJobExecutor> PartialOrd for LazyLoadLayer<'a, E> {
 impl<'a, E: CompactionJobExecutor> Ord for LazyLoadLayer<'a, E> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // reverse order so that we get a min-heap
-        (other.key(), other.lsn()).cmp(&(self.key(), self.lsn()))
+        (other.min_key(), other.min_lsn()).cmp(&(self.min_key(), self.min_lsn()))
     }
 }
 impl<'a, E: CompactionJobExecutor> PartialEq for LazyLoadLayer<'a, E> {

--- a/pageserver/compaction/src/helpers.rs
+++ b/pageserver/compaction/src/helpers.rs
@@ -11,7 +11,7 @@ use std::collections::BinaryHeap;
 use std::collections::VecDeque;
 use std::fmt::Display;
 use std::future::Future;
-use std::ops::Range;
+use std::ops::{DerefMut, Range};
 use std::pin::Pin;
 use std::task::{ready, Poll};
 use utils::lsn::Lsn;
@@ -195,8 +195,8 @@ where
                 match ready!(load_future.as_mut().poll(cx)) {
                     Ok(entries) => {
                         this.load_future.set(None);
-                        this.heap
-                            .push(LazyLoadLayer::Loaded(VecDeque::from(entries)));
+                        *this.heap.peek_mut().unwrap() =
+                            LazyLoadLayer::Loaded(VecDeque::from(entries));
                     }
                     Err(e) => {
                         return Poll::Ready(Some(Err(e)));
@@ -208,25 +208,23 @@ where
             // loading it. Otherwise return the next entry from it and update
             // the layer's position in the heap (this decreaseKey operation is
             // performed implicitly when `top` is dropped).
-            // We have to remove the layer from the heap and then re-add it,
-            // because loading it (or just removing a key from it) can change
-            // its ordering relative to the other layers in the heap.
-            let Some(mut top) = this.heap.pop() else {
-                return Poll::Ready(None);
-            };
-            match top {
-                LazyLoadLayer::Unloaded(ref mut l) => {
-                    let fut = l.load_keys(this.ctx);
-                    this.load_future.set(Some(Box::pin(fut)));
-                    continue;
-                }
-                LazyLoadLayer::Loaded(ref mut entries) => {
-                    let result = entries.pop_front().unwrap();
-                    if !entries.is_empty() {
-                        this.heap.push(top);
+            if let Some(mut top) = this.heap.peek_mut() {
+                match top.deref_mut() {
+                    LazyLoadLayer::Unloaded(ref mut l) => {
+                        let fut = l.load_keys(this.ctx);
+                        this.load_future.set(Some(Box::pin(fut)));
+                        continue;
                     }
-                    return Poll::Ready(Some(Ok(result)));
+                    LazyLoadLayer::Loaded(ref mut entries) => {
+                        let result = entries.pop_front().unwrap();
+                        if entries.is_empty() {
+                            std::collections::binary_heap::PeekMut::pop(top);
+                        }
+                        return Poll::Ready(Some(Ok(result)));
+                    }
                 }
+            } else {
+                return Poll::Ready(None);
             }
         }
     }


### PR DESCRIPTION
This PR does two things:

First, it fixes a bug with tiered compaction's k-merge implementation. It ignored the lsn of a key during ordering, so multiple updates of the same key could be read in arbitrary order, say from different layers. For example there is layers `[(a, 2),(b, 3)]` and `[(a, 1),(c, 2)]` in the heap, they might return `(a,2)` and `(a,1)`.

Ultimately, this change wasn't enough to fix the ordering issues in #7296, in other words there is likely still bugs in the k-merge. So as the second thing, we switch away from the k-merge to an in-memory based one, similar to #4839, but leave the code around to be improved and maybe switched to later on.

Part of #7296