### PR TITLE
Bodobolero/fix root permissions

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -523,6 +523,13 @@ jobs:
       if: ${{ !cancelled() }}
       uses: ./.github/actions/allure-report-generate
 
+    # until https://github.com/neondatabase/neon/issues/8275 is fixed we temporarily install postgresql-16 and thus run this job as root user
+    - name: temporarily ensure no files with root user permissions are left over in work directory from this job that other job steps running as non-root cannot delete
+      if: ${{ !cancelled() }}
+      run: |
+        rm -rf /__w/neon/neon/allure-2.27.0
+        chmod -R 777 /__w/neon/neon
+
     - name: Post to a Slack channel
       if: ${{ github.event.schedule && failure() }}
       uses: slackapi/slack-github-action@v1
@@ -531,11 +538,8 @@ jobs:
         slack-message: "Periodic perf testing ${PLATFORM}: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    # until https://github.com/neondatabase/neon/issues/8275 is fixed we temporarily install postgresql-16 and thus run this job as root user
-    - name: temporarily ensure no files with root user permissions are left over in work directory from this job that other job steps running as non-root cannot delete
-      if: ${{ !cancelled() }}
-      run: |
-        chmod -R 777 /__w/neon/neon
+
+    
 
   clickbench-compare:
     # ClichBench DB for rds-aurora and rds-Postgres deployed to the same clusters

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -514,7 +514,7 @@ jobs:
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
         BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
-        
+
     - name: Benchmark pgvector queries
       uses: ./.github/actions/run-python-test-set
       with:

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init --user root
+      options: --init 
 
     steps:
     - uses: actions/checkout@v4
@@ -159,7 +159,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init --user root
+      options: --init 
 
     steps:
     - uses: actions/checkout@v4
@@ -323,16 +323,12 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init --user root
+      options: --init 
 
     # Increase timeout to 8h, default timeout is 6h
     timeout-minutes: 480
 
     steps:
-    - name: Reset permissions before checkout
-      run: |
-        chmod -R 777 /__w/neon/neon
-
     - uses: actions/checkout@v4
 
     - name: Download Neon artifact
@@ -457,13 +453,14 @@ jobs:
       DEFAULT_PG_VERSION: 16
       TEST_OUTPUT: /tmp/test_output
       BUILD_TYPE: remote
+      LD_LIBRARY_PATH:/home/nonroot/pg/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
       SAVE_PERF_REPORT: ${{ github.event.inputs.save_perf_report || ( github.ref_name == 'main' ) }}
       PLATFORM: ${{ matrix.PLATFORM }}
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init --user root
+      options: --init 
 
     steps:
     - uses: actions/checkout@v4
@@ -472,12 +469,16 @@ jobs:
     # instead of using Neon artifacts containing pgbench
     - name: Install postgresql-16 where pytest expects it
       run: |
-        apt-get update && apt-get install -y postgresql-common
-        /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-        apt-get -y install postgresql-16
+        cd /home/nonroot
+        wget  https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/libpq5_16.3-1.pgdg110%2B1_amd64.deb
+        wget https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-client-16_16.3-1.pgdg110%2B1_amd64.deb
+        wget https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-16_16.3-1.pgdg110%2B1_amd64.deb 
+        dpkg -x libpq5_16.3-1.pgdg110+1_amd64.deb pg
+        dpkg -x postgresql-client-16_16.3-1.pgdg110+1_amd64.deb pg
+        dpkg -x postgresql-16_16.3-1.pgdg110+1_amd64.deb pg
         mkdir -p /tmp/neon/pg_install/v16/bin
-        ln -s /usr/bin/pgbench /tmp/neon/pg_install/v16/bin/pgbench
-        ln -s /usr/bin/psql /tmp/neon/pg_install/v16/bin/psql
+        ln -s /usr/bin/pgbench /home/nonroot/pg/usr/lib/postgresql/16/bin/pgbench 
+        ln -s /usr/bin/psql /home/nonroot/pg/usr/lib/postgresql/16/bin/psql 
 
     - name: Set up Connection String
       id: set-up-connstr
@@ -568,7 +569,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init --user root
+      options: --init 
 
     steps:
     - uses: actions/checkout@v4
@@ -656,7 +657,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init --user root
+      options: --init 
 
     steps:
     - uses: actions/checkout@v4
@@ -742,7 +743,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init --user root
+      options: --init 
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -457,7 +457,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init --user root
+      options: --init # --user root
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -531,7 +531,10 @@ jobs:
         slack-message: "Periodic perf testing ${PLATFORM}: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
+    # until https://github.com/neondatabase/neon/issues/8275 is fixed we temporarily install postgresql-16 and thus run this job as root user
+    - name: temporarily clean up files created with root permissions that other job steps running as non-root cannot delete
+      run: |
+        rm -rf /__w/neon/neon
 
   clickbench-compare:
     # ClichBench DB for rds-aurora and rds-Postgres deployed to the same clusters

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -328,6 +328,10 @@ jobs:
     timeout-minutes: 480
 
     steps:
+    - name: Reset permissions before checkout
+      run: |
+        chmod -R 777 /__w/neon/neon
+
     - uses: actions/checkout@v4
 
     - name: Download Neon artifact

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -532,10 +532,10 @@ jobs:
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     # until https://github.com/neondatabase/neon/issues/8275 is fixed we temporarily install postgresql-16 and thus run this job as root user
-    - name: temporarily clean up files created with root permissions that other job steps running as non-root cannot delete
+    - name: temporarily ensure no files with root user permissions are left over in work directory from this job that other job steps running as non-root cannot delete
       if: ${{ !cancelled() }}
       run: |
-        rm -rf /__w/neon/neon
+        chmod -R 777 /__w/neon/neon
 
   clickbench-compare:
     # ClichBench DB for rds-aurora and rds-Postgres deployed to the same clusters

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init
+      options: --init --user root
 
     steps:
     - uses: actions/checkout@v4
@@ -158,7 +158,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init
+      options: --init --user root
 
     steps:
     - uses: actions/checkout@v4
@@ -322,7 +322,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init
+      options: --init --user root
 
     # Increase timeout to 8h, default timeout is 6h
     timeout-minutes: 480
@@ -457,7 +457,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init # --user root
+      options: --init --user root
 
     steps:
     - uses: actions/checkout@v4
@@ -523,13 +523,6 @@ jobs:
       if: ${{ !cancelled() }}
       uses: ./.github/actions/allure-report-generate
 
-    # until https://github.com/neondatabase/neon/issues/8275 is fixed we temporarily install postgresql-16 and thus run this job as root user
-    - name: temporarily ensure no files with root user permissions are left over in work directory from this job that other job steps running as non-root cannot delete
-      if: ${{ !cancelled() }}
-      run: |
-        rm -rf /__w/neon/neon/allure-2.27.0
-        chmod -R 777 /__w/neon/neon
-
     - name: Post to a Slack channel
       if: ${{ github.event.schedule && failure() }}
       uses: slackapi/slack-github-action@v1
@@ -569,7 +562,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init
+      options: --init --user root
 
     steps:
     - uses: actions/checkout@v4
@@ -657,7 +650,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init
+      options: --init --user root
 
     steps:
     - uses: actions/checkout@v4
@@ -743,7 +736,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init
+      options: --init --user root
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -513,6 +513,7 @@ jobs:
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
         BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
+        LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}
 
     - name: Benchmark pgvector queries
       uses: ./.github/actions/run-python-test-set
@@ -527,6 +528,7 @@ jobs:
         BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
+        LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}
 
     - name: Create Allure report
       if: ${{ !cancelled() }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -479,6 +479,7 @@ jobs:
         mkdir -p /tmp/neon/pg_install/v16/bin
         ln -s /home/nonroot/pg/usr/lib/postgresql/16/bin/pgbench /tmp/neon/pg_install/v16/bin/pgbench  
         ln -s /home/nonroot/pg/usr/lib/postgresql/16/bin/psql /tmp/neon/pg_install/v16/bin/psql  
+        ln -s /home/nonroot/pg/usr/lib/x86_64-linux-gnu /tmp/neon/pg_install/v16/lib 
         /tmp/neon/pg_install/v16/bin/pgbench --version
         /tmp/neon/pg_install/v16/bin/psql --version
 
@@ -513,8 +514,7 @@ jobs:
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
         BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
-        LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}
-
+        
     - name: Benchmark pgvector queries
       uses: ./.github/actions/run-python-test-set
       with:
@@ -528,7 +528,6 @@ jobs:
         BENCHMARK_CONNSTR: ${{ steps.set-up-connstr.outputs.connstr }}
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
-        LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}
 
     - name: Create Allure report
       if: ${{ !cancelled() }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init 
+      options: --init
 
     steps:
     - uses: actions/checkout@v4
@@ -159,7 +159,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init 
+      options: --init
 
     steps:
     - uses: actions/checkout@v4
@@ -323,7 +323,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init 
+      options: --init
 
     # Increase timeout to 8h, default timeout is 6h
     timeout-minutes: 480
@@ -460,7 +460,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init 
+      options: --init
 
     steps:
     - uses: actions/checkout@v4
@@ -542,8 +542,6 @@ jobs:
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-    
-
   clickbench-compare:
     # ClichBench DB for rds-aurora and rds-Postgres deployed to the same clusters
     # we use for performance testing in pgbench-compare.
@@ -572,7 +570,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init 
+      options: --init
 
     steps:
     - uses: actions/checkout@v4
@@ -660,7 +658,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init 
+      options: --init
 
     steps:
     - uses: actions/checkout@v4
@@ -746,7 +744,7 @@ jobs:
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
-      options: --init 
+      options: --init
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -470,9 +470,9 @@ jobs:
     - name: Install postgresql-16 where pytest expects it
       run: |
         cd /home/nonroot
-        wget  https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/libpq5_16.3-1.pgdg110%2B1_amd64.deb
-        wget https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-client-16_16.3-1.pgdg110%2B1_amd64.deb
-        wget https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-16_16.3-1.pgdg110%2B1_amd64.deb 
+        wget -q https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/libpq5_16.3-1.pgdg110%2B1_amd64.deb
+        wget -q https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-client-16_16.3-1.pgdg110%2B1_amd64.deb
+        wget -q https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-16_16.3-1.pgdg110%2B1_amd64.deb 
         dpkg -x libpq5_16.3-1.pgdg110+1_amd64.deb pg
         dpkg -x postgresql-client-16_16.3-1.pgdg110+1_amd64.deb pg
         dpkg -x postgresql-16_16.3-1.pgdg110+1_amd64.deb pg

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -479,7 +479,7 @@ jobs:
         mkdir -p /tmp/neon/pg_install/v16/bin
         ln -s /home/nonroot/pg/usr/lib/postgresql/16/bin/pgbench /tmp/neon/pg_install/v16/bin/pgbench  
         ln -s /home/nonroot/pg/usr/lib/postgresql/16/bin/psql /tmp/neon/pg_install/v16/bin/psql  
-        /tmp/neon/pg_install/v16/bin/pgbenc --version
+        /tmp/neon/pg_install/v16/bin/pgbench --version
         /tmp/neon/pg_install/v16/bin/psql --version
 
     - name: Set up Connection String

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -477,8 +477,8 @@ jobs:
         dpkg -x postgresql-client-16_16.3-1.pgdg110+1_amd64.deb pg
         dpkg -x postgresql-16_16.3-1.pgdg110+1_amd64.deb pg
         mkdir -p /tmp/neon/pg_install/v16/bin
-        ln -s /tmp/neon/pg_install/v16/bin/pgbench /home/nonroot/pg/usr/lib/postgresql/16/bin/pgbench 
-        ln -s /tmp/neon/pg_install/v16/bin/psql /home/nonroot/pg/usr/lib/postgresql/16/bin/psql 
+        ln -s /home/nonroot/pg/usr/lib/postgresql/16/bin/pgbench /tmp/neon/pg_install/v16/bin/pgbench  
+        ln -s /home/nonroot/pg/usr/lib/postgresql/16/bin/psql /tmp/neon/pg_install/v16/bin/psql  
         /tmp/neon/pg_install/v16/bin/pgbenc --version
         /tmp/neon/pg_install/v16/bin/psql --version
 

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -533,6 +533,7 @@ jobs:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     # until https://github.com/neondatabase/neon/issues/8275 is fixed we temporarily install postgresql-16 and thus run this job as root user
     - name: temporarily clean up files created with root permissions that other job steps running as non-root cannot delete
+      if: ${{ !cancelled() }}
       run: |
         rm -rf /__w/neon/neon
 

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -477,8 +477,10 @@ jobs:
         dpkg -x postgresql-client-16_16.3-1.pgdg110+1_amd64.deb pg
         dpkg -x postgresql-16_16.3-1.pgdg110+1_amd64.deb pg
         mkdir -p /tmp/neon/pg_install/v16/bin
-        ln -s /usr/bin/pgbench /home/nonroot/pg/usr/lib/postgresql/16/bin/pgbench 
-        ln -s /usr/bin/psql /home/nonroot/pg/usr/lib/postgresql/16/bin/psql 
+        ln -s /tmp/neon/pg_install/v16/bin/pgbench /home/nonroot/pg/usr/lib/postgresql/16/bin/pgbench 
+        ln -s /tmp/neon/pg_install/v16/bin/psql /home/nonroot/pg/usr/lib/postgresql/16/bin/psql 
+        /tmp/neon/pg_install/v16/bin/pgbenc --version
+        /tmp/neon/pg_install/v16/bin/psql --version
 
     - name: Set up Connection String
       id: set-up-connstr

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -453,7 +453,7 @@ jobs:
       DEFAULT_PG_VERSION: 16
       TEST_OUTPUT: /tmp/test_output
       BUILD_TYPE: remote
-      LD_LIBRARY_PATH:/home/nonroot/pg/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+      LD_LIBRARY_PATH: /home/nonroot/pg/usr/lib/x86_64-linux-gnu
       SAVE_PERF_REPORT: ${{ github.event.inputs.save_perf_report || ( github.ref_name == 'main' ) }}
       PLATFORM: ${{ matrix.PLATFORM }}
 

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -57,6 +57,7 @@ jobs:
   bench:
     if: ${{ github.event.inputs.run_only_pgvector_tests == 'false' || github.event.inputs.run_only_pgvector_tests == null }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - DEFAULT_PG_VERSION: 16
@@ -443,6 +444,7 @@ jobs:
 
   pgbench-pgvector:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - PLATFORM: "neon-captest-pgvector"


### PR DESCRIPTION
## Problem

My prior PR https://github.com/neondatabase/neon/pull/8422
caused leftovers in the GitHub action runner work directory with root permission.
As an example see here https://github.com/neondatabase/neon/actions/runs/10001857641/job/27646237324#step:3:37
To work-around we install vanilla postgres as non-root using deb packages in /home/nonroot user directory

## Summary of changes

- since we cannot use root we install the deb pkgs directly and create symbolic links for psql, pgbench and libs in expected places
- continue jobs an aws even if azure jobs fail (because this region is currently unreliable)

