### PR TITLE
refactor(pageserver): better k-merge implementation for tiered compaction

### DIFF
--- a/pageserver/compaction/src/interface.rs
+++ b/pageserver/compaction/src/interface.rs
@@ -92,7 +92,9 @@ pub trait CompactionJobExecutor {
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
-pub trait CompactionKey: std::cmp::Ord + Clone + Copy + std::fmt::Display {
+pub trait CompactionKey:
+    std::cmp::Ord + Clone + Copy + std::fmt::Display + std::fmt::Debug
+{
     const MIN: Self;
     const MAX: Self;
 


### PR DESCRIPTION
## Problem

The original k-merge implementation might be buggy and is hard to reason about. This pull request rewrites the k-merge implementation to make it easier to read and potentially avoids the bug that keys are not ordered.

ref https://github.com/neondatabase/neon/issues/7703

## Summary of changes

Adds `LayerIterator` and `MergeIterator`. They provide `key_lsn`, `next`, and `is_end` APIs.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
