### PR TITLE
docs: highlight neon env comes with an initial timeline

### DIFF
--- a/test_runner/README.md
+++ b/test_runner/README.md
@@ -285,6 +285,20 @@ def test_foobar(neon_env_builder: NeonEnvBuilder):
     ...
 ```
 
+The env includes a default tenant and timeline. Therefore, you do not need to create your own
+tenant/timeline for testing.
+
+```python
+def test_foobar2(neon_env_builder: NeonEnvBuilder):
+    env = neon_env_builder.init_start() # Start the environment
+    endpoint = env.endpoints.create_start("main") # Start the compute endpoint
+    client = env.pageserver.http_client() # Get the pageserver client
+
+    tenant_id = env.initial_tenant
+    timeline_id = env.initial_timeline
+    client.timeline_detail(tenant_id=tenant_id, timeline_id=timeline_id)
+```
+
 For more information about pytest fixtures, see https://docs.pytest.org/en/stable/fixture.html
 
 At the end of a test, all the nodes in the environment are automatically stopped, so you

--- a/test_runner/README.md
+++ b/test_runner/README.md
@@ -291,7 +291,8 @@ tenant/timeline for testing.
 ```python
 def test_foobar2(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_start() # Start the environment
-    endpoint = env.endpoints.create_start("main") # Start the compute endpoint
+    with env.endpoints.create_start("main") as endpoint:
+        # Start the compute endpoint
     client = env.pageserver.http_client() # Get the pageserver client
 
     tenant_id = env.initial_tenant


### PR DESCRIPTION
## Problem

Quite a few existing test cases create their own timelines instead of using the default one. This pull request highlights that and hopefully people can write simpler tests in the future.

## Summary of changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
