### PR TITLE
chore(remote_storage): serde-deserializable RemoteStorageConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,9 @@ name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "camino-tempfile"

--- a/libs/remote_storage/Cargo.toml
+++ b/libs/remote_storage/Cargo.toml
@@ -14,7 +14,7 @@ aws-config.workspace = true
 aws-sdk-s3.workspace = true
 aws-credential-types.workspace = true
 bytes.workspace = true
-camino.workspace = true
+camino = { workspace = true, features = [ "serde1" ] }
 humantime.workspace = true
 hyper = { workspace = true, features = ["stream"] }
 futures.workspace = true


### PR DESCRIPTION
In https://github.com/neondatabase/neon/pull/7656 I'm switching PageServerConfig parsing to use `serde` derive.

RemoteStorageConfig is part of PageServerConfig, so, it has to be `Deserialize`able as well.

As a bonus, the way the new Deserialize implementation works, we get detection of unknown fields, which we didn't have before.