### PR TITLE
proxy: switch to leaky bucket

### DIFF
--- a/proxy/src/auth/backend.rs
+++ b/proxy/src/auth/backend.rs
@@ -717,8 +717,10 @@ mod tests {
                 _ => panic!("wrong message"),
             }
         });
-        let endpoint_rate_limiter =
-            Arc::new(EndpointRateLimiter::new(&RateBucketInfo::DEFAULT_AUTH_SET));
+        let endpoint_rate_limiter = Arc::new(EndpointRateLimiter::new_with_shards(
+            EndpointRateLimiter::DEFAULT,
+            64,
+        ));
 
         let _creds = auth_quirks(
             &mut ctx,
@@ -767,8 +769,10 @@ mod tests {
             frontend::password_message(b"my-secret-password", &mut write).unwrap();
             client.write_all(&write).await.unwrap();
         });
-        let endpoint_rate_limiter =
-            Arc::new(EndpointRateLimiter::new(&RateBucketInfo::DEFAULT_AUTH_SET));
+        let endpoint_rate_limiter = Arc::new(EndpointRateLimiter::new_with_shards(
+            EndpointRateLimiter::DEFAULT,
+            64,
+        ));
 
         let _creds = auth_quirks(
             &mut ctx,
@@ -818,8 +822,10 @@ mod tests {
             client.write_all(&write).await.unwrap();
         });
 
-        let endpoint_rate_limiter =
-            Arc::new(EndpointRateLimiter::new(&RateBucketInfo::DEFAULT_AUTH_SET));
+        let endpoint_rate_limiter = Arc::new(EndpointRateLimiter::new_with_shards(
+            EndpointRateLimiter::DEFAULT,
+            64,
+        ));
 
         let creds = auth_quirks(
             &mut ctx,

--- a/proxy/src/console/provider/neon.rs
+++ b/proxy/src/console/provider/neon.rs
@@ -12,7 +12,7 @@ use crate::{
     console::messages::{ColdStartInfo, Reason},
     http,
     metrics::{CacheOutcome, Metrics},
-    rate_limiter::EndpointRateLimiter,
+    rate_limiter::WakeComputeRateLimiter,
     scram, EndpointCacheKey,
 };
 use crate::{cache::Cached, context::RequestMonitoring};
@@ -26,7 +26,7 @@ pub struct Api {
     endpoint: http::Endpoint,
     pub caches: &'static ApiCaches,
     pub locks: &'static ApiLocks<EndpointCacheKey>,
-    pub wake_compute_endpoint_rate_limiter: Arc<EndpointRateLimiter>,
+    pub wake_compute_endpoint_rate_limiter: Arc<WakeComputeRateLimiter>,
     jwt: String,
 }
 
@@ -36,7 +36,7 @@ impl Api {
         endpoint: http::Endpoint,
         caches: &'static ApiCaches,
         locks: &'static ApiLocks<EndpointCacheKey>,
-        wake_compute_endpoint_rate_limiter: Arc<EndpointRateLimiter>,
+        wake_compute_endpoint_rate_limiter: Arc<WakeComputeRateLimiter>,
     ) -> Self {
         let jwt: String = match std::env::var("NEON_PROXY_TO_CONTROLPLANE_TOKEN") {
             Ok(v) => v,

--- a/proxy/src/rate_limiter.rs
+++ b/proxy/src/rate_limiter.rs
@@ -3,5 +3,8 @@ mod limiter;
 pub use limit_algorithm::{
     aimd::Aimd, DynamicLimiter, Outcome, RateLimitAlgorithm, RateLimiterConfig, Token,
 };
-pub use limiter::{BucketRateLimiter, EndpointRateLimiter, GlobalRateLimiter, RateBucketInfo};
-pub mod leaky_bucket;
+pub use limiter::{BucketRateLimiter, GlobalRateLimiter, RateBucketInfo, WakeComputeRateLimiter};
+mod leaky_bucket;
+pub use leaky_bucket::{
+    EndpointRateLimiter, LeakyBucketConfig, LeakyBucketRateLimiter, LeakyBucketState,
+};

--- a/proxy/src/rate_limiter.rs
+++ b/proxy/src/rate_limiter.rs
@@ -4,3 +4,4 @@ pub use limit_algorithm::{
     aimd::Aimd, DynamicLimiter, Outcome, RateLimitAlgorithm, RateLimiterConfig, Token,
 };
 pub use limiter::{BucketRateLimiter, EndpointRateLimiter, GlobalRateLimiter, RateBucketInfo};
+pub mod leaky_bucket;

--- a/proxy/src/rate_limiter/leaky_bucket.rs
+++ b/proxy/src/rate_limiter/leaky_bucket.rs
@@ -1,0 +1,91 @@
+use tokio::{sync::Mutex, time::Instant};
+
+pub struct LeakyBucket {
+    rps: f64,
+    max: f64,
+    current: Mutex<(f64, Instant)>,
+}
+
+impl LeakyBucket {
+    pub fn new(rps: f64, max: f64) -> Self {
+        assert!(rps > 0.0, "rps must be positive");
+        assert!(max > 0.0, "max must be positive");
+        Self {
+            rps,
+            max,
+            current: Mutex::new((0.0, Instant::now())),
+        }
+    }
+
+    pub async fn check(&self, n: f64) -> bool {
+        if n > self.max {
+            return false;
+        }
+
+        let now = Instant::now();
+        {
+            let mut current = self.current.lock().await;
+            let drain = now.duration_since(current.1);
+            let drain = drain.as_secs_f64() * self.rps;
+
+            current.0 = (current.0 - drain).clamp(0.0, self.max);
+            current.1 = now;
+
+            if current.0 + n > self.max {
+                return false;
+            }
+            current.0 += n;
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::LeakyBucket;
+
+    #[tokio::test(start_paused = true)]
+    async fn check() {
+        let mut bucket = LeakyBucket::new(500.0, 2000.0);
+
+        // should work for 2000 requests this second
+        for i in 0..2000 {
+            assert!(bucket.check(1.0).await, "should handle the load: {i}");
+        }
+        assert!(!bucket.check(1.0).await, "should not handle the load");
+        assert_eq!(bucket.current.get_mut().0, 2000.0);
+
+        // in 1ms we should drain 0.5 tokens.
+        // make sure we don't lose any tokens
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(!bucket.check(1.0).await, "should not handle the load");
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(bucket.check(1.0).await, "should handle the load");
+
+        // in 10ms we should drain 5 tokens
+        tokio::time::advance(Duration::from_millis(10)).await;
+        for _ in 0..5 {
+            assert!(bucket.check(1.0).await, "should handle the load");
+        }
+        assert!(!bucket.check(1.0).await, "should not handle the load");
+
+        // in 10s we should drain 5000 tokens
+        // but cap is only 2000
+        tokio::time::advance(Duration::from_secs(10)).await;
+        for _ in 0..2000 {
+            assert!(bucket.check(1.0).await, "should handle the load");
+        }
+        assert!(!bucket.check(1.0).await, "should not handle the load");
+
+        // should sustain 500rps
+        for _ in 0..2000 {
+            tokio::time::advance(Duration::from_millis(10)).await;
+            for _ in 0..5 {
+                assert!(bucket.check(1.0).await, "should handle the load");
+            }
+        }
+    }
+}

--- a/proxy/src/rate_limiter/leaky_bucket.rs
+++ b/proxy/src/rate_limiter/leaky_bucket.rs
@@ -1,43 +1,120 @@
-use tokio::{sync::Mutex, time::Instant};
+use std::{
+    hash::Hash,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
-pub struct LeakyBucket {
-    rps: f64,
-    max: f64,
-    current: Mutex<(f64, Instant)>,
+use ahash::RandomState;
+use dashmap::DashMap;
+use rand::{thread_rng, Rng};
+use tokio::time::Instant;
+use tracing::info;
+
+use crate::intern::EndpointIdInt;
+
+// Simple per-endpoint rate limiter.
+pub type EndpointRateLimiter = LeakyBucketRateLimiter<EndpointIdInt>;
+
+pub struct LeakyBucketRateLimiter<Key> {
+    map: DashMap<Key, LeakyBucketState, RandomState>,
+    info: LeakyBucketConfig,
+    access_count: AtomicUsize,
 }
 
-impl LeakyBucket {
-    pub fn new(rps: f64, max: f64) -> Self {
-        assert!(rps > 0.0, "rps must be positive");
-        assert!(max > 0.0, "max must be positive");
+impl<K: Hash + Eq> LeakyBucketRateLimiter<K> {
+    pub const DEFAULT: LeakyBucketConfig = LeakyBucketConfig {
+        rps: 600.0,
+        max: 1500.0,
+    };
+
+    pub fn new_with_shards(info: LeakyBucketConfig, shards: usize) -> Self {
         Self {
-            rps,
-            max,
-            current: Mutex::new((0.0, Instant::now())),
+            map: DashMap::with_hasher_and_shard_amount(RandomState::new(), shards),
+            info,
+            access_count: AtomicUsize::new(0),
         }
     }
 
-    pub async fn check(&self, n: f64) -> bool {
-        if n > self.max {
+    /// Check that number of connections to the endpoint is below `max_rps` rps.
+    pub fn check(&self, key: K, n: u32) -> bool {
+        let now = Instant::now();
+
+        if self.access_count.fetch_add(1, Ordering::AcqRel) % 2048 == 0 {
+            self.do_gc(now);
+        }
+
+        let mut entry = self.map.entry(key).or_insert_with(|| LeakyBucketState {
+            time: now,
+            filled: 0.0,
+        });
+
+        entry.check(&self.info, now, n as f64)
+    }
+
+    fn do_gc(&self, now: Instant) {
+        info!(
+            "cleaning up bucket rate limiter, current size = {}",
+            self.map.len()
+        );
+        let n = self.map.shards().len();
+        let shard = thread_rng().gen_range(0..n);
+        self.map.shards()[shard]
+            .write()
+            .retain(|_, value| !value.get_mut().update(&self.info, now));
+    }
+}
+
+pub struct LeakyBucketConfig {
+    pub rps: f64,
+    pub max: f64,
+}
+
+pub struct LeakyBucketState {
+    filled: f64,
+    time: Instant,
+}
+
+impl LeakyBucketConfig {
+    pub fn new(rps: f64, max: f64) -> Self {
+        assert!(rps > 0.0, "rps must be positive");
+        assert!(max > 0.0, "max must be positive");
+        Self { rps, max }
+    }
+}
+
+impl LeakyBucketState {
+    pub fn new() -> Self {
+        Self {
+            filled: 0.0,
+            time: Instant::now(),
+        }
+    }
+
+    /// updates the timer and returns true if the bucket is empty
+    fn update(&mut self, info: &LeakyBucketConfig, now: Instant) -> bool {
+        let drain = now.duration_since(self.time);
+        let drain = drain.as_secs_f64() * info.rps;
+
+        self.filled = (self.filled - drain).clamp(0.0, info.max);
+        self.time = now;
+
+        self.filled == 0.0
+    }
+
+    pub fn check(&mut self, info: &LeakyBucketConfig, now: Instant, n: f64) -> bool {
+        self.update(info, now);
+
+        if self.filled + n > info.max {
             return false;
         }
-
-        let now = Instant::now();
-        {
-            let mut current = self.current.lock().await;
-            let drain = now.duration_since(current.1);
-            let drain = drain.as_secs_f64() * self.rps;
-
-            current.0 = (current.0 - drain).clamp(0.0, self.max);
-            current.1 = now;
-
-            if current.0 + n > self.max {
-                return false;
-            }
-            current.0 += n;
-        }
+        self.filled += n;
 
         true
+    }
+}
+
+impl Default for LeakyBucketState {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -45,46 +122,49 @@ impl LeakyBucket {
 mod tests {
     use std::time::Duration;
 
-    use super::LeakyBucket;
+    use tokio::time::Instant;
+
+    use super::{LeakyBucketConfig, LeakyBucketState};
 
     #[tokio::test(start_paused = true)]
     async fn check() {
-        let mut bucket = LeakyBucket::new(500.0, 2000.0);
+        let info = LeakyBucketConfig::new(500.0, 2000.0);
+        let mut bucket = LeakyBucketState::new();
 
         // should work for 2000 requests this second
-        for i in 0..2000 {
-            assert!(bucket.check(1.0).await, "should handle the load: {i}");
+        for _ in 0..2000 {
+            assert!(bucket.check(&info, Instant::now(), 1.0));
         }
-        assert!(!bucket.check(1.0).await, "should not handle the load");
-        assert_eq!(bucket.current.get_mut().0, 2000.0);
+        assert!(!bucket.check(&info, Instant::now(), 1.0));
+        assert_eq!(bucket.filled, 2000.0);
 
         // in 1ms we should drain 0.5 tokens.
         // make sure we don't lose any tokens
         tokio::time::advance(Duration::from_millis(1)).await;
-        assert!(!bucket.check(1.0).await, "should not handle the load");
+        assert!(!bucket.check(&info, Instant::now(), 1.0));
         tokio::time::advance(Duration::from_millis(1)).await;
-        assert!(bucket.check(1.0).await, "should handle the load");
+        assert!(bucket.check(&info, Instant::now(), 1.0));
 
         // in 10ms we should drain 5 tokens
         tokio::time::advance(Duration::from_millis(10)).await;
         for _ in 0..5 {
-            assert!(bucket.check(1.0).await, "should handle the load");
+            assert!(bucket.check(&info, Instant::now(), 1.0));
         }
-        assert!(!bucket.check(1.0).await, "should not handle the load");
+        assert!(!bucket.check(&info, Instant::now(), 1.0));
 
         // in 10s we should drain 5000 tokens
         // but cap is only 2000
         tokio::time::advance(Duration::from_secs(10)).await;
         for _ in 0..2000 {
-            assert!(bucket.check(1.0).await, "should handle the load");
+            assert!(bucket.check(&info, Instant::now(), 1.0));
         }
-        assert!(!bucket.check(1.0).await, "should not handle the load");
+        assert!(!bucket.check(&info, Instant::now(), 1.0));
 
         // should sustain 500rps
         for _ in 0..2000 {
             tokio::time::advance(Duration::from_millis(10)).await;
             for _ in 0..5 {
-                assert!(bucket.check(1.0).await, "should handle the load");
+                assert!(bucket.check(&info, Instant::now(), 1.0));
             }
         }
     }

--- a/proxy/src/rate_limiter/limiter.rs
+++ b/proxy/src/rate_limiter/limiter.rs
@@ -249,7 +249,7 @@ mod tests {
     use rustc_hash::FxHasher;
     use tokio::time;
 
-    use super::BucketRateLimiter;
+    use super::{BucketRateLimiter, WakeComputeRateLimiter};
     use crate::{intern::EndpointIdInt, rate_limiter::RateBucketInfo, EndpointId};
 
     #[test]
@@ -297,7 +297,7 @@ mod tests {
             .map(|s| s.parse().unwrap())
             .collect();
         RateBucketInfo::validate(&mut rates).unwrap();
-        let limiter = BucketRateLimiter::new(rates);
+        let limiter = WakeComputeRateLimiter::new(rates);
 
         let endpoint = EndpointId::from("ep-my-endpoint-1234");
         let endpoint = EndpointIdInt::from(endpoint);


### PR DESCRIPTION
## Problem

The current bucket based rate limiter is not very intuitive and has some bad failure cases.

## Summary of changes

Switches from fixed interval buckets to leaky bucket impl. A single bucket per endpoint,
drains over time. Drains by checking the time since the last check, and draining tokens en-masse. Garbage collection works similar to before, it drains a shard (1/64th of the set) every 2048 checks, and it only removes buckets that are empty.

To be compatible with the existing config, I've faffed to make it take the min and the max rps of each as the sustained rps and the max bucket size which should be roughly equivalent.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
