### PR TITLE
 test(pageserver): quantify compaction outcome 

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -18,7 +18,6 @@ use hyper::header;
 use hyper::StatusCode;
 use hyper::{Body, Request, Response, Uri};
 use metrics::launch_timestamp::LaunchTimestamp;
-use pageserver_api::key::Key;
 use pageserver_api::models::AuxFilePolicy;
 use pageserver_api::models::IngestAuxFilesRequest;
 use pageserver_api::models::ListAuxFilesRequest;

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -2,10 +2,8 @@
 //! Management HTTP API
 //!
 use std::cmp::Reverse;
-use std::collections::BTreeSet;
 use std::collections::BinaryHeap;
 use std::collections::HashMap;
-use std::ops::Range;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -2440,83 +2438,8 @@ async fn perf_info(
         active_timeline_of_active_tenant(&state.tenant_manager, tenant_shard_id, timeline_id)
             .await?;
 
-    // First, collect all split points of the layers.
-    let mut split_points = BTreeSet::new();
-    let mut delta_ranges = Vec::new();
-    let mut image_ranges = Vec::new();
+    let result = timeline.perf_info().await;
 
-    let all_layer_files = {
-        let guard = timeline.layers.read().await;
-        guard.all_persistent_layers()
-    };
-    let lsn = timeline.get_last_record_lsn();
-
-    for key in all_layer_files {
-        split_points.insert(key.key_range.start);
-        split_points.insert(key.key_range.end);
-        if key.is_delta {
-            delta_ranges.push((key.key_range.clone(), key.lsn_range.clone()));
-        } else {
-            image_ranges.push((key.key_range.clone(), key.lsn_range.start));
-        }
-    }
-
-    // For each split range, compute the estimated read amplification.
-    let split_points = split_points.into_iter().collect::<Vec<_>>();
-
-    #[derive(serde::Serialize)]
-    struct RangeAnalysis {
-        start: String,
-        end: String,
-        has_image: bool,
-        num_of_deltas_above_image: usize,
-        total_num_of_deltas: usize,
-    }
-
-    let mut result = Vec::new();
-
-    for i in 0..(split_points.len() - 1) {
-        let start = split_points[i];
-        let end = split_points[i + 1];
-        // Find the latest image layer that contains the information
-        let mut maybe_image_layers = image_ranges
-            .iter()
-            .filter(|(key_range, img_lsn)| key_range.contains(&start) && img_lsn <= &lsn)
-            .cloned()
-            .collect::<Vec<_>>();
-        maybe_image_layers.sort_by(|a, b| a.1.cmp(&b.1));
-        let image_layer = maybe_image_layers.last().cloned();
-        let lsn_filter_start = image_layer
-            .as_ref()
-            .map(|(_, lsn)| *lsn)
-            .unwrap_or(Lsn::INVALID);
-
-        fn overlaps_with(lsn_range_a: &Range<Lsn>, lsn_range_b: &Range<Lsn>) -> bool {
-            !(lsn_range_a.end <= lsn_range_b.start || lsn_range_a.start >= lsn_range_b.end)
-        }
-
-        let maybe_delta_layers = delta_ranges
-            .iter()
-            .filter(|(key_range, lsn_range)| {
-                key_range.contains(&start) && overlaps_with(&(lsn_filter_start..lsn), lsn_range)
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-
-        let pitr_delta_layers = delta_ranges
-            .iter()
-            .filter(|(key_range, _)| key_range.contains(&start))
-            .cloned()
-            .collect::<Vec<_>>();
-
-        result.push(RangeAnalysis {
-            start: start.to_string(),
-            end: end.to_string(),
-            has_image: image_layer.is_some(),
-            num_of_deltas_above_image: maybe_delta_layers.len(),
-            total_num_of_deltas: pitr_delta_layers.len(),
-        });
-    }
     json_response(StatusCode::OK, result)
 }
 

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -2452,13 +2452,11 @@ async fn perf_info(
     let lsn = timeline.get_last_record_lsn();
 
     for key in all_layer_files {
+        split_points.insert(key.key_range.start);
+        split_points.insert(key.key_range.end);
         if key.is_delta {
-            split_points.insert(key.key_range.start);
-            split_points.insert(key.key_range.end);
             delta_ranges.push((key.key_range.clone(), key.lsn_range.clone()));
         } else {
-            split_points.insert(key.key_range.start);
-            split_points.insert(key.key_range.end);
             image_ranges.push((key.key_range.clone(), key.lsn_range.start));
         }
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1,3 +1,4 @@
+pub(crate) mod analysis;
 mod compaction;
 pub mod delete;
 pub(crate) mod detach_ancestor;

--- a/pageserver/src/tenant/timeline/analysis.rs
+++ b/pageserver/src/tenant/timeline/analysis.rs
@@ -1,0 +1,90 @@
+use std::{collections::BTreeSet, ops::Range};
+
+use utils::lsn::Lsn;
+
+use super::Timeline;
+
+#[derive(serde::Serialize)]
+pub(crate) struct RangeAnalysis {
+    start: String,
+    end: String,
+    has_image: bool,
+    num_of_deltas_above_image: usize,
+    total_num_of_deltas: usize,
+}
+
+impl Timeline {
+    pub(crate) async fn perf_info(&self) -> Vec<RangeAnalysis> {
+        // First, collect all split points of the layers.
+        let mut split_points = BTreeSet::new();
+        let mut delta_ranges = Vec::new();
+        let mut image_ranges = Vec::new();
+
+        let all_layer_files = {
+            let guard = self.layers.read().await;
+            guard.all_persistent_layers()
+        };
+        let lsn = self.get_last_record_lsn();
+
+        for key in all_layer_files {
+            split_points.insert(key.key_range.start);
+            split_points.insert(key.key_range.end);
+            if key.is_delta {
+                delta_ranges.push((key.key_range.clone(), key.lsn_range.clone()));
+            } else {
+                image_ranges.push((key.key_range.clone(), key.lsn_range.start));
+            }
+        }
+
+        // For each split range, compute the estimated read amplification.
+        let split_points = split_points.into_iter().collect::<Vec<_>>();
+
+        let mut result = Vec::new();
+
+        for i in 0..(split_points.len() - 1) {
+            let start = split_points[i];
+            let end = split_points[i + 1];
+            // Find the latest image layer that contains the information.
+            let mut maybe_image_layers = image_ranges
+                .iter()
+                // We insert split points for all image layers, and therefore a `contains` check for the start point should be enough.
+                .filter(|(key_range, img_lsn)| key_range.contains(&start) && img_lsn <= &lsn)
+                .cloned()
+                .collect::<Vec<_>>();
+            maybe_image_layers.sort_by(|a, b| a.1.cmp(&b.1));
+            let image_layer = maybe_image_layers.last().cloned();
+            let lsn_filter_start = image_layer
+                .as_ref()
+                .map(|(_, lsn)| *lsn)
+                .unwrap_or(Lsn::INVALID);
+
+            fn overlaps_with(lsn_range_a: &Range<Lsn>, lsn_range_b: &Range<Lsn>) -> bool {
+                !(lsn_range_a.end <= lsn_range_b.start || lsn_range_a.start >= lsn_range_b.end)
+            }
+
+            let maybe_delta_layers = delta_ranges
+                .iter()
+                .filter(|(key_range, lsn_range)| {
+                    key_range.contains(&start) && overlaps_with(&(lsn_filter_start..lsn), lsn_range)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+
+            let pitr_delta_layers = delta_ranges
+                .iter()
+                .filter(|(key_range, _)| key_range.contains(&start))
+                .cloned()
+                .collect::<Vec<_>>();
+
+            result.push(RangeAnalysis {
+                start: start.to_string(),
+                end: end.to_string(),
+                has_image: image_layer.is_some(),
+                num_of_deltas_above_image: maybe_delta_layers.len(),
+                total_num_of_deltas: pitr_delta_layers.len(),
+            });
+        }
+
+        result
+    }
+}

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, ensure, Context, Result};
+use itertools::Itertools;
 use pageserver_api::shard::TenantShardId;
 use std::{collections::HashMap, sync::Arc};
 use tracing::trace;
@@ -307,6 +308,10 @@ impl LayerManager {
 
     pub(crate) fn contains(&self, layer: &Layer) -> bool {
         self.layer_fmgr.contains(layer)
+    }
+
+    pub(crate) fn all_persistent_layers(&self) -> Vec<PersistentLayerKey> {
+        self.layer_fmgr.0.keys().cloned().collect_vec()
     }
 }
 

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -921,3 +921,18 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         )
         self.verbose_error(res)
         return res.json()  # type: ignore
+
+    def perf_info(
+        self,
+        tenant_id: Union[TenantId, TenantShardId],
+        timeline_id: TimelineId,
+    ):
+        self.is_testing_enabled_or_skip()
+
+        log.info(f"Requesting perf info: tenant {tenant_id}, timeline {timeline_id}")
+        res = self.post(
+            f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/perf_info",
+        )
+        log.info(f"Got perf info response code: {res.status_code}")
+        self.verbose_error(res)
+        return res.json()

--- a/test_runner/performance/test_gc_feedback.py
+++ b/test_runner/performance/test_gc_feedback.py
@@ -75,11 +75,28 @@ def test_gc_feedback(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenchma
             physical_size = client.timeline_detail(tenant_id, timeline_id)["current_physical_size"]
             log.info(f"Physical storage size {physical_size}")
 
+    max_num_of_deltas_above_image = 0
+    max_total_num_of_deltas = 0
+    for key_range in client.perf_info(tenant_id, timeline_id):
+        max_total_num_of_deltas = max(max_total_num_of_deltas, key_range["max_total_num_of_deltas"])
+        max_num_of_deltas_above_image = max(
+            max_num_of_deltas_above_image, key_range["max_num_of_deltas_above_image"]
+        )
+
     MB = 1024 * 1024
     zenbenchmark.record("logical_size", logical_size // MB, "Mb", MetricReport.LOWER_IS_BETTER)
     zenbenchmark.record("physical_size", physical_size // MB, "Mb", MetricReport.LOWER_IS_BETTER)
     zenbenchmark.record(
         "physical/logical ratio", physical_size / logical_size, "", MetricReport.LOWER_IS_BETTER
+    )
+    zenbenchmark.record(
+        "max_total_num_of_deltas", max_total_num_of_deltas, "", MetricReport.LOWER_IS_BETTER
+    )
+    zenbenchmark.record(
+        "max_num_of_deltas_above_image",
+        max_num_of_deltas_above_image,
+        "",
+        MetricReport.LOWER_IS_BETTER,
     )
 
     layer_map_path = env.repo_dir / "layer-map.json"

--- a/test_runner/performance/test_gc_feedback.py
+++ b/test_runner/performance/test_gc_feedback.py
@@ -78,9 +78,9 @@ def test_gc_feedback(neon_env_builder: NeonEnvBuilder, zenbenchmark: NeonBenchma
     max_num_of_deltas_above_image = 0
     max_total_num_of_deltas = 0
     for key_range in client.perf_info(tenant_id, timeline_id):
-        max_total_num_of_deltas = max(max_total_num_of_deltas, key_range["max_total_num_of_deltas"])
+        max_total_num_of_deltas = max(max_total_num_of_deltas, key_range["total_num_of_deltas"])
         max_num_of_deltas_above_image = max(
-            max_num_of_deltas_above_image, key_range["max_num_of_deltas_above_image"]
+            max_num_of_deltas_above_image, key_range["num_of_deltas_above_image"]
         )
 
     MB = 1024 * 1024


### PR DESCRIPTION
## Problem

A simple API to collect some statistics after compaction to easily understand the result.

The tool reads the layer map, and analyze range by range instead of doing single-key operations, which is more efficient than doing a benchmark to collect the result. It currently computes two key metrics:

* Latest data access efficiency, which finds how many delta layers / image layers the system needs to iterate before returning any key in a key range.
* (Approximate) PiTR efficiency, as in https://github.com/neondatabase/neon/issues/7770, which is simply the number of delta files in the range. The reason behind that is, assume no image layer is created, PiTR efficiency is simply the cost of collect records from the delta layers, and the replay time. Number of delta files (or in the future, estimated size of reads) is a simple yet efficient way of estimating how much effort the page server needs to reconstruct a page. 

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
