### PR TITLE
Grant execute on snapshot functions to neon_superuser

### DIFF
--- a/compute_tools/src/migrations/0009-grant_snapshot_synchronization_funcs.sql
+++ b/compute_tools/src/migrations/0009-grant_snapshot_synchronization_funcs.sql
@@ -1,2 +1,7 @@
-GRANT EXECUTE ON FUNCTION pg_export_snapshot TO neon_superuser;
-GRANT EXECUTE ON FUNCTION  pg_log_standby_snapshot TO neon_superuser;
+DO $$
+BEGIN
+    IF (SELECT setting::numeric >= 160000 FROM pg_settings WHERE name = 'server_version_num') THEN
+       EXECUTE 'GRANT EXECUTE ON FUNCTION pg_export_snapshot TO neon_superuser';
+       EXECUTE 'GRANT EXECUTE ON FUNCTION  pg_log_standby_snapshot TO neon_superuser';
+    END IF;
+END $$;

--- a/compute_tools/src/migrations/0009-grant_snapshot_synchronization_funcs.sql
+++ b/compute_tools/src/migrations/0009-grant_snapshot_synchronization_funcs.sql
@@ -1,0 +1,2 @@
+GRANT EXECUTE ON FUNCTION pg_export_snapshot TO neon_superuser;
+GRANT EXECUTE ON FUNCTION  pg_log_standby_snapshot TO neon_superuser;

--- a/compute_tools/src/migrations/0009-grant_snapshot_synchronization_funcs_to_neon_superuser.sql
+++ b/compute_tools/src/migrations/0009-grant_snapshot_synchronization_funcs_to_neon_superuser.sql
@@ -2,6 +2,6 @@ DO $$
 BEGIN
     IF (SELECT setting::numeric >= 160000 FROM pg_settings WHERE name = 'server_version_num') THEN
        EXECUTE 'GRANT EXECUTE ON FUNCTION pg_export_snapshot TO neon_superuser';
-       EXECUTE 'GRANT EXECUTE ON FUNCTION  pg_log_standby_snapshot TO neon_superuser';
+       EXECUTE 'GRANT EXECUTE ON FUNCTION pg_log_standby_snapshot TO neon_superuser';
     END IF;
 END $$;

--- a/compute_tools/src/spec.rs
+++ b/compute_tools/src/spec.rs
@@ -790,6 +790,7 @@ pub fn handle_migrations(client: &mut Client) -> Result<()> {
             "./migrations/0007-grant_all_on_sequences_to_neon_superuser_with_grant_option.sql"
         ),
         include_str!("./migrations/0008-revoke_replication_for_previously_allowed_roles.sql"),
+        include_str!("./migrations/0009-grant_snapshot_synchronization_funcs.sql"),
     ];
 
     MigrationRunner::new(client, &migrations).run_migrations()?;

--- a/compute_tools/src/spec.rs
+++ b/compute_tools/src/spec.rs
@@ -790,7 +790,9 @@ pub fn handle_migrations(client: &mut Client) -> Result<()> {
             "./migrations/0007-grant_all_on_sequences_to_neon_superuser_with_grant_option.sql"
         ),
         include_str!("./migrations/0008-revoke_replication_for_previously_allowed_roles.sql"),
-        include_str!("./migrations/0009-grant_snapshot_synchronization_funcs_to_neon_superuser.sql"),
+        include_str!(
+            "./migrations/0009-grant_snapshot_synchronization_funcs_to_neon_superuser.sql"
+        ),
     ];
 
     MigrationRunner::new(client, &migrations).run_migrations()?;

--- a/compute_tools/src/spec.rs
+++ b/compute_tools/src/spec.rs
@@ -790,7 +790,7 @@ pub fn handle_migrations(client: &mut Client) -> Result<()> {
             "./migrations/0007-grant_all_on_sequences_to_neon_superuser_with_grant_option.sql"
         ),
         include_str!("./migrations/0008-revoke_replication_for_previously_allowed_roles.sql"),
-        include_str!("./migrations/0009-grant_snapshot_synchronization_funcs.sql"),
+        include_str!("./migrations/0009-grant_snapshot_synchronization_funcs_to_neon_superuser.sql"),
     ];
 
     MigrationRunner::new(client, &migrations).run_migrations()?;

--- a/test_runner/regress/test_migrations.py
+++ b/test_runner/regress/test_migrations.py
@@ -13,7 +13,7 @@ def test_migrations(neon_simple_env: NeonEnv):
 
     endpoint.wait_for_migrations()
 
-    num_migrations = 9
+    num_migrations = 10
 
     with endpoint.cursor() as cur:
         cur.execute("SELECT id FROM neon_migration.migration_id")


### PR DESCRIPTION
## Problem
I need `neon_superuser` to be allowed to create snapshots for replication tests

## Summary of changes
Adds a migration that grants these functions to neon_superuser