### PR TITLE
pageserver: respect cancellation token while streaming S3 response bodies

### DIFF
--- a/pageserver/src/tenant/remote_timeline_client/download.rs
+++ b/pageserver/src/tenant/remote_timeline_client/download.rs
@@ -208,6 +208,7 @@ async fn download_object<'a>(
                         BytesMut::with_capacity(super::BUFFER_SIZE),
                     );
 
+
                     // Cancellation: if our cancellation token fires here, we will return an error and leave
                     // an inccomplete download on disk.  Callers are responsible for cleaning that up: for example
                     // download_layer_file calls this function with a temporary path, so it is safe to leak that
@@ -219,15 +220,13 @@ async fn download_object<'a>(
                             },
                             next = futures::StreamExt::next(&mut download.download_stream) => {
                                 let chunk = match next {
-                                    None => {break;},
-                                    Some(Err(e)) =>return Err(e.into()),
+                                    None => break,
+                                    Some(Err(e)) => return Err(e.into()),
                                     Some(Ok(chunk)) => chunk
                                 };
 
-                            buffered
-                                .write_buffered(tokio_epoll_uring::BoundedBuf::slice_full(chunk), ctx)
-                                .await?;
-                                }
+                                buffered.write_buffered(tokio_epoll_uring::BoundedBuf::slice_full(chunk), ctx).await?;
+                            }
                         }
                     }
 

--- a/pageserver/src/tenant/secondary/downloader.rs
+++ b/pageserver/src/tenant/secondary/downloader.rs
@@ -414,7 +414,7 @@ impl JobGenerator<PendingDownload, RunningDownload, CompleteDownload, DownloadCo
                     tracing::warn!("Insufficient space while downloading.  Will retry later.");
                 }
                 Err(UpdateError::Cancelled) => {
-                    tracing::debug!("Shut down while downloading");
+                    tracing::info!("Shut down while downloading");
                 },
                 Err(UpdateError::Deserialize(e)) => {
                     tracing::error!("Corrupt content while downloading tenant: {e}");
@@ -942,6 +942,10 @@ impl<'a> TenantDownloader<'a> {
 
             let mut result_stream = futures::stream::iter(chunk).buffered(concurrency);
             let mut result_stream = std::pin::pin!(result_stream);
+
+            // Cancellation: we do _not_ check cancellation token here, because if we dropped these futs we might leave
+            // background I/O running to the timeline directory.  Instead, we rely on `download_layer` to properly respect
+            // cancellation, and run all these futures to completion.
             while let Some(result) = result_stream.next().await {
                 match result {
                     Err(e) => return Err(e),


### PR DESCRIPTION
## Problem

Hunting for possible causes of hangs in secondary downloads and timeline shutdown.

Related: https://github.com/neondatabase/cloud/issues/13576

## Summary of changes

- In `download_object`, whereas we previously checked for cancellation during the initial S3 request phase, we now also check for cancellation while streaming the response body.
- In secondary downloads, upgrade the message on cancellations during downloads from debug to info, to aid debugging, and add a comment explaining why we don't explicitly check the cancellation token when iterating through download futures.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
