### PR TITLE
feat(pageserver): support multiple key ranges for image initial flush path

### DIFF
--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -166,7 +166,7 @@ impl LayerManager {
     /// Flush a frozen layer and add the written delta layer to the layer map.
     pub(crate) fn finish_flush_l0_layer(
         &mut self,
-        delta_layer: Option<&ResidentLayer>,
+        delta_layers: &[ResidentLayer],
         frozen_layer_for_check: &Arc<InMemoryLayer>,
         metrics: &TimelineMetrics,
     ) {
@@ -181,10 +181,12 @@ impl LayerManager {
         // layer to disk at the same time, that would not work.
         assert_eq!(Arc::as_ptr(&inmem), Arc::as_ptr(frozen_layer_for_check));
 
-        if let Some(l) = delta_layer {
+        if !delta_layers.is_empty() {
             let mut updates = self.layer_map.batch_update();
-            Self::insert_historic_layer(l.as_ref().clone(), &mut updates, &mut self.layer_fmgr);
-            metrics.record_new_file_metrics(l.layer_desc().file_size);
+            for l in delta_layers {
+                Self::insert_historic_layer(l.as_ref().clone(), &mut updates, &mut self.layer_fmgr);
+                metrics.record_new_file_metrics(l.layer_desc().file_size);
+            }
             updates.flush();
         }
     }


### PR DESCRIPTION
## Problem

We have an assertion to ensure there is only one partition for metadata keys. This is not true after https://github.com/neondatabase/neon/pull/7099. This pull request makes it possible to create delta files on this flush path.

An alternative is to create a single delta layer for all metadata keys, or support initial image creation for metadata keys. Still thinking about what is the best way to do that. This is easy to change in the future, so we don't need to decide it now.

Note that if `create_image_layer = false`, it goes into the normal delta flush path, and only one single delta file is created for all keys.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
