### PR TITLE
ci: adds separate doc checks for markdown files and not triggering the build_and_test ci

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,7 +6,13 @@ on:
       - main
       - release
       - release-proxy
+    paths-ignore:
+      - "**.md"
+      - "docs/**.md"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**.md"
 
 defaults:
   run:
@@ -19,7 +25,7 @@ concurrency:
 
 env:
   RUST_BACKTRACE: 1
-  COPT: '-Werror'
+  COPT: "-Werror"
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY_DEV }}
   # A concurrency group that we use for e2e-tests runs, matches `concurrency.group` above with `github.repository` as a prefix
@@ -33,7 +39,7 @@ jobs:
       github-event-name: ${{ github.event_name }}
 
   cancel-previous-e2e-tests:
-    needs: [ check-permissions ]
+    needs: [check-permissions]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
 
@@ -47,8 +53,8 @@ jobs:
               --field concurrency_group="${{ env.E2E_CONCURRENCY_GROUP }}"
 
   tag:
-    needs: [ check-permissions ]
-    runs-on: [ self-hosted, gen3, small ]
+    needs: [check-permissions]
+    runs-on: [self-hosted, gen3, small]
     container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
     outputs:
       build-tag: ${{steps.build-tag.outputs.tag}}
@@ -78,19 +84,19 @@ jobs:
         id: build-tag
 
   check-build-tools-image:
-    needs: [ check-permissions ]
+    needs: [check-permissions]
     uses: ./.github/workflows/check-build-tools-image.yml
 
   build-build-tools-image:
-    needs: [ check-build-tools-image ]
+    needs: [check-build-tools-image]
     uses: ./.github/workflows/build-build-tools-image.yml
     with:
       image-tag: ${{ needs.check-build-tools-image.outputs.image-tag }}
     secrets: inherit
 
   check-codestyle-python:
-    needs: [ check-permissions, build-build-tools-image ]
-    runs-on: [ self-hosted, gen3, small ]
+    needs: [check-permissions, build-build-tools-image]
+    runs-on: [self-hosted, gen3, small]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:
@@ -124,8 +130,8 @@ jobs:
         run: poetry run mypy .
 
   check-codestyle-rust:
-    needs: [ check-permissions, build-build-tools-image ]
-    runs-on: [ self-hosted, gen3, small ]
+    needs: [check-permissions, build-build-tools-image]
+    runs-on: [self-hosted, gen3, small]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:
@@ -140,16 +146,16 @@ jobs:
           submodules: true
           fetch-depth: 1
 
-#      Disabled for now
-#      - name: Restore cargo deps cache
-#        id: cache_cargo
-#        uses: actions/cache@v4
-#        with:
-#          path: |
-#            !~/.cargo/registry/src
-#            ~/.cargo/git/
-#            target/
-#          key: v1-${{ runner.os }}-${{ runner.arch }}-cargo-clippy-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.lock') }}
+      #      Disabled for now
+      #      - name: Restore cargo deps cache
+      #        id: cache_cargo
+      #        uses: actions/cache@v4
+      #        with:
+      #          path: |
+      #            !~/.cargo/registry/src
+      #            ~/.cargo/git/
+      #            target/
+      #          key: v1-${{ runner.os }}-${{ runner.arch }}-cargo-clippy-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.lock') }}
 
       # Some of our rust modules use FFI and need those to be checked
       - name: Get postgres headers
@@ -174,7 +180,7 @@ jobs:
       - name: Check documentation generation
         run: cargo doc --workspace --no-deps --document-private-items
         env:
-            RUSTDOCFLAGS: "-Dwarnings -Arustdoc::private_intra_doc_links"
+          RUSTDOCFLAGS: "-Dwarnings -Arustdoc::private_intra_doc_links"
 
       # Use `${{ !cancelled() }}` to run quck tests after the longer clippy run
       - name: Check formatting
@@ -194,8 +200,8 @@ jobs:
         run: cargo deny check --hide-inclusion-graph
 
   build-neon:
-    needs: [ check-permissions, tag, build-build-tools-image ]
-    runs-on: [ self-hosted, gen3, large ]
+    needs: [check-permissions, tag, build-build-tools-image]
+    runs-on: [self-hosted, gen3, large]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:
@@ -209,7 +215,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ debug, release ]
+        build_type: [debug, release]
     env:
       BUILD_TYPE: ${{ matrix.build_type }}
       GIT_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -280,19 +286,19 @@ jobs:
       # uncompressed versions of the crates in ~/.cargo/registry/cache
       # directory, and it's faster to let 'cargo' to rebuild it from the
       # compressed crates.
-#      - name: Cache cargo deps
-#        id: cache_cargo
-#        uses: actions/cache@v4
-#        with:
-#          path: |
-#            ~/.cargo/registry/
-#            !~/.cargo/registry/src
-#            ~/.cargo/git/
-#            target/
-#          # Fall back to older versions of the key, if no cache for current Cargo.lock was found
-#          key: |
-#            v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build_type }}-cargo-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.lock') }}
-#            v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build_type }}-cargo-${{ hashFiles('rust-toolchain.toml') }}-
+      #      - name: Cache cargo deps
+      #        id: cache_cargo
+      #        uses: actions/cache@v4
+      #        with:
+      #          path: |
+      #            ~/.cargo/registry/
+      #            !~/.cargo/registry/src
+      #            ~/.cargo/git/
+      #            target/
+      #          # Fall back to older versions of the key, if no cache for current Cargo.lock was found
+      #          key: |
+      #            v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build_type }}-cargo-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.lock') }}
+      #            v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build_type }}-cargo-${{ hashFiles('rust-toolchain.toml') }}-
 
       - name: Cache postgres v14 build
         id: cache_pg_14
@@ -427,8 +433,8 @@ jobs:
         uses: ./.github/actions/save-coverage-data
 
   regress-tests:
-    needs: [ check-permissions, build-neon, build-build-tools-image, tag ]
-    runs-on: [ self-hosted, gen3, large ]
+    needs: [check-permissions, build-neon, build-build-tools-image, tag]
+    runs-on: [self-hosted, gen3, large]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:
@@ -439,8 +445,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ debug, release ]
-        pg_version: [ v14, v15, v16 ]
+        build_type: [debug, release]
+        pg_version: [v14, v15, v16]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -480,8 +486,8 @@ jobs:
   get-benchmarks-durations:
     outputs:
       json: ${{ steps.get-benchmark-durations.outputs.json }}
-    needs: [ check-permissions, build-build-tools-image ]
-    runs-on: [ self-hosted, gen3, small ]
+    needs: [check-permissions, build-build-tools-image]
+    runs-on: [self-hosted, gen3, small]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:
@@ -513,8 +519,14 @@ jobs:
           echo "json=$(jq --compact-output '.' /tmp/benchmark_durations.json)" >> $GITHUB_OUTPUT
 
   benchmarks:
-    needs: [ check-permissions, build-neon, build-build-tools-image, get-benchmarks-durations ]
-    runs-on: [ self-hosted, gen3, small ]
+    needs:
+      [
+        check-permissions,
+        build-neon,
+        build-build-tools-image,
+        get-benchmarks-durations,
+      ]
+    runs-on: [self-hosted, gen3, small]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:
@@ -527,8 +539,8 @@ jobs:
       fail-fast: false
       matrix:
         # the amount of groups (N) should be reflected in `extra_params: --splits N ...`
-        pytest_split_group: [ 1, 2, 3, 4, 5 ]
-        build_type: [ release ]
+        pytest_split_group: [1, 2, 3, 4, 5]
+        build_type: [release]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -554,28 +566,35 @@ jobs:
       # while coverage is currently collected for the debug ones
 
   report-benchmarks-failures:
-    needs: [ benchmarks, create-test-report ]
+    needs: [benchmarks, create-test-report]
     if: github.ref_name == 'main' && failure() && needs.benchmarks.result == 'failure'
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: slackapi/slack-github-action@v1
-      with:
-        channel-id: C060CNA47S9 # on-call-staging-storage-stream
-        slack-message: |
-          Benchmarks failed on main: ${{ github.event.head_commit.url }}
+      - uses: slackapi/slack-github-action@v1
+        with:
+          channel-id: C060CNA47S9 # on-call-staging-storage-stream
+          slack-message: |
+            Benchmarks failed on main: ${{ github.event.head_commit.url }}
 
-          Allure report: ${{ needs.create-test-report.outputs.report-url }}
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+            Allure report: ${{ needs.create-test-report.outputs.report-url }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   create-test-report:
-    needs: [ check-permissions, regress-tests, coverage-report, benchmarks, build-build-tools-image ]
+    needs:
+      [
+        check-permissions,
+        regress-tests,
+        coverage-report,
+        benchmarks,
+        build-build-tools-image,
+      ]
     if: ${{ !cancelled() && contains(fromJSON('["skipped", "success"]'), needs.check-permissions.result) }}
     outputs:
       report-url: ${{ steps.create-allure-report.outputs.report-url }}
 
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: [self-hosted, gen3, small]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:
@@ -621,8 +640,8 @@ jobs:
             })
 
   coverage-report:
-    needs: [ check-permissions, regress-tests, build-build-tools-image ]
-    runs-on: [ self-hosted, gen3, small ]
+    needs: [check-permissions, regress-tests, build-build-tools-image]
+    runs-on: [self-hosted, gen3, small]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:
@@ -632,10 +651,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ debug ]
+        build_type: [debug]
     outputs:
-        coverage-html: ${{ steps.upload-coverage-report-new.outputs.report-url }}
-        coverage-json: ${{ steps.upload-coverage-report-new.outputs.summary-json }}
+      coverage-html: ${{ steps.upload-coverage-report-new.outputs.report-url }}
+      coverage-json: ${{ steps.upload-coverage-report-new.outputs.summary-json }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -726,15 +745,15 @@ jobs:
 
   trigger-e2e-tests:
     if: ${{ !github.event.pull_request.draft || contains( github.event.pull_request.labels.*.name, 'run-e2e-tests-in-draft') || github.ref_name == 'main' || github.ref_name == 'release' || github.ref_name == 'release-proxy' }}
-    needs: [ check-permissions, promote-images, tag ]
+    needs: [check-permissions, promote-images, tag]
     uses: ./.github/workflows/trigger-e2e-tests.yml
     secrets: inherit
 
   neon-image-arch:
-    needs: [ check-permissions, build-build-tools-image, tag ]
+    needs: [check-permissions, build-build-tools-image, tag]
     strategy:
       matrix:
-        arch: [ x64, arm64 ]
+        arch: [x64, arm64]
 
     runs-on: ${{ fromJson(format('["self-hosted", "gen3", "{0}"]', matrix.arch == 'arm64' && 'large-arm64' || 'large')) }}
 
@@ -782,7 +801,7 @@ jobs:
           rm -rf .docker-custom
 
   neon-image:
-    needs: [ neon-image-arch, tag ]
+    needs: [neon-image-arch, tag]
     runs-on: ubuntu-22.04
 
     steps:
@@ -809,12 +828,12 @@ jobs:
                                                                                 neondatabase/neon:${{ needs.tag.outputs.build-tag }}
 
   compute-node-image-arch:
-    needs: [ check-permissions, build-build-tools-image, tag ]
+    needs: [check-permissions, build-build-tools-image, tag]
     strategy:
       fail-fast: false
       matrix:
-        version: [ v14, v15, v16 ]
-        arch: [ x64, arm64 ]
+        version: [v14, v15, v16]
+        arch: [x64, arm64]
 
     runs-on: ${{ fromJson(format('["self-hosted", "gen3", "{0}"]', matrix.arch == 'arm64' && 'large-arm64' || 'large')) }}
 
@@ -913,12 +932,12 @@ jobs:
           rm -rf .docker-custom
 
   compute-node-image:
-    needs: [ compute-node-image-arch, tag ]
+    needs: [compute-node-image-arch, tag]
     runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        version: [ v14, v15, v16 ]
+        version: [v14, v15, v16]
 
     steps:
       - uses: docker/login-action@v3
@@ -964,12 +983,12 @@ jobs:
                                                                                 neondatabase/compute-tools:${{ needs.tag.outputs.build-tag }}
 
   vm-compute-node-image:
-    needs: [ check-permissions, tag, compute-node-image ]
-    runs-on: [ self-hosted, gen3, large ]
+    needs: [check-permissions, tag, compute-node-image]
+    runs-on: [self-hosted, gen3, large]
     strategy:
       fail-fast: false
       matrix:
-        version: [ v14, v15, v16 ]
+        version: [v14, v15, v16]
     env:
       VM_BUILDER_VERSION: v0.29.3
 
@@ -1019,11 +1038,11 @@ jobs:
           rm -rf .docker-custom
 
   test-images:
-    needs: [ check-permissions, tag, neon-image, compute-node-image ]
+    needs: [check-permissions, tag, neon-image, compute-node-image]
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x64, arm64 ]
+        arch: [x64, arm64]
 
     runs-on: ${{ fromJson(format('["self-hosted", "gen3", "{0}"]', matrix.arch == 'arm64' && 'small-arm64' || 'small')) }}
 
@@ -1085,7 +1104,7 @@ jobs:
           rm -rf .docker-custom
 
   promote-images:
-    needs: [ check-permissions, tag, test-images, vm-compute-node-image ]
+    needs: [check-permissions, tag, test-images, vm-compute-node-image]
     runs-on: ubuntu-22.04
 
     env:
@@ -1149,7 +1168,7 @@ jobs:
           done
 
   trigger-custom-extensions-build-and-wait:
-    needs: [ check-permissions, tag ]
+    needs: [check-permissions, tag]
     runs-on: ubuntu-22.04
     steps:
       - name: Set PR's status to pending and request a remote CI test
@@ -1223,10 +1242,17 @@ jobs:
           exit 1
 
   deploy:
-    needs: [ check-permissions, promote-images, tag, regress-tests, trigger-custom-extensions-build-and-wait ]
+    needs:
+      [
+        check-permissions,
+        promote-images,
+        tag,
+        regress-tests,
+        trigger-custom-extensions-build-and-wait,
+      ]
     if: github.ref_name == 'main' || github.ref_name == 'release'|| github.ref_name == 'release-proxy'
 
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: [self-hosted, gen3, small]
     container: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/ansible:latest
     steps:
       - name: Fix git ownership
@@ -1324,10 +1350,10 @@ jobs:
             })
 
   promote-compatibility-data:
-    needs: [ check-permissions, promote-images, tag, regress-tests ]
+    needs: [check-permissions, promote-images, tag, regress-tests]
     if: github.ref_name == 'release'
 
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: [self-hosted, gen3, small]
     container:
       image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/base:pinned
       options: --init
@@ -1363,7 +1389,7 @@ jobs:
           done
 
   pin-build-tools-image:
-    needs: [ build-build-tools-image, promote-images, regress-tests ]
+    needs: [build-build-tools-image, promote-images, regress-tests]
     if: github.ref_name == 'main'
     uses: ./.github/workflows/pin-build-tools-image.yml
     with:

--- a/.github/workflows/doc_checks.yml
+++ b/.github/workflows/doc_checks.yml
@@ -1,0 +1,90 @@
+name: Documentation checks
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.md"
+      - "docs/**"
+  pull_request:
+    paths:
+      - "**.md"
+      - "docs/**"
+
+jobs:
+  check-permissions:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'run-no-ci') }}
+    uses: ./.github/workflows/check-permissions.yml
+    with:
+      github-event-name: ${{ github.event_name }}
+
+  check_docs:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.15.0"
+
+      - name: Install dependencies
+        run: |
+          npm install -g markdownlint-cli
+          npm install -g markdown-link-check
+
+      - name: Check Markdown formatting.
+        run: |
+          cat << EOF > markdownlint.json
+          {
+            "default": true,
+            "MD013": { "line_length": 80 },
+            "MD033": false,
+            "MD041": false
+          }
+          EOF
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -E '\.(md|mdx)$' | xargs -r markdownlint --config markdownlint.json
+          else
+            git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E '\.(md|mdx)$' | xargs -r markdownlint --config markdownlint.json
+          fi
+        continue-on-error: true
+
+      - name: Check Markdown links.
+        run: |
+
+          cat << EOF > link-check.json
+          {
+            "ignorePatterns": [
+              { "pattern": "^https://github.com/neondatabase/neon/issues/" },
+              { "pattern": "^https://github.com/neondatabase/neon/pull/" }
+            ],
+            "replacementPatterns": [
+              {
+                "pattern": "^/",
+                "replacement": "{{BASEURL}}/"
+              }
+            ],
+            "timeout": "20s",
+            "retryOn429": true,
+            "retryCount": 5,
+            "fallbackRetryDelay": "30s"
+          }
+          EOF
+
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -E '\.(md|mdx)$' | xargs -r markdown-link-check -c link-check.json
+          else
+
+            git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E '\.(md|mdx)$' | xargs -r markdown-link-check -c link-check.json
+          fi
+        continue-on-error: true

--- a/.github/workflows/neon_extra_builds.yml
+++ b/.github/workflows/neon_extra_builds.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**.md"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**.md"
 
 defaults:
   run:
@@ -17,7 +23,7 @@ concurrency:
 
 env:
   RUST_BACKTRACE: 1
-  COPT: '-Werror'
+  COPT: "-Werror"
 
 jobs:
   check-permissions:
@@ -27,18 +33,18 @@ jobs:
       github-event-name: ${{ github.event_name}}
 
   check-build-tools-image:
-    needs: [ check-permissions ]
+    needs: [check-permissions]
     uses: ./.github/workflows/check-build-tools-image.yml
 
   build-build-tools-image:
-    needs: [ check-build-tools-image ]
+    needs: [check-build-tools-image]
     uses: ./.github/workflows/build-build-tools-image.yml
     with:
       image-tag: ${{ needs.check-build-tools-image.outputs.image-tag }}
     secrets: inherit
 
   check-macos-build:
-    needs: [ check-permissions ]
+    needs: [check-permissions]
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-extra-build-macos')  ||
       contains(github.event.pull_request.labels.*.name, 'run-extra-build-*') ||
@@ -134,9 +140,9 @@ jobs:
         run: ./run_clippy.sh
 
   check-linux-arm-build:
-    needs: [ check-permissions, build-build-tools-image ]
+    needs: [check-permissions, build-build-tools-image]
     timeout-minutes: 90
-    runs-on: [ self-hosted, small-arm64 ]
+    runs-on: [self-hosted, small-arm64]
 
     env:
       # Use release build only, to have less debug info around
@@ -265,9 +271,9 @@ jobs:
           cargo nextest run --package remote_storage --test test_real_azure -j$(nproc)
 
   check-codestyle-rust-arm:
-    needs: [ check-permissions, build-build-tools-image ]
+    needs: [check-permissions, build-build-tools-image]
     timeout-minutes: 90
-    runs-on: [ self-hosted, small-arm64 ]
+    runs-on: [self-hosted, small-arm64]
 
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
@@ -279,7 +285,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ debug, release ]
+        build_type: [debug, release]
 
     steps:
       - name: Fix git ownership
@@ -329,7 +335,7 @@ jobs:
         if: matrix.build_type == 'release'
         run: cargo doc --workspace --no-deps --document-private-items -j$(nproc)
         env:
-            RUSTDOCFLAGS: "-Dwarnings -Arustdoc::private_intra_doc_links"
+          RUSTDOCFLAGS: "-Dwarnings -Arustdoc::private_intra_doc_links"
 
       # Use `${{ !cancelled() }}` to run quck tests after the longer clippy run
       - name: Check formatting
@@ -349,12 +355,12 @@ jobs:
         run: cargo deny check
 
   gather-rust-build-stats:
-    needs: [ check-permissions, build-build-tools-image ]
+    needs: [check-permissions, build-build-tools-image]
     if: |
       contains(github.event.pull_request.labels.*.name, 'run-extra-build-stats') ||
       contains(github.event.pull_request.labels.*.name, 'run-extra-build-*') ||
       github.ref_name == 'main'
-    runs-on: [ self-hosted, large ]
+    runs-on: [self-hosted, large]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}
       credentials:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 [![Neon](https://github.com/neondatabase/neon/assets/11527560/f15a17f0-836e-40c5-b35d-030606a6b660)](https://neon.tech)
 
-
-
 # Neon
 
 Neon is a serverless open-source alternative to AWS Aurora Postgres. It separates storage and compute and substitutes the PostgreSQL storage layer by redistributing data across a cluster of nodes.
 
 ## Quick start
+
 Try the [Neon Free Tier](https://neon.tech/github) to create a serverless Postgres instance. Then connect to it with your preferred Postgres client (psql, dbeaver, etc) or use the online [SQL Editor](https://neon.tech/docs/get-started-with-neon/query-with-neon-sql-editor/). See [Connect from any application](https://neon.tech/docs/connect/connect-from-any-app/) for connection instructions.
 
 Alternatively, compile and run the project [locally](#running-local-installation).
@@ -16,6 +15,7 @@ Alternatively, compile and run the project [locally](#running-local-installation
 A Neon installation consists of compute nodes and the Neon storage engine. Compute nodes are stateless PostgreSQL nodes backed by the Neon storage engine.
 
 The Neon storage engine consists of two major components:
+
 - Pageserver: Scalable storage backend for the compute nodes.
 - Safekeepers: The safekeepers form a redundant WAL service that received WAL from the compute node, and stores it durably until it has been processed by the pageserver and uploaded to cloud storage.
 
@@ -23,24 +23,29 @@ See developer documentation in [SUMMARY.md](/docs/SUMMARY.md) for more informati
 
 ## Running local installation
 
-
 #### Installing dependencies on Linux
+
 1. Install build dependencies and other applicable packages
 
-* On Ubuntu or Debian, this set of packages should be sufficient to build the code:
+- On Ubuntu or Debian, this set of packages should be sufficient to build the code:
+
 ```bash
 apt install build-essential libtool libreadline-dev zlib1g-dev flex bison libseccomp-dev \
 libssl-dev clang pkg-config libpq-dev cmake postgresql-client protobuf-compiler \
 libcurl4-openssl-dev openssl python3-poetry lsof libicu-dev
 ```
-* On Fedora, these packages are needed:
+
+- On Fedora, these packages are needed:
+
 ```bash
 dnf install flex bison readline-devel zlib-devel openssl-devel \
   libseccomp-devel perl clang cmake postgresql postgresql-contrib protobuf-compiler \
   protobuf-devel libcurl-devel openssl poetry lsof libicu-devel libpq-devel python3-devel \
   libffi-devel
 ```
-* On Arch based systems, these packages are needed:
+
+- On Arch based systems, these packages are needed:
+
 ```bash
 pacman -S base-devel readline zlib libseccomp openssl clang \
 postgresql-libs cmake postgresql protobuf curl lsof
@@ -49,13 +54,16 @@ postgresql-libs cmake postgresql protobuf curl lsof
 Building Neon requires 3.15+ version of `protoc` (protobuf-compiler). If your distribution provides an older version, you can install a newer version from [here](https://github.com/protocolbuffers/protobuf/releases).
 
 2. [Install Rust](https://www.rust-lang.org/tools/install)
+
 ```
 # recommended approach from https://www.rust-lang.org/tools/install
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 #### Installing dependencies on macOS (12.3.1)
+
 1. Install XCode and dependencies
+
 ```
 xcode-select --install
 brew install protobuf openssl flex bison icu4c pkg-config
@@ -65,12 +73,14 @@ echo 'export PATH="$(brew --prefix openssl)/bin:$PATH"' >> ~/.zshrc
 ```
 
 2. [Install Rust](https://www.rust-lang.org/tools/install)
+
 ```
 # recommended approach from https://www.rust-lang.org/tools/install
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 3. Install PostgreSQL Client
+
 ```
 # from https://stackoverflow.com/questions/44654216/correct-way-to-install-psql-without-full-postgres-on-macos
 brew install libpq
@@ -91,6 +101,7 @@ Newer rustc versions most probably will work fine, yet older ones might not be s
 #### Building on Linux
 
 1. Build neon and patched postgres
+
 ```
 # Note: The path to the neon sources can not contain a space.
 
@@ -108,6 +119,7 @@ make -j`nproc` -s
 #### Building on OSX
 
 1. Build neon and patched postgres
+
 ```
 # Note: The path to the neon sources can not contain a space.
 
@@ -123,14 +135,16 @@ make -j`sysctl -n hw.logicalcpu` -s
 ```
 
 #### Dependency installation notes
+
 To run the `psql` client, install the `postgresql-client` package or modify `PATH` and `LD_LIBRARY_PATH` to include `pg_install/bin` and `pg_install/lib`, respectively.
 
 To run the integration tests or Python scripts (not required to use the code), install
 Python (3.9 or higher), and install the python3 packages using `./scripts/pysync` (requires [poetry>=1.3](https://python-poetry.org/)) in the project directory.
 
-
 #### Running neon database
+
 1. Start pageserver and postgres on top of it (should be called from repo root):
+
 ```sh
 # Create repository in .neon with proper paths to binaries and data
 # Later that would be responsibility of a package install script
@@ -167,6 +181,7 @@ Starting postgres at 'postgresql://cloud_admin@127.0.0.1:55432/postgres'
 ```
 
 2. Now, it is possible to connect to postgres and run some queries:
+
 ```text
 > psql -p 55432 -h 127.0.0.1 -U cloud_admin postgres
 postgres=# CREATE TABLE t(key int primary key, value text);
@@ -181,6 +196,7 @@ postgres=# select * from t;
 ```
 
 3. And create branches and run postgres on them:
+
 ```sh
 # create branch named migration_check
 > cargo neon timeline branch --branch-name migration_check
@@ -228,6 +244,7 @@ postgres=# select * from t;
 
 4. If you want to run tests afterwards (see below), you must stop all the running pageserver, safekeeper, and postgres instances
    you have just started. You can terminate them all with one command:
+
 ```sh
 > cargo neon stop
 ```
@@ -270,7 +287,7 @@ DEFAULT_PG_VERSION=15 BUILD_TYPE=release ./scripts/pytest
 You may find yourself in need of flamegraphs for software in this repository.
 You can use [`flamegraph-rs`](https://github.com/flamegraph-rs/flamegraph) or the original [`flamegraph.pl`](https://github.com/brendangregg/FlameGraph). Your choice!
 
->[!IMPORTANT]
+> [!IMPORTANT]
 > If you're using `lld` or `mold`, you need the `--no-rosegment` linker argument.
 > It's a [general thing with Rust / lld / mold](https://crbug.com/919499#c16), not specific to this repository.
 > See [this PR for further instructions](https://github.com/neondatabase/neon/pull/6764).
@@ -300,7 +317,7 @@ Other resources:
 ### Postgres-specific terms
 
 Due to Neon's very close relation with PostgreSQL internals, numerous specific terms are used.
-The same applies to certain spelling: i.e. we use MB to denote 1024 * 1024 bytes, while MiB would be technically more correct, it's inconsistent with what PostgreSQL code and its documentation use.
+The same applies to certain spelling: i.e. we use MB to denote 1024 \* 1024 bytes, while MiB would be technically more correct, it's inconsistent with what PostgreSQL code and its documentation use.
 
 To get more familiar with this aspect, refer to:
 


### PR DESCRIPTION
## Problem

Making any doc changes triggers the entire ci/cd for build and test.


## Summary of changes

This is an attempt to start refactoring the ci for avoiding unnecessary builds for docs.
The change includes: ignoring `*.md` and `docs/*.md` files in PR for `build_and_test` and `neon_extra_builds`, and adding a `doc_checks.yml` ci to handle the docs separately. 


- Ignores *.md and docs folder in "build_and_test.yml" and "neon_extra_builds.yml".
- Adds a new doc-checks for the markdown files that are present in the current pull request.
- Uses rust dprint for *.md formatting, mlc for markdown link checking
- Finally runs `cargo doc` to run any additional rust documentation checks.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
