### PR TITLE
Pass configured compression param to image generation

### DIFF
--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -809,7 +809,8 @@ impl ImageLayerWriterInner {
         ctx: &RequestContext,
     ) -> anyhow::Result<()> {
         ensure!(self.key_range.contains(&key));
-        let (_img, res) = self.blob_writer.write_blob(img, ctx).await;
+        let compression = self.conf.image_compression;
+        let (_img, res) = self.blob_writer.write_blob_maybe_compressed(img, ctx, compression).await;
         // TODO: re-use the buffer for `img` further upstack
         let off = res?;
 

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -810,7 +810,10 @@ impl ImageLayerWriterInner {
     ) -> anyhow::Result<()> {
         ensure!(self.key_range.contains(&key));
         let compression = self.conf.image_compression;
-        let (_img, res) = self.blob_writer.write_blob_maybe_compressed(img, ctx, compression).await;
+        let (_img, res) = self
+            .blob_writer
+            .write_blob_maybe_compressed(img, ctx, compression)
+            .await;
         // TODO: re-use the buffer for `img` further upstack
         let off = res?;
 


### PR DESCRIPTION
We need to pass on the configured compression param during image layer generation.

This was an oversight of #8106, and the likely cause why #8288 didn't bring any interesting regressions.

Part of https://github.com/neondatabase/neon/issues/5431