### PR TITLE
feat(pageserver): do not read past image layers for vectored get

### DIFF
--- a/libs/pageserver_api/src/keyspace.rs
+++ b/libs/pageserver_api/src/keyspace.rs
@@ -307,7 +307,7 @@ impl KeySpace {
     }
 
     /// Merge another keyspace into the current one.
-    /// Note: the keyspaces must not ovelap (enforced via assertions)
+    /// Note: the keyspaces must not overlap (enforced via assertions). To merge overlapping keyspaces, use `KeySpaceRandomAccum`.
     pub fn merge(&mut self, other: &KeySpace) {
         let all_ranges = self
             .ranges

--- a/libs/pageserver_api/src/keyspace.rs
+++ b/libs/pageserver_api/src/keyspace.rs
@@ -307,7 +307,7 @@ impl KeySpace {
     }
 
     /// Merge another keyspace into the current one.
-    /// Note: the keyspaces must not overlap (enforced via assertions). To merge overlapping keyspaces, use `KeySpaceRandomAccum`.
+    /// Note: the keyspaces must not overlap (enforced via assertions). To merge overlapping key ranges, use `KeySpaceRandomAccum`.
     pub fn merge(&mut self, other: &KeySpace) {
         let all_ranges = self
             .ranges

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -6166,7 +6166,7 @@ mod tests {
                     },
                     &ctx,
                 )
-                .await?; // force create an image layer for the keys
+                .await?; // force create an image layer for the keys, TODO: check if the image layer is created
         }
 
         async fn get_vectored_impl_wrapper(

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -113,7 +113,7 @@ impl From<VectoredValueReconstructState> for ValueReconstructState {
     }
 }
 
-/// Bag of data accumulated during a vectored get.
+/// Bag of data accumulated during a vectored get..
 pub(crate) struct ValuesReconstructState {
     /// The keys will be removed after `get_vectored` completes. The caller outside `Timeline`
     /// should not expect to get anything from this hashmap.

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -158,6 +158,7 @@ pub struct ImageLayerInner {
     index_start_blk: u32,
     index_root_blk: u32,
 
+    key_range: Range<Key>,
     lsn: Lsn,
 
     file: VirtualFile,
@@ -419,6 +420,7 @@ impl ImageLayerInner {
             file,
             file_id,
             max_vectored_read_bytes,
+            key_range: actual_summary.key_range,
         }))
     }
 
@@ -477,6 +479,8 @@ impl ImageLayerInner {
 
         self.do_reads_and_update_state(reads, reconstruct_state, ctx)
             .await;
+
+        reconstruct_state.finish_key_range(&self.key_range, self.lsn);
 
         Ok(())
     }

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -480,7 +480,7 @@ impl ImageLayerInner {
         self.do_reads_and_update_state(reads, reconstruct_state, ctx)
             .await;
 
-        reconstruct_state.finish_key_range(&self.key_range, self.lsn);
+        reconstruct_state.on_image_layer_visited(&self.key_range);
 
         Ok(())
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -348,8 +348,8 @@ pub struct Timeline {
     // though let's keep them both for better error visibility.
     pub initdb_lsn: Lsn,
 
-    /// When did we last calculate the partitioning?
-    pub(crate) partitioning: tokio::sync::Mutex<((KeyPartitioning, SparseKeyPartitioning), Lsn)>,
+    /// When did we last calculate the partitioning? Make it pub to test cases.
+    pub(super) partitioning: tokio::sync::Mutex<((KeyPartitioning, SparseKeyPartitioning), Lsn)>,
 
     /// Configuration: how often should the partitioning be recalculated.
     repartition_threshold: u64,
@@ -4140,8 +4140,6 @@ impl Timeline {
         }; // no partitioning for metadata keys for now
         *partitioning_guard = ((dense_partitioning, sparse_partitioning), lsn);
 
-        info!("repartitioning!");
-
         Ok((partitioning_guard.0.clone(), partitioning_guard.1))
     }
 
@@ -4211,7 +4209,6 @@ impl Timeline {
 
         let mut key_request_accum = KeySpaceAccum::new();
         for range in &partition.ranges {
-            info!("partition: {}..{}", range.start, range.end);
             let mut key = range.start;
             while key < range.end {
                 // Decide whether to retain this key: usually we do, but sharded tenants may

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3387,8 +3387,10 @@ impl Timeline {
                 return Err(GetVectoredError::Cancelled);
             }
 
-            let keys_done_last_step = reconstruct_state.consume_done_keys();
+            let (keys_done_last_step, image_coverage_last_step) =
+                reconstruct_state.consume_done_keys();
             unmapped_keyspace.remove_overlapping_with(&keys_done_last_step);
+            unmapped_keyspace.remove_overlapping_with(&image_coverage_last_step);
             completed_keyspace.merge(&keys_done_last_step);
 
             // Do not descent any further if the last layer we visited

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -507,6 +507,13 @@ pub(crate) enum PageReconstructError {
     MissingKey(MissingKeyError),
 }
 
+impl GetVectoredError {
+    #[cfg(test)]
+    pub(crate) fn is_missing_key_error(&self) -> bool {
+        matches!(self, Self::MissingKey(_))
+    }
+}
+
 #[derive(Debug)]
 pub struct MissingKeyError {
     key: Key,
@@ -3338,7 +3345,7 @@ impl Timeline {
             // image layer, which means that the key does not exist.
             for image_layer_keyspace in &covered {
                 // Get the overlapping of the image layer keyspace and the incomplete keyspace.
-                let removed = keyspace.remove_overlapping_with(&image_layer_keyspace);
+                let removed = keyspace.remove_overlapping_with(image_layer_keyspace);
                 if !removed.is_empty() {
                     break 'outer Some(removed);
                 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3425,15 +3425,14 @@ impl Timeline {
                 return Err(GetVectoredError::Cancelled);
             }
 
-            let (keys_done_last_step, image_coverage_last_step) =
+            let (keys_done_last_step, keys_with_image_coverage) =
                 reconstruct_state.consume_done_keys();
             unmapped_keyspace.remove_overlapping_with(&keys_done_last_step);
-            unmapped_keyspace.remove_overlapping_with(&image_coverage_last_step);
             completed_keyspace.merge(&keys_done_last_step);
-            if !image_coverage_last_step.is_empty() {
-                for range in image_coverage_last_step.ranges {
-                    image_covered_keyspace.add_range(range);
-                }
+            if let Some(keys_with_image_coverage) = keys_with_image_coverage {
+                unmapped_keyspace
+                    .remove_overlapping_with(&KeySpace::single(keys_with_image_coverage.clone()));
+                image_covered_keyspace.add_range(keys_with_image_coverage);
             }
 
             // Do not descent any further if the last layer we visited

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3300,12 +3300,12 @@ impl Timeline {
 
         let mut cont_lsn = Lsn(request_lsn.0 + 1);
 
-        loop {
+        let missing_keyspace = 'outer: loop {
             if self.cancel.is_cancelled() {
                 return Err(GetVectoredError::Cancelled);
             }
 
-            let completed = Self::get_vectored_reconstruct_data_timeline(
+            let (completed, covered) = Self::get_vectored_reconstruct_data_timeline(
                 timeline,
                 keyspace.clone(),
                 cont_lsn,
@@ -3324,10 +3324,25 @@ impl Timeline {
                 ranges: vec![NON_INHERITED_RANGE, NON_INHERITED_SPARSE_RANGE],
             });
 
-            // Keyspace is fully retrieved, no ancestor timeline, or metadata scan (where we do not look
-            // into ancestor timelines). TODO: is there any other metadata which we want to inherit?
-            if keyspace.total_raw_size() == 0 || timeline.ancestor_timeline.is_none() {
-                break;
+            // Keyspace is fully retrieved
+            if keyspace.is_empty() {
+                break None;
+            }
+
+            // Not fully retrieved but no ancestor timeline.
+            if timeline.ancestor_timeline.is_none() {
+                break Some(keyspace);
+            }
+
+            // Now we see if there are keys covered by the image layer but does not exist in the
+            // image layer, which means that the key does not exist.
+            for image_layer_keyspace in &covered {
+                // Get the overlapping of the image layer keyspace and the incomplete keyspace.
+                let removed = keyspace.remove_overlapping_with(&image_layer_keyspace);
+                if !removed.is_empty() {
+                    break 'outer Some(removed);
+                }
+                // If we don't break here, `keyspace` should stays the same within the loop.
             }
 
             // Take the min to avoid reconstructing a page with data newer than request Lsn.
@@ -3337,14 +3352,14 @@ impl Timeline {
                 .await
                 .map_err(GetVectoredError::GetReadyAncestorError)?;
             timeline = &*timeline_owned;
-        }
+        };
 
-        if keyspace.total_raw_size() != 0 {
+        if let Some(missing_keyspace) = missing_keyspace {
             return Err(GetVectoredError::MissingKey(MissingKeyError {
-                key: keyspace.start().unwrap(), /* better if we can store the full keyspace */
+                key: missing_keyspace.start().unwrap(), /* better if we can store the full keyspace */
                 shard: self
                     .shard_identity
-                    .get_shard_number(&keyspace.start().unwrap()),
+                    .get_shard_number(&missing_keyspace.start().unwrap()),
                 cont_lsn,
                 request_lsn,
                 ancestor_lsn: Some(timeline.ancestor_lsn),
@@ -3369,6 +3384,9 @@ impl Timeline {
     ///
     /// At each iteration pop the top of the fringe (the layer with the highest Lsn)
     /// and get all the required reconstruct data from the layer in one go.
+    ///
+    /// Returns the completed keyspace and the keyspaces with image coverage. The caller
+    /// decides how to deal with these two keyspaces.
     async fn get_vectored_reconstruct_data_timeline(
         timeline: &Timeline,
         keyspace: KeySpace,
@@ -3376,11 +3394,12 @@ impl Timeline {
         reconstruct_state: &mut ValuesReconstructState,
         cancel: &CancellationToken,
         ctx: &RequestContext,
-    ) -> Result<KeySpace, GetVectoredError> {
+    ) -> Result<(KeySpace, Vec<KeySpace>), GetVectoredError> {
         let mut unmapped_keyspace = keyspace.clone();
         let mut fringe = LayerFringe::new();
 
         let mut completed_keyspace = KeySpace::default();
+        let mut image_covered_keyspaces = Vec::new();
 
         loop {
             if cancel.is_cancelled() {
@@ -3392,6 +3411,9 @@ impl Timeline {
             unmapped_keyspace.remove_overlapping_with(&keys_done_last_step);
             unmapped_keyspace.remove_overlapping_with(&image_coverage_last_step);
             completed_keyspace.merge(&keys_done_last_step);
+            if !image_coverage_last_step.is_empty() {
+                image_covered_keyspaces.push(image_coverage_last_step);
+            }
 
             // Do not descent any further if the last layer we visited
             // completed all keys in the keyspace it inspected. This is not
@@ -3469,7 +3491,7 @@ impl Timeline {
             }
         }
 
-        Ok(completed_keyspace)
+        Ok((completed_keyspace, image_covered_keyspaces))
     }
 
     /// # Cancel-safety


### PR DESCRIPTION
## Problem

Part of https://github.com/neondatabase/neon/issues/7462

On metadata keyspace, vectored get will not stop if a key is not found, and will read past the image layer. However, the semantics is different from single get, because if a key does not exist in the image layer, it means that the key does not exist in the past, or have been deleted. This pull request fixed it by recording image layer coverage during the vectored get process and stop when the full keyspace is covered by an image layer. A corresponding test case is added to ensure generating image layer reduces the number of delta layers.

This optimization (or bug fix) also applies to rel block keyspaces. If a key is missing, we can know it's missing once the first image layer is reached. Page server will not attempt to read lower layers, which potentially incurs layer downloads + evictions.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
