### PR TITLE
Add find-large-objects subcommand to scrubber

### DIFF
--- a/storage_scrubber/src/checks.rs
+++ b/storage_scrubber/src/checks.rs
@@ -259,7 +259,7 @@ pub(crate) enum BlobDataParseResult {
     Incorrect(Vec<String>),
 }
 
-fn parse_layer_object_name(name: &str) -> Result<(LayerName, Generation), String> {
+pub(crate) fn parse_layer_object_name(name: &str) -> Result<(LayerName, Generation), String> {
     match name.rsplit_once('-') {
         // FIXME: this is gross, just use a regex?
         Some((layer_filename, gen)) if gen.len() == 8 => {

--- a/storage_scrubber/src/find_large_objects.rs
+++ b/storage_scrubber/src/find_large_objects.rs
@@ -2,9 +2,7 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    init_remote, list_objects_with_retries,
-    metadata_stream::{stream_tenant_timelines, stream_tenants},
-    BucketConfig, NodeKind,
+    init_remote, list_objects_with_retries, metadata_stream::stream_tenants, BucketConfig, NodeKind,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -29,41 +27,41 @@ pub async fn find_large_objects(
     let mut object_ctr = 0u64;
     while let Some(tenant_shard_id) = tenants.next().await {
         let tenant_shard_id = tenant_shard_id?;
-        let mut timelines =
-            std::pin::pin!(stream_tenant_timelines(&s3_client, &target, tenant_shard_id).await?);
-        while let Some(timeline) = timelines.next().await {
-            let timeline = timeline?;
-            let target = target.timeline_root(&timeline);
-            let mut continuation_token = None;
-            loop {
-                let fetch_response =
-                    list_objects_with_retries(&s3_client, &target, continuation_token.clone())
-                        .await?;
-                for obj in fetch_response.contents().iter().filter(|o| {
-                    if let Some(obj_size) = o.size {
-                        min_size as i64 <= obj_size
-                    } else {
-                        false
-                    }
-                }) {
-                    objects.push(LargeObject {
-                        key: obj
-                            .key()
-                            .map(|k| k.to_owned())
-                            .unwrap_or_else(|| "<unknown key>".to_owned()),
-                        size: obj.size.unwrap() as u64,
-                    })
+        let mut tenant_root = target.tenant_root(&tenant_shard_id);
+        // We want the objects and not just common prefixes
+        tenant_root.delimiter.clear();
+        let mut continuation_token = None;
+        loop {
+            let fetch_response =
+                list_objects_with_retries(&s3_client, &tenant_root, continuation_token.clone())
+                    .await?;
+            for obj in fetch_response.contents().iter().filter(|o| {
+                if let Some(obj_size) = o.size {
+                    min_size as i64 <= obj_size
+                } else {
+                    false
                 }
-                object_ctr += fetch_response.contents().len() as u64;
-                match fetch_response.next_continuation_token {
-                    Some(new_token) => continuation_token = Some(new_token),
-                    None => break,
-                }
+            }) {
+                objects.push(LargeObject {
+                    key: obj
+                        .key()
+                        .map(|k| k.to_owned())
+                        .unwrap_or_else(|| "<unknown key>".to_owned()),
+                    size: obj.size.unwrap() as u64,
+                })
+            }
+            object_ctr += fetch_response.contents().len() as u64;
+            match fetch_response.next_continuation_token {
+                Some(new_token) => continuation_token = Some(new_token),
+                None => break,
             }
         }
+
         tenant_ctr += 1;
         if tenant_ctr % 10 == 0 {
-            tracing::info!("Scanned {tenant_ctr} tenants, {object_ctr} objects. current {tenant_shard_id}.");
+            tracing::info!(
+                "Scanned {tenant_ctr} shards, {object_ctr} objects. current {tenant_shard_id}."
+            );
         }
     }
     //let objects = Vec::new();

--- a/storage_scrubber/src/find_large_objects.rs
+++ b/storage_scrubber/src/find_large_objects.rs
@@ -87,7 +87,7 @@ pub async fn find_large_objects(
         }
 
         tenant_ctr += 1;
-        if tenant_ctr % 10 == 0 {
+        if tenant_ctr % 50 == 0 {
             tracing::info!(
                 "Scanned {tenant_ctr} shards. objects={object_ctr}, found={}, current={tenant_shard_id}.", objects.len()
             );

--- a/storage_scrubber/src/find_large_objects.rs
+++ b/storage_scrubber/src/find_large_objects.rs
@@ -1,0 +1,68 @@
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    init_remote, list_objects_with_retries,
+    metadata_stream::{stream_tenant_timelines, stream_tenants},
+    BucketConfig, NodeKind,
+};
+
+#[derive(Serialize, Deserialize)]
+pub struct LargeObject {
+    pub key: String,
+    pub size: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct LargeObjectListing {
+    pub objects: Vec<LargeObject>,
+}
+
+pub async fn find_large_objects(
+    bucket_config: BucketConfig,
+    min_size: u64,
+) -> anyhow::Result<LargeObjectListing> {
+    let (s3_client, target) = init_remote(bucket_config.clone(), NodeKind::Pageserver)?;
+    let mut tenants = std::pin::pin!(stream_tenants(&s3_client, &target));
+    let mut objects = Vec::new();
+    while let Some(tenant_shard_id) = tenants.next().await {
+        let tenant_shard_id = tenant_shard_id?;
+        let mut timelines =
+            std::pin::pin!(stream_tenant_timelines(&s3_client, &target, tenant_shard_id).await?);
+        while let Some(timeline) = timelines.next().await {
+            let timeline = timeline?;
+            let target = target.timeline_root(&timeline);
+            let mut continuation_token = None;
+            loop {
+                let fetch_response =
+                    list_objects_with_retries(&s3_client, &target, continuation_token.clone())
+                        .await?;
+                for obj in fetch_response.contents().iter().filter(|o| {
+                    if let Some(obj_size) = o.size {
+                        min_size as i64 <= obj_size
+                    } else {
+                        false
+                    }
+                }) {
+                    objects.push(LargeObject {
+                        key: obj
+                            .key()
+                            .map(|k| k.to_owned())
+                            .unwrap_or_else(|| "<unknown key>".to_owned()),
+                        size: obj.size.unwrap() as u64,
+                    })
+                    // TODO
+                }
+                match fetch_response.next_continuation_token {
+                    Some(new_token) => continuation_token = Some(new_token),
+                    None => break,
+                }
+            }
+        }
+        //objects.push();
+    }
+    //let objects = Vec::new();
+
+    // TODO
+    Ok(LargeObjectListing { objects })
+}

--- a/storage_scrubber/src/find_large_objects.rs
+++ b/storage_scrubber/src/find_large_objects.rs
@@ -92,9 +92,6 @@ pub async fn find_large_objects(
                 "Scanned {tenant_ctr} shards. objects={object_ctr}, found={}, current={tenant_shard_id}.", objects.len()
             );
         }
-        if tenant_ctr == 100 {
-            break;
-        }
     }
     Ok(LargeObjectListing { objects })
 }

--- a/storage_scrubber/src/find_large_objects.rs
+++ b/storage_scrubber/src/find_large_objects.rs
@@ -60,7 +60,7 @@ pub async fn find_large_objects(
         tenant_ctr += 1;
         if tenant_ctr % 10 == 0 {
             tracing::info!(
-                "Scanned {tenant_ctr} shards, {object_ctr} objects. current {tenant_shard_id}."
+                "Scanned {tenant_ctr} shards. objects={object_ctr}, found={}, current={tenant_shard_id}.", objects.len()
             );
         }
     }

--- a/storage_scrubber/src/find_large_objects.rs
+++ b/storage_scrubber/src/find_large_objects.rs
@@ -3,7 +3,8 @@ use pageserver::tenant::storage_layer::LayerName;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    checks::parse_layer_object_name, init_remote, list_objects_with_retries, metadata_stream::stream_tenants, BucketConfig, NodeKind
+    checks::parse_layer_object_name, init_remote, list_objects_with_retries,
+    metadata_stream::stream_tenants, BucketConfig, NodeKind,
 };
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -67,10 +68,7 @@ pub async fn find_large_objects(
                     false
                 }
             }) {
-                let key = obj
-                    .key()
-                    .map(|k| k.to_owned())
-                    .unwrap_or_else(|| "<unknown key>".to_owned());
+                let key = obj.key().expect("couldn't get key").to_owned();
                 let kind = LargeObjectKind::from_key(&key);
                 if ignore_deltas && kind == LargeObjectKind::DeltaLayer {
                     continue;

--- a/storage_scrubber/src/lib.rs
+++ b/storage_scrubber/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::undocumented_unsafe_blocks)]
 pub mod checks;
 pub mod cloud_admin_api;
+pub mod find_large_objects;
 pub mod garbage;
 pub mod metadata_stream;
 pub mod pageserver_physical_gc;

--- a/storage_scrubber/src/main.rs
+++ b/storage_scrubber/src/main.rs
@@ -207,8 +207,13 @@ async fn main() -> anyhow::Result<()> {
             println!("{}", serde_json::to_string(&summary).unwrap());
             Ok(())
         }
-        Command::FindLargeObjects { min_size, ignore_deltas } => {
-            let summary = find_large_objects::find_large_objects(bucket_config, min_size, ignore_deltas).await?;
+        Command::FindLargeObjects {
+            min_size,
+            ignore_deltas,
+        } => {
+            let summary =
+                find_large_objects::find_large_objects(bucket_config, min_size, ignore_deltas)
+                    .await?;
             println!("{}", serde_json::to_string(&summary).unwrap());
             Ok(())
         }

--- a/storage_scrubber/src/main.rs
+++ b/storage_scrubber/src/main.rs
@@ -76,6 +76,8 @@ enum Command {
     FindLargeObjects {
         #[arg(long = "min-size")]
         min_size: u64,
+        #[arg(short, long, default_value_t = false)]
+        ignore_deltas: bool,
     },
 }
 
@@ -205,8 +207,8 @@ async fn main() -> anyhow::Result<()> {
             println!("{}", serde_json::to_string(&summary).unwrap());
             Ok(())
         }
-        Command::FindLargeObjects { min_size } => {
-            let summary = find_large_objects::find_large_objects(bucket_config, min_size).await?;
+        Command::FindLargeObjects { min_size, ignore_deltas } => {
+            let summary = find_large_objects::find_large_objects(bucket_config, min_size, ignore_deltas).await?;
             println!("{}", serde_json::to_string(&summary).unwrap());
             Ok(())
         }

--- a/storage_scrubber/src/main.rs
+++ b/storage_scrubber/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::bail;
 use camino::Utf8PathBuf;
 use pageserver_api::shard::TenantShardId;
+use storage_scrubber::find_large_objects;
 use storage_scrubber::garbage::{find_garbage, purge_garbage, PurgeMode};
 use storage_scrubber::pageserver_physical_gc::GcMode;
 use storage_scrubber::scan_pageserver_metadata::scan_metadata;
@@ -72,6 +73,10 @@ enum Command {
         #[arg(short, long, default_value_t = GcMode::IndicesOnly)]
         mode: GcMode,
     },
+    FindLargeObjects {
+        #[arg(long = "min-size")]
+        min_size: u64,
+    },
 }
 
 #[tokio::main]
@@ -86,6 +91,7 @@ async fn main() -> anyhow::Result<()> {
         Command::PurgeGarbage { .. } => "purge-garbage",
         Command::TenantSnapshot { .. } => "tenant-snapshot",
         Command::PageserverPhysicalGc { .. } => "pageserver-physical-gc",
+        Command::FindLargeObjects { .. } => "find-large-objects",
     };
     let _guard = init_logging(&format!(
         "{}_{}_{}_{}.log",
@@ -196,6 +202,11 @@ async fn main() -> anyhow::Result<()> {
         } => {
             let summary =
                 pageserver_physical_gc(bucket_config, tenant_ids, min_age.into(), mode).await?;
+            println!("{}", serde_json::to_string(&summary).unwrap());
+            Ok(())
+        }
+        Command::FindLargeObjects { min_size } => {
+            let summary = find_large_objects::find_large_objects(bucket_config, min_size).await?;
             println!("{}", serde_json::to_string(&summary).unwrap());
             Ok(())
         }


### PR DESCRIPTION
Adds a find-large-objects subcommand to the scrubber to allow listing layer objects larger than a specific size.

To be used like:

```
AWS_PROFILE=dev REGION=us-east-2 BUCKET=neon-dev-storage-us-east-2 cargo run -p storage_scrubber -- find-large-objects --min-size 250000000 --ignore-deltas
```

Part of #5431