### PR TITLE
proxy password threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,6 +4358,7 @@ dependencies = [
 name = "proxy"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-compression",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7446,6 +7446,7 @@ dependencies = [
 name = "workspace_hack"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "aws-config",
  "aws-runtime",
@@ -7455,7 +7456,6 @@ dependencies = [
  "aws-smithy-types",
  "axum",
  "base64 0.21.1",
- "base64ct",
  "bytes",
  "cc",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7480,6 +7480,7 @@ dependencies = [
  "aws-smithy-types",
  "axum",
  "base64 0.21.1",
+ "base64ct",
  "bytes",
  "cc",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,26 +1471,21 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset 0.8.0",
- "scopeguard",
 ]
 
 [[package]]
@@ -3943,33 +3938,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
-]
 
 [[package]]
 name = "peeking_take_while"
@@ -4402,6 +4374,7 @@ dependencies = [
  "chrono",
  "clap",
  "consumption_metrics",
+ "crossbeam-deque",
  "dashmap",
  "env_logger",
  "fallible-iterator",
@@ -4432,7 +4405,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "parquet",
  "parquet_derive",
- "pbkdf2",
  "pin-project-lite",
  "postgres-native-tls",
  "postgres-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3938,10 +3938,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -4406,6 +4429,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "parquet",
  "parquet_derive",
+ "pbkdf2",
  "pin-project-lite",
  "postgres-native-tls",
  "postgres-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ clap = { version = "4.0", features = ["derive"] }
 comfy-table = "6.1"
 const_format = "0.2"
 crc32c = "0.6"
+crossbeam-deque = "0.8.5"
 crossbeam-utils = "0.8.5"
 dashmap = { version = "5.5.0", features = ["raw-api"] }
 either = "1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ license = "Apache-2.0"
 
 ## All dependency versions, used in the project
 [workspace.dependencies]
+ahash = "0.8"
 anyhow = { version = "1.0", features = ["backtrace"] }
 arc-swap = "1.6"
 async-compression = { version = "0.4.0", features = ["tokio", "gzip", "zstd"] }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -107,6 +107,7 @@ workspace_hack.workspace = true
 camino-tempfile.workspace = true
 fallible-iterator.workspace = true
 tokio-tungstenite.workspace = true
+pbkdf2 = { workspace = true, features = ["simple", "std"] }
 rcgen.workspace = true
 rstest.workspace = true
 tokio-postgres-rustls.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -24,6 +24,7 @@ camino.workspace = true
 chrono.workspace = true
 clap.workspace = true
 consumption_metrics.workspace = true
+crossbeam-deque.workspace = true
 dashmap.workspace = true
 env_logger.workspace = true
 framed-websockets.workspace = true
@@ -52,7 +53,6 @@ opentelemetry.workspace = true
 parking_lot.workspace = true
 parquet.workspace = true
 parquet_derive.workspace = true
-pbkdf2 = { workspace = true, features = ["simple", "std"] }
 pin-project-lite.workspace = true
 postgres_backend.workspace = true
 pq_proto.workspace = true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 testing = []
 
 [dependencies]
+ahash.workspace = true
 anyhow.workspace = true
 async-compression.workspace = true
 async-trait.workspace = true

--- a/proxy/src/auth/backend.rs
+++ b/proxy/src/auth/backend.rs
@@ -598,16 +598,12 @@ mod tests {
         }
     }
 
-    static CONFIG: Lazy<AuthenticationConfig> = Lazy::new(|| {
-        let config = AuthenticationConfig {
-            thread_pool: Arc::new(ThreadPool::new()),
-            scram_protocol_timeout: std::time::Duration::from_secs(5),
-            rate_limiter_enabled: true,
-            rate_limiter: AuthRateLimiter::new(&RateBucketInfo::DEFAULT_AUTH_SET),
-            rate_limit_ip_subnet: 64,
-        };
-        config.thread_pool.spawn_workers(1);
-        config
+    static CONFIG: Lazy<AuthenticationConfig> = Lazy::new(|| AuthenticationConfig {
+        thread_pool: ThreadPool::new(1),
+        scram_protocol_timeout: std::time::Duration::from_secs(5),
+        rate_limiter_enabled: true,
+        rate_limiter: AuthRateLimiter::new(&RateBucketInfo::DEFAULT_AUTH_SET),
+        rate_limit_ip_subnet: 64,
     });
 
     async fn read_message(r: &mut (impl AsyncRead + Unpin), b: &mut BytesMut) -> PgMessage {

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -283,6 +283,8 @@ async fn main() -> anyhow::Result<()> {
     let args = ProxyCliArgs::parse();
     let config = build_config(&args)?;
 
+    Metrics::install(config.authentication_config.thread_pool.metrics.clone());
+
     info!("Authentication backend: {}", config.auth_backend);
     info!("Using region: {}", config.aws_region);
 

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -27,6 +27,7 @@ use proxy::redis::cancellation_publisher::RedisPublisherClient;
 use proxy::redis::connection_with_credentials_provider::ConnectionWithCredentialsProvider;
 use proxy::redis::elasticache;
 use proxy::redis::notifications;
+use proxy::scram::threadpool::ThreadPool;
 use proxy::serverless::cancel_set::CancelSet;
 use proxy::serverless::GlobalConnPoolOptions;
 use proxy::usage_metrics;
@@ -132,6 +133,9 @@ struct ProxyCliArgs {
     /// timeout for scram authentication protocol
     #[clap(long, default_value = "15s", value_parser = humantime::parse_duration)]
     scram_protocol_timeout: tokio::time::Duration,
+    /// size of the threadpool for password hashing
+    #[clap(long, default_value_t = 16)]
+    scram_thread_pool_size: usize,
     /// Require that all incoming requests have a Proxy Protocol V2 packet **and** have an IP address associated.
     #[clap(long, default_value_t = false, value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
     require_client_ip: bool,
@@ -624,11 +628,15 @@ fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
         client_conn_threshold: args.sql_over_http.sql_over_http_client_conn_threshold,
     };
     let authentication_config = AuthenticationConfig {
+        thread_pool: Arc::new(ThreadPool::new()),
         scram_protocol_timeout: args.scram_protocol_timeout,
         rate_limiter_enabled: args.auth_rate_limit_enabled,
         rate_limiter: AuthRateLimiter::new(args.auth_rate_limit.clone()),
         rate_limit_ip_subnet: args.auth_rate_limit_ip_subnet,
     };
+    authentication_config
+        .thread_pool
+        .spawn_workers(args.scram_thread_pool_size);
 
     let mut redis_rps_limit = args.redis_rps_limit.clone();
     RateBucketInfo::validate(&mut redis_rps_limit)?;

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -2,6 +2,7 @@ use crate::{
     auth::{self, backend::AuthRateLimiter},
     console::locks::ApiLocks,
     rate_limiter::RateBucketInfo,
+    scram::threadpool::ThreadPool,
     serverless::{cancel_set::CancelSet, GlobalConnPoolOptions},
     Host,
 };
@@ -61,6 +62,7 @@ pub struct HttpConfig {
 }
 
 pub struct AuthenticationConfig {
+    pub thread_pool: Arc<ThreadPool>,
     pub scram_protocol_timeout: tokio::time::Duration,
     pub rate_limiter_enabled: bool,
     pub rate_limiter: AuthRateLimiter,

--- a/proxy/src/scram.rs
+++ b/proxy/src/scram.rs
@@ -10,6 +10,7 @@ mod countmin;
 mod exchange;
 mod key;
 mod messages;
+mod pbkdf2;
 mod secret;
 mod signature;
 pub mod threadpool;

--- a/proxy/src/scram.rs
+++ b/proxy/src/scram.rs
@@ -6,6 +6,7 @@
 //! * <https://github.com/postgres/postgres/blob/94226d4506e66d6e7cbf4b391f1e7393c1962841/src/backend/libpq/auth-scram.c>
 //! * <https://github.com/postgres/postgres/blob/94226d4506e66d6e7cbf4b391f1e7393c1962841/src/interfaces/libpq/fe-auth-scram.c>
 
+mod countmin;
 mod exchange;
 mod key;
 mod messages;

--- a/proxy/src/scram.rs
+++ b/proxy/src/scram.rs
@@ -57,8 +57,6 @@ fn sha256<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use crate::{
         intern::EndpointIdInt,
         sasl::{Mechanism, Step},
@@ -119,8 +117,7 @@ mod tests {
     }
 
     async fn run_round_trip_test(server_password: &str, client_password: &str) {
-        let pool = Arc::new(ThreadPool::new());
-        pool.spawn_workers(1);
+        let pool = ThreadPool::new(1);
 
         let ep = EndpointId::from("foo");
         let ep = EndpointIdInt::from(ep);

--- a/proxy/src/scram.rs
+++ b/proxy/src/scram.rs
@@ -11,6 +11,7 @@ mod key;
 mod messages;
 mod secret;
 mod signature;
+mod threadpool;
 
 pub use exchange::{exchange, Exchange};
 pub use key::ScramKey;

--- a/proxy/src/scram/countmin.rs
+++ b/proxy/src/scram/countmin.rs
@@ -143,6 +143,7 @@ mod tests {
         assert_eq!(eval_precision(1000, 4096.0, 0.99), 1000);
 
         // seems to be more precise than the literature indicates?
+        // probably numbers are too small to truly represent the probabilities.
         assert_eq!(eval_precision(100, 4096.0, 0.90), 100);
         assert_eq!(eval_precision(1000, 4096.0, 0.90), 1000);
         assert_eq!(eval_precision(100, 4096.0, 0.1), 98);

--- a/proxy/src/scram/countmin.rs
+++ b/proxy/src/scram/countmin.rs
@@ -1,0 +1,172 @@
+use std::hash::Hash;
+
+/// estimator of hash jobs per second.
+/// <https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch>
+pub struct CountMinSketch {
+    // one for each depth
+    hashers: Vec<ahash::RandomState>,
+    width: usize,
+    depth: usize,
+    // buckets, width*depth
+    buckets: Vec<u32>,
+}
+
+impl CountMinSketch {
+    /// Given parameters (ε, δ),
+    ///   set width = ceil(e/ε)
+    ///   set depth = ceil(ln(1/δ))
+    ///
+    /// guarantees:
+    /// actual <= estimate
+    /// estimate <= actual + ε * N with probability 1 - δ
+    /// where N is the cardinality of the stream
+    pub fn with_params(epsilon: f64, delta: f64) -> Self {
+        CountMinSketch::new(
+            (std::f64::consts::E / epsilon).ceil() as usize,
+            (1.0_f64 / delta).ln().ceil() as usize,
+        )
+    }
+
+    fn new(width: usize, depth: usize) -> Self {
+        Self {
+            #[cfg(test)]
+            hashers: (0..depth)
+                .map(|i| {
+                    // digits of pi for good randomness
+                    ahash::RandomState::with_seeds(
+                        314159265358979323,
+                        84626433832795028,
+                        84197169399375105,
+                        82097494459230781 + i as u64,
+                    )
+                })
+                .collect(),
+            #[cfg(not(test))]
+            hashers: (0..depth).map(|_| ahash::RandomState::new()).collect(),
+            width,
+            depth,
+            buckets: vec![0; width * depth],
+        }
+    }
+
+    pub fn inc_and_return<T: Hash>(&mut self, t: &T, x: u32) -> u32 {
+        let mut min = u32::MAX;
+        for row in 0..self.depth {
+            let col = (self.hashers[row].hash_one(t) as usize) % self.width;
+
+            let row = &mut self.buckets[row * self.width..][..self.width];
+            row[col] = row[col].saturating_add(x);
+            min = std::cmp::min(min, row[col]);
+        }
+        min
+    }
+
+    pub fn reset(&mut self) {
+        self.buckets.clear();
+        self.buckets.resize(self.width * self.depth, 0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
+
+    use super::CountMinSketch;
+
+    fn eval_precision(n: usize, p: f64, q: f64) -> usize {
+        // fixed value of phi for consistent test
+        let mut rng = StdRng::seed_from_u64(16180339887498948482);
+
+        #[allow(non_snake_case)]
+        let mut N = 0;
+
+        let mut ids = vec![];
+
+        for _ in 0..n {
+            // number of insert operations
+            let n = rng.gen_range(1..100);
+            // number to insert at once
+            let m = rng.gen_range(1..4096);
+
+            let id = uuid::Builder::from_random_bytes(rng.gen()).into_uuid();
+            ids.push((id, n, m));
+
+            // N = sum(actual)
+            N += n * m;
+        }
+
+        // q% of counts will be within p of the actual value
+        let mut sketch = CountMinSketch::with_params(p / N as f64, 1.0 - q);
+
+        dbg!(sketch.buckets.len());
+
+        // insert a bunch of entries in a random order
+        let mut ids2 = ids.clone();
+        while !ids2.is_empty() {
+            ids2.shuffle(&mut rng);
+
+            let mut i = 0;
+            while i < ids2.len() {
+                sketch.inc_and_return(&ids2[i].0, ids2[i].1);
+                ids2[i].2 -= 1;
+                if ids2[i].2 == 0 {
+                    ids2.remove(i);
+                } else {
+                    i += 1;
+                }
+            }
+        }
+
+        let mut within_p = 0;
+        for (id, n, m) in ids {
+            let actual = n * m;
+            let estimate = sketch.inc_and_return(&id, 0);
+
+            // This estimate has the guarantee that actual <= estimate
+            assert!(actual <= estimate);
+
+            // This estimate has the guarantee that estimate <= actual + εN with probability 1 - δ.
+            // ε = p / N, δ = 1 - q;
+            // therefore, estimate <= actual + p with probability q.
+            if estimate as f64 <= actual as f64 + p {
+                within_p += 1;
+            }
+        }
+        within_p
+    }
+
+    #[test]
+    fn precision() {
+        assert_eq!(eval_precision(100, 100.0, 0.99), 100);
+        assert_eq!(eval_precision(1000, 100.0, 0.99), 1000);
+        assert_eq!(eval_precision(100, 4096.0, 0.99), 100);
+        assert_eq!(eval_precision(1000, 4096.0, 0.99), 1000);
+
+        // seems to be more precise than the literature indicates?
+        assert_eq!(eval_precision(100, 4096.0, 0.90), 100);
+        assert_eq!(eval_precision(1000, 4096.0, 0.90), 1000);
+        assert_eq!(eval_precision(100, 4096.0, 0.1), 98);
+        assert_eq!(eval_precision(1000, 4096.0, 0.1), 991);
+    }
+
+    // returns memory usage in bytes, and the time complexity per insert.
+    fn eval_cost(p: f64, q: f64) -> (usize, usize) {
+        #[allow(non_snake_case)]
+        // N = sum(actual)
+        // Let's assume 1021 samples, all of 4096
+        let N = 1021 * 4096;
+        let sketch = CountMinSketch::with_params(p / N as f64, 1.0 - q);
+
+        let memory = std::mem::size_of::<u32>() * sketch.buckets.len();
+        let time = sketch.depth;
+        (memory, time)
+    }
+
+    #[test]
+    fn memory_usage() {
+        assert_eq!(eval_cost(100.0, 0.99), (2273580, 5));
+        assert_eq!(eval_cost(4096.0, 0.99), (55520, 5));
+        assert_eq!(eval_cost(4096.0, 0.90), (33312, 3));
+        assert_eq!(eval_cost(4096.0, 0.1), (11104, 1));
+    }
+}

--- a/proxy/src/scram/exchange.rs
+++ b/proxy/src/scram/exchange.rs
@@ -8,9 +8,10 @@ use sha2::Sha256;
 use super::messages::{
     ClientFinalMessage, ClientFirstMessage, OwnedServerFirstMessage, SCRAM_RAW_NONCE_LEN,
 };
+use super::pbkdf2::Pbkdf2;
 use super::secret::ServerSecret;
 use super::signature::SignatureBuilder;
-use super::threadpool::{Pbkdf2, ThreadPool};
+use super::threadpool::ThreadPool;
 use super::ScramKey;
 use crate::config;
 use crate::intern::EndpointIdInt;

--- a/proxy/src/scram/exchange.rs
+++ b/proxy/src/scram/exchange.rs
@@ -4,15 +4,16 @@ use std::convert::Infallible;
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
-use tokio::task::yield_now;
 
 use super::messages::{
     ClientFinalMessage, ClientFirstMessage, OwnedServerFirstMessage, SCRAM_RAW_NONCE_LEN,
 };
 use super::secret::ServerSecret;
 use super::signature::SignatureBuilder;
+use super::threadpool::{Pbkdf2, ThreadPool};
 use super::ScramKey;
 use crate::config;
+use crate::intern::EndpointIdInt;
 use crate::sasl::{self, ChannelBinding, Error as SaslError};
 
 /// The only channel binding mode we currently support.
@@ -74,37 +75,18 @@ impl<'a> Exchange<'a> {
     }
 }
 
-// copied from <https://github.com/neondatabase/rust-postgres/blob/20031d7a9ee1addeae6e0968e3899ae6bf01cee2/postgres-protocol/src/authentication/sasl.rs#L36-L61>
-async fn pbkdf2(str: &[u8], salt: &[u8], iterations: u32) -> [u8; 32] {
-    let hmac = Hmac::<Sha256>::new_from_slice(str).expect("HMAC is able to accept all key sizes");
-    let mut prev = hmac
-        .clone()
-        .chain_update(salt)
-        .chain_update(1u32.to_be_bytes())
-        .finalize()
-        .into_bytes();
-
-    let mut hi = prev;
-
-    for i in 1..iterations {
-        prev = hmac.clone().chain_update(prev).finalize().into_bytes();
-
-        for (hi, prev) in hi.iter_mut().zip(prev) {
-            *hi ^= prev;
-        }
-        // yield every ~250us
-        // hopefully reduces tail latencies
-        if i % 1024 == 0 {
-            yield_now().await
-        }
-    }
-
-    hi.into()
-}
-
 // copied from <https://github.com/neondatabase/rust-postgres/blob/20031d7a9ee1addeae6e0968e3899ae6bf01cee2/postgres-protocol/src/authentication/sasl.rs#L236-L248>
-async fn derive_client_key(password: &[u8], salt: &[u8], iterations: u32) -> ScramKey {
-    let salted_password = pbkdf2(password, salt, iterations).await;
+async fn derive_client_key(
+    pool: &ThreadPool,
+    endpoint: EndpointIdInt,
+    password: &[u8],
+    salt: &[u8],
+    iterations: u32,
+) -> ScramKey {
+    let salted_password = pool
+        .spawn_job(endpoint, Pbkdf2::start(password, salt, iterations))
+        .await
+        .expect("job should not be cancelled");
 
     let make_key = |name| {
         let key = Hmac::<Sha256>::new_from_slice(&salted_password)
@@ -119,11 +101,13 @@ async fn derive_client_key(password: &[u8], salt: &[u8], iterations: u32) -> Scr
 }
 
 pub async fn exchange(
+    pool: &ThreadPool,
+    endpoint: EndpointIdInt,
     secret: &ServerSecret,
     password: &[u8],
 ) -> sasl::Result<sasl::Outcome<super::ScramKey>> {
     let salt = base64::decode(&secret.salt_base64)?;
-    let client_key = derive_client_key(password, &salt, secret.iterations).await;
+    let client_key = derive_client_key(pool, endpoint, password, &salt, secret.iterations).await;
 
     if secret.is_password_invalid(&client_key).into() {
         Ok(sasl::Outcome::Failure("password doesn't match"))

--- a/proxy/src/scram/pbkdf2.rs
+++ b/proxy/src/scram/pbkdf2.rs
@@ -1,0 +1,89 @@
+use hmac::{
+    digest::{consts::U32, generic_array::GenericArray},
+    Hmac, Mac,
+};
+use sha2::Sha256;
+
+pub struct Pbkdf2 {
+    hmac: Hmac<Sha256>,
+    prev: GenericArray<u8, U32>,
+    hi: GenericArray<u8, U32>,
+    iterations: u32,
+}
+
+// inspired from <https://github.com/neondatabase/rust-postgres/blob/20031d7a9ee1addeae6e0968e3899ae6bf01cee2/postgres-protocol/src/authentication/sasl.rs#L36-L61>
+impl Pbkdf2 {
+    pub fn start(str: &[u8], salt: &[u8], iterations: u32) -> Self {
+        let hmac =
+            Hmac::<Sha256>::new_from_slice(str).expect("HMAC is able to accept all key sizes");
+
+        let prev = hmac
+            .clone()
+            .chain_update(salt)
+            .chain_update(1u32.to_be_bytes())
+            .finalize()
+            .into_bytes();
+
+        Self {
+            hmac,
+            // one consumed for the hash above
+            iterations: iterations - 1,
+            hi: prev,
+            prev,
+        }
+    }
+
+    pub fn cost(&self) -> u32 {
+        (self.iterations).clamp(0, 4096)
+    }
+
+    pub fn turn(&mut self) -> std::task::Poll<[u8; 32]> {
+        let Self {
+            hmac,
+            prev,
+            hi,
+            iterations,
+        } = self;
+
+        // only do 4096 iterations per turn before sharing the thread for fairness
+        let n = (*iterations).clamp(0, 4096);
+        for _ in 0..n {
+            *prev = hmac.clone().chain_update(*prev).finalize().into_bytes();
+
+            for (hi, prev) in hi.iter_mut().zip(*prev) {
+                *hi ^= prev;
+            }
+        }
+
+        *iterations -= n;
+        if *iterations == 0 {
+            std::task::Poll::Ready((*hi).into())
+        } else {
+            std::task::Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Pbkdf2;
+    use pbkdf2::pbkdf2_hmac_array;
+    use sha2::Sha256;
+
+    #[test]
+    fn works() {
+        let salt = b"sodium chloride";
+        let pass = b"Ne0n_!5_50_C007";
+
+        let mut job = Pbkdf2::start(pass, salt, 600000);
+        let hash = loop {
+            let std::task::Poll::Ready(hash) = job.turn() else {
+                continue;
+            };
+            break hash;
+        };
+
+        let expected = pbkdf2_hmac_array::<Sha256, 32>(pass, salt, 600000);
+        assert_eq!(hash, expected)
+    }
+}

--- a/proxy/src/scram/threadpool.rs
+++ b/proxy/src/scram/threadpool.rs
@@ -71,11 +71,9 @@ impl ThreadPool {
             let worker = Worker::new_fifo();
             threads.push(worker.stealer());
 
-            let seed = thread_rng().gen();
-
             let pool = Arc::clone(self);
             std::thread::spawn(move || {
-                let mut rng = SmallRng::seed_from_u64(seed);
+                let mut rng = SmallRng::from_entropy();
                 'wait: loop {
                     // wait for notification of work
                     {

--- a/proxy/src/scram/threadpool.rs
+++ b/proxy/src/scram/threadpool.rs
@@ -1,0 +1,232 @@
+//! Custom threadpool implementation for password hashing.
+//!
+//! Requirements:
+//! 1. Fairness per endpoint.
+//! 2. Yield support for high iteration counts.
+
+use std::sync::{Arc, OnceLock};
+
+use crossbeam_deque::{Injector, Stealer, Worker};
+use hmac::{
+    digest::{consts::U32, generic_array::GenericArray},
+    Hmac, Mac,
+};
+use parking_lot::{Condvar, Mutex};
+use rand::seq::SliceRandom;
+use rand::Rng;
+use sha2::Sha256;
+use tokio::sync::oneshot;
+
+pub struct ThreadPool {
+    queue: Injector<JobSpec>,
+    /// for work stealing
+    threads: OnceLock<Box<[Stealer<JobSpec>]>>,
+    /// for signals about work
+    condvar: Condvar,
+    /// for the condvar notification.
+    lock: Mutex<State>,
+}
+
+enum State {
+    Idle,
+    WorkAvailable,
+    Shutdown,
+}
+
+impl ThreadPool {
+    pub fn new() -> Self {
+        Self {
+            queue: Injector::new(),
+            threads: OnceLock::new(),
+            condvar: Condvar::new(),
+            lock: Mutex::new(State::Idle),
+        }
+    }
+
+    pub fn spawn_job(&self, pbkdf2: Pbkdf2) -> oneshot::Receiver<[u8; 32]> {
+        let (tx, rx) = oneshot::channel();
+
+        self.queue.push(JobSpec {
+            response: tx,
+            pbkdf2,
+        });
+
+        let mut lock = self.lock.lock();
+        *lock = State::WorkAvailable;
+        self.condvar.notify_one();
+
+        rx
+    }
+
+    pub fn shutdown(&self) {
+        let mut lock = self.lock.lock();
+        *lock = State::Shutdown;
+        self.condvar.notify_all();
+    }
+
+    pub fn spawn_workers<R: Rng + Default>(self: &Arc<Self>, workers: usize) {
+        let _guard = self.lock.lock();
+
+        let mut threads = Vec::with_capacity(workers);
+        for _ in 0..workers {
+            let worker = Worker::new_fifo();
+            threads.push(worker.stealer());
+
+            let pool = Arc::clone(self);
+            std::thread::spawn(move || {
+                let mut rng = R::default();
+                'wait: loop {
+                    // wait for notification of work
+                    {
+                        let mut lock = pool.lock.lock();
+                        loop {
+                            match *lock {
+                                State::Idle => pool.condvar.wait(&mut lock),
+                                State::WorkAvailable => break,
+                                State::Shutdown => {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+
+                    for i in 0.. {
+                        let mut job = match worker.pop() {
+                            Some(job) => job,
+                            None => 'job: {
+                                // try steal from the global queue
+                                loop {
+                                    match pool.queue.steal_batch_and_pop(&worker) {
+                                        crossbeam_deque::Steal::Success(job) => break 'job job,
+                                        crossbeam_deque::Steal::Retry => continue,
+                                        crossbeam_deque::Steal::Empty => break,
+                                    }
+                                }
+                                // try steal from a random worker queue
+                                loop {
+                                    let thread =
+                                        pool.threads.get().unwrap().choose(&mut rng).unwrap();
+                                    match thread.steal_batch_and_pop(&worker) {
+                                        crossbeam_deque::Steal::Success(job) => break 'job job,
+                                        crossbeam_deque::Steal::Retry => continue,
+                                        crossbeam_deque::Steal::Empty => continue 'wait,
+                                    }
+                                }
+                            }
+                        };
+
+                        match job.pbkdf2.turn() {
+                            std::task::Poll::Ready(result) => {
+                                let _ = job.response.send(result);
+                            }
+                            std::task::Poll::Pending => worker.push(job),
+                        }
+
+                        // if we get stuck with a few long lived jobs in the queue
+                        // it's better to try and steal from the queue too for fairness
+                        if i % 61 == 0 {
+                            let _ = pool.queue.steal_batch(&worker);
+                        }
+                    }
+                }
+            });
+        }
+
+        self.threads
+            .set(threads.into_boxed_slice())
+            .expect("spawn_workers should not be called multiple times");
+    }
+}
+
+impl Default for ThreadPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct JobSpec {
+    response: oneshot::Sender<[u8; 32]>,
+    pbkdf2: Pbkdf2,
+}
+
+pub struct Pbkdf2 {
+    hmac: Hmac<Sha256>,
+    prev: GenericArray<u8, U32>,
+    hi: GenericArray<u8, U32>,
+    iterations: u32,
+}
+
+// inspired from <https://github.com/neondatabase/rust-postgres/blob/20031d7a9ee1addeae6e0968e3899ae6bf01cee2/postgres-protocol/src/authentication/sasl.rs#L36-L61>
+impl Pbkdf2 {
+    pub fn start(str: &[u8], salt: &[u8], iterations: u32) -> Self {
+        let hmac =
+            Hmac::<Sha256>::new_from_slice(str).expect("HMAC is able to accept all key sizes");
+
+        let prev = hmac
+            .clone()
+            .chain_update(salt)
+            .chain_update(1u32.to_be_bytes())
+            .finalize()
+            .into_bytes();
+
+        Self {
+            hmac,
+            // one consumed for the hash above
+            iterations: iterations - 1,
+            hi: prev,
+            prev,
+        }
+    }
+
+    fn turn(&mut self) -> std::task::Poll<[u8; 32]> {
+        let Self {
+            hmac,
+            prev,
+            hi,
+            iterations,
+        } = self;
+
+        let n = (*iterations).clamp(0, 4096);
+        for _ in 0..n {
+            *prev = hmac.clone().chain_update(*prev).finalize().into_bytes();
+
+            for (hi, prev) in hi.iter_mut().zip(*prev) {
+                *hi ^= prev;
+            }
+        }
+
+        *iterations -= n;
+        if *iterations == 0 {
+            std::task::Poll::Ready((*hi).into())
+        } else {
+            std::task::Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rand::rngs::ThreadRng;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn hash_is_correct() {
+        let pool = Arc::new(ThreadPool::new());
+        pool.spawn_workers::<ThreadRng>(1);
+
+        let salt = [0x55; 32];
+        let actual = pool
+            .spawn_job(Pbkdf2::start(b"password", &salt, 4096))
+            .await
+            .unwrap();
+
+        let expected = [
+            10, 114, 73, 188, 140, 222, 196, 156, 214, 184, 79, 157, 119, 242, 16, 31, 53, 242,
+            178, 43, 95, 8, 225, 182, 122, 40, 219, 21, 89, 147, 64, 140,
+        ];
+        assert_eq!(actual, expected)
+    }
+}

--- a/proxy/src/scram/threadpool.rs
+++ b/proxy/src/scram/threadpool.rs
@@ -4,7 +4,10 @@
 //! 1. Fairness per endpoint.
 //! 2. Yield support for high iteration counts.
 
-use std::sync::{Arc, OnceLock};
+use std::{
+    hash::Hash,
+    sync::{Arc, OnceLock},
+};
 
 use crossbeam_deque::{Injector, Stealer, Worker};
 use hmac::{
@@ -13,9 +16,11 @@ use hmac::{
 };
 use parking_lot::{Condvar, Mutex};
 use rand::Rng;
-use rand::{rngs::SmallRng, seq::SliceRandom, thread_rng, SeedableRng};
+use rand::{rngs::SmallRng, seq::SliceRandom, SeedableRng};
 use sha2::Sha256;
 use tokio::sync::oneshot;
+
+use crate::intern::EndpointIdInt;
 
 pub struct ThreadPool {
     queue: Injector<JobSpec>,
@@ -42,12 +47,17 @@ impl ThreadPool {
         }
     }
 
-    pub fn spawn_job(&self, pbkdf2: Pbkdf2) -> oneshot::Receiver<[u8; 32]> {
+    pub fn spawn_job(
+        &self,
+        endpoint: EndpointIdInt,
+        pbkdf2: Pbkdf2,
+    ) -> oneshot::Receiver<[u8; 32]> {
         let (tx, rx) = oneshot::channel();
 
         self.queue.push(JobSpec {
             response: tx,
             pbkdf2,
+            endpoint,
         });
 
         let mut lock = self.lock.lock();
@@ -74,6 +84,18 @@ impl ThreadPool {
             let pool = Arc::clone(self);
             std::thread::spawn(move || {
                 let mut rng = SmallRng::from_entropy();
+
+                // used to determine whether we should temporarily skip tasks
+                // for fairness
+                let mut sketch = CountMinSketch::new(32, 8);
+
+                /// interval when we should steal from the global queue
+                /// so that tail latencies are managed appropriately
+                const STEAL_INTERVAL: usize = 61;
+
+                /// How often to reset the sketch values
+                const SKETCH_RESET_INTERVAL: usize = 1021;
+
                 'wait: loop {
                     // wait for notification of work
                     {
@@ -115,18 +137,38 @@ impl ThreadPool {
 
                         // receiver is closed, cancel the task
                         if !job.response.is_closed() {
-                            match job.pbkdf2.turn() {
-                                std::task::Poll::Ready(result) => {
-                                    let _ = job.response.send(result);
+                            let rate = sketch.inc(&job.endpoint);
+
+                            const P: f64 = 32.0;
+                            // probability decreases as rate increases.
+                            // lower probability, higher chance of being skipped
+                            // rate = 0    => probability = 100%
+                            // rate = 10   => probability = 92.7%
+                            // rate = 50   => probability = 78.6%
+                            // rate = 500  => probability = 55.2%
+                            // rate = 1021 => probability = 49.8%
+                            let probability = P.ln() / (P + rate as f64).ln();
+                            if rng.gen_bool(probability) {
+                                match job.pbkdf2.turn() {
+                                    std::task::Poll::Ready(result) => {
+                                        let _ = job.response.send(result);
+                                    }
+                                    std::task::Poll::Pending => worker.push(job),
                                 }
-                                std::task::Poll::Pending => worker.push(job),
+                            } else {
+                                // skip for now
+                                worker.push(job)
                             }
                         }
 
                         // if we get stuck with a few long lived jobs in the queue
                         // it's better to try and steal from the queue too for fairness
-                        if i % 61 == 0 {
+                        if i % STEAL_INTERVAL == 0 {
                             let _ = pool.queue.steal_batch(&worker);
+                        }
+
+                        if i % SKETCH_RESET_INTERVAL == 0 {
+                            sketch.reset();
                         }
                     }
                 }
@@ -139,6 +181,53 @@ impl ThreadPool {
     }
 }
 
+/// estimator of hash jobs per second.
+/// <https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch>
+struct CountMinSketch {
+    // one for each width
+    hashers: Vec<ahash::RandomState>,
+    width: usize,
+    depth: usize,
+    // buckets, width*depth
+    buckets: Vec<u64>,
+}
+
+impl CountMinSketch {
+    fn new(width: usize, depth: usize) -> Self {
+        Self {
+            hashers: (0..width).map(|_| ahash::RandomState::new()).collect(),
+            width,
+            depth,
+            buckets: vec![0; width * depth],
+        }
+    }
+
+    fn inc<T: Hash>(&mut self, t: &T) -> u64 {
+        let mut min = 0;
+        for w in 0..self.width {
+            let hash = self.hashers[w].hash_one(t) as usize;
+            let bucket = &mut self.buckets[w * self.depth + hash % self.depth];
+            *bucket = bucket.saturating_add(1);
+            min = std::cmp::min(min, *bucket);
+        }
+        min
+    }
+
+    // fn get<T: Hash>(&mut self, t: &T) -> u64 {
+    //     let mut min = 0;
+    //     for w in 0..self.width {
+    //         let hash = self.hashers[w].hash_one(t) as usize;
+    //         min = std::cmp::min(min, self.buckets[w * self.depth + hash % self.depth]);
+    //     }
+    //     min
+    // }
+
+    fn reset(&mut self) {
+        self.buckets.clear();
+        self.buckets.resize(self.width * self.depth, 0);
+    }
+}
+
 impl Default for ThreadPool {
     fn default() -> Self {
         Self::new()
@@ -148,6 +237,7 @@ impl Default for ThreadPool {
 struct JobSpec {
     response: oneshot::Sender<[u8; 32]>,
     pbkdf2: Pbkdf2,
+    endpoint: EndpointIdInt,
 }
 
 pub struct Pbkdf2 {
@@ -209,6 +299,8 @@ impl Pbkdf2 {
 mod tests {
     use std::sync::Arc;
 
+    use crate::EndpointId;
+
     use super::*;
 
     #[tokio::test]
@@ -216,9 +308,12 @@ mod tests {
         let pool = Arc::new(ThreadPool::new());
         pool.spawn_workers(1);
 
+        let ep = EndpointId::from("foo");
+        let ep = EndpointIdInt::from(ep);
+
         let salt = [0x55; 32];
         let actual = pool
-            .spawn_job(Pbkdf2::start(b"password", &salt, 4096))
+            .spawn_job(ep, Pbkdf2::start(b"password", &salt, 4096))
             .await
             .unwrap();
 

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     context::RequestMonitoring,
     error::{ErrorKind, ReportableError, UserFacingError},
+    intern::EndpointIdInt,
     proxy::{connect_compute::ConnectMechanism, retry::ShouldRetry},
     rate_limiter::EndpointRateLimiter,
     Host,
@@ -66,8 +67,14 @@ impl PoolingBackend {
                 return Err(AuthError::auth_failed(&*user_info.user));
             }
         };
-        let auth_outcome =
-            crate::auth::validate_password_and_exchange(&conn_info.password, secret).await?;
+        let ep = EndpointIdInt::from(&conn_info.user_info.endpoint);
+        let auth_outcome = crate::auth::validate_password_and_exchange(
+            &config.thread_pool,
+            ep,
+            &conn_info.password,
+            secret,
+        )
+        .await?;
         let res = match auth_outcome {
             crate::sasl::Outcome::Success(key) => {
                 info!("user successfully authenticated");

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+ahash = { version = "0.8" }
 anyhow = { version = "1", features = ["backtrace"] }
 aws-config = { version = "1", default-features = false, features = ["rustls", "sso"] }
 aws-runtime = { version = "1", default-features = false, features = ["event-stream", "http-02x", "sigv4a"] }
@@ -22,7 +23,6 @@ aws-smithy-http = { version = "0.60", default-features = false, features = ["eve
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.6", features = ["ws"] }
 base64 = { version = "0.21", features = ["alloc"] }
-base64ct = { version = "1", default-features = false, features = ["std"] }
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"] }
 clap = { version = "4", features = ["derive", "string"] }
@@ -85,6 +85,7 @@ zstd-safe = { version = "7", default-features = false, features = ["arrays", "le
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
 
 [build-dependencies]
+ahash = { version = "0.8" }
 anyhow = { version = "1", features = ["backtrace"] }
 bytes = { version = "1", features = ["serde"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -23,6 +23,7 @@ aws-smithy-http = { version = "0.60", default-features = false, features = ["eve
 aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 axum = { version = "0.6", features = ["ws"] }
 base64 = { version = "0.21", features = ["alloc"] }
+base64ct = { version = "1", default-features = false, features = ["std"] }
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"] }
 clap = { version = "4", features = ["derive", "string"] }


### PR DESCRIPTION
## Problem

Despite making password hashing async, it can still take time away from the network code.

## Summary of changes

Introduce a custom threadpool, inspired by rayon. Features:

### Fairness

Each task is tagged with it's endpoint ID. The more times we have seen the endpoint, the more likely we are to skip the task if it comes up in the queue. This is using a min-count-sketch estimator for the number of times we have seen the endpoint, resetting it every 1000+ steps.

Since tasks are immediately rescheduled if they do not complete, the worker could get stuck in a "always work available loop". To combat this, we check the global queue every 61 steps to ensure all tasks quickly get a worker assigned to them.

### Balanced

Using crossbeam_deque, like rayon does, we have workstealing out of the box. I've tested it a fair amount and it seems to balance the workload accordingly

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
