### PR TITLE
Use Slice<_> in write path instead of B: BoundedBuf<...>

### DIFF
--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -185,7 +185,7 @@ impl<const BUFFERED: bool> BlobWriter<BUFFERED> {
         let remaining = Self::CAPACITY - self.buf.len();
         let src_buf_len = src_buf.bytes_init();
         if src_buf_len == 0 {
-            return_!(src_buf, Ok(()));
+            return (src_buf, Ok(()));
         }
         let mut src_buf = src_buf.slice(0..src_buf_len);
         // First try to copy as much as we can into the buffer

--- a/pageserver/src/tenant/blob_io.rs
+++ b/pageserver/src/tenant/blob_io.rs
@@ -306,13 +306,13 @@ mod tests {
             let file = VirtualFile::create(pathbuf.as_path(), &ctx).await?;
             let mut wtr = BlobWriter::<BUFFERED>::new(file, 0);
             for blob in blobs.iter() {
-                let (_, res) = wtr.write_blob(blob.clone(), &ctx).await;
+                let (_, res) = wtr.write_blob(blob.clone().slice_full(), &ctx).await;
                 let offs = res?;
                 offsets.push(offs);
             }
             // Write out one page worth of zeros so that we can
             // read again with read_blk
-            let (_, res) = wtr.write_blob(vec![0; PAGE_SZ], &ctx).await;
+            let (_, res) = wtr.write_blob(vec![0; PAGE_SZ].slice_full(), &ctx).await;
             let offs = res?;
             println!("Writing final blob at offs={offs}");
             wtr.flush_buffer(&ctx).await?;

--- a/pageserver/src/tenant/ephemeral_file/page_caching.rs
+++ b/pageserver/src/tenant/ephemeral_file/page_caching.rs
@@ -158,7 +158,7 @@ impl crate::virtual_file::owned_buffers_io::write::OwnedAsyncWriter for PreWarmi
         let iobuf = match self.file.write_all(buf, ctx).await {
             (iobuf, Ok(nwritten)) => {
                 assert_eq!(nwritten, buflen);
-                iobuf
+                iobuf.into_inner()
             }
             (_, Err(e)) => {
                 return Err(std::io::Error::new(

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -691,7 +691,7 @@ impl VirtualFile {
 
         let nbytes = buf.bytes_init();
         if nbytes == 0 {
-            return_!(buf, Ok(0));
+            return (buf, Ok(0));
         }
         let mut buf = buf.slice(0..nbytes);
         while !buf.is_empty() {


### PR DESCRIPTION
Adopts `Slice<_>` instead of `BoundedBuf<_>` in the write path. This is a smaller version of what we could have done, as the `OwnedAsyncWriter` trait still uses the old API, but we leave this for the future. Mainly, this change is meant to unblock #8106.

Prior PR: #8186 which did this for the read path.