### PR TITLE
Make async connect work on MacOS: it is necessary top call WaitLatchOrSocket before PQconnectPoll

### DIFF
--- a/pgxn/neon/neon_walreader.c
+++ b/pgxn/neon/neon_walreader.c
@@ -220,7 +220,8 @@ NeonWALReadRemote(NeonWALReader *state, char *buf, XLogRecPtr startptr, Size cou
 			return NEON_WALREAD_ERROR;
 		}
 		/* we'll poll immediately */
-		state->rem_state = RS_CONNECTING_READ;
+		state->rem_state = RS_CONNECTING_WRITE;
+		return NEON_WALREAD_WOULDBLOCK;
 	}
 
 	if (state->rem_state == RS_CONNECTING_READ || state->rem_state == RS_CONNECTING_WRITE)


### PR DESCRIPTION
## Problem

While investigating problem with test_subscriber_restart flukyness, I found out that this test is not passed at all for PG 14/15 at MacOS (while working for PG16). 

## Summary of changes

Rewrite async connect state machine exactly in the same way as in Vanilla: call `WaitLatchOrSocket` with `WL_SOCKETR_WRTEABLE` before calling `PQconnectPoll`.

Please notice that most likely it will not fix flukyness of test_subscriber_restart.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
