### PR TITLE
ci: Trigger E2E test only after images available on registry

### DIFF
--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -6,6 +6,11 @@ on:
       - ready_for_review
   workflow_call:
 
+  workflow_run:
+    workflows: ["Build and Test"]
+    types:
+      - completed
+
 defaults:
   run:
     shell: bash -euxo pipefail {0}


### PR DESCRIPTION
## Problem

Trigger E2E tests getting failed on PR because images not available from same commit. 

## Summary of changes

Adding workflow dependency so that E2E will trigger after building images. 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
