### PR TITLE
CI(promote-images): simplify & fix the job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -987,21 +987,21 @@ jobs:
                                                neondatabase/vm-compute-node-${version}:${{ needs.tag.outputs.build-tag }}
           done
 
-      - name: Add test tag to images
-        # if: github.ref_name == 'main'
+      - name: Add latest tag to images
+        if: github.ref_name == 'main'
         run: |
           for repo in neondatabase 369495373322.dkr.ecr.eu-central-1.amazonaws.com; do
-            docker buildx imagetools create -t $repo/neon:test \
+            docker buildx imagetools create -t $repo/neon:latest \
                                                $repo/neon:${{ needs.tag.outputs.build-tag }}
 
-            docker buildx imagetools create -t $repo/compute-tools:test \
+            docker buildx imagetools create -t $repo/compute-tools:latest \
                                                $repo/compute-tools:${{ needs.tag.outputs.build-tag }}
 
             for version in ${VERSIONS}; do
-              docker buildx imagetools create -t $repo/compute-node-${version}:test \
+              docker buildx imagetools create -t $repo/compute-node-${version}:latest \
                                                  $repo/compute-node-${version}:${{ needs.tag.outputs.build-tag }}
 
-              docker buildx imagetools create -t $repo/vm-compute-node-${version}:test \
+              docker buildx imagetools create -t $repo/vm-compute-node-${version}:latest \
                                                  $repo/vm-compute-node-${version}:${{ needs.tag.outputs.build-tag }}
             done
           done


### PR DESCRIPTION
## Problem

Currently, `latest` tag is added to the images in several cases: 
```
github.ref_name == 'main' || github.ref_name == 'release' || github.ref_name == 'release-proxy'
```

This leads to a race; the `latest` tag jumps back and forth depending on the branch that has built images.

## Summary of changes
- Do not push `latest` images to prod ECR (we don't use it)
- Use `docker buildx imagetools` instead of `crane` for tagging images
- Unify `vm-compute-node-image` job with others and use dockerhub as a first source for images (sync images with ECR)
- Tag images with `latest` only for commits in `main`

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
