### PR TITLE
Refactor PageServerHandler::process_query parsing

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1599,16 +1599,14 @@ where
                 None
             };
 
-            let gzip = if let Some(third_param) = params.get(3) {
-                if *third_param == "--gzip" {
-                    true
-                } else {
+            let gzip = match params.get(3) {
+                Some(&"--gzip") => true,
+                None => false,
+                Some(third_param) => {
                     return Err(QueryError::Other(anyhow::anyhow!(
                         "Parameter in position 3 unknown {third_param}",
-                    )));
+                    )))
                 }
-            } else {
-                false
             };
 
             let metric_recording = metrics::BASEBACKUP_QUERY_TIME.start_recording(&ctx);

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1593,7 +1593,7 @@ where
             let lsn = if let Some(lsn_str) = params.get(2) {
                 Some(
                     Lsn::from_str(lsn_str)
-                        .with_context(|| format!("Failed to parse Lsn from {}", params[2]))?,
+                        .with_context(|| format!("Failed to parse Lsn from {lsn_str}"))?,
                 )
             } else {
                 None
@@ -1694,7 +1694,7 @@ where
             let lsn = if let Some(lsn_str) = params.get(2) {
                 Some(
                     Lsn::from_str(lsn_str)
-                        .with_context(|| format!("Failed to parse Lsn from {}", params[2]))?,
+                        .with_context(|| format!("Failed to parse Lsn from {lsn_str}"))?,
                 )
             } else {
                 None
@@ -1702,7 +1702,7 @@ where
             let prev_lsn = if let Some(prev_lsn_str) = params.get(3) {
                 Some(
                     Lsn::from_str(prev_lsn_str)
-                        .with_context(|| format!("Failed to parse Lsn from {}", params[3]))?,
+                        .with_context(|| format!("Failed to parse Lsn from {prev_lsn_str}"))?,
                 )
             } else {
                 None

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1593,22 +1593,21 @@ where
 
             self.check_permission(Some(tenant_id))?;
 
-            let lsn = if params.len() >= 3 {
+            let lsn = if let Some(lsn_str) = params.get(2) {
                 Some(
-                    Lsn::from_str(params[2])
+                    Lsn::from_str(lsn_str)
                         .with_context(|| format!("Failed to parse Lsn from {}", params[2]))?,
                 )
             } else {
                 None
             };
 
-            let gzip = if params.len() >= 4 {
-                if params[3] == "--gzip" {
+            let gzip = if let Some(third_param) = params.get(3) {
+                if *third_param == "--gzip" {
                     true
                 } else {
                     return Err(QueryError::Other(anyhow::anyhow!(
-                        "Parameter in position 3 unknown {}",
-                        params[3],
+                        "Parameter in position 3 unknown {third_param}",
                     )));
                 }
             } else {
@@ -1699,17 +1698,17 @@ where
                 .record("timeline_id", field::display(timeline_id));
 
             // The caller is responsible for providing correct lsn and prev_lsn.
-            let lsn = if params.len() > 2 {
+            let lsn = if let Some(lsn_str) = params.get(2) {
                 Some(
-                    Lsn::from_str(params[2])
+                    Lsn::from_str(lsn_str)
                         .with_context(|| format!("Failed to parse Lsn from {}", params[2]))?,
                 )
             } else {
                 None
             };
-            let prev_lsn = if params.len() > 3 {
+            let prev_lsn = if let Some(prev_lsn_str) = params.get(3) {
                 Some(
-                    Lsn::from_str(params[3])
+                    Lsn::from_str(prev_lsn_str)
                         .with_context(|| format!("Failed to parse Lsn from {}", params[3]))?,
                 )
             } else {


### PR DESCRIPTION
In the process_query function in page_service.rs there was some redundant duplication. Remove it and create a vector of whitespace separated paths at the start and then use `slice::strip_prefix`. Only use `starts_with` in the places with multiple whitespace separated parameters: here we want to preserve grep/rg ability.

Followup of #7815, requested in https://github.com/neondatabase/neon/pull/7815#pullrequestreview-2068835674