### PR TITLE
fix: EphmeralFiles can outlive their Timeline, new gate version

### DIFF
--- a/libs/utils/src/sync/gate.rs
+++ b/libs/utils/src/sync/gate.rs
@@ -78,8 +78,9 @@ impl Drop for GateGuard {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum GateError {
+    #[error("gate is closed")]
     GateClosed,
 }
 

--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -475,11 +475,13 @@ impl InMemoryLayer {
         timeline_id: TimelineId,
         tenant_shard_id: TenantShardId,
         start_lsn: Lsn,
+        gate_guard: utils::sync::gate::GateGuard,
         ctx: &RequestContext,
     ) -> Result<InMemoryLayer> {
         trace!("initializing new empty InMemoryLayer for writing on timeline {timeline_id} at {start_lsn}");
 
-        let file = EphemeralFile::create(conf, tenant_shard_id, timeline_id, ctx).await?;
+        let file =
+            EphemeralFile::create(conf, tenant_shard_id, timeline_id, gate_guard, ctx).await?;
         let key = InMemoryLayerFileId(file.page_cache_file_id());
 
         Ok(InMemoryLayer {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1914,9 +1914,6 @@ impl Timeline {
         // (The deletion use case is why we can't just hook up remote_client to Self::cancel).)
         self.remote_client.stop();
 
-        // Allow any remaining in-memory layers to do cleanup.
-        self.layers.write().await.drop_inmemory_layers();
-
         // As documented in remote_client.stop()'s doc comment, it's our responsibility
         // to shut down the upload queue tasks.
         // TODO: fix that, task management should be encapsulated inside remote_client.
@@ -1930,6 +1927,15 @@ impl Timeline {
         // TODO: work toward making this a no-op. See this funciton's doc comment for more context.
         tracing::debug!("Waiting for tasks...");
         task_mgr::shutdown_tasks(None, Some(self.tenant_shard_id), Some(self.timeline_id)).await;
+
+        {
+            // Allow any remaining in-memory layers to do cleanup.
+            let mut write_guard = self.write_lock.lock().await;
+            self.layers
+                .write()
+                .await
+                .drop_inmemory_layers(&mut write_guard);
+        }
 
         // Finally wait until any gate-holders are complete.
         //
@@ -5763,7 +5769,7 @@ type TraversalPathItem = (ValueReconstructResult, Lsn, TraversalId);
 /// Tracking writes ingestion does to a particular in-memory layer.
 ///
 /// Cleared upon freezing a layer.
-struct TimelineWriterState {
+pub(crate) struct TimelineWriterState {
     open_layer: Arc<InMemoryLayer>,
     current_size: u64,
     // Previous Lsn which passed through

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3705,6 +3705,7 @@ impl Timeline {
         ctx: &RequestContext,
     ) -> anyhow::Result<Arc<InMemoryLayer>> {
         let mut guard = self.layers.write().await;
+        let gate_guard = self.gate.enter().context("enter gate for inmem layer")?;
         let layer = guard
             .get_layer_for_write(
                 lsn,
@@ -3712,6 +3713,7 @@ impl Timeline {
                 self.conf,
                 self.timeline_id,
                 self.tenant_shard_id,
+                gate_guard,
                 ctx,
             )
             .await?;

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1913,6 +1913,10 @@ impl Timeline {
         // Transition the remote_client into a state where it's only useful for timeline deletion.
         // (The deletion use case is why we can't just hook up remote_client to Self::cancel).)
         self.remote_client.stop();
+
+        // Allow any remaining in-memory layers to do cleanup.
+        self.layers.write().await.drop_inmemory_layers();
+
         // As documented in remote_client.stop()'s doc comment, it's our responsibility
         // to shut down the upload queue tasks.
         // TODO: fix that, task management should be encapsulated inside remote_client.

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3716,10 +3716,18 @@ impl Timeline {
     ) -> anyhow::Result<Arc<InMemoryLayer>> {
         let mut guard = self.layers.write().await;
         let gate_guard = self.gate.enter().context("enter gate for inmem layer")?;
+
+        let last_record_lsn = self.get_last_record_lsn();
+        ensure!(
+            lsn > last_record_lsn,
+            "cannot modify relation after advancing last_record_lsn (incoming_lsn={}, last_record_lsn={})",
+            lsn,
+            last_record_lsn,
+        );
+
         let layer = guard
             .get_layer_for_write(
                 lsn,
-                self.get_last_record_lsn(),
                 self.conf,
                 self.timeline_id,
                 self.tenant_shard_id,

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -220,9 +220,13 @@ impl LayerManager {
     /// order to allow shutdown to complete.
     ///
     /// If there was a want to flush in-memory layers, it must have happened earlier.
-    pub(crate) fn drop_inmemory_layers(&mut self) {
-        self.layer_map.open_layer.take();
+    pub(crate) fn drop_inmemory_layers(&mut self, writer_state: &mut Option<TimelineWriterState>) {
+        let open = self.layer_map.open_layer.take();
+        let frozen = self.layer_map.frozen_layers.len();
         self.layer_map.frozen_layers.clear();
+        assert_eq!(open.is_some(), writer_state.is_some());
+        writer_state.take();
+        tracing::info!(open = open.is_some(), frozen, "dropped inmemory layers");
     }
 
     /// Called when compaction is completed.

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -73,6 +73,7 @@ impl LayerManager {
         conf: &'static PageServerConf,
         timeline_id: TimelineId,
         tenant_shard_id: TenantShardId,
+        gate_guard: utils::sync::gate::GateGuard,
         ctx: &RequestContext,
     ) -> Result<Arc<InMemoryLayer>> {
         ensure!(lsn.is_aligned());
@@ -109,8 +110,15 @@ impl LayerManager {
                 lsn
             );
 
-            let new_layer =
-                InMemoryLayer::create(conf, timeline_id, tenant_shard_id, start_lsn, ctx).await?;
+            let new_layer = InMemoryLayer::create(
+                conf,
+                timeline_id,
+                tenant_shard_id,
+                start_lsn,
+                gate_guard,
+                ctx,
+            )
+            .await?;
             let layer = Arc::new(new_layer);
 
             self.layer_map.open_layer = Some(layer.clone());

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -31,7 +31,7 @@ pub(crate) struct LayerManager {
 
     /// Each [`InMemoryLayer`] in [`LayerMap`] will hold this gate open.
     ///
-    /// Compare to [`Timeline::gate`].
+    /// Compare to [`super::Timeline::gate`].
     pub(super) ephemeral_files: utils::sync::gate::Gate,
 }
 

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -216,6 +216,15 @@ impl LayerManager {
         }
     }
 
+    /// LayerManager shutdown. The in-memory layers do cleanup on drop, so we must drop them in
+    /// order to allow shutdown to complete.
+    ///
+    /// If there was a want to flush in-memory layers, it must have happened earlier.
+    pub(crate) fn drop_inmemory_layers(&mut self) {
+        self.layer_map.open_layer.take();
+        self.layer_map.frozen_layers.clear();
+    }
+
     /// Called when compaction is completed.
     pub(crate) fn finish_compact_l0(
         &mut self,

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -69,7 +69,6 @@ impl LayerManager {
     pub(crate) async fn get_layer_for_write(
         &mut self,
         lsn: Lsn,
-        last_record_lsn: Lsn,
         conf: &'static PageServerConf,
         timeline_id: TimelineId,
         tenant_shard_id: TenantShardId,
@@ -77,13 +76,6 @@ impl LayerManager {
         ctx: &RequestContext,
     ) -> Result<Arc<InMemoryLayer>> {
         ensure!(lsn.is_aligned());
-
-        ensure!(
-            lsn > last_record_lsn,
-            "cannot modify relation after advancing last_record_lsn (incoming_lsn={}, last_record_lsn={})",
-            lsn,
-            last_record_lsn,
-        );
 
         // Do we have a layer open for writing already?
         let layer = if let Some(open_layer) = &self.layer_map.open_layer {


### PR DESCRIPTION
Ephemeral files cleanup on drop but did not delay shutdown, leading to problems with restarting the tenant. The solution is:

- make ephemeral files carry the gate guard to delay Timeline::shutdown
- flush in-memory layers and strong references to those on Timeline::shutdown
- add a different gate `LayerManager::ephmeral_files` which is closed after all Timeline operations are closed

Fixes: #7830