### PR TITLE
chore(storage-scrubber): allow disable file logging

### DIFF
--- a/storage_scrubber/src/lib.rs
+++ b/storage_scrubber/src/lib.rs
@@ -243,15 +243,16 @@ impl ConsoleConfig {
 }
 
 pub fn init_logging(file_name: &str) -> Option<WorkerGuard> {
+    let stderr_logs = fmt::Layer::new()
+        .with_target(false)
+        .with_writer(std::io::stderr);
+
     let disable_file_logging = match std::env::var("PAGESERVER_DISABLE_FILE_LOGGING") {
         Ok(s) => s == "1" || s.to_lowercase() == "true",
         Err(_) => false,
     };
 
     if disable_file_logging {
-        let stderr_logs = fmt::Layer::new()
-            .with_target(false)
-            .with_writer(std::io::stderr);
         tracing_subscriber::registry()
             .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
             .with(stderr_logs)
@@ -260,14 +261,10 @@ pub fn init_logging(file_name: &str) -> Option<WorkerGuard> {
     } else {
         let (file_writer, guard) =
             tracing_appender::non_blocking(tracing_appender::rolling::never("./logs/", file_name));
-
         let file_logs = fmt::Layer::new()
             .with_target(false)
             .with_ansi(false)
             .with_writer(file_writer);
-        let stderr_logs = fmt::Layer::new()
-            .with_target(false)
-            .with_writer(std::io::stderr);
         tracing_subscriber::registry()
             .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
             .with(file_logs)

--- a/storage_scrubber/src/lib.rs
+++ b/storage_scrubber/src/lib.rs
@@ -267,8 +267,8 @@ pub fn init_logging(file_name: &str) -> Option<WorkerGuard> {
             .with_writer(file_writer);
         tracing_subscriber::registry()
             .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-            .with(file_logs)
             .with(stderr_logs)
+            .with(file_logs)
             .init();
         Some(guard)
     }

--- a/storage_scrubber/src/lib.rs
+++ b/storage_scrubber/src/lib.rs
@@ -242,24 +242,39 @@ impl ConsoleConfig {
     }
 }
 
-pub fn init_logging(file_name: &str) -> WorkerGuard {
-    let (file_writer, guard) =
-        tracing_appender::non_blocking(tracing_appender::rolling::never("./logs/", file_name));
+pub fn init_logging(file_name: &str) -> Option<WorkerGuard> {
+    let disable_file_logging = match std::env::var("PAGESERVER_DISABLE_FILE_LOGGING") {
+        Ok(s) => s == "1" || s.to_lowercase() == "true",
+        Err(_) => false,
+    };
 
-    let file_logs = fmt::Layer::new()
-        .with_target(false)
-        .with_ansi(false)
-        .with_writer(file_writer);
-    let stderr_logs = fmt::Layer::new()
-        .with_target(false)
-        .with_writer(std::io::stderr);
-    tracing_subscriber::registry()
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-        .with(file_logs)
-        .with(stderr_logs)
-        .init();
+    if disable_file_logging {
+        let stderr_logs = fmt::Layer::new()
+            .with_target(false)
+            .with_writer(std::io::stderr);
+        tracing_subscriber::registry()
+            .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+            .with(stderr_logs)
+            .init();
+        None
+    } else {
+        let (file_writer, guard) =
+            tracing_appender::non_blocking(tracing_appender::rolling::never("./logs/", file_name));
 
-    guard
+        let file_logs = fmt::Layer::new()
+            .with_target(false)
+            .with_ansi(false)
+            .with_writer(file_writer);
+        let stderr_logs = fmt::Layer::new()
+            .with_target(false)
+            .with_writer(std::io::stderr);
+        tracing_subscriber::registry()
+            .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+            .with(file_logs)
+            .with(stderr_logs)
+            .init();
+        Some(guard)
+    }
 }
 
 pub fn init_s3_client(bucket_region: Region) -> Client {


### PR DESCRIPTION
## Problem

part of https://github.com/neondatabase/cloud/issues/14024, k8s does not always have a volume available for logging, and I'm running into weird permission errors... While I could spend time figuring out how to create temp directories for logging, I think it would be better to just disable file logging as k8s containers are ephemeral and we cannot retrieve anything on the fs after the container gets removed.
  
## Summary of changes

`PAGESERVER_DISABLE_FILE_LOGGING=1` -> file logging disabled

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
