### PR TITLE
[proxy/redis] impr: use redis_auth_type to switch between auth types

### DIFF
--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -340,7 +340,8 @@ async fn main() -> anyhow::Result<()> {
                 ),
             ),
             (None, None) => {
-                bail!("irsa auth requires redis-host and redis-port to be set");
+                warn!("irsa auth requires redis-host and redis-port to be set, continuing without regional_redis_client");
+                None
             }
             _ => {
                 bail!("redis-host and redis-port must be specified together");
@@ -373,7 +374,7 @@ async fn main() -> anyhow::Result<()> {
 
     let cancel_map = CancelMap::default();
 
-    let redis_publisher = match &redis_notifications_client {
+    let redis_publisher = match &regional_redis_client {
         Some(redis_publisher) => Some(Arc::new(Mutex::new(RedisPublisherClient::new(
             redis_publisher.clone(),
             args.region.clone(),

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -322,22 +322,6 @@ async fn main() -> anyhow::Result<()> {
         ),
         aws_credentials_provider,
     ));
-    // let regional_redis_client =  match (args.redis_host, args.redis_port) {
-    //     (Some(host), Some(port)) => Some(
-    //         ConnectionWithCredentialsProvider::new_with_credentials_provider(
-    //             host,
-    //             port,
-    //             elasticache_credentials_provider.clone(),
-    //         ),
-    //     ),
-    //     (None, None) => {
-    //         warn!("Redis events from console are disabled");
-    //         None
-    //     }
-    //     _ => {
-    //         bail!("redis-host and redis-port must be specified together");
-    //     }
-    // };
     let regional_redis_client = match args.redis_auth_type.as_str() {
         "plain" => {
             match args.redis_notifications {

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -323,31 +323,29 @@ async fn main() -> anyhow::Result<()> {
         aws_credentials_provider,
     ));
     let regional_redis_client = match (args.redis_auth_type.as_str(), &args.redis_notifications) {
-        ("plain", redis_url) => {
-            match redis_url {
-                None => {
-                    bail!("plain auth requires redis_notifications to be set");
-                },
-                Some(url) => Some(ConnectionWithCredentialsProvider::new_with_static_credentials(url.to_string())),
+        ("plain", redis_url) => match redis_url {
+            None => {
+                bail!("plain auth requires redis_notifications to be set");
             }
-        }
-        ("irsa", _) => {
-            match (&args.redis_host, args.redis_port) {
-                (Some(host), Some(port)) => Some(
-                    ConnectionWithCredentialsProvider::new_with_credentials_provider(
-                        host.to_string(),
-                        port,
-                        elasticache_credentials_provider.clone(),
-                    ),
+            Some(url) => Some(
+                ConnectionWithCredentialsProvider::new_with_static_credentials(url.to_string()),
+            ),
+        },
+        ("irsa", _) => match (&args.redis_host, args.redis_port) {
+            (Some(host), Some(port)) => Some(
+                ConnectionWithCredentialsProvider::new_with_credentials_provider(
+                    host.to_string(),
+                    port,
+                    elasticache_credentials_provider.clone(),
                 ),
-                (None, None) => {
-                    bail!("irsa auth requires redis-host and redis-port to be set");
-                }
-                _ => {
-                    bail!("redis-host and redis-port must be specified together");
-                }
+            ),
+            (None, None) => {
+                bail!("irsa auth requires redis-host and redis-port to be set");
             }
-        }
+            _ => {
+                bail!("redis-host and redis-port must be specified together");
+            }
+        },
         _ => {
             bail!("unknown auth type given");
         }

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -354,7 +354,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let redis_notifications_client = if let Some(url) = &args.redis_notifications {
-        Some(ConnectionWithCredentialsProvider::new_with_static_credentials(url))
+        Some(ConnectionWithCredentialsProvider::new_with_static_credentials(url.to_string()))
     } else {
         regional_redis_client.clone()
     };


### PR DESCRIPTION
## Problem

On Azure we need to use username-password authentication in proxy for regional redis client.

## Summary of changes

This adds `redis_auth_type` to the config with default value of "irsa". Not specifying it will enforce the `regional_redis_client` to be configured with IRSA redis (as it's done now). 
If "plain" is specified, then the regional client is condifigured with `redis_notifications`, consuming username:password auth from URI. We plan to do that for the Azure cloud.

Configuring `regional_redis_client` is required now, there is no opt-out from configuring it.
