### PR TITLE
Use std page format for main forknum in neon_wallog_page

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1387,11 +1387,10 @@ neon_wallog_page(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, co
 	 */
 	if ((force || forknum == FSM_FORKNUM || forknum == VISIBILITYMAP_FORKNUM) && !RecoveryInProgress())
 	{
-		/* FSM is never WAL-logged and we don't care. */
 		XLogRecPtr	recptr;
 
 		recptr = log_newpage_copy(&InfoFromSMgrRel(reln), forknum, blocknum,
-								  (Page) buffer, false);
+								  (Page) buffer, forknum == MAIN_FORKNUM);
 		XLogFlush(recptr);
 		lsn = recptr;
 		ereport(SmgrTrace,


### PR DESCRIPTION
## Problem

`neon_wallog_page` is called from neon_write/neon_extend and force wallowing of
1. FSM page
2. VN page
3. filling gap when extending relation

Only in first two cases non-standard page format is used.
Non-stadnard page format disables hole optimization.

## Summary of changes

1. Remove incorrect (obsolete) comment.
2. Use std format for main fork pages which are forced wallgged.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
