### PR TITLE
Bump vm-builder v0.28.1 -> v0.29.3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -934,7 +934,7 @@ jobs:
       matrix:
         version: [ v14, v15, v16 ]
     env:
-      VM_BUILDER_VERSION: v0.28.1
+      VM_BUILDER_VERSION: v0.29.3
 
     steps:
       - name: Checkout


### PR DESCRIPTION
One change:
runner: allow coredump collection (#931)

