### PR TITLE
proxy fix wake compute console retry

### DIFF
--- a/proxy/src/console/messages.rs
+++ b/proxy/src/console/messages.rs
@@ -1,12 +1,11 @@
 use measured::FixedCardinalityLabel;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
-use std::time::Duration;
 
 use crate::auth::IpPattern;
 
 use crate::intern::{BranchIdInt, EndpointIdInt, ProjectIdInt};
-use crate::proxy::retry::{CouldRetry, Retry};
+use crate::proxy::retry::CouldRetry;
 
 /// Generic error response with human-readable description.
 /// Note that we can't always present it to user as is.
@@ -66,13 +65,13 @@ impl Display for ConsoleError {
 }
 
 impl CouldRetry for ConsoleError {
-    fn could_retry(&self) -> Option<Retry> {
+    fn could_retry(&self) -> bool {
         // retry if the retry info is set.
         // if no status or retry info, do not retry.
         self.status
             .as_ref()
             .and_then(|status| status.details.retry_info.as_ref())
-            .map(|info| Retry::Fixed(Duration::from_millis(info.retry_delay_ms)))
+            .is_some()
     }
 }
 

--- a/proxy/src/console/messages.rs
+++ b/proxy/src/console/messages.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use crate::auth::IpPattern;
 
 use crate::intern::{BranchIdInt, EndpointIdInt, ProjectIdInt};
-use crate::proxy::retry::{Retry, ShouldRetry};
+use crate::proxy::retry::{CouldRetry, Retry};
 
 /// Generic error response with human-readable description.
 /// Note that we can't always present it to user as is.
@@ -65,20 +65,14 @@ impl Display for ConsoleError {
     }
 }
 
-impl ShouldRetry for ConsoleError {
-    fn could_retry(&self) -> Retry {
+impl CouldRetry for ConsoleError {
+    fn could_retry(&self) -> Option<Retry> {
         // retry if the retry info is set.
         // if no status or retry info, do not retry.
-        let retry = self
-            .status
+        self.status
             .as_ref()
             .and_then(|status| status.details.retry_info.as_ref())
-            .map(|info| Duration::from_millis(info.retry_delay_ms));
-
-        match retry {
-            Some(x) => Retry::Fixed(x),
-            None => Retry::Never,
-        }
+            .map(|info| Retry::Fixed(Duration::from_millis(info.retry_delay_ms)))
     }
 }
 

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -27,7 +27,7 @@ pub mod errors {
     use crate::{
         console::messages::{self, ConsoleError},
         error::{io_error, ReportableError, UserFacingError},
-        proxy::retry::{CouldRetry, Retry},
+        proxy::retry::CouldRetry,
     };
     use thiserror::Error;
 
@@ -129,7 +129,7 @@ pub mod errors {
     }
 
     impl CouldRetry for ApiError {
-        fn could_retry(&self) -> Option<Retry> {
+        fn could_retry(&self) -> bool {
             match self {
                 // retry some transport errors
                 Self::Transport(io) => io.could_retry(),
@@ -241,12 +241,12 @@ pub mod errors {
     }
 
     impl CouldRetry for WakeComputeError {
-        fn could_retry(&self) -> Option<Retry> {
+        fn could_retry(&self) -> bool {
             match self {
-                WakeComputeError::BadComputeAddress(_) => None,
+                WakeComputeError::BadComputeAddress(_) => false,
                 WakeComputeError::ApiError(e) => e.could_retry(),
-                WakeComputeError::TooManyConnections => None,
-                WakeComputeError::TooManyConnectionAttempts(_) => None,
+                WakeComputeError::TooManyConnections => false,
+                WakeComputeError::TooManyConnectionAttempts(_) => false,
             }
         }
     }

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -24,10 +24,12 @@ use tokio::time::Instant;
 use tracing::info;
 
 pub mod errors {
+    use std::time::Duration;
+
     use crate::{
         console::messages::{self, ConsoleError},
         error::{io_error, ReportableError, UserFacingError},
-        proxy::retry::ShouldRetry,
+        proxy::retry::{retry_after, ShouldRetry},
     };
     use thiserror::Error;
 
@@ -136,6 +138,12 @@ pub mod errors {
                 Self::Console(e) => e.could_retry(),
             }
         }
+        fn retry_after(&self, num_retries: u32, config: crate::config::RetryConfig) -> Duration {
+            match self {
+                ApiError::Console(e) => e.retry_after(num_retries, config),
+                ApiError::Transport(e) => e.retry_after(num_retries, config),
+            }
+        }
     }
 
     impl From<reqwest::Error> for ApiError {
@@ -236,6 +244,29 @@ pub mod errors {
                 WakeComputeError::ApiError(e) => e.get_error_kind(),
                 WakeComputeError::TooManyConnections => crate::error::ErrorKind::RateLimit,
                 WakeComputeError::TooManyConnectionAttempts(e) => e.get_error_kind(),
+            }
+        }
+    }
+
+    impl ShouldRetry for WakeComputeError {
+        fn could_retry(&self) -> bool {
+            match self {
+                WakeComputeError::BadComputeAddress(_) => false,
+                WakeComputeError::ApiError(e) => e.could_retry(),
+                WakeComputeError::TooManyConnections => false,
+                WakeComputeError::TooManyConnectionAttempts(_) => false,
+            }
+        }
+        fn retry_after(
+            &self,
+            num_retries: u32,
+            config: crate::config::RetryConfig,
+        ) -> tokio::time::Duration {
+            match self {
+                WakeComputeError::BadComputeAddress(_) => retry_after(num_retries, config),
+                WakeComputeError::ApiError(e) => e.retry_after(num_retries, config),
+                WakeComputeError::TooManyConnections => retry_after(num_retries, config),
+                WakeComputeError::TooManyConnectionAttempts(_) => retry_after(num_retries, config),
             }
         }
     }

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -25,7 +25,7 @@ use tracing::info;
 
 pub mod errors {
     use crate::{
-        console::messages::{self, ConsoleError},
+        console::messages::{self, ConsoleError, Reason},
         error::{io_error, ReportableError, UserFacingError},
         proxy::retry::CouldRetry,
     };
@@ -76,21 +76,22 @@ pub mod errors {
                 ApiError::Console(e) => {
                     use crate::error::ErrorKind::*;
                     match e.get_reason() {
-                        crate::console::messages::Reason::RoleProtected => User,
-                        crate::console::messages::Reason::ResourceNotFound => User,
-                        crate::console::messages::Reason::ProjectNotFound => User,
-                        crate::console::messages::Reason::EndpointNotFound => User,
-                        crate::console::messages::Reason::BranchNotFound => User,
-                        crate::console::messages::Reason::RateLimitExceeded => ServiceRateLimit,
-                        crate::console::messages::Reason::NonPrimaryBranchComputeTimeExceeded => {
-                            User
-                        }
-                        crate::console::messages::Reason::ActiveTimeQuotaExceeded => User,
-                        crate::console::messages::Reason::ComputeTimeQuotaExceeded => User,
-                        crate::console::messages::Reason::WrittenDataQuotaExceeded => User,
-                        crate::console::messages::Reason::DataTransferQuotaExceeded => User,
-                        crate::console::messages::Reason::LogicalSizeQuotaExceeded => User,
-                        crate::console::messages::Reason::Unknown => match &e {
+                        Reason::RoleProtected => User,
+                        Reason::ResourceNotFound => User,
+                        Reason::ProjectNotFound => User,
+                        Reason::EndpointNotFound => User,
+                        Reason::BranchNotFound => User,
+                        Reason::RateLimitExceeded => ServiceRateLimit,
+                        Reason::NonDefaultBranchComputeTimeExceeded => User,
+                        Reason::ActiveTimeQuotaExceeded => User,
+                        Reason::ComputeTimeQuotaExceeded => User,
+                        Reason::WrittenDataQuotaExceeded => User,
+                        Reason::DataTransferQuotaExceeded => User,
+                        Reason::LogicalSizeQuotaExceeded => User,
+                        Reason::ConcurrencyLimitReached => ControlPlane,
+                        Reason::LockAlreadyTaken => ControlPlane,
+                        Reason::RunningOperations => ControlPlane,
+                        Reason::Unknown => match &e {
                             ConsoleError {
                                 http_status_code:
                                     http::StatusCode::NOT_FOUND | http::StatusCode::NOT_ACCEPTABLE,

--- a/proxy/src/console/provider.rs
+++ b/proxy/src/console/provider.rs
@@ -27,7 +27,7 @@ pub mod errors {
     use crate::{
         console::messages::{self, ConsoleError},
         error::{io_error, ReportableError, UserFacingError},
-        proxy::retry::{Retry, ShouldRetry},
+        proxy::retry::{CouldRetry, Retry},
     };
     use thiserror::Error;
 
@@ -128,8 +128,8 @@ pub mod errors {
         }
     }
 
-    impl ShouldRetry for ApiError {
-        fn could_retry(&self) -> Retry {
+    impl CouldRetry for ApiError {
+        fn could_retry(&self) -> Option<Retry> {
             match self {
                 // retry some transport errors
                 Self::Transport(io) => io.could_retry(),
@@ -240,13 +240,13 @@ pub mod errors {
         }
     }
 
-    impl ShouldRetry for WakeComputeError {
-        fn could_retry(&self) -> Retry {
+    impl CouldRetry for WakeComputeError {
+        fn could_retry(&self) -> Option<Retry> {
             match self {
-                WakeComputeError::BadComputeAddress(_) => Retry::Never,
+                WakeComputeError::BadComputeAddress(_) => None,
                 WakeComputeError::ApiError(e) => e.could_retry(),
-                WakeComputeError::TooManyConnections => Retry::Never,
-                WakeComputeError::TooManyConnectionAttempts(_) => Retry::Never,
+                WakeComputeError::TooManyConnections => None,
+                WakeComputeError::TooManyConnectionAttempts(_) => None,
             }
         }
     }

--- a/proxy/src/proxy/retry.rs
+++ b/proxy/src/proxy/retry.rs
@@ -1,44 +1,62 @@
 use crate::{compute, config::RetryConfig};
-use std::{error::Error, io};
+use std::{error::Error, io, time::Duration};
 use tokio::time;
 
-pub trait ShouldRetry {
-    fn could_retry(&self) -> bool;
-    fn should_retry(&self, num_retries: u32, config: RetryConfig) -> bool {
+pub enum Retry {
+    Never,
+    Backoff,
+    Fixed(Duration),
+}
+
+impl Retry {
+    pub fn is_retriable(&self) -> bool {
         match self {
-            _ if num_retries >= config.max_retries => false,
-            err => err.could_retry(),
+            Retry::Never => false,
+            Retry::Backoff => true,
+            Retry::Fixed(_) => true,
+        }
+    }
+}
+
+pub trait ShouldRetry {
+    fn could_retry(&self) -> Retry;
+    fn should_retry(&self, num_retries: u32, config: RetryConfig) -> Option<Duration> {
+        match self {
+            _ if num_retries >= config.max_retries => None,
+            err => match err.could_retry() {
+                Retry::Never => None,
+                Retry::Backoff => Some(retry_after(num_retries, config)),
+                Retry::Fixed(fixed) => Some(fixed),
+            },
         }
     }
     fn should_retry_database_address(&self) -> bool {
         true
     }
-
-    fn retry_after(&self, num_retries: u32, config: RetryConfig) -> time::Duration {
-        retry_after(num_retries, config)
-    }
 }
 
 impl ShouldRetry for io::Error {
-    fn could_retry(&self) -> bool {
+    fn could_retry(&self) -> Retry {
         use std::io::ErrorKind;
-        matches!(
-            self.kind(),
-            ErrorKind::ConnectionRefused | ErrorKind::AddrNotAvailable | ErrorKind::TimedOut
-        )
+        match self.kind() {
+            ErrorKind::ConnectionRefused | ErrorKind::AddrNotAvailable | ErrorKind::TimedOut => {
+                Retry::Backoff
+            }
+            _ => Retry::Never,
+        }
     }
 }
 
 impl ShouldRetry for tokio_postgres::error::DbError {
-    fn could_retry(&self) -> bool {
+    fn could_retry(&self) -> Retry {
         use tokio_postgres::error::SqlState;
-        matches!(
-            self.code(),
+        match self.code() {
             &SqlState::CONNECTION_FAILURE
-                | &SqlState::CONNECTION_EXCEPTION
-                | &SqlState::CONNECTION_DOES_NOT_EXIST
-                | &SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION,
-        )
+            | &SqlState::CONNECTION_EXCEPTION
+            | &SqlState::CONNECTION_DOES_NOT_EXIST
+            | &SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION => Retry::Backoff,
+            _ => Retry::Never,
+        }
     }
     fn should_retry_database_address(&self) -> bool {
         use tokio_postgres::error::SqlState;
@@ -58,13 +76,13 @@ impl ShouldRetry for tokio_postgres::error::DbError {
 }
 
 impl ShouldRetry for tokio_postgres::Error {
-    fn could_retry(&self) -> bool {
+    fn could_retry(&self) -> Retry {
         if let Some(io_err) = self.source().and_then(|x| x.downcast_ref()) {
             io::Error::could_retry(io_err)
         } else if let Some(db_err) = self.source().and_then(|x| x.downcast_ref()) {
             tokio_postgres::error::DbError::could_retry(db_err)
         } else {
-            false
+            Retry::Never
         }
     }
     fn should_retry_database_address(&self) -> bool {
@@ -79,12 +97,12 @@ impl ShouldRetry for tokio_postgres::Error {
 }
 
 impl ShouldRetry for compute::ConnectionError {
-    fn could_retry(&self) -> bool {
+    fn could_retry(&self) -> Retry {
         match self {
             compute::ConnectionError::Postgres(err) => err.could_retry(),
             compute::ConnectionError::CouldNotConnect(err) => err.could_retry(),
             compute::ConnectionError::WakeComputeError(err) => err.could_retry(),
-            _ => false,
+            _ => Retry::Never,
         }
     }
     fn should_retry_database_address(&self) -> bool {
@@ -97,18 +115,31 @@ impl ShouldRetry for compute::ConnectionError {
             _ => true,
         }
     }
-    fn retry_after(&self, num_retries: u32, config: RetryConfig) -> time::Duration {
-        match self {
-            compute::ConnectionError::Postgres(e) => e.retry_after(num_retries, config),
-            compute::ConnectionError::CouldNotConnect(e) => e.retry_after(num_retries, config),
-            compute::ConnectionError::WakeComputeError(e) => e.retry_after(num_retries, config),
-            _ => retry_after(num_retries, config),
-        }
-    }
 }
 
-pub fn retry_after(num_retries: u32, config: RetryConfig) -> time::Duration {
+fn retry_after(num_retries: u32, config: RetryConfig) -> time::Duration {
     config
         .base_delay
         .mul_f64(config.backoff_factor.powi((num_retries as i32) - 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::{config::RetryConfig, proxy::retry::retry_after};
+
+    #[test]
+    fn connect_compute_total_wait() {
+        let mut total_wait = tokio::time::Duration::ZERO;
+        let config = RetryConfig {
+            base_delay: Duration::from_secs(1),
+            max_retries: 5,
+            backoff_factor: 2.0,
+        };
+        for num_retries in 1..config.max_retries {
+            total_wait += retry_after(num_retries, config);
+        }
+        assert!(f64::abs(total_wait.as_secs_f64() - 15.0) < 0.1);
+    }
 }

--- a/proxy/src/proxy/retry.rs
+++ b/proxy/src/proxy/retry.rs
@@ -3,61 +3,57 @@ use std::{error::Error, io, time::Duration};
 use tokio::time;
 
 pub enum Retry {
-    Never,
     Backoff,
     Fixed(Duration),
 }
 
-impl Retry {
-    pub fn is_retriable(&self) -> bool {
-        match self {
-            Retry::Never => false,
-            Retry::Backoff => true,
-            Retry::Fixed(_) => true,
-        }
+pub trait CouldRetry {
+    fn could_retry(&self) -> Option<Retry>;
+}
+
+pub trait CouldRetry2 {
+    fn should_retry_database_address(&self) -> bool;
+}
+
+pub fn should_retry(
+    err: &impl CouldRetry,
+    num_retries: u32,
+    config: RetryConfig,
+) -> Option<Duration> {
+    match err {
+        _ if num_retries >= config.max_retries => None,
+        err => match err.could_retry()? {
+            Retry::Backoff => Some(retry_after(num_retries, config)),
+            Retry::Fixed(fixed) => Some(fixed),
+        },
     }
 }
 
-pub trait ShouldRetry {
-    fn could_retry(&self) -> Retry;
-    fn should_retry(&self, num_retries: u32, config: RetryConfig) -> Option<Duration> {
-        match self {
-            _ if num_retries >= config.max_retries => None,
-            err => match err.could_retry() {
-                Retry::Never => None,
-                Retry::Backoff => Some(retry_after(num_retries, config)),
-                Retry::Fixed(fixed) => Some(fixed),
-            },
-        }
-    }
-    fn should_retry_database_address(&self) -> bool {
-        true
-    }
-}
-
-impl ShouldRetry for io::Error {
-    fn could_retry(&self) -> Retry {
+impl CouldRetry for io::Error {
+    fn could_retry(&self) -> Option<Retry> {
         use std::io::ErrorKind;
         match self.kind() {
             ErrorKind::ConnectionRefused | ErrorKind::AddrNotAvailable | ErrorKind::TimedOut => {
-                Retry::Backoff
+                Some(Retry::Backoff)
             }
-            _ => Retry::Never,
+            _ => None,
         }
     }
 }
 
-impl ShouldRetry for tokio_postgres::error::DbError {
-    fn could_retry(&self) -> Retry {
+impl CouldRetry for tokio_postgres::error::DbError {
+    fn could_retry(&self) -> Option<Retry> {
         use tokio_postgres::error::SqlState;
-        match self.code() {
-            &SqlState::CONNECTION_FAILURE
-            | &SqlState::CONNECTION_EXCEPTION
-            | &SqlState::CONNECTION_DOES_NOT_EXIST
-            | &SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION => Retry::Backoff,
-            _ => Retry::Never,
+        match *self.code() {
+            SqlState::CONNECTION_FAILURE
+            | SqlState::CONNECTION_EXCEPTION
+            | SqlState::CONNECTION_DOES_NOT_EXIST
+            | SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION => Some(Retry::Backoff),
+            _ => None,
         }
     }
+}
+impl CouldRetry2 for tokio_postgres::error::DbError {
     fn should_retry_database_address(&self) -> bool {
         use tokio_postgres::error::SqlState;
         // Here are errors that happens after the user successfully authenticated to the database.
@@ -75,20 +71,20 @@ impl ShouldRetry for tokio_postgres::error::DbError {
     }
 }
 
-impl ShouldRetry for tokio_postgres::Error {
-    fn could_retry(&self) -> Retry {
+impl CouldRetry for tokio_postgres::Error {
+    fn could_retry(&self) -> Option<Retry> {
         if let Some(io_err) = self.source().and_then(|x| x.downcast_ref()) {
             io::Error::could_retry(io_err)
         } else if let Some(db_err) = self.source().and_then(|x| x.downcast_ref()) {
             tokio_postgres::error::DbError::could_retry(db_err)
         } else {
-            Retry::Never
+            None
         }
     }
+}
+impl CouldRetry2 for tokio_postgres::Error {
     fn should_retry_database_address(&self) -> bool {
-        if let Some(io_err) = self.source().and_then(|x| x.downcast_ref()) {
-            io::Error::should_retry_database_address(io_err)
-        } else if let Some(db_err) = self.source().and_then(|x| x.downcast_ref()) {
+        if let Some(db_err) = self.source().and_then(|x| x.downcast_ref()) {
             tokio_postgres::error::DbError::should_retry_database_address(db_err)
         } else {
             true
@@ -96,20 +92,20 @@ impl ShouldRetry for tokio_postgres::Error {
     }
 }
 
-impl ShouldRetry for compute::ConnectionError {
-    fn could_retry(&self) -> Retry {
+impl CouldRetry for compute::ConnectionError {
+    fn could_retry(&self) -> Option<Retry> {
         match self {
             compute::ConnectionError::Postgres(err) => err.could_retry(),
             compute::ConnectionError::CouldNotConnect(err) => err.could_retry(),
             compute::ConnectionError::WakeComputeError(err) => err.could_retry(),
-            _ => Retry::Never,
+            _ => None,
         }
     }
+}
+impl CouldRetry2 for compute::ConnectionError {
     fn should_retry_database_address(&self) -> bool {
         match self {
             compute::ConnectionError::Postgres(err) => err.should_retry_database_address(),
-            compute::ConnectionError::CouldNotConnect(err) => err.should_retry_database_address(),
-            compute::ConnectionError::WakeComputeError(err) => err.should_retry_database_address(),
             // the cache entry was not checked for validity
             compute::ConnectionError::TooManyConnectionAttempts(_) => false,
             _ => true,

--- a/proxy/src/proxy/tests.rs
+++ b/proxy/src/proxy/tests.rs
@@ -12,7 +12,7 @@ use crate::auth::backend::{
 };
 use crate::config::{CertResolver, RetryConfig};
 use crate::console::caches::NodeInfoCache;
-use crate::console::messages::{ConsoleError, MetricsAuxInfo};
+use crate::console::messages::{ConsoleError, Details, MetricsAuxInfo, Status};
 use crate::console::provider::{CachedAllowedIps, CachedRoleSecret, ConsoleBackend};
 use crate::console::{self, CachedNodeInfo, NodeInfo};
 use crate::error::ErrorKind;
@@ -475,7 +475,7 @@ impl TestBackend for TestConnectMechanism {
             ConnectAction::Wake => Ok(helper_create_cached_node_info(self.cache)),
             ConnectAction::WakeFail => {
                 let err = console::errors::ApiError::Console(ConsoleError {
-                    http_status_code: http::StatusCode::FORBIDDEN,
+                    http_status_code: http::StatusCode::BAD_REQUEST,
                     error: "TEST".into(),
                     status: None,
                 });
@@ -486,7 +486,15 @@ impl TestBackend for TestConnectMechanism {
                 let err = console::errors::ApiError::Console(ConsoleError {
                     http_status_code: http::StatusCode::BAD_REQUEST,
                     error: "TEST".into(),
-                    status: None,
+                    status: Some(Status {
+                        code: "error".into(),
+                        message: "error".into(),
+                        details: Details {
+                            error_info: None,
+                            retry_info: Some(console::messages::RetryInfo { retry_delay_ms: 1 }),
+                            user_facing_message: None,
+                        },
+                    }),
                 });
                 assert!(err.could_retry().is_retriable());
                 Err(console::errors::WakeComputeError::ApiError(err))

--- a/proxy/src/proxy/tests.rs
+++ b/proxy/src/proxy/tests.rs
@@ -19,7 +19,7 @@ use crate::error::ErrorKind;
 use crate::{http, sasl, scram, BranchId, EndpointId, ProjectId};
 use anyhow::{bail, Context};
 use async_trait::async_trait;
-use retry::{retry_after, CouldRetry2};
+use retry::{retry_after, ShouldRetryWakeCompute};
 use rstest::rstest;
 use rustls::pki_types;
 use tokio_postgres::config::SslMode;
@@ -443,8 +443,8 @@ impl CouldRetry for TestConnectError {
         self.retryable
     }
 }
-impl CouldRetry2 for TestConnectError {
-    fn should_retry_database_address(&self) -> bool {
+impl ShouldRetryWakeCompute for TestConnectError {
+    fn should_retry_wake_compute(&self) -> bool {
         true
     }
 }

--- a/proxy/src/proxy/wake_compute.rs
+++ b/proxy/src/proxy/wake_compute.rs
@@ -1,5 +1,5 @@
 use crate::config::RetryConfig;
-use crate::console::messages::ConsoleError;
+use crate::console::messages::{ConsoleError, Reason};
 use crate::console::{errors::WakeComputeError, provider::CachedNodeInfo};
 use crate::context::RequestMonitoring;
 use crate::metrics::{
@@ -66,43 +66,22 @@ fn report_error(e: &WakeComputeError, retry: bool) {
         WakeComputeError::BadComputeAddress(_) => WakeupFailureKind::BadComputeAddress,
         WakeComputeError::ApiError(ApiError::Transport(_)) => WakeupFailureKind::ApiTransportError,
         WakeComputeError::ApiError(ApiError::Console(e)) => match e.get_reason() {
-            crate::console::messages::Reason::RoleProtected => {
-                WakeupFailureKind::ApiConsoleBadRequest
-            }
-            crate::console::messages::Reason::ResourceNotFound => {
-                WakeupFailureKind::ApiConsoleBadRequest
-            }
-            crate::console::messages::Reason::ProjectNotFound => {
-                WakeupFailureKind::ApiConsoleBadRequest
-            }
-            crate::console::messages::Reason::EndpointNotFound => {
-                WakeupFailureKind::ApiConsoleBadRequest
-            }
-            crate::console::messages::Reason::BranchNotFound => {
-                WakeupFailureKind::ApiConsoleBadRequest
-            }
-            crate::console::messages::Reason::RateLimitExceeded => {
-                WakeupFailureKind::ApiConsoleLocked
-            }
-            crate::console::messages::Reason::NonPrimaryBranchComputeTimeExceeded => {
-                WakeupFailureKind::QuotaExceeded
-            }
-            crate::console::messages::Reason::ActiveTimeQuotaExceeded => {
-                WakeupFailureKind::QuotaExceeded
-            }
-            crate::console::messages::Reason::ComputeTimeQuotaExceeded => {
-                WakeupFailureKind::QuotaExceeded
-            }
-            crate::console::messages::Reason::WrittenDataQuotaExceeded => {
-                WakeupFailureKind::QuotaExceeded
-            }
-            crate::console::messages::Reason::DataTransferQuotaExceeded => {
-                WakeupFailureKind::QuotaExceeded
-            }
-            crate::console::messages::Reason::LogicalSizeQuotaExceeded => {
-                WakeupFailureKind::QuotaExceeded
-            }
-            crate::console::messages::Reason::Unknown => match e {
+            Reason::RoleProtected => WakeupFailureKind::ApiConsoleBadRequest,
+            Reason::ResourceNotFound => WakeupFailureKind::ApiConsoleBadRequest,
+            Reason::ProjectNotFound => WakeupFailureKind::ApiConsoleBadRequest,
+            Reason::EndpointNotFound => WakeupFailureKind::ApiConsoleBadRequest,
+            Reason::BranchNotFound => WakeupFailureKind::ApiConsoleBadRequest,
+            Reason::RateLimitExceeded => WakeupFailureKind::ApiConsoleLocked,
+            Reason::NonDefaultBranchComputeTimeExceeded => WakeupFailureKind::QuotaExceeded,
+            Reason::ActiveTimeQuotaExceeded => WakeupFailureKind::QuotaExceeded,
+            Reason::ComputeTimeQuotaExceeded => WakeupFailureKind::QuotaExceeded,
+            Reason::WrittenDataQuotaExceeded => WakeupFailureKind::QuotaExceeded,
+            Reason::DataTransferQuotaExceeded => WakeupFailureKind::QuotaExceeded,
+            Reason::LogicalSizeQuotaExceeded => WakeupFailureKind::QuotaExceeded,
+            Reason::ConcurrencyLimitReached => WakeupFailureKind::ApiConsoleLocked,
+            Reason::LockAlreadyTaken => WakeupFailureKind::ApiConsoleLocked,
+            Reason::RunningOperations => WakeupFailureKind::ApiConsoleLocked,
+            Reason::Unknown => match e {
                 ConsoleError {
                     http_status_code: StatusCode::LOCKED,
                     ref error,

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -18,7 +18,7 @@ use crate::{
     intern::EndpointIdInt,
     proxy::{
         connect_compute::ConnectMechanism,
-        retry::{CouldRetry, CouldRetry2, Retry},
+        retry::{CouldRetry, CouldRetry2},
     },
     rate_limiter::EndpointRateLimiter,
     Host,
@@ -183,14 +183,14 @@ impl UserFacingError for HttpConnError {
 }
 
 impl CouldRetry for HttpConnError {
-    fn could_retry(&self) -> Option<Retry> {
+    fn could_retry(&self) -> bool {
         match self {
             HttpConnError::ConnectionError(e) => e.could_retry(),
             HttpConnError::ConnectionClosedAbruptly(_)
             | HttpConnError::GetAuthInfo(_)
             | HttpConnError::AuthError(_)
             | HttpConnError::WakeCompute(_)
-            | HttpConnError::TooManyConnectionAttempts(_) => None,
+            | HttpConnError::TooManyConnectionAttempts(_) => false,
         }
     }
 }

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -18,7 +18,7 @@ use crate::{
     intern::EndpointIdInt,
     proxy::{
         connect_compute::ConnectMechanism,
-        retry::{CouldRetry, CouldRetry2},
+        retry::{CouldRetry, ShouldRetryWakeCompute},
     },
     rate_limiter::EndpointRateLimiter,
     Host,
@@ -194,10 +194,10 @@ impl CouldRetry for HttpConnError {
         }
     }
 }
-impl CouldRetry2 for HttpConnError {
-    fn should_retry_database_address(&self) -> bool {
+impl ShouldRetryWakeCompute for HttpConnError {
+    fn should_retry_wake_compute(&self) -> bool {
         match self {
-            HttpConnError::ConnectionError(e) => e.should_retry_database_address(),
+            HttpConnError::ConnectionError(e) => e.should_retry_wake_compute(),
             // we never checked cache validity
             HttpConnError::TooManyConnectionAttempts(_) => false,
             _ => true,

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -186,11 +186,11 @@ impl CouldRetry for HttpConnError {
     fn could_retry(&self) -> bool {
         match self {
             HttpConnError::ConnectionError(e) => e.could_retry(),
-            HttpConnError::ConnectionClosedAbruptly(_)
-            | HttpConnError::GetAuthInfo(_)
-            | HttpConnError::AuthError(_)
-            | HttpConnError::WakeCompute(_)
-            | HttpConnError::TooManyConnectionAttempts(_) => false,
+            HttpConnError::ConnectionClosedAbruptly(_) => false,
+            HttpConnError::GetAuthInfo(_) => false,
+            HttpConnError::AuthError(_) => false,
+            HttpConnError::WakeCompute(_) => false,
+            HttpConnError::TooManyConnectionAttempts(_) => false,
         }
     }
 }

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -16,7 +16,10 @@ use crate::{
     context::RequestMonitoring,
     error::{ErrorKind, ReportableError, UserFacingError},
     intern::EndpointIdInt,
-    proxy::{connect_compute::ConnectMechanism, retry::ShouldRetry},
+    proxy::{
+        connect_compute::ConnectMechanism,
+        retry::{Retry, ShouldRetry},
+    },
     rate_limiter::EndpointRateLimiter,
     Host,
 };
@@ -180,14 +183,14 @@ impl UserFacingError for HttpConnError {
 }
 
 impl ShouldRetry for HttpConnError {
-    fn could_retry(&self) -> bool {
+    fn could_retry(&self) -> Retry {
         match self {
             HttpConnError::ConnectionError(e) => e.could_retry(),
-            HttpConnError::ConnectionClosedAbruptly(_) => false,
-            HttpConnError::GetAuthInfo(_) => false,
-            HttpConnError::AuthError(_) => false,
-            HttpConnError::WakeCompute(_) => false,
-            HttpConnError::TooManyConnectionAttempts(_) => false,
+            HttpConnError::ConnectionClosedAbruptly(_) => Retry::Never,
+            HttpConnError::GetAuthInfo(_) => Retry::Never,
+            HttpConnError::AuthError(_) => Retry::Never,
+            HttpConnError::WakeCompute(_) => Retry::Never,
+            HttpConnError::TooManyConnectionAttempts(_) => Retry::Never,
         }
     }
     fn should_retry_database_address(&self) -> bool {


### PR DESCRIPTION
## Problem

1. Proxy is retrying errors from cplane that shouldn't be retried
2. ~~Proxy is not using the retry_after_ms value~~

## Summary of changes

1. Correct the could_retry impl for ConsoleError.
2. ~~Update could_retry interface to support returning a fixed wait duration.~~

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
