### PR TITLE
feat(rtc): maintain dirty and uploaded IndexPart

### DIFF
--- a/pageserver/ctl/src/index_part.rs
+++ b/pageserver/ctl/src/index_part.rs
@@ -26,7 +26,7 @@ pub(crate) async fn main(cmd: &IndexPartCmd) -> anyhow::Result<()> {
 
             let output = Output {
                 layer_metadata: &des.layer_metadata,
-                disk_consistent_lsn: des.get_disk_consistent_lsn(),
+                disk_consistent_lsn: des.metadata.disk_consistent_lsn(),
                 timeline_metadata: &des.metadata,
             };
 

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -2185,7 +2185,7 @@ async fn tenant_scan_remote_handler(
             {
                 Ok((index_part, index_generation)) => {
                     tracing::info!("Found timeline {tenant_shard_id}/{timeline_id} metadata (gen {index_generation:?}, {} layers, {} consistent LSN)",
-                        index_part.layer_metadata.len(), index_part.get_disk_consistent_lsn());
+                        index_part.layer_metadata.len(), index_part.metadata.disk_consistent_lsn());
                     generation = std::cmp::max(generation, index_generation);
                 }
                 Err(DownloadError::NotFound) => {

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -2172,12 +2172,14 @@ impl Tenant {
             };
 
             for child_shard in child_shards {
+                let serialized = serde_json::to_vec(&index_part)?;
+                let serialized = bytes::Bytes::from(serialized);
                 upload_index_part(
                     &self.remote_storage,
                     child_shard,
                     &timeline.timeline_id,
                     self.generation,
-                    &index_part,
+                    serialized,
                     &self.cancel,
                 )
                 .await?;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -2172,14 +2172,12 @@ impl Tenant {
             };
 
             for child_shard in child_shards {
-                let serialized = serde_json::to_vec(&index_part)?;
-                let serialized = bytes::Bytes::from(serialized);
                 upload_index_part(
                     &self.remote_storage,
                     child_shard,
                     &timeline.timeline_id,
                     self.generation,
-                    serialized,
+                    &index_part,
                     &self.cancel,
                 )
                 .await?;

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -647,11 +647,13 @@ impl RemoteTimelineClient {
         self: &Arc<Self>,
         upload_queue: &mut UploadQueueInitialized,
     ) -> anyhow::Result<()> {
+        let disk_consistent_lsn = upload_queue.dirty.metadata.disk_consistent_lsn();
+        // fix up the duplicated field
+        upload_queue.dirty.disk_consistent_lsn = disk_consistent_lsn;
+
         let serialized =
             serde_json::to_vec(&upload_queue.dirty).context("serialize index_part.json")?;
         let serialized = bytes::Bytes::from(serialized);
-
-        let disk_consistent_lsn = upload_queue.dirty.metadata.disk_consistent_lsn();
 
         let index_part = &upload_queue.dirty;
 

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -114,8 +114,7 @@
 //!
 //! # Completion
 //!
-//! Once an operation has completed, we update
-//! [`UploadQueueInitialized::projected_remote_consistent_lsn`] immediately,
+//! Once an operation has completed, we update [`UploadQueueInitialized::clean`] immediately,
 //! and submit a request through the DeletionQueue to update
 //! [`UploadQueueInitialized::visible_remote_consistent_lsn`] after it has
 //! validated that our generation is not stale.  It is this visible value

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -91,8 +91,7 @@
 //!
 //! The *actual* remote state lags behind the *desired* remote state while
 //! there are in-flight operations.
-//! We keep track of the desired remote state in
-//! [`UploadQueueInitialized::latest_files`] and [`UploadQueueInitialized::latest_metadata`].
+//! We keep track of the desired remote state in [`UploadQueueInitialized::dirty`].
 //! It is initialized based on the [`IndexPart`] that was passed during init
 //! and updated with every `schedule_*` function call.
 //! All this is necessary necessary to compute the future [`IndexPart`]s

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1730,7 +1730,6 @@ impl RemoteTimelineClient {
                 }
                 UploadOp::UploadMetadata { ref uploaded } => {
                     upload_queue.num_inprogress_metadata_uploads -= 1;
-                    // XXX monotonicity check?
 
                     let last_updater = upload_queue.clean.1;
                     let is_later = last_updater.is_some_and(|task_id| task_id < task.task_id);

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1734,8 +1734,9 @@ impl RemoteTimelineClient {
 
                     let last_updater = upload_queue.clean.1;
                     let is_later = last_updater.is_some_and(|task_id| task_id < task.task_id);
+                    let monotone = is_later || last_updater.is_none();
 
-                    if is_later || last_updater.is_none() {
+                    if monotone {
                         // not taking ownership is wasteful
                         upload_queue.clean.0.clone_from(uploaded);
                         upload_queue.clean.1 = Some(task.task_id);

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1731,6 +1731,8 @@ impl RemoteTimelineClient {
                 UploadOp::UploadMetadata { ref uploaded } => {
                     upload_queue.num_inprogress_metadata_uploads -= 1;
 
+                    // the task id is reused as a monotonicity check for storing the "clean"
+                    // IndexPart.
                     let last_updater = upload_queue.clean.1;
                     let is_later = last_updater.is_some_and(|task_id| task_id < task.task_id);
                     let monotone = is_later || last_updater.is_none();

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -650,6 +650,11 @@ impl RemoteTimelineClient {
         // fix up the duplicated field
         upload_queue.dirty.disk_consistent_lsn = disk_consistent_lsn;
 
+        // make sure it serializes before doing it in perform_upload_task so that it doesn't
+        // look like a retryable error
+        let void = std::io::sink();
+        serde_json::to_writer(void, &upload_queue.dirty).context("serialize index_part.json")?;
+
         let index_part = &upload_queue.dirty;
 
         info!(

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -415,6 +415,7 @@ impl RemoteTimelineClient {
         Ok(())
     }
 
+    /// Returns `None` if nothing is yet uplodaded, `Some(disk_consistent_lsn)` otherwise.
     pub fn remote_consistent_lsn_projected(&self) -> Option<Lsn> {
         match &mut *self.upload_queue.lock().unwrap() {
             UploadQueue::Uninitialized => None,
@@ -1744,8 +1745,6 @@ impl RemoteTimelineClient {
 
                         let lsn = upload_queue.clean.0.metadata.disk_consistent_lsn();
 
-                        // FIXME: read this through clean
-                        upload_queue.projected_remote_consistent_lsn = Some(lsn);
                         if self.generation.is_none() {
                             // Legacy mode: skip validating generation
                             upload_queue.visible_remote_consistent_lsn.store(lsn);
@@ -1894,7 +1893,6 @@ impl RemoteTimelineClient {
                         dirty: initialized.dirty.clone(),
                         clean: initialized.clean.clone(),
                         latest_files_changes_since_metadata_upload_scheduled: 0,
-                        projected_remote_consistent_lsn: None,
                         visible_remote_consistent_lsn: initialized
                             .visible_remote_consistent_lsn
                             .clone(),

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1756,7 +1756,17 @@ impl RemoteTimelineClient {
                     } else {
                         // do we want to log? this is perfectly valid, since the ordering in
                         // which completing tasks get to lock the upload_queue is not the task
-                        // spawning order.
+                        // spawning order. log because it is very rare situation requiring two
+                        // consecutive index uploads (like we do with gc).
+
+                        // keeping this warn to see if it's immediatedly triggered in regress tests
+                        tracing::warn!(
+                            prev=?last_updater,
+                            now=?task.task_id,
+                            prev_lsn=%upload_queue.clean.0.metadata.disk_consistent_lsn(),
+                            now_lsn=%uploaded.metadata.disk_consistent_lsn(),
+                            "monotonicity check failed"
+                        );
                         None
                     }
                 }

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -41,7 +41,7 @@ pub struct IndexPart {
     // 'disk_consistent_lsn' is a copy of the 'disk_consistent_lsn' in the metadata.
     // It's duplicated for convenience when reading the serialized structure, but is
     // private because internally we would read from metadata instead.
-    disk_consistent_lsn: Lsn,
+    pub(super) disk_consistent_lsn: Lsn,
 
     #[serde(rename = "metadata_bytes")]
     pub metadata: TimelineMetadata,

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -100,6 +100,18 @@ impl IndexPart {
         }
     }
 
+    pub(crate) fn empty(metadata: TimelineMetadata) -> Self {
+        IndexPart {
+            version: Self::LATEST_VERSION,
+            layer_metadata: Default::default(),
+            disk_consistent_lsn: metadata.disk_consistent_lsn(),
+            metadata,
+            deleted_at: None,
+            lineage: Default::default(),
+            last_aux_file_policy: None,
+        }
+    }
+
     pub fn get_version(&self) -> usize {
         self.version
     }
@@ -120,14 +132,7 @@ impl IndexPart {
 
     #[cfg(test)]
     pub(crate) fn example() -> Self {
-        let example_metadata = TimelineMetadata::example();
-        Self::new(
-            &HashMap::new(),
-            example_metadata.disk_consistent_lsn(),
-            example_metadata,
-            Default::default(),
-            Some(AuxFilePolicy::V1),
-        )
+        Self::empty(TimelineMetadata::example())
     }
 
     pub(crate) fn last_aux_file_policy(&self) -> Option<AuxFilePolicy> {

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -97,7 +97,7 @@ impl IndexPart {
 
     /// If you want this under normal operations, read it from self.metadata:
     /// this method is just for the scrubber to use when validating an index.
-    pub fn get_disk_consistent_lsn(&self) -> Lsn {
+    pub fn duplicated_disk_consistent_lsn(&self) -> Lsn {
         self.disk_consistent_lsn
     }
 

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -201,8 +201,13 @@ impl Lineage {
             Some((branchpoint.0, branchpoint.1, chrono::Utc::now().naive_utc()));
     }
 
-    pub(crate) fn original_ancestor_lsn(&self) -> Option<Lsn> {
-        self.original_ancestor.map(|(_, lsn, _)| lsn)
+    /// The queried lsn is most likely the basebackup lsn, and this answers question "is it allowed
+    /// to start a read/write primary at this lsn".
+    ///
+    /// Returns true if the Lsn was previously our branch point.
+    pub(crate) fn is_previous_ancestor_lsn(&self, lsn: Lsn) -> bool {
+        self.original_ancestor
+            .is_some_and(|(_, ancestor_lsn, _)| ancestor_lsn == lsn)
     }
 }
 

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -11,7 +11,6 @@ use utils::id::TimelineId;
 
 use crate::tenant::metadata::TimelineMetadata;
 use crate::tenant::storage_layer::LayerName;
-use crate::tenant::upload_queue::UploadQueueInitialized;
 use crate::tenant::Generation;
 use pageserver_api::shard::ShardIndex;
 
@@ -80,26 +79,6 @@ impl IndexPart {
 
     pub const FILE_NAME: &'static str = "index_part.json";
 
-    fn new(
-        layers_and_metadata: &HashMap<LayerName, LayerFileMetadata>,
-        disk_consistent_lsn: Lsn,
-        metadata: TimelineMetadata,
-        lineage: Lineage,
-        last_aux_file_policy: Option<AuxFilePolicy>,
-    ) -> Self {
-        let layer_metadata = layers_and_metadata.clone();
-
-        Self {
-            version: Self::LATEST_VERSION,
-            layer_metadata,
-            disk_consistent_lsn,
-            metadata,
-            deleted_at: None,
-            lineage,
-            last_aux_file_policy,
-        }
-    }
-
     pub(crate) fn empty(metadata: TimelineMetadata) -> Self {
         IndexPart {
             version: Self::LATEST_VERSION,
@@ -137,22 +116,6 @@ impl IndexPart {
 
     pub(crate) fn last_aux_file_policy(&self) -> Option<AuxFilePolicy> {
         self.last_aux_file_policy
-    }
-}
-
-impl From<&UploadQueueInitialized> for IndexPart {
-    fn from(uq: &UploadQueueInitialized) -> Self {
-        let disk_consistent_lsn = uq.latest_metadata.disk_consistent_lsn();
-        let metadata = uq.latest_metadata.clone();
-        let lineage = uq.latest_lineage.clone();
-
-        Self::new(
-            &uq.latest_files,
-            disk_consistent_lsn,
-            metadata,
-            lineage,
-            uq.last_aux_file_policy,
-        )
     }
 }
 

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -201,14 +201,8 @@ impl Lineage {
             Some((branchpoint.0, branchpoint.1, chrono::Utc::now().naive_utc()));
     }
 
-    /// The queried lsn is most likely the basebackup lsn, and this answers question "is it allowed
-    /// to start a read/write primary at this lsn".
-    ///
-    /// Returns true if the Lsn was previously a branch point.
-    pub(crate) fn is_previous_ancestor_lsn(&self, lsn: Lsn) -> bool {
-        self.original_ancestor
-            .as_ref()
-            .is_some_and(|(_, ancestor_lsn, _)| lsn == *ancestor_lsn)
+    pub(crate) fn original_ancestor_lsn(&self) -> Option<Lsn> {
+        self.original_ancestor.map(|(_, lsn, _)| lsn)
     }
 }
 

--- a/pageserver/src/tenant/remote_timeline_client/upload.rs
+++ b/pageserver/src/tenant/remote_timeline_client/upload.rs
@@ -1,6 +1,7 @@
 //! Helper functions to upload files to remote storage with a RemoteStorage
 
 use anyhow::{bail, Context};
+use bytes::Bytes;
 use camino::Utf8Path;
 use fail::fail_point;
 use pageserver_api::shard::TenantShardId;
@@ -13,8 +14,7 @@ use utils::{backoff, pausable_failpoint};
 
 use super::Generation;
 use crate::tenant::remote_timeline_client::{
-    index::IndexPart, remote_index_path, remote_initdb_archive_path,
-    remote_initdb_preserved_archive_path,
+    remote_index_path, remote_initdb_archive_path, remote_initdb_preserved_archive_path,
 };
 use remote_storage::{GenericRemoteStorage, RemotePath, TimeTravelError};
 use utils::id::{TenantId, TimelineId};
@@ -27,7 +27,7 @@ pub(crate) async fn upload_index_part<'a>(
     tenant_shard_id: &TenantShardId,
     timeline_id: &TimelineId,
     generation: Generation,
-    index_part: &'a IndexPart,
+    index_part: Bytes,
     cancel: &CancellationToken,
 ) -> anyhow::Result<()> {
     tracing::trace!("uploading new index part");
@@ -37,16 +37,12 @@ pub(crate) async fn upload_index_part<'a>(
     });
     pausable_failpoint!("before-upload-index-pausable");
 
-    let index_part_bytes = index_part
-        .to_s3_bytes()
-        .context("serialize index part file into bytes")?;
-    let index_part_size = index_part_bytes.len();
-    let index_part_bytes = bytes::Bytes::from(index_part_bytes);
+    let index_part_size = index_part.len();
 
     let remote_path = remote_index_path(tenant_shard_id, timeline_id, generation);
     storage
         .upload_storage_object(
-            futures::stream::once(futures::future::ready(Ok(index_part_bytes))),
+            futures::stream::once(futures::future::ready(Ok(index_part))),
             index_part_size,
             &remote_path,
             cancel,

--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -64,6 +64,9 @@ pub(crate) struct UploadQueueInitialized {
     pub(crate) projected_remote_consistent_lsn: Option<Lsn>,
     pub(crate) visible_remote_consistent_lsn: Arc<AtomicLsn>,
 
+    /// For timelines detached from their ancestor, this was their original `ancestor_lsn`.
+    pub(crate) original_ancestor_lsn: Option<Lsn>,
+
     // Breakdown of different kinds of tasks currently in-progress
     pub(crate) num_inprogress_layer_uploads: usize,
     pub(crate) num_inprogress_metadata_uploads: usize,
@@ -168,6 +171,7 @@ impl UploadQueue {
             latest_files_changes_since_metadata_upload_scheduled: 0,
             projected_remote_consistent_lsn: None,
             visible_remote_consistent_lsn: Arc::new(AtomicLsn::new(0)),
+            original_ancestor_lsn: None,
             // what follows are boring default initializations
             task_counter: 0,
             num_inprogress_layer_uploads: 0,
@@ -208,6 +212,7 @@ impl UploadQueue {
             visible_remote_consistent_lsn: Arc::new(
                 index_part.metadata.disk_consistent_lsn().into(),
             ),
+            original_ancestor_lsn: index_part.lineage.original_ancestor_lsn(),
             // what follows are boring default initializations
             task_counter: 0,
             num_inprogress_layer_uploads: 0,
@@ -280,6 +285,7 @@ pub(crate) enum UploadOp {
         serialized: bytes::Bytes,
         mention_having_future_layers: bool,
         uploaded_remote_physical_size: u64,
+        original_ancestor_lsn: Option<Lsn>,
         disk_consistent_lsn: Lsn,
     },
 

--- a/s3_scrubber/src/checks.rs
+++ b/s3_scrubber/src/checks.rs
@@ -93,12 +93,12 @@ pub(crate) fn branch_cleanup_and_check_errors(
                     }
 
                     if index_part.metadata.disk_consistent_lsn()
-                        != index_part.get_disk_consistent_lsn()
+                        != index_part.duplicated_disk_consistent_lsn()
                     {
                         result.errors.push(format!(
                             "Mismatching disk_consistent_lsn in TimelineMetadata ({}) and in the index_part ({})",
                             index_part.metadata.disk_consistent_lsn(),
-                            index_part.get_disk_consistent_lsn(),
+                            index_part.duplicated_disk_consistent_lsn(),
                         ))
                     }
 


### PR DESCRIPTION
RemoteTimelineClient maintains a copy of "next IndexPart" as a number of fields which are like an IndexPart but this is not immediately obvious. Instead of multiple fields, maintain a `dirty` ("next IndexPart") and `clean` ("uploaded IndexPart") fields.

Additional cleanup:
- rename `IndexPart::disk_consistent_lsn` accessor `duplicated_disk_consistent_lsn`
    - no one except scrubber should be looking at it, even scrubber is a stretch
    - remove usage elsewhere (pagectl used by tests, metadata scan endpoint)
- serialize index part *before* the index upload operation
    - avoid upload operation being retried because of serialization error
    - serialization error is fatal anyway for timeline -- it can only make transient local progress after that, at least the error is bubbled up now
- gather exploded IndexPart fields into single actual `UploadQueueInitialized::dirty` of which the uploaded snapshot is serialized
- implement the long wished monotonicity check with the `clean` IndexPart with an assertion which is not expected to fire

Continued work from #7860 towards next step of #6994.