### PR TITLE
storcon_cli: add 'drop' and eviction interval utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5819,6 +5819,7 @@ dependencies = [
  "anyhow",
  "clap",
  "comfy-table",
+ "humantime",
  "hyper 0.14.26",
  "pageserver_api",
  "pageserver_client",

--- a/control_plane/storcon_cli/Cargo.toml
+++ b/control_plane/storcon_cli/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 comfy-table.workspace = true
+humantime.workspace = true
 hyper.workspace = true
 pageserver_api.workspace = true
 pageserver_client.workspace = true

--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -7,8 +7,9 @@ use pageserver_api::{
         TenantDescribeResponse, TenantPolicyRequest,
     },
     models::{
-        LocationConfigSecondary, ShardParameters, TenantConfig, TenantConfigRequest,
-        TenantCreateRequest, TenantShardSplitRequest, TenantShardSplitResponse,
+        EvictionPolicy, EvictionPolicyLayerAccessThreshold, LocationConfigSecondary,
+        ShardParameters, TenantConfig, TenantConfigRequest, TenantCreateRequest,
+        TenantShardSplitRequest, TenantShardSplitResponse,
     },
     shard::{ShardStripeSize, TenantShardId},
 };
@@ -124,6 +125,28 @@ enum Command {
     TenantWarmup {
         #[arg(long)]
         tenant_id: TenantId,
+    },
+    /// Uncleanly drop a tenant from the storage controller: this doesn't delete anything from pageservers. Appropriate
+    /// if you e.g. used `tenant-warmup` by mistake on a tenant ID that doesn't really exist, or is in some other region.
+    TenantDrop {
+        #[arg(long)]
+        tenant_id: TenantId,
+        #[arg(long)]
+        unclean: bool,
+    },
+    NodeDrop {
+        #[arg(long)]
+        node_id: NodeId,
+        #[arg(long)]
+        unclean: bool,
+    },
+    TenantSetTimeBasedEviction {
+        #[arg(long)]
+        tenant_id: TenantId,
+        #[arg(long)]
+        period: humantime::Duration,
+        #[arg(long)]
+        threshold: humantime::Duration,
     },
 }
 
@@ -673,6 +696,66 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
             }
+        }
+        Command::TenantDrop { tenant_id, unclean } => {
+            if !unclean {
+                anyhow::bail!("This command is not a tenant deletion, and uncleanly drops all controller state for the tenant.  If you know what you're doing, add `--unclean` to proceed.")
+            }
+            storcon_client
+                .dispatch::<(), ()>(
+                    Method::POST,
+                    format!("debug/v1/tenant/{tenant_id}/drop"),
+                    None,
+                )
+                .await?;
+        }
+        Command::NodeDrop { node_id, unclean } => {
+            if !unclean {
+                anyhow::bail!("This command is not a clean node decommission, and uncleanly drops all controller state for the node, without checking if any tenants still refer to it.  If you know what you're doing, add `--unclean` to proceed.")
+            }
+            storcon_client
+                .dispatch::<(), ()>(Method::POST, format!("debug/v1/node/{node_id}/drop"), None)
+                .await?;
+        }
+        Command::TenantSetTimeBasedEviction {
+            tenant_id,
+            period,
+            threshold,
+        } => {
+            vps_client
+                .tenant_config(&TenantConfigRequest {
+                    tenant_id,
+                    config: TenantConfig {
+                        checkpoint_distance: None,
+                        checkpoint_timeout: None,
+                        compaction_target_size: None,
+                        compaction_period: None,
+                        compaction_threshold: None,
+                        compaction_algorithm: None,
+                        gc_horizon: None,
+                        gc_period: None,
+                        image_creation_threshold: None,
+                        pitr_interval: None,
+                        walreceiver_connect_timeout: None,
+                        lagging_wal_timeout: None,
+                        max_lsn_wal_lag: None,
+                        trace_read_requests: None,
+                        eviction_policy: Some(EvictionPolicy::LayerAccessThreshold(
+                            EvictionPolicyLayerAccessThreshold {
+                                period: period.into(),
+                                threshold: threshold.into(),
+                            },
+                        )),
+                        min_resident_size_override: None,
+                        evictions_low_residence_duration_metric_threshold: None,
+                        heatmap_period: None,
+                        lazy_slru_download: None,
+                        timeline_get_throttle: None,
+                        image_layer_creation_check_threshold: None,
+                        switch_aux_file_policy: None,
+                    },
+                })
+                .await?;
         }
     }
 

--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -726,33 +726,13 @@ async fn main() -> anyhow::Result<()> {
                 .tenant_config(&TenantConfigRequest {
                     tenant_id,
                     config: TenantConfig {
-                        checkpoint_distance: None,
-                        checkpoint_timeout: None,
-                        compaction_target_size: None,
-                        compaction_period: None,
-                        compaction_threshold: None,
-                        compaction_algorithm: None,
-                        gc_horizon: None,
-                        gc_period: None,
-                        image_creation_threshold: None,
-                        pitr_interval: None,
-                        walreceiver_connect_timeout: None,
-                        lagging_wal_timeout: None,
-                        max_lsn_wal_lag: None,
-                        trace_read_requests: None,
                         eviction_policy: Some(EvictionPolicy::LayerAccessThreshold(
                             EvictionPolicyLayerAccessThreshold {
                                 period: period.into(),
                                 threshold: threshold.into(),
                             },
                         )),
-                        min_resident_size_override: None,
-                        evictions_low_residence_duration_metric_threshold: None,
-                        heatmap_period: None,
-                        lazy_slru_download: None,
-                        timeline_get_throttle: None,
-                        image_layer_creation_check_threshold: None,
-                        switch_aux_file_policy: None,
+                        ..Default::default()
                     },
                 })
                 .await?;


### PR DESCRIPTION

The storage controller has 'drop' APIs for tenants and nodes, for use in situations where something weird has happened:
- node-drop is useful until we implement proper node decom, or if we have a partially provisioned node that somehow gets registered with the storage controller but is then dead.
- tenant-drop is useful if we accidentally add a tenant that shouldn't be there at all, or if we want to make the controller forget about a tenant without deleting its data.  For example, if one uses the tenant-warmup command with a bad tenant ID and needs to clean that up.

The drop commands require an `--unsafe` parameter, to reduce the chance that someone incorrectly assumes these are the normal/clean ways to delete things.

This PR also adds a convenience command for setting the time based eviction parameters on a tenant.  This is useful when onboarding an existing tenant that has high resident size due to storage amplification in compaction: setting a lower time based eviction threshold brings down the resident size ahead of doing a shard split.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
