### PR TITLE
Fix partial upload bug with invalid remote state

### DIFF
--- a/safekeeper/src/timeline_eviction.rs
+++ b/safekeeper/src/timeline_eviction.rs
@@ -200,7 +200,7 @@ async fn redownload_partial_segment(
 
     let final_path = local_segment_path(mgr, partial);
     info!(
-        "downloaded {} bytes, renaming to {}",
+        "downloaded {actual_len} bytes, renaming to {final_path}",
         actual_len, final_path,
     );
     if let Err(e) = durable_rename(&tmp_file, &final_path, !mgr.conf.no_sync).await {

--- a/safekeeper/src/timeline_eviction.rs
+++ b/safekeeper/src/timeline_eviction.rs
@@ -201,7 +201,7 @@ async fn redownload_partial_segment(
     let final_path = local_segment_path(mgr, partial);
     info!(
         "downloaded {} bytes, renaming to {}",
-        final_path, final_path,
+        actual_len, final_path,
     );
     if let Err(e) = durable_rename(&tmp_file, &final_path, !mgr.conf.no_sync).await {
         // Probably rename succeeded, but fsync of it failed. Remove

--- a/safekeeper/src/timeline_eviction.rs
+++ b/safekeeper/src/timeline_eviction.rs
@@ -199,10 +199,7 @@ async fn redownload_partial_segment(
     file.flush().await?;
 
     let final_path = local_segment_path(mgr, partial);
-    info!(
-        "downloaded {actual_len} bytes, renaming to {final_path}",
-        actual_len, final_path,
-    );
+    info!("downloaded {actual_len} bytes, renaming to {final_path}");
     if let Err(e) = durable_rename(&tmp_file, &final_path, !mgr.conf.no_sync).await {
         // Probably rename succeeded, but fsync of it failed. Remove
         // the file then to avoid using it.

--- a/safekeeper/src/wal_backup_partial.rs
+++ b/safekeeper/src/wal_backup_partial.rs
@@ -289,6 +289,18 @@ impl PartialBackup {
             })
             .collect();
 
+        if new_segments.len() == 1 {
+            // we have an uploaded segment, it must not be deleted from remote storage
+            segments_to_delete.retain(|name| name != &new_segments[0].name);
+        } else {
+            // there should always be zero or one uploaded segment
+            assert!(
+                new_segments.is_empty(),
+                "too many uploaded segments: {:?}",
+                new_segments
+            );
+        }
+
         info!("deleting objects: {:?}", segments_to_delete);
         let mut objects_to_delete = vec![];
         for seg in segments_to_delete.iter() {


### PR DESCRIPTION
We have an issue that some partial uploaded segments can be actually missing in remote storage. I found this issue when was looking at the logs in staging, and it can be triggered by failed uploads:
1. Code tries to upload `SEG_TERM_LSN_LSN_sk5.partial`, but receives error from S3
2. The failed attempt is saved to `segments` vec
3. After some time, the code tries to upload `SEG_TERM_LSN_LSN_sk5.partial` again
4. This time the upload is successful and code calls `gc()` to delete previous uploads
5. Since new object and old object share the same name, uploaded data gets deleted from remote storage

This commit fixes the issue by patching `gc()` not to delete objects with the same name as currently uploaded.