### PR TITLE
virtual_file: take a `Slice` in the read APIs, eliminate `read_exact_at_n`, fix UB for engine `std-fs`

### DIFF
--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -320,37 +320,6 @@ impl Drop for PageWriteGuard<'_> {
     }
 }
 
-/// SAFETY: page cache slots are stable in memory and are zero-initialized.
-unsafe impl tokio_epoll_uring::IoBuf for PageWriteGuard<'static> {
-    fn stable_ptr(&self) -> *const u8 {
-        let data: &[u8; PAGE_SZ] = self.deref();
-        data.as_ptr()
-    }
-
-    fn bytes_init(&self) -> usize {
-        PAGE_SZ
-    }
-
-    fn bytes_total(&self) -> usize {
-        PAGE_SZ
-    }
-}
-
-/// SAFETY: underlying RwLockGuard guarantees unique access to the buffer
-/// and the `&mut self` ensures something has unique ownership of `Self`.
-unsafe impl tokio_epoll_uring::IoBufMut for PageWriteGuard<'static> {
-    fn stable_mut_ptr(&mut self) -> *mut u8 {
-        let data: &mut [u8; PAGE_SZ] = self.deref_mut();
-        data.as_mut_ptr()
-    }
-
-    unsafe fn set_init(&mut self, pos: usize) {
-        // There should never be a reason to call this because bytes_init() == bytes_total().
-        // But there's nothing preventing a caller from doing so.
-        assert_eq!(pos, PAGE_SZ);
-    }
-}
-
 /// lock_for_read() return value
 pub enum ReadBufResult<'a> {
     Found(PageReadGuard<'a>),

--- a/pageserver/src/tenant/vectored_blob_io.rs
+++ b/pageserver/src/tenant/vectored_blob_io.rs
@@ -20,6 +20,7 @@ use std::num::NonZeroUsize;
 
 use bytes::BytesMut;
 use pageserver_api::key::Key;
+use tokio_epoll_uring::BoundedBuf;
 use utils::lsn::Lsn;
 use utils::vec_map::VecMap;
 
@@ -316,8 +317,9 @@ impl<'a> VectoredBlobReader<'a> {
         );
         let buf = self
             .file
-            .read_exact_at_n(buf, read.start, read.size(), ctx)
-            .await?;
+            .read_exact_at(buf.slice(0..read.size()), read.start, ctx)
+            .await?
+            .into_inner();
 
         let blobs_at = read.blobs_at.as_slice();
         let start_offset = blobs_at.first().expect("VectoredRead is never empty").0;

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -586,26 +586,6 @@ impl VirtualFile {
         Ok(self.pos)
     }
 
-    /// Read `buf.bytes_total()` bytes into buf, starting at offset `offset`.
-    ///
-    /// The returned slice is guaranteed to be the same view into the underlying `Buf` as the input argument `buf`.
-    pub async fn read_exact_at<Buf, B>(
-        &self,
-        buf: B,
-        offset: u64,
-        ctx: &RequestContext,
-    ) -> Result<tokio_epoll_uring::Slice<Buf>, Error>
-    where
-        Buf: IoBufMut + Send,
-        B: BoundedBufMut<BufMut = Buf>,
-    {
-        let (buf, res) = read_exact_at_impl(buf, offset, None, |buf, offset| {
-            self.read_at(buf, offset, ctx)
-        })
-        .await;
-        res.map(|()| buf)
-    }
-
     /// Read `count` bytes into `buf`, starting at offset `offset`.
     ///
     /// The returned `B` is the same `buf` that was passed in.

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -786,13 +786,13 @@ pub async fn read_exact_at_impl<B, F, Fut>(
     mut offset: u64,
     count: Option<usize>,
     mut read_at: F,
-) -> (B, std::io::Result<()>)
+) -> (B::Buf, std::io::Result<()>)
 where
-    B: IoBufMut + Send,
-    F: FnMut(tokio_epoll_uring::Slice<B>, u64) -> Fut,
-    Fut: std::future::Future<Output = (tokio_epoll_uring::Slice<B>, std::io::Result<usize>)>,
+    B: BoundedBuf + Send,
+    F: FnMut(tokio_epoll_uring::Slice<B::Buf>, u64) -> Fut,
+    Fut: std::future::Future<Output = (tokio_epoll_uring::Slice<B::Buf>, std::io::Result<usize>)>,
 {
-    let mut buf: tokio_epoll_uring::Slice<B> = match count {
+    let mut buf: tokio_epoll_uring::Slice<_> = match count {
         Some(count) => {
             assert!(count <= buf.bytes_total());
             assert!(count > 0);

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -906,7 +906,7 @@ mod test_read_exact_at_impl {
         })
         .await;
         assert!(res.is_ok());
-        assert_eq!(buf, vec![b'a', b'b', b'c', b'd', b'e']);
+        assert_eq!(buf.into_inner(), vec![b'a', b'b', b'c', b'd', b'e']);
     }
 
     #[tokio::test]
@@ -926,7 +926,7 @@ mod test_read_exact_at_impl {
         })
         .await;
         assert!(res.is_ok());
-        assert_eq!(buf, vec![b'a', b'b', b'c']);
+        assert_eq!(buf.into_inner(), vec![b'a', b'b', b'c']);
     }
 
     #[tokio::test]
@@ -966,7 +966,7 @@ mod test_read_exact_at_impl {
         })
         .await;
         assert!(res.is_ok());
-        assert_eq!(buf, vec![b'a', b'b', b'c', b'd']);
+        assert_eq!(buf.into_inner(), vec![b'a', b'b', b'c', b'd']);
     }
 
     #[tokio::test]

--- a/pageserver/src/virtual_file/io_engine.rs
+++ b/pageserver/src/virtual_file/io_engine.rs
@@ -107,7 +107,7 @@ use std::{
     sync::atomic::{AtomicU8, Ordering},
 };
 
-use super::{FileGuard, Metadata};
+use super::{owned_buffers_io::slice::SliceExt, FileGuard, Metadata};
 
 #[cfg(target_os = "linux")]
 fn epoll_uring_error_to_std(e: tokio_epoll_uring::Error<std::io::Error>) -> std::io::Error {
@@ -120,38 +120,29 @@ fn epoll_uring_error_to_std(e: tokio_epoll_uring::Error<std::io::Error>) -> std:
 }
 
 impl IoEngine {
-    pub(super) async fn read_at<B>(
+    pub(super) async fn read_at<Buf>(
         &self,
         file_guard: FileGuard,
         offset: u64,
-        mut buf: B,
-    ) -> ((FileGuard, B), std::io::Result<usize>)
+        mut slice: tokio_epoll_uring::Slice<Buf>,
+    ) -> (
+        (FileGuard, tokio_epoll_uring::Slice<Buf>),
+        std::io::Result<usize>,
+    )
     where
-        B: tokio_epoll_uring::BoundedBufMut + Send,
+        Buf: tokio_epoll_uring::IoBufMut + Send,
     {
         match self {
             IoEngine::NotSet => panic!("not initialized"),
             IoEngine::StdFs => {
-                // SAFETY: `dst` only lives at most as long as this match arm, during which buf remains valid memory.
-                let dst = unsafe {
-                    std::slice::from_raw_parts_mut(buf.stable_mut_ptr(), buf.bytes_total())
-                };
-                let res = file_guard.with_std_file(|std_file| std_file.read_at(dst, offset));
-                if let Ok(nbytes) = &res {
-                    assert!(*nbytes <= buf.bytes_total());
-                    // SAFETY: see above assertion
-                    unsafe {
-                        buf.set_init(*nbytes);
-                    }
-                }
-                #[allow(dropping_references)]
-                drop(dst);
-                ((file_guard, buf), res)
+                let rust_slice = slice.as_mut_rust_slice_full_zeroed();
+                let res = file_guard.with_std_file(|std_file| std_file.read_at(rust_slice, offset));
+                ((file_guard, slice), res)
             }
             #[cfg(target_os = "linux")]
             IoEngine::TokioEpollUring => {
                 let system = tokio_epoll_uring_ext::thread_local_system().await;
-                let (resources, res) = system.read(file_guard, offset, buf).await;
+                let (resources, res) = system.read(file_guard, offset, slice).await;
                 (resources, res.map_err(epoll_uring_error_to_std))
             }
         }

--- a/pageserver/src/virtual_file/owned_buffers_io/slice.rs
+++ b/pageserver/src/virtual_file/owned_buffers_io/slice.rs
@@ -1,0 +1,77 @@
+use tokio_epoll_uring::BoundedBuf;
+use tokio_epoll_uring::BoundedBufMut;
+use tokio_epoll_uring::IoBufMut;
+use tokio_epoll_uring::Slice;
+
+pub(crate) trait SliceExt {
+    /// Get a `&mut[0..self.bytes_total()`] slice, for when you need to do borrow-based IO.
+    ///
+    /// See the test case `test_slice_full_zeroed` for the difference to just doing `&slice[..]`
+    fn as_mut_rust_slice_full_zeroed(&mut self) -> &mut [u8];
+}
+
+impl<B> SliceExt for Slice<B>
+where
+    B: IoBufMut,
+{
+    #[inline(always)]
+    fn as_mut_rust_slice_full_zeroed(&mut self) -> &mut [u8] {
+        // zero-initialize the uninitialized parts of the buffer so we can create a Rust slice
+        //
+        // SAFETY: we own `slice`, don't write outside the bounds
+        unsafe {
+            let to_init = self.bytes_total() - self.bytes_init();
+            self.stable_mut_ptr()
+                .add(self.bytes_init())
+                .write_bytes(0, to_init);
+            self.set_init(self.bytes_total());
+        };
+        let bytes_total = self.bytes_total();
+        &mut self[0..bytes_total]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use super::*;
+    use bytes::Buf;
+    use tokio_epoll_uring::Slice;
+
+    #[test]
+    fn test_slice_full_zeroed() {
+        let buf = Vec::with_capacity(3);
+
+        let mut slice: Slice<_> = buf.slice_full();
+        assert_eq!(Slice::get_mut(&mut slice).len(), 0);
+        assert_eq!(Slice::get_mut(&mut slice).capacity(), 0);
+
+        let make_fake_file = || bytes::BytesMut::from(&b"123"[..]).reader();
+
+        // the Slice derefs to &[u8] with bounds [0..bytes_INIT()]
+        {
+            assert_eq!(slice[..].len(), 0);
+            let mut file = make_fake_file();
+            file.read_exact(&mut slice[..]).unwrap();
+            assert_eq!(&slice[..] as &[u8], &[][..] as &[u8]);
+        }
+
+        // that is unlike the behavior we get when passing the `Slice`
+        // into owned buffers IO like with VirtualFile. There, you can
+        // pass in a `Slice` with bytes_init()=0 but bytes_total()=5
+        // and it will read 5 bytes.
+
+        // To get the same behavior with a Rust slice, we need to zero-initialize the
+        // uninitialized parts of the `Slice` first, then create a Rust slice from it.
+        {
+            let rust_slice = slice.as_mut_rust_slice_full_zeroed();
+            assert_eq!(rust_slice.len(), 3);
+            assert_eq!(rust_slice, &[0, 0, 0, 0, 0]);
+            let mut file = make_fake_file();
+            file.read_exact(rust_slice).unwrap();
+            assert_eq!(rust_slice, b"123");
+            assert_eq!(&slice[..], b"123");
+        }
+    }
+}


### PR DESCRIPTION
part of https://github.com/neondatabase/neon/issues/7418

I reviewed how the VirtualFile API's `read` methods look like and came to the conclusion that we've been using `IoBufMut` / `BoundedBufMut` / `Slice` wrong.

This patch rectifies the situation.

# Change 1: take `tokio_epoll_uring::Slice` in the read APIs

Before, we took an `IoBufMut`, which is too low of a primitive and while it _seems_ convenient to be able to pass in a `Vec<u8>` without any fuzz, it's actually very unclear at the callsite that we're going to fill up that `Vec` up to its `capacity()`, because that's what `IoBuf::bytes_total()` returns and that's what `VirtualFile::read_exact_at` fills.

By passing a `Slice` instead, a caller that "just wants to read into a `Vec`" is forced to be explicit about it, adding either `slice_full()` or `slice(x..y)`, and these methods panic if the read is outside of the bounds of the `Vec::capacity()`.

Last, passing slices is more similar to what the `std::io` APIs look like.

# Change 2: fix UB in `virtual_file_io_engine=std-fs`

While reviewing call sites, I noticed that the `io_engine::IoEngine::read_at` method for `StdFs` mode has been constructing an `&mut[u8]` from raw parts that were uninitialized.

We then used `std::fs::File::read_exact` to initialize that memory, but, IIUC we must not even be constructing an `&mut[u8]` where some of the memory isn't initialized.

So, stop doing that and add a helper ext trait on `Slice` to do the zero-initialization.

# Change 3: eliminate  `read_exact_at_n`

The `read_exact_at_n` doesn't make sense because the caller can just

1. `slice = buf.slice()` the exact memory it wants to fill 
2. `slice = read_exact_at(slice)`
3. `buf = slice.into_inner()`

Again, the `std::io` APIs specify the length of the read via the Rust slice length.
We should do the same for the owned buffers IO APIs, i.e., via `Slice::bytes_total()`.

# Change 4: simplify filling of `PageWriteGuard`

The `PageWriteGuardBuf::init_up_to` was never necessary.
Remove it. See changes to doc comment for more details.

---

Reviewers should probably look at the added test case first, it illustrates my case a bit.