### PR TITLE
Add a pagectl tool to recompress image layers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,6 +2947,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,6 +3621,7 @@ dependencies = [
  "hyper 0.14.26",
  "itertools",
  "leaky-bucket",
+ "lz4_flex",
  "md5",
  "metrics",
  "nix 0.27.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ jsonwebtoken = "9"
 lasso = "0.7"
 leaky-bucket = "1.0.1"
 libc = "0.2"
+lz4_flex = "0.11"
 md5 = "0.7.0"
 measured = { version = "0.0.21", features=["lasso"] }
 measured-process = { version = "0.0.21" }

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -469,6 +469,7 @@ pub enum CompactionAlgorithm {
 )]
 #[strum(serialize_all = "kebab-case")]
 pub enum ImageCompressionAlgorithm {
+    ZstdLow,
     Zstd,
     ZstdHigh,
     LZ4,

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -470,6 +470,7 @@ pub enum CompactionAlgorithm {
 #[strum(serialize_all = "kebab-case")]
 pub enum ImageCompressionAlgorithm {
     Zstd,
+    ZstdHigh,
     LZ4,
 }
 

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -455,6 +455,24 @@ pub enum CompactionAlgorithm {
     Tiered,
 }
 
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum_macros::FromRepr,
+    strum_macros::EnumString,
+    enum_map::Enum,
+)]
+#[strum(serialize_all = "kebab-case")]
+pub enum ImageCompressionAlgorithm {
+    Zstd,
+    LZ4,
+}
+
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct CompactionAlgorithmSettings {
     pub kind: CompactionAlgorithm,

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -37,6 +37,7 @@ humantime-serde.workspace = true
 hyper.workspace = true
 itertools.workspace = true
 leaky-bucket.workspace = true
+lz4_flex.workspace = true
 md5.workspace = true
 nix.workspace = true
 # hack to get the number of worker threads tokio uses

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -317,12 +317,12 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                     LayerName::from_str(file_without_generation.0)
                 else {
                     // Skipping because it's either not a layer or a delta layer
-                    println!("object {file_name}: not a delta layer");
+                    //println!("object {file_name}: not a delta layer");
                     continue;
                 };
                 let json_file_path = layers_dir.join(format!("{file_name}.json"));
                 if tokio::fs::try_exists(&json_file_path).await? {
-                    println!("object {file_name}: report already created");
+                    //println!("object {file_name}: report already created");
                     // If we have already created a report for the layer, skip it.
                     continue;
                 }
@@ -342,6 +342,7 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                     let mut dest_layer_file = tokio::fs::File::create(&local_layer_path).await?;
                     let mut body = tokio_util::io::StreamReader::new(download.download_stream);
                     let _size = tokio::io::copy_buf(&mut body, &mut dest_layer_file).await?;
+                    println!("Downloaded file to {local_layer_path}");
                     let ctx = RequestContext::new(TaskKind::DebugTool, DownloadBehavior::Error);
                     let stats =
                         ImageLayer::compression_statistics(&tmp_dir, &local_layer_path, &ctx)

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -310,14 +310,15 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                 let Some(file_name) = file_key.object_name() else {
                     continue;
                 };
+                // Split off the final part. Sometimes this cuts off actually important pieces in case of legacy layer files, but usually it doesn't.
                 let Some(file_without_generation) = file_name.rsplit_once('-') else {
                     continue;
                 };
                 let Ok(LayerName::Image(_layer_file_name)) =
                     LayerName::from_str(file_without_generation.0)
                 else {
-                    // Skipping because it's either not a layer or a delta layer
-                    //println!("object {file_name}: not a delta layer");
+                    // Skipping because it's either not a layer or an image layer
+                    //println!("object {file_name}: not an image layer");
                     continue;
                 };
                 let json_file_path = layers_dir.join(format!("{file_name}.json"));

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -310,7 +310,12 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                 let Some(file_name) = file_key.object_name() else {
                     continue;
                 };
-                let Ok(LayerName::Image(_layer_file_name)) = LayerName::from_str(file_name) else {
+                let Some(file_without_generation) = file_name.rsplit_once('-') else {
+                    continue;
+                };
+                let Ok(LayerName::Image(_layer_file_name)) =
+                    LayerName::from_str(file_without_generation.0)
+                else {
                     // Skipping because it's either not a layer or a delta layer
                     println!("object {file_name}: not a delta layer");
                     continue;

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -344,7 +344,7 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                     tmp_dir: Utf8PathBuf,
                     storage: Arc<GenericRemoteStorage>,
                     file_key: RemotePath,
-                ) -> Result<Vec<(Option<ImageCompressionAlgorithm>, u64, u64)>, anyhow::Error>
+                ) -> Result<Vec<(Option<ImageCompressionAlgorithm>, u64, u64, u64)>, anyhow::Error>
                 {
                     let _permit = semaphore.acquire().await?;
                     let cancel = CancellationToken::new();

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -303,6 +303,8 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
 
             println!("Listing gave {} keys", files_list.keys.len());
 
+            tokio::fs::create_dir_all(&layers_dir).await?;
+
             let semaphore = Arc::new(Semaphore::new(parallelism.unwrap_or(1) as usize));
 
             let mut tasks = JoinSet::new();

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -301,6 +301,8 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                 .list(Some(&path), ListingMode::NoDelimiter, max_files, &cancel)
                 .await?;
 
+            println!("Listing gave {} keys", files_list.keys.len());
+
             let semaphore = Arc::new(Semaphore::new(parallelism.unwrap_or(1) as usize));
 
             let mut tasks = JoinSet::new();

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -312,10 +312,12 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                 };
                 let Ok(LayerName::Image(_layer_file_name)) = LayerName::from_str(file_name) else {
                     // Skipping because it's either not a layer or a delta layer
+                    println!("object {file_name}: not a delta layer");
                     continue;
                 };
                 let json_file_path = layers_dir.join(format!("{file_name}.json"));
                 if tokio::fs::try_exists(&json_file_path).await? {
+                    println!("object {file_name}: report already created");
                     // If we have already created a report for the layer, skip it.
                     continue;
                 }

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -370,7 +370,10 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                         file_key,
                     )
                     .await;
-                    println!("Statistics for {file_name}: {stats:#?}\n");
+                    match stats {
+                        Ok(stats) => println!("Statistics for {file_name}: {stats:#?}\n"),
+                        Err(e) => eprintln!("Error for {file_name}: {e:?}"),
+                    };
                 });
             }
             while let Some(_res) = tasks.join_next().await {}

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -362,7 +362,7 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                 let storage = storage.clone();
                 let tmp_dir = tmp_dir.to_owned();
                 let file_name = file_name.to_owned();
-                let percent = (file_idx * 100) / files_list.keys.len();
+                let percent = (file_idx * 100) as f64 / files_list.keys.len() as f64;
                 tasks.spawn(async move {
                     let stats = stats(
                         semaphore,
@@ -375,7 +375,7 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                     .await;
                     match stats {
                         Ok(stats) => {
-                            println!("Statistics for {file_name} ({percent}%): {stats:?}\n")
+                            println!("Statistics for {file_name} ({percent:.1}%): {stats:?}\n")
                         }
                         Err(e) => eprintln!("Error for {file_name}: {e:?}"),
                     };

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -371,7 +371,7 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                     )
                     .await;
                     match stats {
-                        Ok(stats) => println!("Statistics for {file_name}: {stats:#?}\n"),
+                        Ok(stats) => println!("Statistics for {file_name}: {stats:?}\n"),
                         Err(e) => eprintln!("Error for {file_name}: {e:?}"),
                     };
                 });

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -344,7 +344,7 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
                     tmp_dir: Utf8PathBuf,
                     storage: Arc<GenericRemoteStorage>,
                     file_key: RemotePath,
-                ) -> Result<Vec<(Option<ImageCompressionAlgorithm>, u64)>, anyhow::Error>
+                ) -> Result<Vec<(Option<ImageCompressionAlgorithm>, u64, u64)>, anyhow::Error>
                 {
                     let _permit = semaphore.acquire().await?;
                     let cancel = CancellationToken::new();

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -338,6 +338,8 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
 
                         let stats_str = serde_json::to_string(&stats).unwrap();
                         tokio::fs::write(json_file_path, stats_str).await?;
+
+                        tokio::fs::remove_file(&local_layer_path).await?;
                         Ok(stats)
                     }
                     let semaphore = semaphore.clone();

--- a/pageserver/ctl/src/layers.rs
+++ b/pageserver/ctl/src/layers.rs
@@ -296,7 +296,7 @@ pub(crate) async fn main(cmd: &LayerCmd) -> Result<()> {
 
             let cancel = CancellationToken::new();
             let path = RemotePath::from_string(tenant_remote_prefix)?;
-            let max_files = NonZeroU32::new(16000);
+            let max_files = NonZeroU32::new(128_000);
             let files_list = storage
                 .list(Some(&path), ListingMode::NoDelimiter, max_files, &cancel)
                 .await?;

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -1367,6 +1367,7 @@ background_task_maximum_delay = '334 s'
                         .expect("Invalid default constant")
                 ),
                 validate_vectored_get: defaults::DEFAULT_VALIDATE_VECTORED_GET,
+                image_compression: defaults::DEFAULT_IMAGE_COMPRESSION,
                 ephemeral_bytes_per_memory_kb: defaults::DEFAULT_EPHEMERAL_BYTES_PER_MEMORY_KB,
             },
             "Correct defaults should be used when no config values are provided"
@@ -1440,6 +1441,7 @@ background_task_maximum_delay = '334 s'
                         .expect("Invalid default constant")
                 ),
                 validate_vectored_get: defaults::DEFAULT_VALIDATE_VECTORED_GET,
+                image_compression: defaults::DEFAULT_IMAGE_COMPRESSION,
                 ephemeral_bytes_per_memory_kb: defaults::DEFAULT_EPHEMERAL_BYTES_PER_MEMORY_KB,
             },
             "Should be able to parse all basic config values correctly"

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -322,7 +322,7 @@ impl<const BUFFERED: bool> BlobWriter<BUFFERED> {
                         };
                         let slice = srcbuf.slice(..);
                         encoder.write_all(&slice[..]).await.unwrap();
-                        encoder.flush().await.unwrap();
+                        encoder.shutdown().await.unwrap();
                         let compressed = encoder.into_inner();
                         if compressed.len() < len {
                             let compressed_len = len;

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -266,10 +266,16 @@ impl<const BUFFERED: bool> BlobWriter<BUFFERED> {
                 const UNCOMPRESSED: u8 = 0x80;
                 const ZSTD: u8 = UNCOMPRESSED | 0x10;
                 const LZ4: u8 = UNCOMPRESSED | 0x20;
+                use ImageCompressionAlgorithm::*;
                 let (high_bit_mask, len_written, srcbuf) = match algorithm {
-                    Some(ImageCompressionAlgorithm::Zstd | ImageCompressionAlgorithm::ZstdHigh) => {
+                    Some(ZstdLow | Zstd | ZstdHigh) => {
                         let mut encoder =
-                            if matches!(algorithm, Some(ImageCompressionAlgorithm::ZstdHigh)) {
+                            if matches!(algorithm, Some(ZstdLow)) {
+                                async_compression::tokio::write::ZstdEncoder::with_quality(
+                                    Vec::new(),
+                                    Level::Precise(1),
+                                )
+                            } else if matches!(algorithm, Some(ZstdHigh)) {
                                 async_compression::tokio::write::ZstdEncoder::with_quality(
                                     Vec::new(),
                                     Level::Precise(6),

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -269,20 +269,19 @@ impl<const BUFFERED: bool> BlobWriter<BUFFERED> {
                 use ImageCompressionAlgorithm::*;
                 let (high_bit_mask, len_written, srcbuf) = match algorithm {
                     Some(ZstdLow | Zstd | ZstdHigh) => {
-                        let mut encoder =
-                            if matches!(algorithm, Some(ZstdLow)) {
-                                async_compression::tokio::write::ZstdEncoder::with_quality(
-                                    Vec::new(),
-                                    Level::Precise(1),
-                                )
-                            } else if matches!(algorithm, Some(ZstdHigh)) {
-                                async_compression::tokio::write::ZstdEncoder::with_quality(
-                                    Vec::new(),
-                                    Level::Precise(6),
-                                )
-                            } else {
-                                async_compression::tokio::write::ZstdEncoder::new(Vec::new())
-                            };
+                        let mut encoder = if matches!(algorithm, Some(ZstdLow)) {
+                            async_compression::tokio::write::ZstdEncoder::with_quality(
+                                Vec::new(),
+                                Level::Precise(1),
+                            )
+                        } else if matches!(algorithm, Some(ZstdHigh)) {
+                            async_compression::tokio::write::ZstdEncoder::with_quality(
+                                Vec::new(),
+                                Level::Precise(6),
+                            )
+                        } else {
+                            async_compression::tokio::write::ZstdEncoder::new(Vec::new())
+                        };
                         let slice = srcbuf.slice(..);
                         encoder.write_all(&slice[..]).await.unwrap();
                         encoder.flush().await.unwrap();

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -114,6 +114,7 @@ impl<'a> BlockCursor<'a> {
             if compression_bits == BYTE_ZSTD {
                 let mut decoder = async_compression::tokio::write::ZstdDecoder::new(dstbuf);
                 decoder.write_all(buf_to_write).await?;
+                decoder.flush().await?;
             } else if compression_bits == BYTE_LZ4 {
                 let decompressed = lz4_flex::block::decompress(&buf_to_write, 128 as usize)
                     .map_err(|_| {

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -346,6 +346,7 @@ impl<const BUFFERED: bool> BlobWriter<BUFFERED> {
                     None => (BYTE_UNCOMPRESSED, len, srcbuf.slice(..).into_inner()),
                 };
                 let mut len_buf = (len_written as u32).to_be_bytes();
+                assert_eq!(len_buf[0] & 0xf0, 0);
                 len_buf[0] |= high_bit_mask;
                 io_buf.extend_from_slice(&len_buf[..]);
                 (self.write_all(io_buf, ctx).await, srcbuf)

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -325,7 +325,7 @@ impl<const BUFFERED: bool> BlobWriter<BUFFERED> {
                         encoder.shutdown().await.unwrap();
                         let compressed = encoder.into_inner();
                         if compressed.len() < len {
-                            let compressed_len = len;
+                            let compressed_len = compressed.len();
                             compressed_buf = Some(compressed);
                             (BYTE_ZSTD, compressed_len, slice.into_inner())
                         } else {
@@ -336,7 +336,7 @@ impl<const BUFFERED: bool> BlobWriter<BUFFERED> {
                         let slice = srcbuf.slice(..);
                         let compressed = lz4_flex::block::compress(&slice[..]);
                         if compressed.len() < len {
-                            let compressed_len = len;
+                            let compressed_len = compressed.len();
                             compressed_buf = Some(compressed);
                             (BYTE_LZ4, compressed_len, slice.into_inner())
                         } else {
@@ -418,8 +418,22 @@ mod tests {
             for blob in blobs.iter() {
                 let (_, res) = match COMPRESSION {
                     0 => wtr.write_blob(blob.clone(), &ctx).await,
-                    1 => wtr.write_blob_compressed(blob.clone(), &ctx, Some(ImageCompressionAlgorithm::ZstdLow)).await,
-                    2 => wtr.write_blob_compressed(blob.clone(), &ctx, Some(ImageCompressionAlgorithm::LZ4)).await,
+                    1 => {
+                        wtr.write_blob_compressed(
+                            blob.clone(),
+                            &ctx,
+                            Some(ImageCompressionAlgorithm::ZstdLow),
+                        )
+                        .await
+                    }
+                    2 => {
+                        wtr.write_blob_compressed(
+                            blob.clone(),
+                            &ctx,
+                            Some(ImageCompressionAlgorithm::LZ4),
+                        )
+                        .await
+                    }
                     _ => unreachable!("Invalid compression {COMPRESSION}"),
                 };
                 let offs = res?;

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -14,7 +14,6 @@
 use async_compression::Level;
 use bytes::{BufMut, BytesMut};
 use pageserver_api::models::ImageCompressionAlgorithm;
-use postgres_ffi::BLCKSZ;
 use tokio::io::AsyncWriteExt;
 use tokio_epoll_uring::{BoundedBuf, IoBuf, Slice};
 

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -395,8 +395,9 @@ impl ImageLayer {
         for (image_compression, conf) in image_compressions.into_iter().zip(confs) {
             let start_compression = Instant::now();
             let compressed_path = Self::compress_for_conf(path, ctx, conf).await?;
+            let path_to_delete = compressed_path.clone();
             scopeguard::defer!({
-                let _ = std::fs::remove_file(compressed_path);
+                let _ = std::fs::remove_file(path_to_delete);
             });
             let size = path.metadata()?.size();
             let elapsed_ms = start_compression.elapsed().as_millis() as u64;

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -381,6 +381,7 @@ impl ImageLayer {
         }
         let image_compressions = [
             None,
+            Some(ImageCompressionAlgorithm::ZstdLow),
             Some(ImageCompressionAlgorithm::Zstd),
             Some(ImageCompressionAlgorithm::ZstdHigh),
             Some(ImageCompressionAlgorithm::LZ4),

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -393,6 +393,7 @@ impl ImageLayer {
             )
             .await?;
             stats.push((image_compression, size));
+            tokio::task::yield_now().await;
         }
         Ok(stats)
     }

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -528,6 +528,7 @@ impl ImageLayer {
                 content_a, content_b,
                 "mismatch for key={key} cmp={cmp:?} and {path_a}:{path_b}"
             );
+            println!("match for key={key} cmp={cmp:?} from {path_a}");
         }
         Ok(())
     }

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -382,6 +382,7 @@ impl ImageLayer {
         let image_compressions = [
             None,
             Some(ImageCompressionAlgorithm::Zstd),
+            Some(ImageCompressionAlgorithm::ZstdHigh),
             Some(ImageCompressionAlgorithm::LZ4),
         ];
         let mut stats = Vec::new();

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -511,7 +511,7 @@ impl ImageLayer {
         let mut key_offset_stream_a = std::pin::pin!(tree_readers_cursors[0]
             .0
             .get_stream_from(&[0u8; KEY_SIZE], ctx));
-        let mut key_offset_stream_b = std::pin::pin!(tree_readers_cursors[0]
+        let mut key_offset_stream_b = std::pin::pin!(tree_readers_cursors[1]
             .0
             .get_stream_from(&[0u8; KEY_SIZE], ctx));
         while let Some(r) = key_offset_stream_a.next().await {
@@ -528,7 +528,7 @@ impl ImageLayer {
                 content_a, content_b,
                 "mismatch for key={key} cmp={cmp:?} and {path_a}:{path_b}"
             );
-            println!("match for key={key} cmp={cmp:?} from {path_a}");
+            //println!("match for key={key} cmp={cmp:?} from {path_a}");
         }
         Ok(())
     }

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -402,7 +402,7 @@ impl ImageLayer {
             let size = path.metadata()?.size();
             let elapsed_ms = start_compression.elapsed().as_millis() as u64;
             let start_decompression = Instant::now();
-            Self::compare_are_equal(path, &compressed_path, ctx).await?;
+            Self::compare_are_equal(path, &compressed_path, ctx, &image_compression).await?;
             let elapsed_decompression_ms = start_decompression.elapsed().as_millis() as u64;
             stats.push((
                 image_compression,
@@ -471,6 +471,7 @@ impl ImageLayer {
         path_a: &Utf8Path,
         path_b: &Utf8Path,
         ctx: &RequestContext,
+        cmp: &Option<ImageCompressionAlgorithm>,
     ) -> anyhow::Result<()> {
         let mut files = Vec::new();
         for path in [path_a, path_b] {
@@ -525,7 +526,7 @@ impl ImageLayer {
             let content_b = tree_readers_cursors[1].1.read_blob(offset_b, ctx).await?;
             assert_eq!(
                 content_a, content_b,
-                "mismatch for key={key} and {path_a}:{path_b}"
+                "mismatch for key={key} cmp={cmp:?} and {path_a}:{path_b}"
             );
         }
         Ok(())

--- a/scripts/plot-compression-report.py
+++ b/scripts/plot-compression-report.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env -S python3 -u
+
+import argparse
+import json
+import os
+from pprint import pprint
+
+import matplotlib.pyplot as plt
+
+parser = argparse.ArgumentParser(prog="compression-report")
+parser.add_argument("dir")
+args = parser.parse_args()
+
+files = []
+for file_name in os.listdir(args.dir):
+    if not file_name.endswith(".json"):
+        continue
+    file_path = os.path.join(args.dir, file_name)
+    with open(file_path) as json_str:
+        json_data = json.load(json_str)
+    files.append((file_name, json_data))
+#pprint(files)
+
+extra_zstd_lines = True
+dc = 2 # data column to use (1 for sizes, 2 for time)
+sort_by = "ZstdHigh"
+files.sort(key=lambda file_data: [x for x in file_data[1] if x[0] == sort_by][0][dc])
+
+
+x_axis = []
+data_baseline = []
+data_lz4 = []
+data_zstd = []
+data_zstd_low = []
+data_zstd_high = []
+
+for idx, f in enumerate(files):
+    file_data = f[1]
+    #pprint(file_data)
+
+    x_axis.append(idx)
+    data_baseline.append([x for x in file_data if x[0] is None][0][dc])
+    data_lz4.append([x for x in file_data if x[0] == "LZ4"][0][dc])
+    data_zstd.append([x for x in file_data if x[0] == "Zstd"][0][dc])
+    if extra_zstd_lines:
+        data_zstd_low.append([x for x in file_data if x[0] == "ZstdLow"][0][dc])
+        data_zstd_high.append([x for x in file_data if x[0] == "ZstdHigh"][0][dc])
+
+plt.plot(x_axis, data_baseline, "x", markeredgewidth=2, label="baseline")
+plt.plot(x_axis, data_lz4, "x", markeredgewidth=2, label="lz4")
+plt.plot(x_axis, data_zstd, "x", markeredgewidth=2, label="Zstd")
+if extra_zstd_lines:
+    plt.plot(x_axis, data_zstd_low, "x", markeredgewidth=2, label="ZstdLow")
+    plt.plot(x_axis, data_zstd_high, "x", markeredgewidth=2, label="ZstdHigh")
+
+# plt.style.use('_mpl-gallery')
+plt.ylim(bottom=0)
+plt.legend(loc="upper left")
+
+figure_path = os.path.join(args.dir, "figure.png")
+print(f"saving figure to {figure_path}")
+plt.savefig(figure_path)
+plt.show()


### PR DESCRIPTION
Adds a pagectl subcommand to recompress image layers with various compression algorithms and output the different sizes.

still wip.

Part of https://github.com/neondatabase/neon/issues/5431