### PR TITLE
storcon: improve drain and fill shard placement

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5323,28 +5323,30 @@ impl Service {
                         }
                     };
 
-                    if tenant_shard.intent.demote_attached(scheduler, node_id) {
-                        match tenant_shard.schedule(scheduler, &mut schedule_context) {
-                            Err(e) => {
-                                tracing::warn!(
-                                    tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
-                                    "Scheduling error when draining pageserver {} : {e}", node_id
-                                );
-                            }
-                            Ok(()) => {
-                                let scheduled_to = tenant_shard.intent.get_attached();
-                                tracing::info!(
-                                    tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
-                                    "Rescheduled shard while draining node {}: {} -> {:?}",
-                                    node_id,
-                                    node_id,
-                                    scheduled_to
-                                );
+                    match tenant_shard.reschedule_to_secondary(
+                        node_id,
+                        scheduler,
+                        &mut schedule_context,
+                    ) {
+                        Err(e) => {
+                            tracing::warn!(
+                                tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
+                                "Scheduling error when draining pageserver {} : {e}", node_id
+                            );
+                        }
+                        Ok(()) => {
+                            let scheduled_to = tenant_shard.intent.get_attached();
+                            tracing::info!(
+                                tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
+                                "Rescheduled shard while draining node {}: {} -> {:?}",
+                                node_id,
+                                node_id,
+                                scheduled_to
+                            );
 
-                                let waiter = self.maybe_reconcile_shard(tenant_shard, nodes);
-                                if let Some(some) = waiter {
-                                    waiters.push(some);
-                                }
+                            let waiter = self.maybe_reconcile_shard(tenant_shard, nodes);
+                            if let Some(some) = waiter {
+                                waiters.push(some);
                             }
                         }
                     }

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5328,7 +5328,7 @@ impl Service {
                         continue;
                     }
 
-                    match tenant_shard.reschedule_to_secondary(Some(node_id), None, scheduler) {
+                    match tenant_shard.reschedule_to_secondary(None, scheduler) {
                         Err(e) => {
                             tracing::warn!(
                                 tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
@@ -5526,11 +5526,7 @@ impl Service {
                             }
 
                             let previously_attached_to = *tenant_shard.intent.get_attached();
-                            match tenant_shard.reschedule_to_secondary(
-                                previously_attached_to,
-                                Some(node_id),
-                                scheduler,
-                            ) {
+                            match tenant_shard.reschedule_to_secondary(Some(node_id), scheduler) {
                                 Err(e) => {
                                     tracing::warn!(
                                         tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5282,7 +5282,6 @@ impl Service {
         let mut last_inspected_shard: Option<TenantShardId> = None;
         let mut inspected_all_shards = false;
         let mut waiters = Vec::new();
-        let mut schedule_context = ScheduleContext::default();
 
         while !inspected_all_shards {
             if cancel.is_cancelled() {
@@ -5323,11 +5322,7 @@ impl Service {
                         }
                     };
 
-                    match tenant_shard.reschedule_to_secondary(
-                        node_id,
-                        scheduler,
-                        &mut schedule_context,
-                    ) {
+                    match tenant_shard.reschedule_to_secondary(Some(node_id), None, scheduler) {
                         Err(e) => {
                             tracing::warn!(
                                 tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),
@@ -5489,9 +5484,7 @@ impl Service {
         // secondaries are warm. This is not always true (e.g. we just migrated the
         // tenant). Take that into consideration by checking the secondary status.
         let mut tids_to_promote = self.fill_node_plan(node_id);
-
         let mut waiters = Vec::new();
-        let mut schedule_context = ScheduleContext::default();
 
         // Execute the plan we've composed above. Before aplying each move from the plan,
         // we validate to ensure that it has not gone stale in the meantime.
@@ -5527,9 +5520,11 @@ impl Service {
                             }
 
                             let previously_attached_to = *tenant_shard.intent.get_attached();
-
-                            tenant_shard.intent.promote_attached(scheduler, node_id);
-                            match tenant_shard.schedule(scheduler, &mut schedule_context) {
+                            match tenant_shard.reschedule_to_secondary(
+                                previously_attached_to,
+                                Some(node_id),
+                                scheduler,
+                            ) {
                                 Err(e) => {
                                     tracing::warn!(
                                         tenant_id=%tid.tenant_id, shard_id=%tid.shard_slug(),

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5322,6 +5322,12 @@ impl Service {
                         }
                     };
 
+                    // If the shard is not attached to the node being drained, skip it.
+                    if *tenant_shard.intent.get_attached() != Some(node_id) {
+                        last_inspected_shard = Some(*tid);
+                        continue;
+                    }
+
                     match tenant_shard.reschedule_to_secondary(Some(node_id), None, scheduler) {
                         Err(e) => {
                             tracing::warn!(

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -656,7 +656,6 @@ impl TenantShard {
     /// the scheduler to recommend a node
     pub(crate) fn reschedule_to_secondary(
         &mut self,
-        attached_to: Option<NodeId>,
         promote_to: Option<NodeId>,
         scheduler: &mut Scheduler,
     ) -> Result<(), ScheduleError> {
@@ -672,8 +671,8 @@ impl TenantShard {
 
         assert!(self.intent.get_secondary().contains(&promote_to));
 
-        if let Some(node) = attached_to {
-            let demoted = self.intent.demote_attached(scheduler, node);
+        if let Some(node) = self.intent.get_attached() {
+            let demoted = self.intent.demote_attached(scheduler, *node);
             if !demoted {
                 return Err(ScheduleError::ImpossibleConstraint);
             }

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -646,6 +646,49 @@ impl TenantShard {
         Ok(())
     }
 
+    /// Attempt to reschedule the tenant shard to one of its secondary locations.
+    /// If no schedulable secondary is found, roll back any changes to the intent state.
+    /// If the `attached_to` node argument doesn't match the intent state, no changes
+    /// are made and the function returns successfully.
+    pub(crate) fn reschedule_to_secondary(
+        &mut self,
+        attached_to: NodeId,
+        scheduler: &mut Scheduler,
+        context: &mut ScheduleContext,
+    ) -> Result<(), ScheduleError> {
+        let original_secondaries = self.intent.get_secondary().clone();
+
+        if self.intent.demote_attached(scheduler, attached_to) {
+            let res = match self.schedule(scheduler, context) {
+                Ok(()) => {
+                    let rescheduled_to_secondary =
+                        self.intent.get_attached().map_or(false, |node| {
+                            original_secondaries.iter().any(|sec| *sec == node)
+                        });
+
+                    if rescheduled_to_secondary {
+                        Ok(())
+                    } else {
+                        Err(ScheduleError::ImpossibleConstraint)
+                    }
+                }
+                Err(e) => Err(e),
+            };
+
+            if res.is_err() {
+                self.intent.set_attached(scheduler, Some(attached_to));
+                self.intent.clear_secondary(scheduler);
+                for sec in original_secondaries {
+                    self.intent.push_secondary(scheduler, sec);
+                }
+            }
+
+            return res;
+        }
+
+        Ok(())
+    }
+
     /// Optimize attachments: if a shard has a secondary location that is preferable to
     /// its primary location based on soft constraints, switch that secondary location
     /// to be attached.

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -681,6 +681,11 @@ impl TenantShard {
 
         self.intent.promote_attached(scheduler, promote_to);
 
+        // Increment the sequence number for the edge case where a
+        // reconciler is already running to avoid waiting on the
+        // current reconcile instead of spawning a new one.
+        self.sequence = self.sequence.next();
+
         Ok(())
     }
 

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -646,45 +646,40 @@ impl TenantShard {
         Ok(())
     }
 
-    /// Attempt to reschedule the tenant shard to one of its secondary locations.
-    /// If no schedulable secondary is found, roll back any changes to the intent state.
-    /// If the `attached_to` node argument doesn't match the intent state, no changes
-    /// are made and the function returns successfully.
+    /// Reschedule this tenant shard to one of its secondary locations. Returns a scheduling error
+    /// if the swap is not possible and leaves the intent state in its original state.
+    ///
+    /// Arguments:
+    /// `attached_to`: the currently attached location matching the intent state (may be None if the
+    /// shard is not attached)
+    /// `promote_to`: an optional secondary location of this tenant shard. If set to None, we ask
+    /// the scheduler to recommend a node
     pub(crate) fn reschedule_to_secondary(
         &mut self,
-        attached_to: NodeId,
+        attached_to: Option<NodeId>,
+        promote_to: Option<NodeId>,
         scheduler: &mut Scheduler,
-        context: &mut ScheduleContext,
     ) -> Result<(), ScheduleError> {
-        let original_secondaries = self.intent.get_secondary().clone();
-
-        if self.intent.demote_attached(scheduler, attached_to) {
-            let res = match self.schedule(scheduler, context) {
-                Ok(()) => {
-                    let rescheduled_to_secondary =
-                        self.intent.get_attached().map_or(false, |node| {
-                            original_secondaries.iter().any(|sec| *sec == node)
-                        });
-
-                    if rescheduled_to_secondary {
-                        Ok(())
-                    } else {
-                        Err(ScheduleError::ImpossibleConstraint)
-                    }
+        let promote_to = match promote_to {
+            Some(node) => node,
+            None => match scheduler.node_preferred(self.intent.get_secondary()) {
+                Some(node) => node,
+                None => {
+                    return Err(ScheduleError::ImpossibleConstraint);
                 }
-                Err(e) => Err(e),
-            };
+            },
+        };
 
-            if res.is_err() {
-                self.intent.set_attached(scheduler, Some(attached_to));
-                self.intent.clear_secondary(scheduler);
-                for sec in original_secondaries {
-                    self.intent.push_secondary(scheduler, sec);
-                }
+        assert!(self.intent.get_secondary().contains(&promote_to));
+
+        if let Some(node) = attached_to {
+            let demoted = self.intent.demote_attached(scheduler, node);
+            if !demoted {
+                return Err(ScheduleError::ImpossibleConstraint);
             }
-
-            return res;
         }
+
+        self.intent.promote_attached(scheduler, promote_to);
 
         Ok(())
     }


### PR DESCRIPTION
## Problem
While adapting the storage controller scale test to do graceful rolling restarts via
drain and fill, I noticed that secondaries are also being rescheduled, which, in turn,
caused the storage controller to optimise attachments.

## Summary of changes
* Introduce a transactional looking rescheduling primitive (i.e. "try to schedule to this
secondary, but leave everything as is if you can't")
* Use it for the drain and fill stages to avoid calling into `Scheduler::schedule` and having
secondaries move around.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
