### PR TITLE
storcon: add transactional-ish demotion to secondary

### DIFF
--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -646,6 +646,49 @@ impl TenantShard {
         Ok(())
     }
 
+    /// Attempt to reschedule the tenant shard to one of its secondary locations.
+    /// If no schedulable secondary is found, roll back any changes to the intent state.
+    /// If the `attached_to` node argument doesn't match the intent state, no changes
+    /// are made and the function returns successfully.
+    pub(crate) fn reschedule_to_secondary(
+        &mut self,
+        attached_to: NodeId,
+        scheduler: &mut Scheduler,
+        context: &mut ScheduleContext,
+    ) -> Result<(), ScheduleError> {
+        let original_secondaries = self.intent.get_secondary().clone();
+
+        if self.intent.demote_attached(scheduler, attached_to) {
+            let res = match self.schedule(scheduler, context) {
+                Ok(()) => {
+                    let rescheduled_to_secondary =
+                        self.intent.get_attached().map_or(false, |node| {
+                            original_secondaries.iter().any(|sec| *sec == node)
+                        });
+
+                    if rescheduled_to_secondary {
+                        Ok(())
+                    } else {
+                        Err(ScheduleError::ImpossibleConstraint)
+                    }
+                }
+                Err(e) => Err(e),
+            };
+
+            if res.is_err() {
+                self.intent.set_attached(scheduler, Some(attached_to));
+                self.intent.clear_secondary(scheduler);
+                for sec in original_secondaries {
+                    self.intent.push_secondary(scheduler, sec);
+                }
+            }
+
+            return res;
+        }
+
+        Ok(())
+    }
+
     /// Optimize attachments: if a shard has a secondary location that is preferable to
     /// its primary location based on soft constraints, switch that secondary location
     /// to be attached.


### PR DESCRIPTION
## Problem

Recently, we've had a couple scenarios where we'd like to attempt rescheduling a tenant
shard to a secondary, but roll back any changes in case the scheduler failed to do so.

## Summary of changes
This PR introduces such an utility. The code looks a bit odd because we have to operate in
terms of scheduler operations to keep the reference counts valid.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
