### PR TITLE
chore(test): add version check for forward compat test

### DIFF
--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -246,8 +246,6 @@ def test_forward_compatibility(
             compatibility_snapshot_dir / "repo",
         )
 
-        neon_env_builder.start()
-
         # not using env.pageserver.version because it was initialized before
         prev_pageserver_version_str = env.get_binary_version("pageserver")
         prev_pageserver_version_match = re.search(
@@ -261,15 +259,17 @@ def test_forward_compatibility(
                 "cannot find git hash in the version string: " + prev_pageserver_version_str
             )
 
+        neon_env_builder.start()
+
+        # ensure the specified pageserver is running
+        assert env.pageserver.log_contains("git-env:" + prev_pageserver_version)
+
         check_neon_works(
             env,
             test_output_dir=test_output_dir,
             sql_dump_path=compatibility_snapshot_dir / "dump.sql",
             repo_dir=env.repo_dir,
         )
-
-        # ensure the specified pageserver is running
-        assert env.pageserver.log_contains("git-env:" + prev_pageserver_version)
 
     except Exception:
         if breaking_changes_allowed:

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -250,11 +250,16 @@ def test_forward_compatibility(
 
         # not using env.pageserver.version because it was initialized before
         prev_pageserver_version_str = env.get_binary_version("pageserver")
-        print(prev_pageserver_version_str)
-        prev_pageserver_version = re.search(
+        prev_pageserver_version_match = re.search(
             "Neon page server git-env:(.*) failpoints: (.*), features: (.*)",
             prev_pageserver_version_str,
-        ).group(0)
+        )
+        if prev_pageserver_version_match is not None:
+            prev_pageserver_version = prev_pageserver_version_match.group(1)
+        else:
+            raise AssertionError(
+                "cannot find git hash in the version string: " + prev_pageserver_version_str
+            )
 
         check_neon_works(
             env,

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -259,6 +259,9 @@ def test_forward_compatibility(
                 "cannot find git hash in the version string: " + prev_pageserver_version_str
             )
 
+        # does not include logs from previous runs
+        assert not env.pageserver.log_contains("git-env:" + prev_pageserver_version)
+
         neon_env_builder.start()
 
         # ensure the specified pageserver is running


### PR DESCRIPTION
## Problem

A test for https://github.com/neondatabase/neon/pull/7684.

This pull request checks if the pageserver version we specified is the one actually running by comparing the git hash in forward compatibility tests.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
