### PR TITLE
feat(pageserver): remove aux v1 keyspace if user fully switches to v2

### DIFF
--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -873,8 +873,12 @@ impl Timeline {
 
         result.add_key(CONTROLFILE_KEY);
         result.add_key(CHECKPOINT_KEY);
-        if self.get(AUX_FILES_KEY, lsn, ctx).await.is_ok() {
-            result.add_key(AUX_FILES_KEY);
+
+        // Remove v1 keyspace if the user has fully switched to v2.
+        if self.last_aux_file_policy.load() != Some(AuxFilePolicy::V2) {
+            if self.get(AUX_FILES_KEY, lsn, ctx).await.is_ok() {
+                result.add_key(AUX_FILES_KEY);
+            }
         }
 
         Ok((

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3970,7 +3970,7 @@ mod tests {
     use crate::DEFAULT_PG_VERSION;
     use bytes::{Bytes, BytesMut};
     use hex_literal::hex;
-    use pageserver_api::key::{AUX_KEY_PREFIX, NON_INHERITED_RANGE};
+    use pageserver_api::key::{AUX_FILES_KEY, AUX_KEY_PREFIX, NON_INHERITED_RANGE};
     use pageserver_api::keyspace::KeySpace;
     use pageserver_api::models::CompactionAlgorithm;
     use rand::{thread_rng, Rng};
@@ -5995,6 +5995,10 @@ mod tests {
             files.get("pg_logical/mappings/test3"),
             Some(&bytes::Bytes::from_static(b"last"))
         );
+
+        // Check if we are going to remove v1 aux files.
+        let (mut dense_keyspace, _) = tline.collect_keyspace(lsn, &ctx).await.unwrap();
+        assert!(dense_keyspace.remove_overlapping_with(&KeySpace::single(AUX_FILES_KEY..AUX_FILES_KEY.next())).is_empty());
     }
 
     #[tokio::test]

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -5996,7 +5996,7 @@ mod tests {
             Some(&bytes::Bytes::from_static(b"last"))
         );
 
-        // Check if we are going to remove v1 aux files.
+        // Check that we are going to remove v1 aux files.
         let (mut dense_keyspace, _) = tline.collect_keyspace(lsn, &ctx).await.unwrap();
         assert!(dense_keyspace.remove_overlapping_with(&KeySpace::single(AUX_FILES_KEY..AUX_FILES_KEY.next())).is_empty());
     }


### PR DESCRIPTION
## Problem

A follow-up on https://github.com/neondatabase/neon/issues/7462

If a user is switched to v2, their v1 data is no longer accessible, so we can remove them by not including the aux_file_key in the keyspace.

No need to merge it now in case we want to force switch some user back from v2, but I'd like to get an approval first so that we can merge it any time we want.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
