### PR TITLE
Add neon.max_vacuum_defer_cleanup_age to restrict bloat of master in case of using hot_standby_feedback

### DIFF
--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -63,6 +63,8 @@ char	   *wal_acceptors_list = "";
 int			wal_acceptor_reconnect_timeout = 1000;
 int			wal_acceptor_connection_timeout = 10000;
 
+int         max_vacuum_defer_cleanup_age = 0;
+
 /* Set to true in the walproposer bgw. */
 static bool am_walproposer;
 static WalproposerShmemState *walprop_shared;
@@ -217,6 +219,16 @@ nwp_register_gucs(void)
 							10000, 0, INT_MAX,
 							PGC_SIGHUP,
 							GUC_UNIT_MS,
+							NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+							"neon.max_vacuum_defer_cleanup_age",
+							"Restrict oldest xmin pinned by hot standby feedback to prevent bloating of master",
+							NULL,
+							&max_vacuum_defer_cleanup_age,
+							0, 0, INT_MAX,
+							PGC_SIGHUP,
+							0,
 							NULL, NULL, NULL);
 }
 
@@ -1855,6 +1867,7 @@ walprop_pg_process_safekeeper_feedback(WalProposer *wp, Safekeeper *sk)
 		FullTransactionId xmin = hsFeedback.xmin;
 		FullTransactionId catalog_xmin = hsFeedback.catalog_xmin;
 		FullTransactionId next_xid = ReadNextFullTransactionId();
+
 		/*
 		 * Page server is updating nextXid in checkpoint each 1024 transactions,
 		 * so feedback xmin can be actually larger then nextXid and
@@ -1863,8 +1876,14 @@ walprop_pg_process_safekeeper_feedback(WalProposer *wp, Safekeeper *sk)
 		 */
 		if (FullTransactionIdPrecedes(next_xid, xmin))
 			xmin = next_xid;
+		else if (max_vacuum_defer_cleanup_age != 0 && xmin.value < next_xid.value - max_vacuum_defer_cleanup_age)
+			xmin.value = next_xid.value - max_vacuum_defer_cleanup_age;
+
 		if (FullTransactionIdPrecedes(next_xid, catalog_xmin))
 			catalog_xmin = next_xid;
+		else if (max_vacuum_defer_cleanup_age != 0 && catalog_xmin.value < next_xid.value - max_vacuum_defer_cleanup_age)
+			catalog_xmin.value = next_xid.value - max_vacuum_defer_cleanup_age;
+
 		agg_hs_feedback = hsFeedback;
 		elog(DEBUG2, "ProcessStandbyHSFeedback(xmin=%d, catalog_xmin=%d", XidFromFullTransactionId(hsFeedback.xmin), XidFromFullTransactionId(hsFeedback.catalog_xmin));
 		ProcessStandbyHSFeedback(hsFeedback.ts,


### PR DESCRIPTION
## Problem

There is dilemma for PostgreSQL hit standby configuration: 
- either enable `hot_standby_feedback` and get a risk of primary node bloating
- either not enable `hot_standby_feedback` and get a risk of query conflict and replication lag at replica

Briefly arguments pros/cons switching  hot_standby_feedback by default.

Pros:
- Replicas in Neon makes sense only for load balancing and if queries at replicas will be frequently failed because of conflicts with recovery, then such replica will have no sense
- Lack of hot_standby_feedback cause conflicts of walreceiver with RO queries, and so slowdown applying WAL and replica's lag

Cons:
- In Postgres by default hot_standby_feedback is disabled.
- hot_standby_feedback can bloat master which not only increase storage size bit also leads to degrade of performance (skip old versions)
- In Neon replica can be switched off, in this case vacuum at master can be blocked forever

## Summary of changes

This PR introduces `neon.max_vacuum_defer_cleanup_age` which limits age of xmin pinned by replica

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
