### PR TITLE
Tiered compaction: fix early exit check in main loop

### DIFF
--- a/pageserver/compaction/src/compact_tiered.rs
+++ b/pageserver/compaction/src/compact_tiered.rs
@@ -108,7 +108,7 @@ pub async fn compact_tiered<E: CompactionJobExecutor>(
         .await?;
         if current_level_target_height == u64::MAX {
             // our target height includes all possible lsns
-            debug!(
+            info!(
                 level = current_level_no,
                 depth = depth,
                 "compaction loop reached max current_level_target_height"

--- a/pageserver/compaction/src/compact_tiered.rs
+++ b/pageserver/compaction/src/compact_tiered.rs
@@ -106,7 +106,13 @@ pub async fn compact_tiered<E: CompactionJobExecutor>(
             ctx,
         )
         .await?;
-        if target_file_size == u64::MAX {
+        if current_level_target_height == u64::MAX {
+            // our target height includes all possible lsns
+            debug!(
+                level = current_level_no,
+                depth = depth,
+                "compaction loop reached max current_level_target_height"
+            );
             break;
         }
         current_level_no += 1;


### PR DESCRIPTION
The old test based on the immutable `target_file_size` that was a parameter to the function.

It makes no sense to go further once `current_level_target_height` has reached `u64::MAX`, as lsn's are u64 typed. In practice, we should only run into this if there is a bug, as the practical lsn range usually ends much earlier.

Testing on `target_file_size` makes less sense, it basically implements a mode where you turn off the loop and only run one iteration of it. @hlinnaka agrees that `current_level_target_height` is better here.

Part of #7554