### PR TITLE
fix: update lsn lease binary protocol to use text API. 

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -14,6 +14,7 @@ use std::time;
 use std::time::Instant;
 use std::time::SystemTime;
 
+use anyhow::bail;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use futures::future::join_all;
@@ -21,6 +22,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use nix::unistd::Pid;
 use postgres::error::SqlState;
+use postgres::SimpleQueryMessage;
 use postgres::{Client, NoTls};
 use tracing::{debug, error, info, instrument, warn};
 use utils::id::{TenantId, TimelineId};
@@ -1452,9 +1454,12 @@ fn lsn_lease_request(configs: &[postgres::Config], cmd: &str) -> Result<u128> {
         .iter()
         .map(|config| {
             let mut client = config.connect(NoTls)?;
-            let msg = client.query_one(cmd, &[])?;
-            let bytes: &[u8] = msg.try_get("valid_until")?;
-            Ok(u128::from_be_bytes(bytes.try_into()?))
+            let msg = client.simple_query(cmd)?;
+            if let SimpleQueryMessage::Row(row) = &msg[0] {
+                Ok(u128::from_str(row.get("valid_until").unwrap())?)
+            } else {
+                bail!("error parsing lsn lease response");
+            }
         })
         .collect::<Result<Vec<u128>>>()?
         .into_iter()

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -945,9 +945,8 @@ impl PageServerHandler {
             b"valid_until",
         )]))?
         .write_message_noflush(&BeMessage::DataRow(&[Some(
-            &valid_until.as_millis().to_be_bytes(),
-        )]))?
-        .write_message_noflush(&BeMessage::CommandComplete(b"SELECT 1"))?;
+            valid_until.as_millis().to_string().as_bytes(),
+        )]))?;
 
         Ok(())
     }


### PR DESCRIPTION
## Problem

As part of the work in #7994, @prepor found that the client will receive an "unexpected message from server" error when calling the lsn lease libpq API. Upon investigation, it seems the problem is due to serialization.

## Summary of changes

Use text serialization for the `valid_until` field to indicate expiration time.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
