### PR TITLE
Increase partial backup timeout to 3 hours

### DIFF
--- a/safekeeper/src/lib.rs
+++ b/safekeeper/src/lib.rs
@@ -49,7 +49,7 @@ pub mod defaults {
 
     pub const DEFAULT_HEARTBEAT_TIMEOUT: &str = "5000ms";
     pub const DEFAULT_MAX_OFFLOADER_LAG_BYTES: u64 = 128 * (1 << 20);
-    pub const DEFAULT_PARTIAL_BACKUP_TIMEOUT: &str = "15m";
+    pub const DEFAULT_PARTIAL_BACKUP_TIMEOUT: &str = "3h";
 }
 
 #[derive(Debug, Clone)]

--- a/safekeeper/src/wal_backup_partial.rs
+++ b/safekeeper/src/wal_backup_partial.rs
@@ -1,6 +1,6 @@
 //! Safekeeper timeline has a background task which is subscribed to `commit_lsn`
 //! and `flush_lsn` updates. After the partial segment was updated (`flush_lsn`
-//! was changed), the segment will be uploaded to S3 in about 15 minutes.
+//! was changed), the segment will be uploaded to S3 in about 3 hours.
 //!
 //! The filename format for partial segments is
 //! `Segment_Term_Flush_Commit_skNN.partial`, where:


### PR DESCRIPTION
In #7732, it was noted that because of our segment size being megabytes large, we can have potentially huge size differences between additional WAL written in a given time period (say 80 bytes in a 15 minute period) and the average partial segment size (order of megabytes, half of the complete segment size assuming linear growth). This leads to blowups that can be in the hundreds of thousands in the worst cases.

This increases the default partial backup timeout 12-fold to 3 hours, to reduce the total impact of this feature. It doesn't address the fundamental issue, but our use cases don't require a 15 minute timeout either.