### PR TITLE
Report search_path to make it possible to use it in pgbouncer track_extra_parameters

### DIFF
--- a/pgxn/neon/neon.c
+++ b/pgxn/neon/neon.c
@@ -582,7 +582,8 @@ RestoreRunningXactsFromClog(CheckPoint *checkpoint, TransactionId **xids, int *n
 		pfree(restored_xids);
 	if (prepared_xids)
 		pfree(prepared_xids);
-	return false;}
+	return false;
+}
 
 
 /*


### PR DESCRIPTION
## Problem

When pooled connections are used, session semantic its not preserved, including GUC settings.
Many customers have particular problem with setting search_path.
But pgbouncer 1.20 has `track_extra_parameters` settings which allows to track parameters included in startup package which are reported by Postgres. Postgres has [an official list of parameters that it reports to the client](https://www.postgresql.org/docs/15/protocol-flow.html#PROTOCOL-ASYNC).
This PR makes Postgres also report `search_path` and so allows to include it in `track_extra_parameters`.



## Summary of changes

Set GUC_REPORT flag  for `search_path`.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
