### PR TITLE
[neon/azure] impr: push directly into ACR

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -515,6 +515,10 @@ jobs:
 
   neon-image:
     needs: [ neon-image-arch, tag ]
+    permissions: # This is for Azure login to work.
+      id-token: write
+      contents: read
+    environment: dev
     runs-on: ubuntu-22.04
 
     steps:
@@ -539,6 +543,18 @@ jobs:
         run: |
           docker buildx imagetools create -t 369495373322.dkr.ecr.eu-central-1.amazonaws.com/neon:${{ needs.tag.outputs.build-tag }} \
                                                                                 neondatabase/neon:${{ needs.tag.outputs.build-tag }}
+
+      - name: Azure login
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a  # @v2.1.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Copy docker images to ACR-dev
+        run: |
+          docker buildx imagetools create -t neoneastus2.azurecr.io/neondatabase/neon:${{ needs.tag.outputs.build-tag }} \
+                                             neondatabase/neon:${{ needs.tag.outputs.build-tag }}
 
   compute-node-image-arch:
     needs: [ check-permissions, build-build-tools-image, tag ]
@@ -647,6 +663,10 @@ jobs:
           rm -rf .docker-custom
 
   compute-node-image:
+    permissions: # This is for Azure login to work.
+      id-token: write
+      contents: read
+    environment: dev
     needs: [ compute-node-image-arch, tag ]
     runs-on: ubuntu-22.04
 
@@ -695,6 +715,24 @@ jobs:
         if: matrix.version == 'v16'
         run: |
           docker buildx imagetools create -t 369495373322.dkr.ecr.eu-central-1.amazonaws.com/compute-tools:${{ needs.tag.outputs.build-tag }} \
+                                                                                neondatabase/compute-tools:${{ needs.tag.outputs.build-tag }}
+
+      - name: Azure login
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a  # @v2.1.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Push multi-arch compute-node-${{ matrix.version }} image to ACR
+        run: |
+          docker buildx imagetools create -t neoneastus2.azurecr.io/neondatabase/compute-node-${{ matrix.version }}:${{ needs.tag.outputs.build-tag }} \
+                                                                                neondatabase/compute-node-${{ matrix.version }}:${{ needs.tag.outputs.build-tag }}
+
+      - name: Push multi-arch compute-tools image to ACR
+        if: matrix.version == 'v16'
+        run: |
+          docker buildx imagetools create -t neoneastus2.azurecr.io/neondatabase/compute-tools:${{ needs.tag.outputs.build-tag }} \
                                                                                 neondatabase/compute-tools:${{ needs.tag.outputs.build-tag }}
 
   vm-compute-node-image:
@@ -819,6 +857,10 @@ jobs:
           rm -rf .docker-custom
 
   promote-images:
+    permissions: # This is for Azure login to work.
+      id-token: write
+      contents: read
+    environment: dev
     needs: [ check-permissions, tag, test-images, vm-compute-node-image ]
     runs-on: ubuntu-22.04
 
@@ -843,6 +885,20 @@ jobs:
           for version in ${VERSIONS}; do
             docker buildx imagetools create -t 369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-${version}:${{ needs.tag.outputs.build-tag }} \
                                                neondatabase/vm-compute-node-${version}:${{ needs.tag.outputs.build-tag }}
+          done
+
+      - name: Azure login
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a  # @v2.1.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Copy docker images to ACR-dev
+        run: |
+          for version in ${VERSIONS}; do
+          docker buildx imagetools create -t neoneastus2.azurecr.io/neondatabase/vm-compute-node-${version}:${{ needs.tag.outputs.build-tag }} \
+                                             neondatabase/vm-compute-node-${version}:${{ needs.tag.outputs.build-tag }}
           done
 
       - name: Add latest tag to images


### PR DESCRIPTION
As we observed [^1], messing up with compute image, trying to use an unexistent one, results in cplane schedules too many pods for the pool that cannot pull the image because it does not exist, reaching out to the docker hub too often, which results in our token being rate-limited. So, we need to push the images directly into ACR, instead of using pull-through cache.

[^1]: https://neondb.slack.com/archives/C06SJG60FRB/p1721749525396229

https://github.com/neondatabase/cloud/issues/14640