### PR TITLE
devx: nicer diff hunk headers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# allows for nicer hunk headers with git show
+*.rs diff=rust


### PR DESCRIPTION
By default git does not find a nice hunk header with rust. New(er) versions ship with a handy xfuncname pattern, so lets enable that for all developers.

Example of how this should help: https://github.com/rust-lang/rust/commit/39046172ab91805efb79a55870c2ced2d61cfc3a