### PR TITLE
Make vectored read_blobs function not fill buffer correctly

### DIFF
--- a/pageserver/src/tenant/vectored_blob_io.rs
+++ b/pageserver/src/tenant/vectored_blob_io.rs
@@ -315,7 +315,7 @@ impl<'a> VectoredBlobReader<'a> {
             read.size(),
             buf.capacity()
         );
-        let buf = self
+        let mut buf = self
             .file
             .read_exact_at(buf.slice(0..read.size()), read.start, ctx)
             .await?
@@ -363,6 +363,8 @@ impl<'a> VectoredBlobReader<'a> {
             };
 
             assert_eq!(end - start, blob_size);
+
+            buf[start as usize..end as usize].fill(0xaf);
 
             metas.push(VectoredBlob {
                 start: start as usize,


### PR DESCRIPTION
There was barely any breakage in #8288 so I'm wondering whether pytests work at all for vectored reads.

DO NOT MERGE.