### PR TITLE
storcon: add drain and fill background operations for graceful cluster restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5801,6 +5801,7 @@ dependencies = [
  "r2d2",
  "reqwest 0.12.4",
  "routerify",
+ "scopeguard",
  "serde",
  "serde_json",
  "strum",

--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -209,6 +209,7 @@ pub enum NodeSchedulingPolicy {
     Active,
     Filling,
     Pause,
+    PauseForRestart,
     Draining,
 }
 
@@ -220,6 +221,7 @@ impl FromStr for NodeSchedulingPolicy {
             "active" => Ok(Self::Active),
             "filling" => Ok(Self::Filling),
             "pause" => Ok(Self::Pause),
+            "pause_for_restart" => Ok(Self::PauseForRestart),
             "draining" => Ok(Self::Draining),
             _ => Err(anyhow::anyhow!("Unknown scheduling state '{s}'")),
         }
@@ -233,6 +235,7 @@ impl From<NodeSchedulingPolicy> for String {
             Active => "active",
             Filling => "filling",
             Pause => "pause",
+            PauseForRestart => "pause_for_restart",
             Draining => "draining",
         }
         .to_string()

--- a/storage_controller/Cargo.toml
+++ b/storage_controller/Cargo.toml
@@ -40,6 +40,7 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 measured.workspace = true
+scopeguard.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 

--- a/storage_controller/src/background_node_operations.rs
+++ b/storage_controller/src/background_node_operations.rs
@@ -25,6 +25,8 @@ pub(crate) enum Operation {
 pub(crate) enum OperationError {
     #[error("Node state changed during operation: {0}")]
     NodeStateChanged(Cow<'static, str>),
+    #[error("Operation finalize error: {0}")]
+    FinalizeError(Cow<'static, str>),
     #[error("Operation cancelled")]
     Cancelled,
 }

--- a/storage_controller/src/background_node_operations.rs
+++ b/storage_controller/src/background_node_operations.rs
@@ -1,23 +1,21 @@
-use std::{borrow::Cow, collections::HashMap, fmt::Debug, fmt::Display, sync::Arc};
+use std::{borrow::Cow, fmt::Debug, fmt::Display};
 
-use tokio::{sync::mpsc::error::TrySendError, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use utils::id::NodeId;
-
-use crate::service::Service;
 
 pub(crate) const MAX_RECONCILES_PER_OPERATION: usize = 10;
 
 #[derive(Copy, Clone)]
 pub(crate) struct Drain {
-    node_id: NodeId,
+    pub(crate) node_id: NodeId,
 }
 
 #[derive(Copy, Clone)]
 pub(crate) struct Fill {
-    node_id: NodeId,
+    pub(crate) node_id: NodeId,
 }
 
+#[derive(Copy, Clone)]
 pub(crate) enum Operation {
     Drain(Drain),
     Fill(Fill),
@@ -25,184 +23,16 @@ pub(crate) enum Operation {
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum OperationError {
-    #[error("Operation precondition failed: {0}")]
-    PreconditionFailed(Cow<'static, str>),
     #[error("Node state changed during operation: {0}")]
     NodeStateChanged(Cow<'static, str>),
     #[error("Operation cancelled")]
     Cancelled,
-    #[error("Shutting down")]
-    ShuttingDown,
 }
 
-struct OperationHandler {
-    operation: Operation,
+pub(crate) struct OperationHandler {
+    pub(crate) operation: Operation,
     #[allow(unused)]
-    cancel: CancellationToken,
-    #[allow(unused)]
-    handle: JoinHandle<Result<(), OperationError>>,
-}
-
-#[derive(Default, Clone)]
-struct OngoingOperations(Arc<std::sync::RwLock<HashMap<NodeId, OperationHandler>>>);
-
-pub(crate) struct Controller {
-    ongoing: OngoingOperations,
-    service: Arc<Service>,
-    sender: tokio::sync::mpsc::Sender<Operation>,
-}
-
-impl Controller {
-    pub(crate) fn new(service: Arc<Service>) -> (Self, tokio::sync::mpsc::Receiver<Operation>) {
-        let (operations_tx, operations_rx) = tokio::sync::mpsc::channel(1);
-        (
-            Self {
-                ongoing: Default::default(),
-                service,
-                sender: operations_tx,
-            },
-            operations_rx,
-        )
-    }
-
-    pub(crate) fn drain_node(&self, node_id: NodeId) -> Result<(), OperationError> {
-        if let Some(handler) = self.ongoing.0.read().unwrap().get(&node_id) {
-            return Err(OperationError::PreconditionFailed(
-                format!(
-                    "Background operation already ongoing for node: {}",
-                    handler.operation
-                )
-                .into(),
-            ));
-        }
-
-        self.sender.try_send(Operation::Drain(Drain { node_id }))?;
-
-        Ok(())
-    }
-
-    pub(crate) fn fill_node(&self, node_id: NodeId) -> Result<(), OperationError> {
-        if let Some(handler) = self.ongoing.0.read().unwrap().get(&node_id) {
-            return Err(OperationError::PreconditionFailed(
-                format!(
-                    "Background operation already ongoing for node: {}",
-                    handler.operation
-                )
-                .into(),
-            ));
-        }
-
-        self.sender.try_send(Operation::Fill(Fill { node_id }))?;
-
-        Ok(())
-    }
-
-    pub(crate) async fn handle_operations(
-        &self,
-        mut receiver: tokio::sync::mpsc::Receiver<Operation>,
-    ) {
-        while let Some(op) = receiver.recv().await {
-            match op {
-                Operation::Drain(drain) => self.handle_drain(drain),
-                Operation::Fill(fill) => self.handle_fill(fill),
-            }
-        }
-    }
-
-    fn handle_drain(&self, drain: Drain) {
-        let node_id = drain.node_id;
-
-        let cancel = CancellationToken::new();
-
-        let (_holder, waiter) = utils::completion::channel();
-
-        let handle = tokio::task::spawn({
-            let service = self.service.clone();
-            let ongoing = self.ongoing.clone();
-            let cancel = cancel.clone();
-
-            async move {
-                scopeguard::defer! {
-                    let removed = ongoing.0.write().unwrap().remove(&drain.node_id);
-                    if let Some(Operation::Drain(removed_drain)) = removed.map(|h| h.operation) {
-                        assert_eq!(removed_drain.node_id, drain.node_id, "We always remove the same operation");
-                    } else {
-                        panic!("We always remove the same operation")
-                    }
-                }
-
-                waiter.wait().await;
-                service.drain_node(drain.node_id, cancel).await
-            }
-        });
-
-        let replaced = self.ongoing.0.write().unwrap().insert(
-            node_id,
-            OperationHandler {
-                operation: Operation::Drain(drain),
-                cancel,
-                handle,
-            },
-        );
-
-        assert!(
-            replaced.is_none(),
-            "The channel size is 1 and we checked before enqueing"
-        );
-    }
-
-    fn handle_fill(&self, fill: Fill) {
-        let node_id = fill.node_id;
-
-        let cancel = CancellationToken::new();
-
-        let (_holder, waiter) = utils::completion::channel();
-
-        let handle = tokio::task::spawn({
-            let service = self.service.clone();
-            let ongoing = self.ongoing.clone();
-            let cancel = cancel.clone();
-
-            async move {
-                scopeguard::defer! {
-                    let removed = ongoing.0.write().unwrap().remove(&fill.node_id);
-                    if let Some(Operation::Fill(removed_fill)) = removed.map(|h| h.operation) {
-                        assert_eq!(removed_fill.node_id, fill.node_id, "We always remove the same operation");
-                    } else {
-                        panic!("We always remove the same operation")
-                    }
-                }
-
-                waiter.wait().await;
-                service.fill_node(fill.node_id, cancel).await
-            }
-        });
-
-        let replaced = self.ongoing.0.write().unwrap().insert(
-            node_id,
-            OperationHandler {
-                operation: Operation::Fill(fill),
-                cancel,
-                handle,
-            },
-        );
-
-        assert!(
-            replaced.is_none(),
-            "The channel size is 1 and we checked before enqueing"
-        );
-    }
-}
-
-impl<T> From<TrySendError<T>> for OperationError {
-    fn from(value: TrySendError<T>) -> Self {
-        match value {
-            TrySendError::Full(_) => {
-                Self::PreconditionFailed("Too many background operation in progress".into())
-            }
-            TrySendError::Closed(_) => Self::ShuttingDown,
-        }
-    }
+    pub(crate) cancel: CancellationToken,
 }
 
 impl Display for Drain {
@@ -223,11 +53,5 @@ impl Display for Operation {
             Operation::Drain(op) => write!(f, "{op}"),
             Operation::Fill(op) => write!(f, "{op}"),
         }
-    }
-}
-
-impl Debug for Controller {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "backround_node_operations::Controller")
     }
 }

--- a/storage_controller/src/background_node_operations.rs
+++ b/storage_controller/src/background_node_operations.rs
@@ -1,0 +1,157 @@
+use std::{borrow::Cow, collections::HashMap, fmt::Debug, fmt::Display, sync::Arc};
+
+use tokio::{sync::mpsc::error::TrySendError, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+use utils::id::NodeId;
+
+use crate::service::Service;
+
+pub(crate) const MAX_RECONCILES_PER_OPERATION: usize = 10;
+
+#[derive(Copy, Clone)]
+pub(crate) struct Drain {
+    node_id: NodeId,
+}
+
+#[derive(Copy, Clone)]
+pub(crate) struct Fill {
+    node_id: NodeId,
+}
+
+pub(crate) enum Operation {
+    Drain(Drain),
+    Fill(Fill),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OperationError {
+    #[error("Operation precondition failed: {0}")]
+    PreconditionFailed(Cow<'static, str>),
+    #[error("Node state changed during operation: {0}")]
+    NodeStateChanged(Cow<'static, str>),
+    #[error("Operation cancelled")]
+    Cancelled,
+    #[error("Shutting down")]
+    ShuttingDown,
+}
+
+struct OperationHandler {
+    operation: Operation,
+    #[allow(unused)]
+    cancel: CancellationToken,
+    #[allow(unused)]
+    handle: JoinHandle<Result<(), OperationError>>,
+}
+
+#[derive(Default, Clone)]
+struct OngoingOperations(Arc<std::sync::RwLock<HashMap<NodeId, OperationHandler>>>);
+
+pub(crate) struct Controller {
+    ongoing: OngoingOperations,
+    service: Arc<Service>,
+    sender: tokio::sync::mpsc::Sender<Operation>,
+}
+
+impl Controller {
+    pub(crate) fn new(service: Arc<Service>) -> (Self, tokio::sync::mpsc::Receiver<Operation>) {
+        let (operations_tx, operations_rx) = tokio::sync::mpsc::channel(1);
+        (
+            Self {
+                ongoing: Default::default(),
+                service,
+                sender: operations_tx,
+            },
+            operations_rx,
+        )
+    }
+
+    pub(crate) fn drain_node(&self, node_id: NodeId) -> Result<(), OperationError> {
+        if let Some(handler) = self.ongoing.0.read().unwrap().get(&node_id) {
+            return Err(OperationError::PreconditionFailed(
+                format!(
+                    "Background operation already ongoing for node: {}",
+                    handler.operation
+                )
+                .into(),
+            ));
+        }
+
+        self.sender.try_send(Operation::Drain(Drain { node_id }))?;
+
+        Ok(())
+    }
+
+    pub(crate) fn fill_node(&self, node_id: NodeId) -> Result<(), OperationError> {
+        if let Some(handler) = self.ongoing.0.read().unwrap().get(&node_id) {
+            return Err(OperationError::PreconditionFailed(
+                format!(
+                    "Background operation already ongoing for node: {}",
+                    handler.operation
+                )
+                .into(),
+            ));
+        }
+
+        self.sender.try_send(Operation::Fill(Fill { node_id }))?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn handle_operations(
+        &self,
+        mut receiver: tokio::sync::mpsc::Receiver<Operation>,
+    ) {
+        while let Some(op) = receiver.recv().await {
+            match op {
+                Operation::Drain(drain) => self.handle_drain(drain),
+                Operation::Fill(fill) => self.handle_fill(fill),
+            }
+        }
+    }
+
+    fn handle_drain(&self, _drain: Drain) {
+        todo!("A later commit implements this stub");
+    }
+
+    fn handle_fill(&self, _fill: Fill) {
+        todo!("A later commit implements this stub")
+    }
+}
+
+impl<T> From<TrySendError<T>> for OperationError {
+    fn from(value: TrySendError<T>) -> Self {
+        match value {
+            TrySendError::Full(_) => {
+                Self::PreconditionFailed("Too many background operation in progress".into())
+            }
+            TrySendError::Closed(_) => Self::ShuttingDown,
+        }
+    }
+}
+
+impl Display for Drain {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "drain {}", self.node_id)
+    }
+}
+
+impl Display for Fill {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "fill {}", self.node_id)
+    }
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Operation::Drain(op) => write!(f, "{op}"),
+            Operation::Fill(op) => write!(f, "{op}"),
+        }
+    }
+}
+
+impl Debug for Controller {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "backround_node_operations::Controller")
+    }
+}

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -480,6 +480,28 @@ async fn handle_node_configure(mut req: Request<Body>) -> Result<Response<Body>,
     )
 }
 
+async fn handle_node_drain(req: Request<Body>) -> Result<Response<Body>, ApiError> {
+    check_permissions(&req, Scope::Admin)?;
+
+    let state = get_state(&req);
+    let node_id: NodeId = parse_request_param(&req, "node_id")?;
+
+    state.service.start_node_drain(node_id).await?;
+
+    json_response(StatusCode::ACCEPTED, ())
+}
+
+async fn handle_node_fill(req: Request<Body>) -> Result<Response<Body>, ApiError> {
+    check_permissions(&req, Scope::Admin)?;
+
+    let state = get_state(&req);
+    let node_id: NodeId = parse_request_param(&req, "node_id")?;
+
+    state.service.start_node_fill(node_id).await?;
+
+    json_response(StatusCode::ACCEPTED, ())
+}
+
 async fn handle_tenant_shard_split(
     service: Arc<Service>,
     mut req: Request<Body>,
@@ -832,6 +854,13 @@ pub fn make_router(
                 RequestName("control_v1_node_config"),
             )
         })
+        .put("/control/v1/node/:node_id/drain", |r| {
+            named_request_span(r, handle_node_drain, RequestName("control_v1_node_drain"))
+        })
+        .put("/control/v1/node/:node_id/fill", |r| {
+            named_request_span(r, handle_node_fill, RequestName("control_v1_node_fill"))
+        })
+        // TODO(vlad): endpoint for cancelling drain and fill
         // Tenant Shard operations
         .put("/control/v1/tenant/:tenant_shard_id/migrate", |r| {
             tenant_service_handler(

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -486,7 +486,7 @@ async fn handle_node_status(req: Request<Body>) -> Result<Response<Body>, ApiErr
     let state = get_state(&req);
     let node_id: NodeId = parse_request_param(&req, "node_id")?;
 
-    let node_status = state.service.get_node_status(node_id).await?;
+    let node_status = state.service.get_node(node_id).await?;
 
     json_response(StatusCode::OK, node_status)
 }

--- a/storage_controller/src/lib.rs
+++ b/storage_controller/src/lib.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use utils::seqwait::MonotonicCounter;
 
 mod auth;
+mod background_node_operations;
 mod compute_hook;
 mod heartbeater;
 pub mod http;

--- a/storage_controller/src/node.rs
+++ b/storage_controller/src/node.rs
@@ -145,6 +145,7 @@ impl Node {
             NodeSchedulingPolicy::Draining => MaySchedule::No,
             NodeSchedulingPolicy::Filling => MaySchedule::Yes(score),
             NodeSchedulingPolicy::Pause => MaySchedule::No,
+            NodeSchedulingPolicy::PauseForRestart => MaySchedule::No,
         }
     }
 

--- a/storage_controller/src/node.rs
+++ b/storage_controller/src/node.rs
@@ -59,6 +59,10 @@ impl Node {
         self.id
     }
 
+    pub(crate) fn get_scheduling(&self) -> NodeSchedulingPolicy {
+        self.scheduling
+    }
+
     pub(crate) fn set_scheduling(&mut self, scheduling: NodeSchedulingPolicy) {
         self.scheduling = scheduling
     }

--- a/storage_controller/src/node.rs
+++ b/storage_controller/src/node.rs
@@ -162,7 +162,7 @@ impl Node {
             listen_http_port,
             listen_pg_addr,
             listen_pg_port,
-            scheduling: NodeSchedulingPolicy::Filling,
+            scheduling: NodeSchedulingPolicy::Active,
             availability: NodeAvailability::Offline,
             cancel: CancellationToken::new(),
         }

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5192,7 +5192,6 @@ impl Service {
                     };
 
                     if tenant_shard.intent.demote_attached(scheduler, node_id) {
-                        tenant_shard.sequence = tenant_shard.sequence.next();
                         match tenant_shard.schedule(scheduler, &mut schedule_context) {
                             Err(e) => {
                                 tracing::warn!(%tid, "Scheduling error when draining pageserver {} : {e}", node_id);

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5140,6 +5140,8 @@ impl Service {
         self.gate.close().await;
     }
 
+    /// Drain a node by moving the shards attached to it as primaries.
+    /// This is a long running operation and it should run as a separate Tokio task.
     pub(crate) async fn drain_node(
         &self,
         node_id: NodeId,
@@ -5303,6 +5305,10 @@ impl Service {
         plan
     }
 
+    /// Fill a node by promoting its secondaries until the cluster is balanced
+    /// with regards to attached shard counts. Note that this operation only
+    /// makes sense as a counterpart to the drain implemented in [`Service::drain_node`].
+    /// This is a long running operation and it should run as a separate Tokio task.
     pub(crate) async fn fill_node(
         &self,
         node_id: NodeId,

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5268,13 +5268,16 @@ impl Service {
                     if tenant_shard.intent.demote_attached(scheduler, node_id) {
                         match tenant_shard.schedule(scheduler, &mut schedule_context) {
                             Err(e) => {
-                                tracing::warn!(%tid, "Scheduling error when draining pageserver {} : {e}", node_id);
+                                tracing::warn!(
+                                    tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
+                                    "Scheduling error when draining pageserver {} : {e}", node_id
+                                );
                             }
                             Ok(()) => {
                                 let scheduled_to = tenant_shard.intent.get_attached();
                                 tracing::info!(
-                                    "Rescheduled shard {} while draining node {}: {} -> {:?}",
-                                    tid,
+                                    tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
+                                    "Rescheduled shard while draining node {}: {} -> {:?}",
                                     node_id,
                                     node_id,
                                     scheduled_to
@@ -5446,12 +5449,15 @@ impl Service {
                             tenant_shard.intent.promote_attached(scheduler, node_id);
                             match tenant_shard.schedule(scheduler, &mut schedule_context) {
                                 Err(e) => {
-                                    tracing::warn!(%tid, "Scheduling error when filling pageserver {} : {e}", node_id);
+                                    tracing::warn!(
+                                        tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
+                                        "Scheduling error when filling pageserver {} : {e}", node_id
+                                    );
                                 }
                                 Ok(()) => {
                                     tracing::info!(
-                                        "Rescheduled shard {} while filling node {}: {:?} -> {}",
-                                        tid,
+                                        tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
+                                        "Rescheduled shard while filling node {}: {:?} -> {}",
                                         node_id,
                                         previously_attached_to,
                                         node_id

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -1908,7 +1908,7 @@ impl Service {
 
     /// Same as [`Service::await_waiters`], but returns the waiters which are still
     /// in progress
-    async fn kick_waiters(
+    async fn await_waiters_remainder(
         &self,
         waiters: Vec<ReconcilerWaiter>,
         timeout: Duration,
@@ -5210,11 +5210,11 @@ impl Service {
                 }
             }
 
-            waiters = self.kick_waiters(waiters, SHORT_RECONCILE_TIMEOUT).await;
+            waiters = self.await_waiters_remainder(waiters, SHORT_RECONCILE_TIMEOUT).await;
         }
 
         while !waiters.is_empty() {
-            waiters = self.kick_waiters(waiters, SHORT_RECONCILE_TIMEOUT).await;
+            waiters = self.await_waiters_remainder(waiters, SHORT_RECONCILE_TIMEOUT).await;
         }
 
         // At this point we have done the best we could to drain shards from this node.
@@ -5367,11 +5367,11 @@ impl Service {
                 }
             }
 
-            waiters = self.kick_waiters(waiters, SHORT_RECONCILE_TIMEOUT).await;
+            waiters = self.await_waiters_remainder(waiters, SHORT_RECONCILE_TIMEOUT).await;
         }
 
         while !waiters.is_empty() {
-            waiters = self.kick_waiters(waiters, SHORT_RECONCILE_TIMEOUT).await;
+            waiters = self.await_waiters_remainder(waiters, SHORT_RECONCILE_TIMEOUT).await;
         }
 
         if let Err(err) = self

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -4202,7 +4202,7 @@ impl Service {
         Ok(nodes)
     }
 
-    pub(crate) async fn get_node_status(&self, node_id: NodeId) -> Result<Node, ApiError> {
+    pub(crate) async fn get_node(&self, node_id: NodeId) -> Result<Node, ApiError> {
         self.inner
             .read()
             .unwrap()

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5275,6 +5275,8 @@ impl Service {
         }
 
         while !waiters.is_empty() {
+            tracing::info!("Awaiting {} pending drain reconciliations", waiters.len());
+
             waiters = self
                 .await_waiters_remainder(waiters, SHORT_RECONCILE_TIMEOUT)
                 .await;
@@ -5452,6 +5454,8 @@ impl Service {
         }
 
         while !waiters.is_empty() {
+            tracing::info!("Awaiting {} pending fill reconciliations", waiters.len());
+
             waiters = self
                 .await_waiters_remainder(waiters, SHORT_RECONCILE_TIMEOUT)
                 .await;

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -8,7 +8,9 @@ use std::{
 };
 
 use crate::{
-    background_node_operations::{self, Controller, OperationError, MAX_RECONCILES_PER_OPERATION},
+    background_node_operations::{
+        Drain, Fill, Operation, OperationError, OperationHandler, MAX_RECONCILES_PER_OPERATION,
+    },
     compute_hook::NotifyError,
     id_lock_map::{trace_exclusive_lock, trace_shared_lock, IdLockMap, WrappedWriteGuard},
     persistence::{AbortShardSplitStatus, TenantFilter},
@@ -136,6 +138,11 @@ struct ServiceState {
 
     scheduler: Scheduler,
 
+    /// Ongoing background operation on the cluster if any is running.
+    /// Note that only one such operation may run at any given time,
+    /// hence the type choice.
+    ongoing_operation: Option<OperationHandler>,
+
     /// Queue of tenants who are waiting for concurrency limits to permit them to reconcile
     delayed_reconcile_rx: tokio::sync::mpsc::Receiver<TenantShardId>,
 }
@@ -187,6 +194,7 @@ impl ServiceState {
             tenants,
             nodes: Arc::new(nodes),
             scheduler,
+            ongoing_operation: None,
             delayed_reconcile_rx,
         }
     }
@@ -277,8 +285,6 @@ pub struct Service {
     /// use a VecDeque instead of a channel to reduce synchronization overhead, at the cost of some code complexity.
     delayed_reconcile_tx: tokio::sync::mpsc::Sender<TenantShardId>,
 
-    background_operations_controller: std::sync::OnceLock<Controller>,
-
     // Process shutdown will fire this token
     cancel: CancellationToken,
 
@@ -303,11 +309,9 @@ impl From<ReconcileWaitError> for ApiError {
 impl From<OperationError> for ApiError {
     fn from(value: OperationError) -> Self {
         match value {
-            OperationError::PreconditionFailed(err) => ApiError::PreconditionFailed(err.into()),
             OperationError::NodeStateChanged(err) => {
                 ApiError::InternalServerError(anyhow::anyhow!(err))
             }
-            OperationError::ShuttingDown => ApiError::ShuttingDown,
             OperationError::Cancelled => ApiError::Conflict("Operation was cancelled".into()),
         }
     }
@@ -1107,19 +1111,11 @@ impl Service {
             delayed_reconcile_tx,
             abort_tx,
             startup_complete: startup_complete.clone(),
-            background_operations_controller: Default::default(),
             cancel,
             gate: Gate::default(),
             tenant_op_locks: Default::default(),
             node_op_locks: Default::default(),
         });
-
-        let (controller, node_operations_receiver) =
-            background_node_operations::Controller::new(this.clone());
-
-        this.background_operations_controller
-            .set(controller)
-            .expect("This is the only code path that sets the controller");
 
         let result_task_this = this.clone();
         tokio::task::spawn(async move {
@@ -1189,19 +1185,6 @@ impl Service {
             async move {
                 startup_complete.wait().await;
                 this.spawn_heartbeat_driver().await;
-            }
-        });
-
-        tokio::task::spawn({
-            let this = this.clone();
-            let startup_complete = startup_complete.clone();
-            async move {
-                startup_complete.wait().await;
-                this.background_operations_controller
-                    .get()
-                    .expect("Initialized at start up")
-                    .handle_operations(node_operations_receiver)
-                    .await;
             }
         });
 
@@ -4451,8 +4434,11 @@ impl Service {
         Ok(())
     }
 
-    pub(crate) async fn start_node_drain(&self, node_id: NodeId) -> Result<(), ApiError> {
-        let (node_available, node_policy, schedulable_nodes_count) = {
+    pub(crate) async fn start_node_drain(
+        self: &Arc<Self>,
+        node_id: NodeId,
+    ) -> Result<(), ApiError> {
+        let (ongoing_op, node_available, node_policy, schedulable_nodes_count) = {
             let locked = self.inner.read().unwrap();
             let nodes = &locked.nodes;
             let node = nodes.get(&node_id).ok_or(ApiError::NotFound(
@@ -4464,11 +4450,21 @@ impl Service {
                 .count();
 
             (
+                locked
+                    .ongoing_operation
+                    .as_ref()
+                    .map(|ongoing| ongoing.operation),
                 node.is_available(),
                 node.get_scheduling(),
                 schedulable_nodes_count,
             )
         };
+
+        if let Some(ongoing) = ongoing_op {
+            return Err(ApiError::PreconditionFailed(
+                format!("Background operation already ongoing for node: {}", ongoing).into(),
+            ));
+        }
 
         if !node_available {
             return Err(ApiError::ResourceUnavailable(
@@ -4486,11 +4482,30 @@ impl Service {
             NodeSchedulingPolicy::Active | NodeSchedulingPolicy::Pause => {
                 self.node_configure(node_id, None, Some(NodeSchedulingPolicy::Draining))
                     .await?;
-                let controller = self
-                    .background_operations_controller
-                    .get()
-                    .expect("Initialized at start up");
-                controller.drain_node(node_id)?;
+
+                let cancel = CancellationToken::new();
+
+                self.inner.write().unwrap().ongoing_operation = Some(OperationHandler {
+                    operation: Operation::Drain(Drain { node_id }),
+                    cancel: cancel.clone(),
+                });
+
+                tokio::task::spawn({
+                    let service = self.clone();
+                    let cancel = cancel.clone();
+                    async move {
+                        scopeguard::defer! {
+                            let prev = service.inner.write().unwrap().ongoing_operation.take();
+
+                            if let Some(Operation::Drain(removed_drain)) = prev.map(|h| h.operation) {
+                                assert_eq!(removed_drain.node_id, node_id, "We always take the same operation");
+                            } else {
+                                panic!("We always remove the same operation")
+                            }
+                        }
+                        service.drain_node(node_id, cancel).await
+                    }
+                });
             }
             NodeSchedulingPolicy::Draining => {
                 return Err(ApiError::Conflict(format!(
@@ -4507,16 +4522,30 @@ impl Service {
         Ok(())
     }
 
-    pub(crate) async fn start_node_fill(&self, node_id: NodeId) -> Result<(), ApiError> {
-        let (node_available, node_policy, total_nodes_count) = {
+    pub(crate) async fn start_node_fill(self: &Arc<Self>, node_id: NodeId) -> Result<(), ApiError> {
+        let (ongoing_op, node_available, node_policy, total_nodes_count) = {
             let locked = self.inner.read().unwrap();
             let nodes = &locked.nodes;
             let node = nodes.get(&node_id).ok_or(ApiError::NotFound(
                 anyhow::anyhow!("Node {} not registered", node_id).into(),
             ))?;
 
-            (node.is_available(), node.get_scheduling(), nodes.len())
+            (
+                locked
+                    .ongoing_operation
+                    .as_ref()
+                    .map(|ongoing| ongoing.operation),
+                node.is_available(),
+                node.get_scheduling(),
+                nodes.len(),
+            )
         };
+
+        if let Some(ongoing) = ongoing_op {
+            return Err(ApiError::PreconditionFailed(
+                format!("Background operation already ongoing for node: {}", ongoing).into(),
+            ));
+        }
 
         if !node_available {
             return Err(ApiError::ResourceUnavailable(
@@ -4534,11 +4563,31 @@ impl Service {
             NodeSchedulingPolicy::Active => {
                 self.node_configure(node_id, None, Some(NodeSchedulingPolicy::Filling))
                     .await?;
-                let controller = self
-                    .background_operations_controller
-                    .get()
-                    .expect("Initialized at start up");
-                controller.fill_node(node_id)?;
+
+                let cancel = CancellationToken::new();
+
+                self.inner.write().unwrap().ongoing_operation = Some(OperationHandler {
+                    operation: Operation::Fill(Fill { node_id }),
+                    cancel: cancel.clone(),
+                });
+
+                tokio::task::spawn({
+                    let service = self.clone();
+                    let cancel = cancel.clone();
+                    async move {
+                        scopeguard::defer! {
+                            let prev = service.inner.write().unwrap().ongoing_operation.take();
+
+                            if let Some(Operation::Fill(removed_fill)) = prev.map(|h| h.operation) {
+                                assert_eq!(removed_fill.node_id, node_id, "We always take the same operation");
+                            } else {
+                                panic!("We always remove the same operation")
+                            }
+                        }
+
+                        service.fill_node(node_id, cancel).await
+                    }
+                });
             }
             NodeSchedulingPolicy::Filling => {
                 return Err(ApiError::Conflict(format!(

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -311,6 +311,12 @@ pub(crate) struct ReconcilerWaiter {
     seq: Sequence,
 }
 
+pub(crate) enum ReconcilerStatus {
+    Done,
+    Failed,
+    InProgress,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum ReconcileWaitError {
     #[error("Timeout waiting for shard {0}")]
@@ -372,6 +378,16 @@ impl ReconcilerWaiter {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn get_status(&self) -> ReconcilerStatus {
+        if self.seq_wait.would_wait_for(self.seq).is_err() {
+            ReconcilerStatus::Done
+        } else if self.error_seq_wait.would_wait_for(self.seq).is_err() {
+            ReconcilerStatus::Failed
+        } else {
+            ReconcilerStatus::InProgress
+        }
     }
 }
 

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -10,7 +10,9 @@ use crate::{
     reconciler::ReconcileUnits,
     scheduler::{AffinityScore, MaySchedule, RefCountUpdate, ScheduleContext},
 };
-use pageserver_api::controller_api::{PlacementPolicy, ShardSchedulingPolicy};
+use pageserver_api::controller_api::{
+    NodeSchedulingPolicy, PlacementPolicy, ShardSchedulingPolicy,
+};
 use pageserver_api::{
     models::{LocationConfig, LocationConfigMode, TenantConfig},
     shard::{ShardIdentity, TenantShardId},
@@ -668,13 +670,17 @@ impl TenantShard {
         let mut scores = all_pageservers
             .iter()
             .flat_map(|node_id| {
-                if matches!(
-                    nodes
-                        .get(node_id)
-                        .map(|n| n.may_schedule())
-                        .unwrap_or(MaySchedule::No),
-                    MaySchedule::No
+                let node = nodes.get(node_id);
+                if node.is_none() {
+                    None
+                } else if matches!(
+                    node.unwrap().get_scheduling(),
+                    NodeSchedulingPolicy::Filling
                 ) {
+                    // If the node is currently filling, don't count it as a candidate to avoid,
+                    // racing with the background fill.
+                    None
+                } else if matches!(node.unwrap().may_schedule(), MaySchedule::No) {
                     None
                 } else {
                     let affinity_score = schedule_context.get_node_affinity(*node_id);

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2213,6 +2213,30 @@ class NeonStorageController(MetricsGetter, LogUtils):
             headers=self.headers(TokenScope.ADMIN),
         )
 
+    def node_drain(self, node_id):
+        log.info(f"node_drain({node_id})")
+        self.request(
+            "PUT",
+            f"{self.env.storage_controller_api}/control/v1/node/{node_id}/drain",
+            headers=self.headers(TokenScope.ADMIN),
+        )
+
+    def node_fill(self, node_id):
+        log.info(f"node_fill({node_id})")
+        self.request(
+            "PUT",
+            f"{self.env.storage_controller_api}/control/v1/node/{node_id}/fill",
+            headers=self.headers(TokenScope.ADMIN),
+        )
+
+    def node_status(self, node_id):
+        response = self.request(
+            "GET",
+            f"{self.env.storage_controller_api}/control/v1/node/{node_id}",
+            headers=self.headers(TokenScope.ADMIN),
+        )
+        return response.json()
+
     def node_list(self):
         response = self.request(
             "GET",

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -1477,3 +1477,120 @@ def test_tenant_import(neon_env_builder: NeonEnvBuilder, shard_count, remote_sto
         workload = Workload(env, tenant_id, timeline, branch_name=branch)
         workload.expect_rows = expect_rows
         workload.validate()
+
+
+def test_graceful_cluster_restart(neon_env_builder: NeonEnvBuilder):
+    """
+    Graceful reststart of storage controller clusters use the drain and
+    fill hooks in order to migrate attachments away from pageservers before
+    restarting. In practice, Ansible will drive this process.
+    """
+    neon_env_builder.num_pageservers = 2
+    env = neon_env_builder.init_configs()
+    env.start()
+
+    tenant_count = 5
+    shard_count_per_tenant = 8
+    total_shards = tenant_count * shard_count_per_tenant
+    tenant_ids = []
+
+    for _ in range(0, tenant_count):
+        tid = TenantId.generate()
+        tenant_ids.append(tid)
+        env.neon_cli.create_tenant(
+            tid, placement_policy='{"Attached":1}', shard_count=shard_count_per_tenant
+        )
+
+    # Give things a chance to settle.
+    # A call to `reconcile_until_idle` could be used here instead,
+    # however since all attachments are placed on the same node,
+    # we'd have to wait for a long time (2 minutes-ish) for optimizations
+    # to quiesce.
+    # TODO: once the initial attachment selection is fixed, update this
+    # to use `reconcile_until_idle`.
+    time.sleep(2)
+
+    nodes = env.storage_controller.node_list()
+    assert len(nodes) == 2
+
+    def retryable_node_operation(op, ps_id, max_attempts, backoff):
+        while max_attempts > 0:
+            try:
+                op(ps_id)
+                return
+            except StorageControllerApiException as e:
+                max_attempts -= 1
+                log.info(f"Operation failed ({max_attempts} attempts left): {e}")
+
+                if max_attempts == 0:
+                    raise e
+
+                time.sleep(backoff)
+
+    def poll_node_status(node_id, desired_scheduling_policy, max_attempts, backoff):
+        log.info(f"Polling {node_id} for {desired_scheduling_policy} scheduling policy")
+        while max_attempts > 0:
+            try:
+                status = env.storage_controller.node_status(node_id)
+                policy = status["scheduling"]
+                if policy == desired_scheduling_policy:
+                    return
+                else:
+                    max_attempts -= 1
+                    log.info(f"Status call returned {policy=} ({max_attempts} attempts left)")
+
+                    if max_attempts == 0:
+                        raise AssertionError(
+                            f"Status for {node_id=} did not reach {desired_scheduling_policy=}"
+                        )
+
+                    time.sleep(backoff)
+            except StorageControllerApiException as e:
+                max_attempts -= 1
+                log.info(f"Status call failed ({max_attempts} retries left): {e}")
+
+                if max_attempts == 0:
+                    raise e
+
+                time.sleep(backoff)
+
+    def assert_shard_counts_balanced(env: NeonEnv, shard_counts, total_shards):
+        # Assert that all nodes have some attached shards
+        assert len(shard_counts) == len(env.pageservers)
+
+        min_shard_count = min(shard_counts.values())
+        max_shard_count = max(shard_counts.values())
+
+        flake_factor = 5 / 100
+        assert max_shard_count - min_shard_count <= int(total_shards * flake_factor)
+
+    # Perform a graceful rolling restart
+    for ps in env.pageservers:
+        retryable_node_operation(
+            lambda ps_id: env.storage_controller.node_drain(ps_id), ps.id, max_attempts=3, backoff=2
+        )
+        poll_node_status(ps.id, "PauseForRestart", max_attempts=6, backoff=5)
+
+        shard_counts = get_node_shard_counts(env, tenant_ids)
+        log.info(f"Shard counts after draining node {ps.id}: {shard_counts}")
+        # Assert that we've drained the node
+        assert shard_counts[str(ps.id)] == 0
+        # Assert that those shards actually went somewhere
+        assert sum(shard_counts.values()) == total_shards
+
+        ps.restart()
+        poll_node_status(ps.id, "Active", max_attempts=10, backoff=1)
+
+        retryable_node_operation(
+            lambda ps_id: env.storage_controller.node_fill(ps_id), ps.id, max_attempts=3, backoff=2
+        )
+        poll_node_status(ps.id, "Active", max_attempts=6, backoff=5)
+
+        shard_counts = get_node_shard_counts(env, tenant_ids)
+        log.info(f"Shard counts after filling node {ps.id}: {shard_counts}")
+        assert_shard_counts_balanced(env, shard_counts, total_shards)
+
+    # Now check that shards are reasonably balanced
+    shard_counts = get_node_shard_counts(env, tenant_ids)
+    log.info(f"Shard counts after rolling restart: {shard_counts}")
+    assert_shard_counts_balanced(env, shard_counts, total_shards)

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -40,7 +40,7 @@ from werkzeug.wrappers.response import Response
 
 
 def get_node_shard_counts(env: NeonEnv, tenant_ids):
-    counts: defaultdict[str, int] = defaultdict(int)
+    counts: defaultdict[int, int] = defaultdict(int)
     for tid in tenant_ids:
         for shard in env.storage_controller.locate(tid):
             counts[shard["node_id"]] += 1
@@ -1574,7 +1574,7 @@ def test_graceful_cluster_restart(neon_env_builder: NeonEnvBuilder):
         shard_counts = get_node_shard_counts(env, tenant_ids)
         log.info(f"Shard counts after draining node {ps.id}: {shard_counts}")
         # Assert that we've drained the node
-        assert shard_counts[str(ps.id)] == 0
+        assert shard_counts[ps.id] == 0
         # Assert that those shards actually went somewhere
         assert sum(shard_counts.values()) == total_shards
 


### PR DESCRIPTION
## Problem
Pageserver restarts cause read availablity downtime for tenants. See `Motivation` section in the [RFC](https://github.com/neondatabase/neon/pull/7704).

## Summary of changes
* Introduce a new `NodeSchedulingPolicy`: `PauseForRestart`
* Implement the first take of drain and fill algorithms
* Add a node status endpoint which can be polled to figure out when an operation is done

The implementation follows the RFC, so it might be useful to peek at it as you're reviewing.
Since the PR is rather chunky, I've made sure all commits build (with warnings), so you can
review by commit if you prefer that.

RFC: https://github.com/neondatabase/neon/pull/7704
Related https://github.com/neondatabase/neon/issues/7387

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
