### PR TITLE
Fix query error in vm-image-spec.yaml

### DIFF
--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -304,7 +304,9 @@ files:
           - slot_name
         values: [restart_lsn]
         query: |
-          select slot_name, (restart_lsn - '0/0')::FLOAT8 from pg_replication_slots where slot_type = 'logical';
+          select slot_name, (restart_lsn - '0/0')::FLOAT8 as restart_lsn
+          from pg_replication_slots
+          where slot_type = 'logical';
 
       - metric_name: retained_wal
         type: gauge


### PR DESCRIPTION
This query causes metrics exporter to complain about missing data because it can't find the correct column.

Issue was introduced with https://github.com/neondatabase/neon/pull/7761

## Problem

There are a lot of logs `Error gathering metrics: [from Gatherer #1] [collector=neon_collector,query=logical_slot_restart_lsn] Missing values for the requested columns: ["restart_lsn"]`

## Summary of changes

This fixes the query so that it does have an output column `restart_lsn`

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
