### PR TITLE
pgvector: test performance difference between generic binaries and optimized binaries

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -727,7 +727,7 @@ jobs:
     needs: [ check-permissions, build-build-tools-image, tag ]
     strategy:
       matrix:
-        arch: [ x64, arm64 ]
+        arch: [ x64 ]
 
     runs-on: ${{ fromJson(format('["self-hosted", "gen3", "{0}"]', matrix.arch == 'arm64' && 'large-arm64' || 'large')) }}
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -727,7 +727,7 @@ jobs:
     needs: [ check-permissions, build-build-tools-image, tag ]
     strategy:
       matrix:
-        arch: [ x64 ]
+        arch: [ x64, arm64 ]
 
     runs-on: ${{ fromJson(format('["self-hosted", "gen3", "{0}"]', matrix.arch == 'arm64' && 'large-arm64' || 'large')) }}
 

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -250,8 +250,8 @@ RUN wget https://github.com/pgvector/pgvector/archive/refs/tags/v0.7.2.tar.gz -O
     echo "617fba855c9bcb41a2a9bc78a78567fd2e147c72afd5bf9d37b31b9591632b30 pgvector.tar.gz" | sha256sum --check && \
     mkdir pgvector-src && cd pgvector-src && tar xzf ../pgvector.tar.gz --strip-components=1 -C . && \
     patch -p1 < /pgvector.patch && \
-    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS=" -march=native " PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
-    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS=" -march=native " install PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
+    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS=" -march=x86-64 " PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
+    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS=" -march=x86-64 " install PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/vector.control
 
 #########################################################################################

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -250,8 +250,8 @@ RUN wget https://github.com/pgvector/pgvector/archive/refs/tags/v0.7.2.tar.gz -O
     echo "617fba855c9bcb41a2a9bc78a78567fd2e147c72afd5bf9d37b31b9591632b30 pgvector.tar.gz" | sha256sum --check && \
     mkdir pgvector-src && cd pgvector-src && tar xzf ../pgvector.tar.gz --strip-components=1 -C . && \
     patch -p1 < /pgvector.patch && \
-    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS="" PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
-    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS="" install PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
+    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS=" -march=native " PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
+    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS=" -march=native " install PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/vector.control
 
 #########################################################################################

--- a/Dockerfile.compute-node
+++ b/Dockerfile.compute-node
@@ -246,12 +246,17 @@ COPY patches/pgvector.patch /pgvector.patch
 # By default, pgvector Makefile uses `-march=native`. We don't want that,
 # because we build the images on different machines than where we run them.
 # Pass OPTFLAGS="" to remove it.
-RUN wget https://github.com/pgvector/pgvector/archive/refs/tags/v0.7.2.tar.gz -O pgvector.tar.gz && \
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+        OPTFLAGS=" -march=x86-64 "; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        OPTFLAGS=""; \
+    fi && \
+    wget https://github.com/pgvector/pgvector/archive/refs/tags/v0.7.2.tar.gz -O pgvector.tar.gz && \
     echo "617fba855c9bcb41a2a9bc78a78567fd2e147c72afd5bf9d37b31b9591632b30 pgvector.tar.gz" | sha256sum --check && \
     mkdir pgvector-src && cd pgvector-src && tar xzf ../pgvector.tar.gz --strip-components=1 -C . && \
     patch -p1 < /pgvector.patch && \
-    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS=" -march=x86-64 " PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
-    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS=" -march=x86-64 " install PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
+    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS="$OPTFLAGS" PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
+    make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS="$OPTFLAGS" install PG_CONFIG=/usr/local/pgsql/bin/pg_config && \
     echo 'trusted = true' >> /usr/local/pgsql/share/extension/vector.control
 
 #########################################################################################


### PR DESCRIPTION
WIP - DO NOT YET REVIEW

Currently we use OPTFLAGS = "" for pgvector to run same binary on different servers, including local testing on Macs with Apple silicon.

This PR will test out different march=xxx options to achieve a good balance between generality and performance.

## Problem

We did not yet verify the performance degradation on Neon using OPTFLAGS="" that we introduced in https://github.com/neondatabase/neon/pull/7854

### Periodic performance runs

Runs with OPTFLAGS=""

https://github.com/neondatabase/neon/actions/runs/9518206985/job/26240957716
https://github.com/neondatabase/neon/actions/runs/9525012136/job/26258625015

RUN with OPTFLAGS=" -march=native "

https://github.com/neondatabase/neon/actions/runs/9527097439/job/26263305246

RUN with OPTFLAGS=" -march=x86-64 "

https://github.com/neondatabase/neon/actions/runs/9527843825/job/26264904216

  | HNSW indexing (fp32) | halfvec indexing | queries hnsw tps | queries hnsw #txns | queries hnsw avg lat | halfvec queries tps | halfvec queries #txns | halfvec queries avg lat |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
OPTFLAGS="" | 419.9 | 1365 | 478.5 | 429534 | 208.9 ms | 163.2 | 147274 | 609.5 ms |  
OPTFLAGS=" -march=native " | 423.1 | 1511 | 20.8 | 18681 | 4811.0 ms | 7.3 | 6582 | 13692 ms |  
OPTFLAGS=" -march=x86-64 " | 394.8 | 1362 | 421.1 | 379471 | 236.5 ms | 156.2 | 140244 | 640.0 ms |  
scheduled OPTFLAGS="" | 401 | 1327 | 454 | 408966 | 219.4 ms | 166.6 | 150303 | 597.2 ms


In summary, I did not see an improvement using march=native or march=x86-64 over OPTFLAGS=""

The problem for march=native could be that our build processor type is so much different than our production processor type that the effect is negative instead of positive.

So for now we can close this PR without committing any changes.

