### PR TITLE
Set result.not_modified_since as minimum of last_written_lsn and replay lsn

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1528,9 +1528,13 @@ neon_get_request_lsns(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber blkno)
 	{
 		/* Request the page at the last replayed LSN. */
 		result.request_lsn = GetXLogReplayRecPtr(NULL);
-		result.not_modified_since = last_written_lsn;
 		result.effective_request_lsn = result.request_lsn;
-		Assert(last_written_lsn <= result.request_lsn);
+		/*
+		 * lastReplayedEndRecPtr is advanced after applying WAL record while
+		 * last written LSN can be advanced while applying WAL record this is why
+		 * last_written_lsn can be larger than GetXLogReplayRecPtr(NULL).
+		 */
+		result.not_modified_since = Min(last_written_lsn, result.request_lsn);
 
 		neon_log(DEBUG1, "neon_get_request_lsns request lsn %X/%X, not_modified_since %X/%X",
 				 LSN_FORMAT_ARGS(result.request_lsn), LSN_FORMAT_ARGS(result.not_modified_since));


### PR DESCRIPTION
## Problem

See https://neondb.slack.com/archives/C04DGM6SMTM/p1715785588061879?thread_ts=1715772441.057759&cid=C04DGM6SMTM

`lastReplayedEndRecPtr` is advanced after applying WAL record while last written LSN can be advanced while 
applying WAL record this is why `last_written_lsn` can be larger than `GetXLogReplayRecPtr(NULL)`.

## Summary of changes

```
result.not_modified_since = Min(last_written_lsn, result.request_lsn);
```

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
