### PR TITLE
test(pageserver): add test wal record for unit testing

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -6703,7 +6703,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_bottom_most_compaction_images() -> anyhow::Result<()> {
-        let harness = TenantHarness::create("test_simple_bottom_most_compaction")?;
+        let harness = TenantHarness::create("test_simple_bottom_most_compaction_images")?;
         let (tenant, ctx) = harness.load().await;
 
         fn get_key(id: u32) -> Key {
@@ -6875,35 +6875,35 @@ mod tests {
             (
                 get_key(1),
                 Lsn(0x20),
-                Value::WalRecord(NeonWalRecord::Test {
-                    append: ",0x20".to_string(),
-                    clear: false,
-                }),
+                Value::WalRecord(NeonWalRecord::wal_append(",0x20")),
             ),
             (
                 get_key(1),
                 Lsn(0x30),
-                Value::WalRecord(NeonWalRecord::Test {
-                    append: ",0x30".to_string(),
-                    clear: false,
-                }),
+                Value::WalRecord(NeonWalRecord::wal_append(",0x30")),
             ),
             (get_key(2), Lsn(0x10), Value::Image("0x10".into())),
             (
                 get_key(2),
                 Lsn(0x20),
-                Value::WalRecord(NeonWalRecord::Test {
-                    append: ",0x20".to_string(),
-                    clear: false,
-                }),
+                Value::WalRecord(NeonWalRecord::wal_append(",0x20")),
             ),
             (
                 get_key(2),
                 Lsn(0x30),
-                Value::WalRecord(NeonWalRecord::Test {
-                    append: ",0x30".to_string(),
-                    clear: false,
-                }),
+                Value::WalRecord(NeonWalRecord::wal_append(",0x30")),
+            ),
+            (get_key(3), Lsn(0x10), Value::Image("0x10".into())),
+            (
+                get_key(3),
+                Lsn(0x20),
+                Value::WalRecord(NeonWalRecord::wal_clear()),
+            ),
+            (get_key(4), Lsn(0x10), Value::Image("0x10".into())),
+            (
+                get_key(4),
+                Lsn(0x20),
+                Value::WalRecord(NeonWalRecord::wal_init()),
             ),
         ];
         let image1 = vec![(get_key(1), "0x10".into())];
@@ -6928,6 +6928,8 @@ mod tests {
             tline.get(get_key(2), Lsn(0x50), &ctx).await?,
             Bytes::from_static(b"0x10,0x20,0x30")
         );
+        // assert_eq!(tline.get(get_key(3), Lsn(0x50), &ctx).await?, Bytes::new());
+        // assert_eq!(tline.get(get_key(4), Lsn(0x50), &ctx).await?, Bytes::new());
 
         Ok(())
     }

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -52,7 +52,16 @@ pub enum NeonWalRecord {
 
     #[cfg(test)]
     /// A testing record for unit testing purposes. It supports append data to an existing image, or clear it.
-    Test { append: String, clear: bool },
+    Test {
+        /// Append a string to the image.
+        append: String,
+        /// Clear the image before appending.
+        clear: bool,
+        /// Treat this record as an init record. `clear` should be set to true if this field is set
+        /// to true. This record does not need the history WALs to reconstruct. See [`NeonWalRecord::will_init`] and
+        /// its references in `timeline.rs`.
+        will_init: bool,
+    },
 }
 
 impl NeonWalRecord {
@@ -63,9 +72,36 @@ impl NeonWalRecord {
         match self {
             NeonWalRecord::Postgres { will_init, rec: _ } => *will_init,
             #[cfg(test)]
-            NeonWalRecord::Test { clear, .. } => *clear,
+            NeonWalRecord::Test { will_init, .. } => *will_init,
             // None of the special neon record types currently initialize the page
             _ => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wal_append(s: impl AsRef<str>) -> Self {
+        Self::Test {
+            append: s.as_ref().to_string(),
+            clear: false,
+            will_init: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wal_clear() -> Self {
+        Self::Test {
+            append: "".to_string(),
+            clear: true,
+            will_init: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn wal_init() -> Self {
+        Self::Test {
+            append: "".to_string(),
+            clear: true,
+            will_init: true,
         }
     }
 }

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -50,8 +50,8 @@ pub enum NeonWalRecord {
         content: Option<Bytes>,
     },
 
-    #[cfg(test)]
     /// A testing record for unit testing purposes. It supports append data to an existing image, or clear it.
+    #[cfg(test)]
     Test {
         /// Append a string to the image.
         append: String,

--- a/pageserver/src/walrecord.rs
+++ b/pageserver/src/walrecord.rs
@@ -49,6 +49,10 @@ pub enum NeonWalRecord {
         file_path: String,
         content: Option<Bytes>,
     },
+
+    #[cfg(test)]
+    /// A testing record for unit testing purposes. It supports append data to an existing image, or clear it.
+    Test { append: String, clear: bool },
 }
 
 impl NeonWalRecord {
@@ -58,7 +62,8 @@ impl NeonWalRecord {
         // If you change this function, you'll also need to change ValueBytes::will_init
         match self {
             NeonWalRecord::Postgres { will_init, rec: _ } => *will_init,
-
+            #[cfg(test)]
+            NeonWalRecord::Test { clear, .. } => *clear,
             // None of the special neon record types currently initialize the page
             _ => false,
         }

--- a/pageserver/src/walredo/apply_neon.rs
+++ b/pageserver/src/walredo/apply_neon.rs
@@ -245,12 +245,18 @@ pub(crate) fn apply_in_neon(
             dir.ser_into(&mut writer)?;
         }
         #[cfg(test)]
-        NeonWalRecord::Test { append, clear } => {
+        NeonWalRecord::Test {
+            append,
+            clear,
+            will_init,
+        } => {
+            if *will_init {
+                assert!(*clear, "init record must be clear to ensure correctness");
+            }
             if *clear {
                 page.clear();
-            } else {
-                page.put_slice(append.as_bytes());
             }
+            page.put_slice(append.as_bytes());
         }
     }
     Ok(())

--- a/pageserver/src/walredo/apply_neon.rs
+++ b/pageserver/src/walredo/apply_neon.rs
@@ -244,6 +244,14 @@ pub(crate) fn apply_in_neon(
             let mut writer = page.writer();
             dir.ser_into(&mut writer)?;
         }
+        #[cfg(test)]
+        NeonWalRecord::Test { append, clear } => {
+            if *clear {
+                page.clear();
+            } else {
+                page.put_slice(append.as_bytes());
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Problem

https://github.com/neondatabase/neon/issues/8002

## Summary of changes

We need mock WAL record to make it easier to write unit tests. This pull request adds such a record. It has `clear` flag and `append` field. The tests for legacy-enhanced compaction are not modified yet and will be part of the next pull request.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
