### PR TITLE
pageserver: add time based image layer creation check

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4498,11 +4498,12 @@ impl Timeline {
 
             let distance_based_decision = distance.0 >= min_distance;
 
-            let mut last_check_instant = self.last_image_layer_creation_check_instant.lock().unwrap();
+            let mut last_check_instant =
+                self.last_image_layer_creation_check_instant.lock().unwrap();
             let time_based_decision = match *last_check_instant {
                 Some(last_check) => {
                     let elapsed = last_check.elapsed();
-                    elapsed > self.get_checkpoint_timeout()
+                    elapsed >= self.get_checkpoint_timeout()
                 }
                 None => true,
             };
@@ -4511,7 +4512,6 @@ impl Timeline {
             // WAL since the last check or a checkpoint timeout interval has elapsed since the last
             // check.
             let decision = distance_based_decision || time_based_decision;
-
 
             if decision {
                 self.last_image_layer_creation_check_at.store(lsn);


### PR DESCRIPTION
## Problem
Assume a timeline with the following workload: very slow ingest of updates to a small number of keys
that fit within the same partition (as decided by `KeySpace::partition`). These tenants will create small
L0 layers since due to time based rolling, and, consequently, the L1 layers will also be small.

Currently, by default, we need to ingest 512 MiB of WAL before checking if an image layer is required.
This scheme works fine under the assumption that L1s are roughly of checkpoint distance size, but
as the first paragraph explained, that's not the case for all workloads.

## Summary of changes
Check if new image layers are required at least once every checkpoint timeout interval.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
