### PR TITLE
fix(Layer): carry gate until eviction is complete

### DIFF
--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1333,7 +1333,7 @@ impl LayerInner {
 
         is_good_to_continue(&rx.borrow_and_update())?;
 
-        let Ok(_gate) = timeline.gate.enter() else {
+        let Ok(gate) = timeline.gate.enter() else {
             return Err(EvictionCancelled::TimelineGone);
         };
 
@@ -1420,6 +1420,7 @@ impl LayerInner {
         // reads. We will need to add cancellation for that if necessary.
         Self::spawn_blocking(move || {
             let _span = span.entered();
+            let _gate = gate;
 
             let res = self.evict_blocking(&timeline, &permit);
 


### PR DESCRIPTION
the gate was accidentially being dropped before the final blocking phase, possibly explaining the resident physical size global problems during deletions.

it could had caused more harm as well, but the path is not actively being tested because cplane no longer puts locationconfigs with higher generation number during normal operation which prompted the last wave of fixes.

Cc: #7341.