### PR TITLE
scrubber: remove metadata histograms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,16 +2384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
-name = "histogram"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e673d137229619d5c2c8903b6ed5852b43636c0017ff2e66b1aafb8ccf04b80b"
-dependencies = [
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5831,7 +5821,6 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "histogram",
  "humantime",
  "itertools",
  "once_cell",

--- a/storage_scrubber/Cargo.toml
+++ b/storage_scrubber/Cargo.toml
@@ -36,9 +36,18 @@ rustls-native-certs.workspace = true
 once_cell.workspace = true
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-chrono = { workspace = true, default-features = false, features = ["clock", "serde"] }
-reqwest = { workspace = true, default-features = false, features = ["rustls-tls", "json"] }
-aws-config = { workspace = true, default-features = false, features = ["rustls", "sso"] }
+chrono = { workspace = true, default-features = false, features = [
+    "clock",
+    "serde",
+] }
+reqwest = { workspace = true, default-features = false, features = [
+    "rustls-tls",
+    "json",
+] }
+aws-config = { workspace = true, default-features = false, features = [
+    "rustls",
+    "sso",
+] }
 
 pageserver = { path = "../pageserver" }
 pageserver_api = { path = "../libs/pageserver_api" }
@@ -48,6 +57,5 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 clap.workspace = true
 tracing-appender = "0.2"
-histogram = "0.7"
 
 futures.workspace = true

--- a/storage_scrubber/Cargo.toml
+++ b/storage_scrubber/Cargo.toml
@@ -36,18 +36,9 @@ rustls-native-certs.workspace = true
 once_cell.workspace = true
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-chrono = { workspace = true, default-features = false, features = [
-    "clock",
-    "serde",
-] }
-reqwest = { workspace = true, default-features = false, features = [
-    "rustls-tls",
-    "json",
-] }
-aws-config = { workspace = true, default-features = false, features = [
-    "rustls",
-    "sso",
-] }
+chrono = { workspace = true, default-features = false, features = ["clock", "serde"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls-tls", "json"] }
+aws-config = { workspace = true, default-features = false, features = ["rustls", "sso"] }
 
 pageserver = { path = "../pageserver" }
 pageserver_api = { path = "../libs/pageserver_api" }


### PR DESCRIPTION
The histograms in the metadata summary were added experimentally. We will remove them since we can get most of the insights from prometheus stats. Also reduce noise when maximum value go out of the range.