### PR TITLE
fix: do TimelineMetrics::shutdown only once

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -2256,8 +2256,9 @@ impl TimelineMetrics {
             .swap(true, std::sync::atomic::Ordering::Relaxed);
 
         if was_shutdown {
-            // See https://github.com/neondatabase/neon/issues/7341#issuecomment-2152205276
-            tracing::warn!("double-shutdown for TimelineMetrics, ignoring...");
+            // this happens on tenant deletion because tenant first shuts down timelines, then
+            // invokes timeline deletion which first shuts down the timeline again.
+            // TODO: this can be removed once https://github.com/neondatabase/neon/issues/5080
             return;
         }
 


### PR DESCRIPTION
Related to #7341 tenant deletion will end up shutting down timelines twice, once before actually starting and the second time when per timeline deletion is requested. Shutting down TimelineMetrics causes underflows. Add an atomic boolean and only do the shutdown once.