### PR TITLE
feat(pageserver): use json for timeline metadata encoding

### DIFF
--- a/libs/postgres_ffi/src/lib.rs
+++ b/libs/postgres_ffi/src/lib.rs
@@ -157,7 +157,9 @@ pub fn generate_wal_segment(
     dispatch_pgversion!(
         pg_version,
         pgv::xlog_utils::generate_wal_segment(segno, system_id, lsn),
-        Err(SerializeError::BadInput)
+        Err(SerializeError::BadInput(anyhow::anyhow!(
+            "failed to generate wal segment"
+        )))
     )
 }
 

--- a/libs/utils/src/bin_ser.rs
+++ b/libs/utils/src/bin_ser.rs
@@ -48,8 +48,8 @@ impl From<bincode::Error> for DeserializeError {
 #[derive(Debug, Error)]
 pub enum SerializeError {
     /// The serializer isn't able to serialize the supplied data.
-    #[error("serialize error")]
-    BadInput,
+    #[error("serialize error: {0}")]
+    BadInput(anyhow::Error),
     /// While serializing into a `Write` sink, an `io::Error` occurred.
     #[error("serialize error: {0}")]
     Io(io::Error),
@@ -59,7 +59,7 @@ impl From<bincode::Error> for SerializeError {
     fn from(e: bincode::Error) -> Self {
         match *e {
             bincode::ErrorKind::Io(io_err) => SerializeError::Io(io_err),
-            _ => SerializeError::BadInput,
+            err => SerializeError::BadInput(err.into()),
         }
     }
 }


### PR DESCRIPTION
## Problem

close https://github.com/neondatabase/neon/issues/7540

## Summary of changes

Change the encoding of timeline metadata to JSON. Note that the index_part still uses a weird representation that:

```
{
  "metadata_bytes": "<non-ascii header><timeline JSON>"
}
```

but using JSON at least gives us easy forward compatibility that serde_json ignores unknown fields, and new fields can be defined as `Option<X>` so that forward/backward compatibility is guaranteed.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
