### PR TITLE
Fix flakiness of test_tenant_creation_fails

### DIFF
--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -155,6 +155,9 @@ pub struct NeonStorageControllerConf {
 
     /// Threshold for auto-splitting a tenant into shards
     pub split_threshold: Option<u64>,
+
+    /// Whether to enable background reconciliation
+    pub background_reconcile: Option<bool>,
 }
 
 impl NeonStorageControllerConf {
@@ -168,6 +171,7 @@ impl Default for NeonStorageControllerConf {
         Self {
             max_unavailable: Self::DEFAULT_MAX_UNAVAILABLE_INTERVAL,
             split_threshold: None,
+            background_reconcile: None,
         }
     }
 }

--- a/storage_controller/src/main.rs
+++ b/storage_controller/src/main.rs
@@ -75,6 +75,10 @@ struct Cli {
     #[arg(long)]
     reconciler_concurrency: Option<usize>,
 
+    /// Whether to spawn a background reconciliation task (enabled by default)
+    #[arg(long)]
+    background_reconcile: Option<bool>,
+
     /// How long to wait for the initial database connection to be available.
     #[arg(long, default_value = "5s")]
     db_connect_timeout: humantime::Duration,
@@ -266,6 +270,7 @@ async fn async_main() -> anyhow::Result<()> {
         reconciler_concurrency: args
             .reconciler_concurrency
             .unwrap_or(RECONCILER_CONCURRENCY_DEFAULT),
+        background_reconcile: args.background_reconcile.unwrap_or(true),
         split_threshold: args.split_threshold,
         neon_local_repo_dir: args.neon_local_repo_dir,
     };

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -17,7 +17,6 @@ from fixtures.metrics import (
     parse_metrics,
 )
 from fixtures.neon_fixtures import (
-    NeonEnv,
     NeonEnvBuilder,
     wait_for_last_flush_lsn,
 )
@@ -29,7 +28,14 @@ from fixtures.utils import wait_until
 from prometheus_client.samples import Sample
 
 
-def test_tenant_creation_fails(neon_simple_env: NeonEnv):
+def test_tenant_creation_fails(neon_env_builder: NeonEnvBuilder):
+
+    neon_env_builder.storage_controller_config = {
+        "background_reconcile": False
+    }
+
+    neon_simple_env = neon_env_builder.init_start()
+
     tenants_dir = neon_simple_env.pageserver.tenant_dir()
     initial_tenants = sorted(
         map(lambda t: t.split()[0], neon_simple_env.neon_cli.list_tenants().stdout.splitlines())


### PR DESCRIPTION
Fix #8266 based on the theory that the flakiness was caused by the following sequence of events:

1. test instructs the storage controller to create the tenant
2. storage controller adds the tenant and persists it to the database. issues a creation request
3. the pageserver restarts with the failpoint disabled
4. storage controller's background reconciliation still wants to create the tenant
5. pageserver gets new request to create the tenant from background reconciliation

This PR adds a flag to disable background reconciliation. In my local testing this fixes the flakiness.