### PR TITLE
Allow the new clippy::doc_lazy_continuation lint

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3409,6 +3409,7 @@ impl Timeline {
         }
     }
 
+    #[allow(unknown_lints)] // doc_lazy_continuation is still a new lint
     #[allow(clippy::doc_lazy_continuation)]
     /// Get the data needed to reconstruct all keys in the provided keyspace
     ///


### PR DESCRIPTION
The `doc_lazy_continuation` lint of clippy is still unknown on latest rust stable.

Fixes fall-out from #8151.