### PR TITLE
safekeeper: remove .partial suffix on the last WAL file.

### DIFF
--- a/libs/utils/scripts/restore_from_wal.sh
+++ b/libs/utils/scripts/restore_from_wal.sh
@@ -17,6 +17,5 @@ declare -i WAL_SIZE=$REDO_POS+114
 "$PG_BIN"/pg_ctl -D "$DATA_DIR" -l "$DATA_DIR/logfile.log" stop -m immediate
 cp "$DATA_DIR"/pg_wal/000000010000000000000001 .
 cp "$WAL_PATH"/* "$DATA_DIR"/pg_wal/
-for partial in "$DATA_DIR"/pg_wal/*.partial ; do mv "$partial" "${partial%.partial}" ; done
 dd if=000000010000000000000001 of="$DATA_DIR"/pg_wal/000000010000000000000001 bs=$WAL_SIZE count=1 conv=notrunc
 rm -f 000000010000000000000001

--- a/libs/utils/scripts/restore_from_wal_initdb.sh
+++ b/libs/utils/scripts/restore_from_wal_initdb.sh
@@ -16,6 +16,5 @@ declare -i WAL_SIZE=$REDO_POS+114
 "$PG_BIN"/pg_ctl -D "$DATA_DIR" -l "$DATA_DIR/logfile.log" stop -m immediate
 cp "$DATA_DIR"/pg_wal/000000010000000000000001 .
 cp "$WAL_PATH"/* "$DATA_DIR"/pg_wal/
-for partial in "$DATA_DIR"/pg_wal/*.partial ; do mv "$partial" "${partial%.partial}" ; done
 dd if=000000010000000000000001 of="$DATA_DIR"/pg_wal/000000010000000000000001 bs=$WAL_SIZE count=1 conv=notrunc
 rm -f 000000010000000000000001

--- a/safekeeper/src/wal_backup_partial.rs
+++ b/safekeeper/src/wal_backup_partial.rs
@@ -117,10 +117,6 @@ impl PartialBackup {
             self.conf.my_id.0,
         )
     }
-
-    fn local_segment_name(&self, segno: u64) -> String {
-        format!("{}.partial", self.segment_name(segno))
-    }
 }
 
 impl PartialBackup {
@@ -152,7 +148,7 @@ impl PartialBackup {
         // We're going to backup bytes from the start of the segment up to flush_lsn.
         let backup_bytes = flush_lsn.segment_offset(self.wal_seg_size);
 
-        let local_path = self.local_prefix.join(self.local_segment_name(segno));
+        let local_path = self.local_prefix.join(self.segment_name(segno));
         let remote_path = RemotePath::new(self.remote_prefix.join(&prepared.name).as_ref())?;
 
         // Upload first `backup_bytes` bytes of the segment to the remote storage.

--- a/test_runner/regress/test_pg_waldump.py
+++ b/test_runner/regress/test_pg_waldump.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 from fixtures.neon_fixtures import NeonEnv, PgBin
 from fixtures.utils import subprocess_capture
@@ -48,14 +47,13 @@ def test_pg_waldump(neon_simple_env: NeonEnv, test_output_dir, pg_bin: PgBin):
     endpoint.stop()
 
     assert endpoint.pgdata_dir
-    wal_path = os.path.join(endpoint.pgdata_dir, "pg_wal/000000010000000000000001")
+    seg_path = os.path.join(endpoint.pgdata_dir, "pg_wal/000000010000000000000001")
     pg_waldump_path = os.path.join(pg_bin.pg_bin_path, "pg_waldump")
     # check segment on compute
-    check_wal_segment(pg_waldump_path, wal_path, test_output_dir)
+    check_wal_segment(pg_waldump_path, seg_path, test_output_dir)
 
-    # Check file on safekeepers as well. pg_waldump is strict about file naming, so remove .partial suffix.
+    # Check file on safekeepers as well.
     sk = env.safekeepers[0]
     sk_tli_dir = sk.timeline_dir(tenant_id, timeline_id)
-    non_partial_path = os.path.join(sk_tli_dir, "000000010000000000000001")
-    shutil.copyfile(os.path.join(sk_tli_dir, "000000010000000000000001.partial"), non_partial_path)
-    check_wal_segment(pg_waldump_path, non_partial_path, test_output_dir)
+    seg_path = os.path.join(sk_tli_dir, "000000010000000000000001")
+    check_wal_segment(pg_waldump_path, seg_path, test_output_dir)

--- a/test_runner/regress/test_wal_acceptor.py
+++ b/test_runner/regress/test_wal_acceptor.py
@@ -590,10 +590,10 @@ def test_s3_wal_replay(neon_env_builder: NeonEnvBuilder):
 
     # save the last (partial) file to put it back after recreation; others will be fetched from s3
     sk = env.safekeepers[0]
-    tli_dir = Path(sk.data_dir) / str(tenant_id) / str(timeline_id)
-    f_partial = Path([f for f in os.listdir(tli_dir) if f.endswith(".partial")][0])
+    tli_dir = sk.data_dir / str(tenant_id) / str(timeline_id)
+    f_partial = sk.list_segments(tenant_id, timeline_id)[-1]
     f_partial_path = tli_dir / f_partial
-    f_partial_saved = Path(sk.data_dir) / f_partial.name
+    f_partial_saved = sk.data_dir / f_partial
     f_partial_path.rename(f_partial_saved)
 
     pg_version = sk.http_client().timeline_status(tenant_id, timeline_id).pg_version


### PR DESCRIPTION
Reasons:
- it makes pg_waldump usage slightly more cumbersome, forcing to rename file.
- it makes pull_timeline slightly more cumbersome because at any moment source file can be renamed from partial to full.

Leave ability to read .partial files for backward compatibility.

Fixes https://github.com/neondatabase/neon/issues/4459