### PR TITLE
feat(detach_ancestor): persistent gc blocking

### DIFF
--- a/libs/pageserver_api/src/models/detach_ancestor.rs
+++ b/libs/pageserver_api/src/models/detach_ancestor.rs
@@ -1,6 +1,8 @@
+use std::collections::HashSet;
+
 use utils::id::TimelineId;
 
 #[derive(Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AncestorDetached {
-    pub reparented_timelines: Vec<TimelineId>,
+    pub reparented_timelines: HashSet<TimelineId>,
 }

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1832,7 +1832,6 @@ async fn timeline_detach_ancestor_handler(
             detach_ancestor::Progress::Done(resp) => resp,
         };
 
-        // FIXME: if the ordering is really needed and not a hashset, move it here?
         json_response(StatusCode::OK, resp)
     }
     .instrument(span)

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1823,7 +1823,6 @@ async fn timeline_detach_ancestor_handler(
                         ctx,
                     )
                     .await
-                    .context("timeline detach ancestor completion")
                     .map_err(ApiError::InternalServerError)?;
 
                 AncestorDetached {

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -2024,7 +2024,7 @@ impl TenantManager {
 
         let timeline = tenant.get_timeline(timeline_id, true)?;
 
-        let resp = timeline
+        let (resp, reparented_all) = timeline
             .complete_detaching_timeline_ancestor(&tenant, prepared, ctx)
             .await?;
 
@@ -2063,11 +2063,19 @@ impl TenantManager {
 
         slot_guard.upsert(TenantSlot::Attached(tenant.clone()))?;
 
-        // finally ask the restarted tenant to complete the detach
-        tenant
-            .ongoing_timeline_detach
-            .complete(attempt, &tenant)
-            .await?;
+        if reparented_all {
+            // finally ask the restarted tenant to complete the detach
+            tenant
+                .ongoing_timeline_detach
+                .complete(attempt, &tenant)
+                .await?;
+        } else {
+            // at least the latest versions have now been downloaded and refreshed; be ready to
+            // retry another time.
+            return Err(anyhow::anyhow!(
+                "failed to reparent all candidate timelines, please retry"
+            ));
+        }
 
         Ok(resp)
     }

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -2025,7 +2025,7 @@ impl TenantManager {
         let timeline = tenant.get_timeline(timeline_id, true)?;
 
         let (resp, reparented_all) = timeline
-            .complete_detaching_timeline_ancestor(&tenant, prepared, ctx)
+            .detach_from_ancestor_and_reparent(&tenant, prepared, ctx)
             .await?;
 
         let mut slot_guard = slot_guard.into_inner();

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -13,7 +13,7 @@ use pageserver_api::upcall_api::ReAttachResponseTenant;
 use rand::{distributions::Alphanumeric, Rng};
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1975,7 +1975,7 @@ impl TenantManager {
         prepared: PreparedTimelineDetach,
         mut attempt: detach_ancestor::Attempt,
         ctx: &RequestContext,
-    ) -> Result<Vec<TimelineId>, anyhow::Error> {
+    ) -> Result<HashSet<TimelineId>, anyhow::Error> {
         // FIXME: this is unnecessary, slotguard already has these semantics
         struct RevertOnDropSlot(Option<SlotGuard>);
 

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -2072,6 +2072,7 @@ impl TenantManager {
         } else {
             // at least the latest versions have now been downloaded and refreshed; be ready to
             // retry another time.
+            tenant.ongoing_timeline_detach.cancel(attempt);
             return Err(anyhow::anyhow!(
                 "failed to reparent all candidate timelines, please retry"
             ));

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -683,6 +683,9 @@ impl RemoteTimelineClient {
         Ok(())
     }
 
+    /// Reparent this timeline to a new parent.
+    ///
+    /// A retryable step of timeline ancestor detach.
     pub(crate) async fn schedule_reparenting_and_wait(
         self: &Arc<Self>,
         new_parent: &TimelineId,

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -710,8 +710,6 @@ impl RemoteTimelineClient {
 
                 if modified {
                     self.schedule_index_upload(upload_queue)?;
-                } else {
-                    // the modifications are already being uploaded
                 }
 
                 Some(self.schedule_barrier0(upload_queue))

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -300,7 +300,8 @@ impl GcBlocking {
         self.clone()
     }
 
-    /// Returns a version of self without the reason of detach_ancestor.
+    /// Returns a version of self without the reason of detach_ancestor. Assumption is that if
+    /// there are no more reasons, we can unblock the gc.
     pub(super) fn without_detach_ancestor(&self) -> Option<Self> {
         None
     }

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -275,16 +275,16 @@ impl Lineage {
     }
 }
 
+// FIXME: restructure and rename this as a generic method of gc blocking
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct OngoingDetachAncestor {
-    first_started_at: NaiveDateTime,
-    // FIXME: include last start, number of restarts?
+    pub(crate) first_started_at: NaiveDateTime,
 }
 
-impl From<NaiveDateTime> for OngoingDetachAncestor {
-    fn from(value: NaiveDateTime) -> Self {
+impl OngoingDetachAncestor {
+    pub(super) fn started_now() -> Self {
         OngoingDetachAncestor {
-            first_started_at: value,
+            first_started_at: chrono::Utc::now().naive_utc(),
         }
     }
 }
@@ -682,7 +682,7 @@ mod tests {
                 "pg_version": 14
             },
             "ongoing_detach_ancestor": {
-                "first_started_at": "2024-07-19T09:00:00.123"
+                "started_at": "2024-07-19T09:00:00.123"
             }
         }"#;
 
@@ -712,7 +712,9 @@ mod tests {
             ).with_recalculated_checksum().unwrap(),
             deleted_at: None,
             lineage: Default::default(),
-            ongoing_detach_ancestor: Some(OngoingDetachAncestor { first_started_at: parse_naive_datetime("2024-07-19T09:00:00.123000000") }),
+            ongoing_detach_ancestor: Some(OngoingDetachAncestor {
+                started_at: parse_naive_datetime("2024-07-19T09:00:00.123000000"),
+            }),
             last_aux_file_policy: Default::default(),
         };
 

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4746,18 +4746,23 @@ impl Timeline {
         detach_ancestor::prepare(self, tenant, options, ctx).await
     }
 
-    /// Completes the ancestor detach. This method is to be called while holding the
-    /// TenantManager's tenant slot, so during this method we cannot be deleted nor can any
-    /// timeline be deleted. After this method returns successfully, tenant must be reloaded.
+    /// Second step of detach from ancestor; detaches the `self` from it's current ancestor and
+    /// reparents any reparentable children of previous ancestor.
+    ///
+    /// This method is to be called while
+    /// holding the TenantManager's tenant slot, so during this method we cannot be deleted nor can
+    /// any timeline be deleted. After this method returns successfully, tenant must be reloaded.
+    ///
+    /// Final step will be to complete after optionally resetting the tenant.
     ///
     /// Pageserver receiving a SIGKILL during this operation is not supported (yet).
-    pub(crate) async fn complete_detaching_timeline_ancestor(
+    pub(crate) async fn detach_from_ancestor_and_reparent(
         self: &Arc<Timeline>,
         tenant: &crate::tenant::Tenant,
         prepared: detach_ancestor::PreparedTimelineDetach,
         ctx: &RequestContext,
-    ) -> Result<(Vec<TimelineId>, bool), anyhow::Error> {
-        detach_ancestor::complete(self, tenant, prepared, ctx).await
+    ) -> Result<detach_ancestor::DetachingAndReparenting, anyhow::Error> {
+        detach_ancestor::detach_and_reparent(self, tenant, prepared, ctx).await
     }
 
     /// Switch aux file policy and schedule upload to the index part.

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4749,13 +4749,11 @@ impl Timeline {
     /// Second step of detach from ancestor; detaches the `self` from it's current ancestor and
     /// reparents any reparentable children of previous ancestor.
     ///
-    /// This method is to be called while
-    /// holding the TenantManager's tenant slot, so during this method we cannot be deleted nor can
-    /// any timeline be deleted. After this method returns successfully, tenant must be reloaded.
+    /// This method is to be called while holding the TenantManager's tenant slot, so during this
+    /// method we cannot be deleted nor can any timeline be deleted. After this method returns
+    /// successfully, tenant must be reloaded.
     ///
     /// Final step will be to complete after optionally resetting the tenant.
-    ///
-    /// Pageserver receiving a SIGKILL during this operation is not supported (yet).
     pub(crate) async fn detach_from_ancestor_and_reparent(
         self: &Arc<Timeline>,
         tenant: &crate::tenant::Tenant,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3707,10 +3707,6 @@ impl Timeline {
         Ok(ancestor.clone())
     }
 
-    pub(crate) fn get_ancestor_timeline(&self) -> Option<Arc<Timeline>> {
-        self.ancestor_timeline.clone()
-    }
-
     pub(crate) fn get_shard_identity(&self) -> &ShardIdentity {
         &self.shard_identity
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -4760,7 +4760,7 @@ impl Timeline {
         tenant: &crate::tenant::Tenant,
         prepared: detach_ancestor::PreparedTimelineDetach,
         ctx: &RequestContext,
-    ) -> Result<Vec<TimelineId>, anyhow::Error> {
+    ) -> Result<(Vec<TimelineId>, bool), anyhow::Error> {
         detach_ancestor::complete(self, tenant, prepared, ctx).await
     }
 

--- a/pageserver/src/tenant/timeline/delete.rs
+++ b/pageserver/src/tenant/timeline/delete.rs
@@ -221,6 +221,8 @@ impl DeleteTimelineFlow {
         // Now that the Timeline is in Stopping state, request all the related tasks to shut down.
         timeline.shutdown(super::ShutdownMode::Hard).await;
 
+        tenant.ongoing_timeline_detach.on_delete(&timeline);
+
         fail::fail_point!("timeline-delete-before-index-deleted-at", |_| {
             Err(anyhow::anyhow!(
                 "failpoint: timeline-delete-before-index-deleted-at"

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1069,7 +1069,7 @@ pub(super) async fn detach_and_reparent(
         "to detach and reparent, gc must still be blocked"
     );
 
-    let (ancestor, ancestor_lsn) = match ancestor {
+    let (ancestor, ancestor_lsn, was_detached) = match ancestor {
         Ancestor::NotDetached(ancestor, ancestor_lsn) => {
             // this has to complete before any reparentings because otherwise they would not have
             // layers on the new parent.
@@ -1082,9 +1082,9 @@ pub(super) async fn detach_and_reparent(
                 .await
                 .context("publish layers and detach ancestor")?;
 
-            (ancestor, ancestor_lsn)
+            (ancestor, ancestor_lsn, true)
         }
-        Ancestor::Detached(ancestor, ancestor_lsn) => (ancestor, ancestor_lsn),
+        Ancestor::Detached(ancestor, ancestor_lsn) => (ancestor, ancestor_lsn, false),
     };
 
     let mut tasks = tokio::task::JoinSet::new();
@@ -1215,7 +1215,7 @@ pub(super) async fn detach_and_reparent(
         Ok(DetachingAndReparenting::Reparented(reparented))
     } else {
         Ok(DetachingAndReparenting::SomeReparentingFailed {
-            must_restart: reparented.is_empty(),
+            must_restart: !reparented.is_empty() || was_detached,
         })
     }
 }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -297,6 +297,8 @@ impl SharedState {
         // TODO: pause failpoint here to catch the situation where detached timeline is deleted...?
         // we are not yet holding the gate so it could advance to the point of removing from
         // timelines.
+        //
+        // pause failpoint which triggers after activating but before completing here
 
         let Some(timeline) = tenant
             .timelines

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1114,7 +1114,7 @@ pub(super) async fn detach_and_reparent(
     let ancestor = if let Some(ancestor) = detached.ancestor_timeline.as_ref() {
         assert!(
             recorded_branchpoint.is_none(),
-            "it should be impossible to get to here without having gone through the tenant reset"
+            "it should be impossible to get to here without having gone through the tenant reset; if the tenant was reset, then the ancestor_timeline would be None"
         );
         Ancestor::NotDetached(ancestor.clone(), detached.ancestor_lsn)
     } else if let Some((ancestor_id, ancestor_lsn)) = recorded_branchpoint {

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1132,6 +1132,10 @@ pub(super) async fn detach_and_reparent(
         if let Some(ancestor) = existing {
             Ancestor::Detached(ancestor, ancestor_lsn)
         } else {
+            assert!(
+                still_ongoing,
+                "cannot complete if the operation is not still ongoing"
+            );
             let direct_children =
                 reparented_direct_children(detached, tenant).map_err(Error::from)?;
             return Ok(DetachingAndReparenting::AlreadyDone(direct_children));

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1266,13 +1266,14 @@ pub(super) async fn detach_and_reparent(
     let reparented_all = reparenting_candidates == reparented.len();
 
     if reparented_all {
+        Ok(DetachingAndReparenting::Reparented(reparented))
+    } else {
         tracing::info!(
             reparented = reparented.len(),
             candidates = reparenting_candidates,
             "failed to reparent all candidates; they can be retried after the restart",
         );
-        Ok(DetachingAndReparenting::Reparented(reparented))
-    } else {
+
         let must_restart = !reparented.is_empty() || was_detached;
 
         Ok(DetachingAndReparenting::SomeReparentingFailed { must_restart })

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1275,12 +1275,10 @@ pub(super) async fn detach_and_reparent(
     let reparented_all = reparenting_candidates == reparented.len();
 
     if reparented_all {
-        // FIXME: we must return 503 kind of response in the end and do the restart anyways because
-        // otherwise the runtime state remains diverged
         tracing::info!(
             reparented = reparented.len(),
             candidates = reparenting_candidates,
-            "failed to reparent all candidates; they will be retried after the restart",
+            "failed to reparent all candidates; they can be retried after the restart",
         );
 
         reparented.sort_unstable();
@@ -1292,8 +1290,8 @@ pub(super) async fn detach_and_reparent(
 
         Ok(DetachingAndReparenting::Reparented(reparented))
     } else {
-        Ok(DetachingAndReparenting::SomeReparentingFailed {
-            must_restart: !reparented.is_empty() || was_detached,
-        })
+        let must_restart = !reparented.is_empty() || was_detached;
+
+        Ok(DetachingAndReparenting::SomeReparentingFailed { must_restart })
     }
 }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1168,6 +1168,12 @@ pub(super) async fn detach_and_reparent(
                 .await
                 .context("publish layers and detach ancestor")?;
 
+            tracing::info!(
+                ancestor=%ancestor.timeline_id,
+                %ancestor_lsn,
+                inherited_layers=%layers.len(),
+                "detached from ancestor"
+            );
             (ancestor, ancestor_lsn, true)
         }
         Ancestor::Detached(ancestor, ancestor_lsn) => (ancestor, ancestor_lsn, false),

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1161,7 +1161,7 @@ pub(super) async fn complete(
     let reparented_all = reparenting_candidates == reparented.len();
 
     if reparented_all {
-        // FIXME: we must return 503 kind of response in the end; do the restart anyways because
+        // FIXME: we must return 503 kind of response in the end and do the restart anyways because
         // otherwise the runtime state remains diverged
         tracing::info!(
             reparented = reparented.len(),

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1179,75 +1179,54 @@ pub(super) async fn detach_and_reparent(
 
     // because we are now keeping the slot in progress, it is unlikely that there will be any
     // timeline deletions during this time. if we raced one, then we'll just ignore it.
-    tenant
-        .timelines
-        .lock()
-        .unwrap()
-        .values()
-        .filter_map(|tl| {
-            if Arc::ptr_eq(tl, detached) {
-                return None;
-            }
+    {
+        let g = tenant.timelines.lock().unwrap();
+        reparentable_timelines(g.values(), detached, &ancestor, ancestor_lsn)
+            .cloned()
+            .for_each(|timeline| {
+                // important in this scope: we are holding the Tenant::timelines lock
+                let span = tracing::info_span!("reparent", reparented=%timeline.timeline_id);
+                let new_parent = detached.timeline_id;
+                #[cfg(feature = "testing")]
+                let failpoint_sem = failpoint_sem.clone();
 
-            let tl_ancestor = tl.ancestor_timeline.as_ref()?;
-            let is_same = Arc::ptr_eq(&ancestor, tl_ancestor);
-            let is_earlier = tl.get_ancestor_lsn() <= ancestor_lsn;
+                tasks.spawn(
+                    async move {
+                        let res = async {
+                            #[cfg(feature = "testing")]
+                            if let Some(failpoint_sem) = failpoint_sem {
+                                let _permit = failpoint_sem.acquire().await.map_err(|_| {
+                                    anyhow::anyhow!(
+                                        "failpoint: timeline-detach-ancestor::allow_one_reparented",
+                                    )
+                                })?;
+                                failpoint_sem.close();
+                            }
 
-            let is_deleting = tl
-                .delete_progress
-                .try_lock()
-                .map(|flow| !flow.is_not_started())
-                .unwrap_or(true);
-
-            if is_same && is_earlier && !is_deleting {
-                Some(tl.clone())
-            } else {
-                None
-            }
-        })
-        .for_each(|timeline| {
-            // important in this scope: we are holding the Tenant::timelines lock
-            let span = tracing::info_span!("reparent", reparented=%timeline.timeline_id);
-            let new_parent = detached.timeline_id;
-            #[cfg(feature = "testing")]
-            let failpoint_sem = failpoint_sem.clone();
-
-            tasks.spawn(
-                async move {
-                    let res = async {
-                        #[cfg(feature = "testing")]
-                        if let Some(failpoint_sem) = failpoint_sem {
-                            let _permit = failpoint_sem.acquire().await.map_err(|_| {
-                                anyhow::anyhow!(
-                                    "failpoint: timeline-detach-ancestor::allow_one_reparented",
-                                )
-                            })?;
-                            failpoint_sem.close();
+                            timeline
+                                .remote_client
+                                .schedule_reparenting_and_wait(&new_parent)
+                                .await
                         }
+                        .await;
 
-                        timeline
-                            .remote_client
-                            .schedule_reparenting_and_wait(&new_parent)
-                            .await
-                    }
-                    .await;
-
-                    match res {
-                        Ok(()) => {
-                            tracing::info!("reparented");
-                            Some(timeline)
-                        }
-                        Err(e) => {
-                            // with the use of tenant slot, raced timeline deletion is the most
-                            // likely reason.
-                            tracing::warn!("reparenting failed: {e:#}");
-                            None
+                        match res {
+                            Ok(()) => {
+                                tracing::info!("reparented");
+                                Some(timeline)
+                            }
+                            Err(e) => {
+                                // with the use of tenant slot, raced timeline deletion is the most
+                                // likely reason.
+                                tracing::warn!("reparenting failed: {e:#}");
+                                None
+                            }
                         }
                     }
-                }
-                .instrument(span),
-            );
-        });
+                    .instrument(span),
+                );
+            });
+    }
 
     let reparenting_candidates = tasks.len();
     let mut reparented = Vec::with_capacity(tasks.len());
@@ -1294,4 +1273,36 @@ pub(super) async fn detach_and_reparent(
 
         Ok(DetachingAndReparenting::SomeReparentingFailed { must_restart })
     }
+}
+
+fn reparentable_timelines<'a, I>(
+    timelines: I,
+    detached: &'a Arc<Timeline>,
+    ancestor: &'a Arc<Timeline>,
+    ancestor_lsn: Lsn,
+) -> impl Iterator<Item = &'a Arc<Timeline>> + 'a
+where
+    I: Iterator<Item = &'a Arc<Timeline>> + 'a,
+{
+    timelines.filter_map(move |tl| {
+        if Arc::ptr_eq(tl, detached) {
+            return None;
+        }
+
+        let tl_ancestor = tl.ancestor_timeline.as_ref()?;
+        let is_same = Arc::ptr_eq(ancestor, tl_ancestor);
+        let is_earlier = tl.get_ancestor_lsn() <= ancestor_lsn;
+
+        let is_deleting = tl
+            .delete_progress
+            .try_lock()
+            .map(|flow| !flow.is_not_started())
+            .unwrap_or(true);
+
+        if is_same && is_earlier && !is_deleting {
+            Some(tl)
+        } else {
+            None
+        }
+    })
 }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -507,7 +507,7 @@ impl SharedStateBuilder {
 
         assert_eq!(g.latest.is_none(), g.known_ongoing.is_empty());
 
-        g.known_ongoing.extend(self.inprogress.into_iter());
+        g.known_ongoing.extend(self.inprogress);
         if g.latest.is_none() && !g.known_ongoing.is_empty() {
             g.latest = Some((ExistingAttempt::ReadFromIndexPart, false));
         }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1139,7 +1139,7 @@ pub(super) async fn detach_and_reparent(
     } else {
         // TODO: make sure there are no `?` before tenant_reset from after a questionmark from
         // here.
-        panic!("bug: complete called on a timeline which has not been detached or which has no live ancestor");
+        panic!("bug: detach_and_reparent called on a timeline which has not been detached or which has no live ancestor");
     };
 
     // publish the prepared layers before we reparent any of the timelines, so that on restart

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -970,8 +970,8 @@ async fn remote_copy(
         .map_err(CopyFailed)
 }
 
-/// See [`Timeline::complete_detaching_timeline_ancestor`].
-pub(super) async fn complete(
+/// See [`Timeline::detach_from_ancestor_and_reparent`].
+pub(super) async fn detach_and_reparent(
     detached: &Arc<Timeline>,
     tenant: &Tenant,
     prepared: PreparedTimelineDetach,

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -202,28 +202,23 @@ impl SharedState {
 
         let completion = {
             let mut guard = self.inner.lock().unwrap();
-
             let completion = guard.start_new(&detached.timeline_id)?;
-
             // now that we changed the contents, notify any long-sleeping gc
             self.gc_waiting.notify_one();
-
             completion
         };
 
         let started_at = std::time::Instant::now();
-
         let mut cancelled = std::pin::pin!(detached.cancel.cancelled());
 
         loop {
             tokio::select! {
                 _ = &mut cancelled => { return Err(Error::ShuttingDown); },
-                _ = self.attempt_waiting.notified() => {
-                    // reading a notification which was not intended for us is not a problem,
-                    // because we check if *our* progress has been witnessed by gc.
-                },
+                _ = self.attempt_waiting.notified() => {},
             };
 
+            // reading a notification which was not intended for us is not a problem,
+            // because we check if *our* progress has been witnessed by gc.
             let g = self.inner.lock().unwrap();
             if g.is_gc_paused(&detached.timeline_id) {
                 break;
@@ -232,7 +227,6 @@ impl SharedState {
 
         // finally
         let gate_entered = detached.gate.enter().map_err(|_| Error::ShuttingDown)?;
-
         let synced_in = started_at.elapsed();
 
         detached

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -101,6 +101,21 @@ impl From<FlushLayerError> for Error {
     }
 }
 
+impl From<GetActiveTenantError> for Error {
+    fn from(value: GetActiveTenantError) -> Self {
+        use pageserver_api::models::TenantState;
+        use GetActiveTenantError::*;
+
+        match value {
+            Cancelled | WillNotBecomeActive(TenantState::Stopping { .. }) => Error::ShuttingDown,
+            WaitForActiveTimeout { .. } | NotFound(_) | Broken(_) | WillNotBecomeActive(_) => {
+                // NotFound seems out-of-place
+                Error::WaitToActivate(value)
+            }
+        }
+    }
+}
+
 pub(crate) enum Progress {
     Prepared(Attempt, PreparedTimelineDetach),
     Done(AncestorDetached),
@@ -192,23 +207,45 @@ impl SharedState {
     }
 
     /// Acquire the exclusive lock for a new detach ancestor attempt and ensure that GC task has
-    /// been persistently paused via [`crate::tenant::IndexPart`], awaiting for completion.
+    /// been transiently paused.
     ///
     /// Cancellation safe.
     async fn start_new_attempt(&self, detached: &Arc<Timeline>) -> Result<Attempt, Error> {
+        let started_at = std::time::Instant::now();
+
+        let completion = self.obtain_exclusive_permit(detached)?;
+
+        let gate_entered = detached.gate.enter().map_err(|_| Error::ShuttingDown)?;
+
+        self.wait_until_gc_is_paused(detached).await?;
+
+        let ready_in = started_at.elapsed();
+
+        tracing::info!(elapsed_ms = ready_in.as_millis(), "gc paused, gate entered");
+
+        Ok(Attempt {
+            timeline_id: detached.timeline_id,
+            _guard: completion,
+            gate_entered: Some(gate_entered),
+        })
+    }
+
+    fn obtain_exclusive_permit(
+        &self,
+        detached: &Arc<Timeline>,
+    ) -> Result<completion::Completion, Error> {
         if detached.cancel.is_cancelled() {
             return Err(Error::ShuttingDown);
         }
 
-        let completion = {
-            let mut guard = self.inner.lock().unwrap();
-            let completion = guard.start_new(&detached.timeline_id)?;
-            // now that we changed the contents, notify any long-sleeping gc
-            self.gc_waiting.notify_one();
-            completion
-        };
+        let mut guard = self.inner.lock().unwrap();
+        let completion = guard.start_new(&detached.timeline_id)?;
+        // now that we changed the contents, notify any long-sleeping gc
+        self.gc_waiting.notify_one();
+        Ok(completion)
+    }
 
-        let started_at = std::time::Instant::now();
+    async fn wait_until_gc_is_paused(&self, detached: &Arc<Timeline>) -> Result<(), Error> {
         let mut cancelled = std::pin::pin!(detached.cancel.cancelled());
 
         loop {
@@ -221,35 +258,9 @@ impl SharedState {
             // because we check if *our* progress has been witnessed by gc.
             let g = self.inner.lock().unwrap();
             if g.is_gc_paused(&detached.timeline_id) {
-                break;
+                return Ok(());
             }
         }
-
-        // finally
-        let gate_entered = detached.gate.enter().map_err(|_| Error::ShuttingDown)?;
-        let synced_in = started_at.elapsed();
-
-        detached
-            .remote_client
-            .schedule_started_detach_ancestor_mark_and_wait()
-            .await
-            // FIXME: aaaargh
-            .map_err(|_| Error::ShuttingDown)?;
-
-        let uploaded_in = started_at.elapsed() - synced_in;
-
-        // FIXME: get rid of this logging or make it a metric or two
-        tracing::info!(
-            sync_ms = synced_in.as_millis(),
-            upload_ms = uploaded_in.as_millis(),
-            "gc paused, gate entered, and uploaded"
-        );
-
-        Ok(Attempt {
-            timeline_id: detached.timeline_id,
-            _guard: completion,
-            gate_entered: Some(gate_entered),
-        })
     }
 
     /// Completes a previously started detach ancestor attempt. To be called *after* the operation
@@ -270,12 +281,9 @@ impl SharedState {
         // find the timeline the attempt represents
         // using the timelines remote client, upload an index part with completion information
 
-        {
-            let g = self.inner.lock().unwrap();
+        self.inner.lock().unwrap().validate(&attempt);
 
-            // TODO: cover the case where retry completes?
-            g.validate(&attempt);
-        }
+        // FIXME: could check more preconditions, like that the timeline has been detached?
 
         let mut attempt = scopeguard::guard(attempt, |attempt| {
             // our attempt will no longer be valid, so release it
@@ -284,8 +292,7 @@ impl SharedState {
 
         tenant
             .wait_to_become_active(std::time::Duration::from_secs(9999))
-            .await
-            .map_err(Error::WaitToActivate)?;
+            .await?;
 
         // TODO: pause failpoint here to catch the situation where detached timeline is deleted...?
         // we are not yet holding the gate so it could advance to the point of removing from
@@ -302,7 +309,7 @@ impl SharedState {
             unreachable!("unsure if there is an ordering, but perhaps this is possible?");
         };
 
-        // the gate being antered does not matter much, but lets be strict
+        // the gate being entered does not matter much, but lets be strict
         if attempt.gate_entered.is_none() {
             let entered = timeline.gate.enter().map_err(|_| Error::ShuttingDown)?;
             attempt.gate_entered = Some(entered);
@@ -620,21 +627,14 @@ pub(super) async fn prepare(
 
         if still_in_progress {
             // gc is still blocked, we can still reparent and complete.
-            //
-            // this of course represents a challenge: how to *not* reparent branches which were not
-            // there when we started? cannot, unfortunately, if not recorded to the ongoing_detach_ancestor.
-            //
-            // FIXME: if a new timeline had been created on ancestor which was reparentable between
-            // the attempts, we could end up with it having different ancestry across shards. Fix
-            // this by locking the parentable timelines before the operation starts, and storing
-            // them in index_part.json.
-            //
-            // because the ancestor of detached is already set to none, we have published all
-            // of the layers.
+            // we are safe to reparent remaining, because they were locked in in the beginning.
             let attempt = tenant
                 .ongoing_timeline_detach
                 .start_new_attempt(detached)
                 .await?;
+
+            // because the ancestor of detached is already set to none, we have published all
+            // of the layers, so we are still "prepared."
             return Ok(Progress::Prepared(
                 attempt,
                 PreparedTimelineDetach { layers: Vec::new() },
@@ -649,6 +649,8 @@ pub(super) async fn prepare(
 
         // IDEA? add the non-reparented in to the response -- these would be the reparentable, but
         // no longer reparentable because they appeared *after* gc blocking was released.
+        //
+        // will not be needed once we have the locking in.
         return Ok(Progress::Done(AncestorDetached {
             reparented_timelines,
         }));
@@ -670,6 +672,17 @@ pub(super) async fn prepare(
         .ongoing_timeline_detach
         .start_new_attempt(detached)
         .await?;
+
+    // FIXME: is the assumption that no one else is making these changes except us strong
+    // enough...? need a witness in the RemoteTimelineClient api?
+    //
+    // if it wasn't persistently started already, mark the ancestor detach persistently started.
+    detached
+        .remote_client
+        .schedule_started_detach_ancestor_mark_and_wait()
+        .await
+        // FIXME: aaaargh
+        .map_err(|_| Error::ShuttingDown)?;
 
     utils::pausable_failpoint!("timeline-detach-ancestor::before_starting_after_locking_pausable");
 
@@ -735,7 +748,8 @@ pub(super) async fn prepare(
     };
 
     // TODO: layers are already sorted by something: use that to determine how much of remote
-    // copies are already done.
+    // copies are already done -- gc is blocked, but a compaction could had happened on ancestor,
+    // which is something to keep in mind if copy skipping is implemented.
     tracing::info!(filtered=%filtered_layers, to_rewrite = straddling_branchpoint.len(), historic=%rest_of_historic.len(), "collected layers");
 
     // TODO: copying and lsn prefix copying could be done at the same time with a single fsync after
@@ -844,25 +858,25 @@ fn reparented_direct_children(
     tenant: &Tenant,
 ) -> Result<Vec<TimelineId>, Error> {
     let mut all_direct_children = tenant
-            .timelines
-            .lock()
-            .unwrap()
-            .values()
-            .filter_map(|tl| {
-                let is_direct_child = matches!(tl.ancestor_timeline.as_ref(), Some(ancestor) if Arc::ptr_eq(ancestor, detached));
+        .timelines
+        .lock()
+        .unwrap()
+        .values()
+        .filter_map(|tl| {
+            let is_direct_child = matches!(tl.ancestor_timeline.as_ref(), Some(ancestor) if Arc::ptr_eq(ancestor, detached));
 
-                if is_direct_child {
-                    Some((tl.ancestor_lsn, tl.clone()))
-                } else {
-                    if let Some(timeline) = tl.ancestor_timeline.as_ref() {
-                        assert_ne!(timeline.timeline_id, detached.timeline_id);
-                    }
-                    None
+            if is_direct_child {
+                Some((tl.ancestor_lsn, tl.clone()))
+            } else {
+                if let Some(timeline) = tl.ancestor_timeline.as_ref() {
+                    assert_ne!(timeline.timeline_id, detached.timeline_id);
                 }
-            })
-                // Collect to avoid lock taking order problem with Tenant::timelines and
-                // Timeline::remote_client
-            .collect::<Vec<_>>();
+                None
+            }
+        })
+        // Collect to avoid lock taking order problem with Tenant::timelines and
+        // Timeline::remote_client
+        .collect::<Vec<_>>();
 
     let mut any_shutdown = false;
 
@@ -1097,7 +1111,7 @@ pub(super) async fn detach_and_reparent(
         Detached(Arc<Timeline>, Lsn),
     }
 
-    let (recorded_branchpoint, detach_is_ongoing) = {
+    let (recorded_branchpoint, still_ongoing) = {
         let access = detached.remote_client.initialized_upload_queue()?;
         let latest = access.latest_uploaded_index_part();
 
@@ -1128,7 +1142,8 @@ pub(super) async fn detach_and_reparent(
         if let Some(ancestor) = existing {
             Ancestor::Detached(ancestor, ancestor_lsn)
         } else {
-            let direct_children = reparented_direct_children(detached, tenant)?;
+            let direct_children =
+                reparented_direct_children(detached, tenant).map_err(Error::from)?;
             return Ok(DetachingAndReparenting::AlreadyDone(direct_children));
         }
     } else {
@@ -1143,8 +1158,8 @@ pub(super) async fn detach_and_reparent(
     // if we crash after this operation, a retry will allow reparenting the remaining timelines as
     // gc is blocked.
     assert!(
-        detach_is_ongoing,
-        "to detach and reparent, gc must still be blocked"
+        still_ongoing,
+        "to detach or reparent, gc must still be blocked"
     );
 
     let (ancestor, ancestor_lsn, was_detached) = match ancestor {

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -146,6 +146,7 @@ impl SharedState {
             .lock()
             .unwrap()
             .continue_existing_attempt(attempt);
+        self.gc_waiting.notify_one();
     }
 
     /// Only GC must be paused while a detach ancestor is ongoing. Compaction can happen, to aid
@@ -513,6 +514,7 @@ impl SharedStateBuilder {
         g.known_ongoing.extend(self.inprogress);
         if g.latest.is_none() && !g.known_ongoing.is_empty() {
             g.latest = Some((ExistingAttempt::ReadFromIndexPart, false));
+            target.gc_waiting.notify_one();
         }
     }
 }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -969,10 +969,60 @@ pub(super) async fn complete(
 ) -> Result<(Vec<TimelineId>, bool), anyhow::Error> {
     let PreparedTimelineDetach { layers } = prepared;
 
-    let ancestor = detached
-        .get_ancestor_timeline()
-        .expect("must still have a ancestor");
-    let ancestor_lsn = detached.get_ancestor_lsn();
+    #[derive(Debug)]
+    enum Ancestor {
+        NotDetached(Arc<Timeline>, Lsn),
+        Detached(Arc<Timeline>, Lsn),
+        Deleted(TimelineId, Lsn),
+    }
+
+    impl Ancestor {
+        fn as_branchpoint(&self) -> Option<(&Arc<Timeline>, &Lsn)> {
+            use Ancestor::*;
+
+            match self {
+                NotDetached(tl, lsn) | Detached(tl, lsn) => Some((tl, lsn)),
+                Deleted(..) => None,
+            }
+        }
+    }
+
+    let (recorded_branchpoint, detach_is_ongoing) = {
+        let access = detached.remote_client.initialized_upload_queue()?;
+        let latest = access.latest_uploaded_index_part();
+
+        (
+            latest.lineage.detached_previous_ancestor(),
+            latest.ongoing_detach_ancestor.is_some(),
+        )
+    };
+
+    let ancestor = if let Some(ancestor) = detached.ancestor_timeline.as_ref() {
+        assert!(
+            recorded_branchpoint.is_none(),
+            "it should be impossible to get to here without having gone through the tenant reset"
+        );
+        Ancestor::NotDetached(ancestor.clone(), detached.ancestor_lsn)
+    } else if let Some((ancestor_id, ancestor_lsn)) = recorded_branchpoint {
+        // it has been either:
+        // - detached but still exists => we can try reparenting
+        // - detached and deleted
+        //
+        // either way, we must complete
+        assert!(
+            layers.is_empty(),
+            "no layers should had been copied as detach is done"
+        );
+        let existing = tenant.timelines.lock().unwrap().get(&ancestor_id).cloned();
+
+        if let Some(ancestor) = existing {
+            Ancestor::Detached(ancestor, ancestor_lsn)
+        } else {
+            Ancestor::Deleted(ancestor_id, ancestor_lsn)
+        }
+    } else {
+        panic!("bug: complete called on a timeline which has not been detached or which has no live ancestor");
+    };
 
     // publish the prepared layers before we reparent any of the timelines, so that on restart
     // reparented timelines find layers. also do the actual detaching.
@@ -983,140 +1033,144 @@ pub(super) async fn complete(
     //
     // this is not perfect, but it avoids us a retry happening after a compaction or gc on restart
     // which could give us a completely wrong layer combination.
-    detached
-        .remote_client
-        .schedule_adding_existing_layers_to_index_detach_and_wait(
-            &layers,
-            (ancestor.timeline_id, ancestor_lsn),
-        )
-        .await
-        .context("publish layers and detach ancestor")?;
 
-    // FIXME: assert that the persistent record of inprogress detach exists
-    // FIXME: assert that gc is still blocked
-
-    let mut tasks = tokio::task::JoinSet::new();
-
-    fn fail_all_but_one() -> bool {
-        fail::fail_point!("timeline-detach-ancestor::allow_one_reparented", |_| true);
-        false
+    if let Ancestor::NotDetached(ancestor, ancestor_lsn) = &ancestor {
+        detached
+            .remote_client
+            .schedule_adding_existing_layers_to_index_detach_and_wait(
+                &layers,
+                (ancestor.timeline_id, *ancestor_lsn),
+            )
+            .await
+            .context("publish layers and detach ancestor")?;
     }
 
-    let failpoint_sem = if fail_all_but_one() {
-        Some(Arc::new(tokio::sync::Semaphore::new(1)))
-    } else {
-        None
-    };
+    let (mut reparented, reparented_all) =
+        if let Some((ancestor, ancestor_lsn)) = ancestor.as_branchpoint() {
+            assert!(detach_is_ongoing, "to reparent, gc must still be blocked");
+            let mut tasks = tokio::task::JoinSet::new();
 
-    // because we are now keeping the slot in progress, it is unlikely that there will be any
-    // timeline deletions during this time. if we raced one, then we'll just ignore it.
-    tenant
-        .timelines
-        .lock()
-        .unwrap()
-        .values()
-        .filter_map(|tl| {
-            if Arc::ptr_eq(tl, detached) {
-                return None;
+            fn fail_all_but_one() -> bool {
+                fail::fail_point!("timeline-detach-ancestor::allow_one_reparented", |_| true);
+                false
             }
 
-            if !tl.is_active() {
-                return None;
-            }
-
-            let tl_ancestor = tl.ancestor_timeline.as_ref()?;
-            let is_same = Arc::ptr_eq(&ancestor, tl_ancestor);
-            let is_earlier = tl.get_ancestor_lsn() <= ancestor_lsn;
-
-            let is_deleting = tl
-                .delete_progress
-                .try_lock()
-                .map(|flow| !flow.is_not_started())
-                .unwrap_or(true);
-
-            if is_same && is_earlier && !is_deleting {
-                Some(tl.clone())
+            let failpoint_sem = if fail_all_but_one() {
+                Some(Arc::new(tokio::sync::Semaphore::new(1)))
             } else {
                 None
-            }
-        })
-        .for_each(|timeline| {
-            // important in this scope: we are holding the Tenant::timelines lock
-            let span = tracing::info_span!("reparent", reparented=%timeline.timeline_id);
-            let new_parent = detached.timeline_id;
-            let failpoint_sem = failpoint_sem.clone();
+            };
 
-            tasks.spawn(
-                async move {
-                    let res = async {
-                        if let Some(failpoint_sem) = failpoint_sem {
-                            let permit = failpoint_sem.acquire().await.map_err(|_| {
-                                anyhow::anyhow!(
-                                    "failpoint: timeline-detach-ancestor::allow_one_reparented",
-                                )
-                            })?;
-                            permit.forget();
-                            failpoint_sem.close();
-                        }
-
-                        timeline
-                            .remote_client
-                            .schedule_reparenting_and_wait(&new_parent)
-                            .await
+            // because we are now keeping the slot in progress, it is unlikely that there will be any
+            // timeline deletions during this time. if we raced one, then we'll just ignore it.
+            tenant
+                .timelines
+                .lock()
+                .unwrap()
+                .values()
+                .filter_map(|tl| {
+                    if Arc::ptr_eq(tl, detached) {
+                        return None;
                     }
-                    .await;
 
-                    match res {
-                        Ok(()) => {
-                            tracing::info!("reparented");
-                            Some(timeline)
-                        }
-                        Err(e) => {
-                            // with the use of tenant slot, timeline deletion is the most likely
-                            // reason.
-                            tracing::warn!("reparenting failed: {e:#}");
-                            None
-                        }
+                    let tl_ancestor = tl.ancestor_timeline.as_ref()?;
+                    let is_same = Arc::ptr_eq(&ancestor, tl_ancestor);
+                    let is_earlier = tl.get_ancestor_lsn() <= *ancestor_lsn;
+
+                    let is_deleting = tl
+                        .delete_progress
+                        .try_lock()
+                        .map(|flow| !flow.is_not_started())
+                        .unwrap_or(true);
+
+                    if is_same && is_earlier && !is_deleting {
+                        Some(tl.clone())
+                    } else {
+                        None
                     }
+                })
+                .for_each(|timeline| {
+                    // important in this scope: we are holding the Tenant::timelines lock
+                    let span = tracing::info_span!("reparent", reparented=%timeline.timeline_id);
+                    let new_parent = detached.timeline_id;
+                    let failpoint_sem = failpoint_sem.clone();
+
+                    tasks.spawn(
+                        async move {
+                            let res = async {
+                                if let Some(failpoint_sem) = failpoint_sem {
+                                    let permit = failpoint_sem.acquire().await.map_err(|_| {
+                                        anyhow::anyhow!(
+                                        "failpoint: timeline-detach-ancestor::allow_one_reparented",
+                                    )
+                                    })?;
+                                    permit.forget();
+                                    failpoint_sem.close();
+                                }
+
+                                timeline
+                                    .remote_client
+                                    .schedule_reparenting_and_wait(&new_parent)
+                                    .await
+                            }
+                            .await;
+
+                            match res {
+                                Ok(()) => {
+                                    tracing::info!("reparented");
+                                    Some(timeline)
+                                }
+                                Err(e) => {
+                                    // with the use of tenant slot, timeline deletion is the most likely
+                                    // reason.
+                                    tracing::warn!("reparenting failed: {e:#}");
+                                    None
+                                }
+                            }
+                        }
+                        .instrument(span),
+                    );
+                });
+
+            let reparenting_candidates = tasks.len();
+            let mut reparented = Vec::with_capacity(tasks.len());
+
+            while let Some(res) = tasks.join_next().await {
+                match res {
+                    Ok(Some(timeline)) => {
+                        reparented.push((timeline.ancestor_lsn, timeline.timeline_id));
+                    }
+                    Ok(None) => {
+                        // lets just ignore this for now. one or all reparented timelines could had
+                        // started deletion, and that is fine. deleting a timeline is the most likely
+                        // reason for this.
+                    }
+                    Err(je) if je.is_cancelled() => unreachable!("not used"),
+                    Err(je) if je.is_panic() => {
+                        // ignore; it's better to continue with a single reparenting failing (or even
+                        // all of them) in order to get to the goal state. we will retry this after
+                        // restart.
+                    }
+                    Err(je) => tracing::error!("unexpected join error: {je:?}"),
                 }
-                .instrument(span),
-            );
-        });
-
-    let reparenting_candidates = tasks.len();
-    let mut reparented = Vec::with_capacity(tasks.len());
-
-    while let Some(res) = tasks.join_next().await {
-        match res {
-            Ok(Some(timeline)) => {
-                reparented.push((timeline.ancestor_lsn, timeline.timeline_id));
             }
-            Ok(None) => {
-                // lets just ignore this for now. one or all reparented timelines could had
-                // started deletion, and that is fine. deleting a timeline is the most likely
-                // reason for this.
-            }
-            Err(je) if je.is_cancelled() => unreachable!("not used"),
-            Err(je) if je.is_panic() => {
-                // ignore; it's better to continue with a single reparenting failing (or even
-                // all of them) in order to get to the goal state. we will retry this after
-                // restart.
-            }
-            Err(je) => tracing::error!("unexpected join error: {je:?}"),
-        }
-    }
 
-    let reparented_all = reparenting_candidates == reparented.len();
+            let reparented_all = reparenting_candidates == reparented.len();
 
-    if reparented_all {
-        // FIXME: we must return 503 kind of response in the end; do the restart anyways because
-        // otherwise the runtime state remains diverged
-        tracing::info!(
-            reparented = reparented.len(),
-            candidates = reparenting_candidates,
-            "failed to reparent all candidates; they will be retried after the restart",
-        );
-    }
+            if reparented_all {
+                // FIXME: we must return 503 kind of response in the end; do the restart anyways because
+                // otherwise the runtime state remains diverged
+                tracing::info!(
+                    reparented = reparented.len(),
+                    candidates = reparenting_candidates,
+                    "failed to reparent all candidates; they will be retried after the restart",
+                );
+            }
+            (reparented, reparented_all)
+        } else {
+            // FIXME: again, get the list of (ancestor_lsn, reparented)
+            (Vec::new(), true)
+        };
 
     reparented.sort_unstable();
 

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -984,7 +984,6 @@ pub(super) async fn complete(
     enum Ancestor {
         NotDetached(Arc<Timeline>, Lsn),
         Detached(Arc<Timeline>, Lsn),
-        Deleted(TimelineId, Lsn),
     }
 
     let (recorded_branchpoint, detach_is_ongoing) = {
@@ -1018,7 +1017,7 @@ pub(super) async fn complete(
         if let Some(ancestor) = existing {
             Ancestor::Detached(ancestor, ancestor_lsn)
         } else {
-            Ancestor::Deleted(ancestor_id, ancestor_lsn)
+            return Ok((reparented_direct_children(detached, tenant)?, true));
         }
     } else {
         panic!("bug: complete called on a timeline which has not been detached or which has no live ancestor");
@@ -1036,6 +1035,8 @@ pub(super) async fn complete(
 
     let (ancestor, ancestor_lsn) = match ancestor {
         Ancestor::NotDetached(ancestor, ancestor_lsn) => {
+            // this has to complete before any reparentings because otherwise they would not have
+            // layers on the new parent.
             detached
                 .remote_client
                 .schedule_adding_existing_layers_to_index_detach_and_wait(
@@ -1048,9 +1049,6 @@ pub(super) async fn complete(
             (ancestor, ancestor_lsn)
         }
         Ancestor::Detached(ancestor, ancestor_lsn) => (ancestor, ancestor_lsn),
-        Ancestor::Deleted(..) => {
-            return Ok((reparented_direct_children(detached, tenant)?, true));
-        }
     };
 
     assert!(detach_is_ongoing, "to reparent, gc must still be blocked");

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -446,6 +446,42 @@ impl SharedStateInner {
         assert!(!self.known_ongoing.is_empty());
         self.latest = Some((ExistingAttempt::ReadFromIndexPart, witnessed));
     }
+
+    fn on_delete(&mut self, timeline_id: &TimelineId) {
+        let witnessed = match self.latest.as_ref() {
+            Some((ExistingAttempt::Actual(x, barrier), witnessed)) if x == timeline_id => {
+                assert!(
+                    barrier.is_ready(),
+                    "the attempt is still ongoing; is this call happening before closing the gate?"
+                );
+                *witnessed
+            }
+            Some((ExistingAttempt::ContinuedOverRestart(x), witnessed)) if x == timeline_id => {
+                *witnessed
+            }
+            Some((ExistingAttempt::ReadFromIndexPart, witnessed))
+                if self.known_ongoing.contains(timeline_id) =>
+            {
+                *witnessed
+            }
+            _ => return,
+        };
+
+        assert!(self.known_ongoing.remove(timeline_id));
+
+        if self.known_ongoing.is_empty() {
+            self.latest = None;
+            tracing::info!("gc is now unblocked following timeline deletion");
+        } else {
+            self.latest = Some((ExistingAttempt::ReadFromIndexPart, witnessed));
+            tracing::info!(
+                n = self.known_ongoing.len(),
+                "gc is still blocked for remaining ongoing detaches"
+            );
+        }
+
+        todo!("there should be a test for this.")
+    }
 }
 
 #[derive(Debug)]

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -310,7 +310,6 @@ impl SharedState {
             self.inner.lock().unwrap().cancel(attempt);
         });
 
-        // the gate being entered does not matter much, but lets be strict
         if attempt.gate_entered.is_none() {
             let entered = timeline.gate.enter().map_err(|_| Error::ShuttingDown)?;
             attempt.gate_entered = Some(entered);

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -672,9 +672,7 @@ pub(super) async fn prepare(
 
         let mut wrote_any = false;
 
-        let limiter = Arc::new(tokio::sync::Semaphore::new(
-            options.rewrite_concurrency.get(),
-        ));
+        let limiter = Arc::new(Semaphore::new(options.rewrite_concurrency.get()));
 
         for layer in straddling_branchpoint {
             let limiter = limiter.clone();
@@ -727,7 +725,7 @@ pub(super) async fn prepare(
     }
 
     let mut tasks = tokio::task::JoinSet::new();
-    let limiter = Arc::new(tokio::sync::Semaphore::new(options.copy_concurrency.get()));
+    let limiter = Arc::new(Semaphore::new(options.copy_concurrency.get()));
 
     for adopted in rest_of_historic {
         let limiter = limiter.clone();
@@ -1060,7 +1058,7 @@ pub(super) async fn complete(
     #[cfg(feature = "testing")]
     let failpoint_sem = || -> Option<Arc<Semaphore>> {
         fail::fail_point!("timeline-detach-ancestor::allow_one_reparented", |_| Some(
-            Arc::new(tokio::sync::Semaphore::new(1))
+            Arc::new(Semaphore::new(1))
         ));
         None
     }();

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1139,8 +1139,7 @@ pub(super) async fn detach_and_reparent(
         if let Some(ancestor) = existing {
             Ancestor::Detached(ancestor, ancestor_lsn)
         } else {
-            let direct_children =
-                reparented_direct_children(detached, tenant).map_err(Error::from)?;
+            let direct_children = reparented_direct_children(detached, tenant)?;
             return Ok(DetachingAndReparenting::AlreadyDone(direct_children));
         }
     } else {

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -283,8 +283,6 @@ impl SharedState {
 
         self.inner.lock().unwrap().validate(&attempt);
 
-        // FIXME: could check more preconditions, like that the timeline has been detached?
-
         let mut attempt = scopeguard::guard(attempt, |attempt| {
             // our attempt will no longer be valid, so release it
             self.inner.lock().unwrap().cancel(attempt);
@@ -318,6 +316,8 @@ impl SharedState {
         } else {
             // Some(gate_entered) means the tenant was not restarted, as is not required
         }
+
+        assert!(timeline.ancestor_timeline.is_none());
 
         // this should be an 503 at least...?
         fail::fail_point!(

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -302,6 +302,8 @@ impl SharedState {
             .get(&attempt.timeline_id)
             .cloned()
         else {
+            // no need to cancel the attempt, because timeline deletion and/or tenant restart has
+            // already marked it unblocked.
             return Err(Error::DetachedNotFoundAfterRestart);
         };
 

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1113,6 +1113,10 @@ pub(super) async fn detach_and_reparent(
                 .is_some_and(|b| b.blocked_by_detach_ancestor()),
         )
     };
+    assert!(
+        still_ongoing,
+        "cannot (detach? reparent)? complete if the operation is not still ongoing"
+    );
 
     let ancestor = if let Some(ancestor) = detached.ancestor_timeline.as_ref() {
         assert!(
@@ -1135,10 +1139,6 @@ pub(super) async fn detach_and_reparent(
         if let Some(ancestor) = existing {
             Ancestor::Detached(ancestor, ancestor_lsn)
         } else {
-            assert!(
-                still_ongoing,
-                "cannot complete if the operation is not still ongoing"
-            );
             let direct_children =
                 reparented_direct_children(detached, tenant).map_err(Error::from)?;
             return Ok(DetachingAndReparenting::AlreadyDone(direct_children));
@@ -1154,10 +1154,6 @@ pub(super) async fn detach_and_reparent(
     //
     // if we crash after this operation, a retry will allow reparenting the remaining timelines as
     // gc is blocked.
-    assert!(
-        still_ongoing,
-        "to detach or reparent, gc must still be blocked"
-    );
 
     let (ancestor, ancestor_lsn, was_detached) = match ancestor {
         Ancestor::NotDetached(ancestor, ancestor_lsn) => {

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -579,7 +579,11 @@ impl SharedStateBuilder {
         timeline_id: &TimelineId,
         index_part: &crate::tenant::IndexPart,
     ) {
-        if index_part.gc_blocking.is_some() {
+        if index_part
+            .gc_blocking
+            .as_ref()
+            .is_some_and(|b| b.blocked_by_detach_ancestor())
+        {
             // if the loading a timeline fails, tenant loading must fail as it does right now, or
             // something more elaborate needs to be done with this tracking
             self.inprogress.insert(*timeline_id);

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     virtual_file::{MaybeFatalIo, VirtualFile},
 };
+use anyhow::Context;
 use pageserver_api::models::detach_ancestor::AncestorDetached;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -958,7 +959,7 @@ pub(super) async fn complete(
     tenant: &Tenant,
     prepared: PreparedTimelineDetach,
     _ctx: &RequestContext,
-) -> Result<Vec<TimelineId>, anyhow::Error> {
+) -> Result<(Vec<TimelineId>, bool), anyhow::Error> {
     let PreparedTimelineDetach { layers } = prepared;
 
     let ancestor = detached
@@ -981,12 +982,24 @@ pub(super) async fn complete(
             &layers,
             (ancestor.timeline_id, ancestor_lsn),
         )
-        .await?;
+        .await
+        .context("publish layers and detach ancestor")?;
 
     // FIXME: assert that the persistent record of inprogress detach exists
     // FIXME: assert that gc is still blocked
 
     let mut tasks = tokio::task::JoinSet::new();
+
+    fn fail_all_but_one() -> bool {
+        fail::fail_point!("timeline-detach-ancestor::allow_one_reparented", |_| true);
+        false
+    }
+
+    let failpoint_sem = if fail_all_but_one() {
+        Some(Arc::new(tokio::sync::Semaphore::new(1)))
+    } else {
+        None
+    };
 
     // because we are now keeping the slot in progress, it is unlikely that there will be any
     // timeline deletions during this time. if we raced one, then we'll just ignore it.
@@ -1024,18 +1037,36 @@ pub(super) async fn complete(
             // important in this scope: we are holding the Tenant::timelines lock
             let span = tracing::info_span!("reparent", reparented=%timeline.timeline_id);
             let new_parent = detached.timeline_id;
+            let failpoint_sem = failpoint_sem.clone();
 
             tasks.spawn(
                 async move {
-                    let res = timeline
-                        .remote_client
-                        .schedule_reparenting_and_wait(&new_parent)
-                        .await;
+                    let res = async {
+                        if let Some(failpoint_sem) = failpoint_sem {
+                            let permit = failpoint_sem.acquire().await.map_err(|_| {
+                                anyhow::anyhow!(
+                                    "failpoint: timeline-detach-ancestor::allow_one_reparented",
+                                )
+                            })?;
+                            permit.forget();
+                            failpoint_sem.close();
+                        }
+
+                        timeline
+                            .remote_client
+                            .schedule_reparenting_and_wait(&new_parent)
+                            .await
+                    }
+                    .await;
 
                     match res {
-                        Ok(()) => Some(timeline),
+                        Ok(()) => {
+                            tracing::info!("reparented");
+                            Some(timeline)
+                        }
                         Err(e) => {
-                            // with the use of tenant slot, we no longer expect these.
+                            // with the use of tenant slot, timeline deletion is the most likely
+                            // reason.
                             tracing::warn!("reparenting failed: {e:#}");
                             None
                         }
@@ -1051,28 +1082,33 @@ pub(super) async fn complete(
     while let Some(res) = tasks.join_next().await {
         match res {
             Ok(Some(timeline)) => {
-                tracing::info!(reparented=%timeline.timeline_id, "reparenting done");
                 reparented.push((timeline.ancestor_lsn, timeline.timeline_id));
             }
             Ok(None) => {
                 // lets just ignore this for now. one or all reparented timelines could had
-                // started deletion, and that is fine.
+                // started deletion, and that is fine. deleting a timeline is the most likely
+                // reason for this.
             }
             Err(je) if je.is_cancelled() => unreachable!("not used"),
             Err(je) if je.is_panic() => {
                 // ignore; it's better to continue with a single reparenting failing (or even
-                // all of them) in order to get to the goal state.
-                //
-                // these timelines will never be reparentable, but they can be always detached as
-                // separate tree roots.
+                // all of them) in order to get to the goal state. we will retry this after
+                // restart.
             }
             Err(je) => tracing::error!("unexpected join error: {je:?}"),
         }
     }
 
-    if reparenting_candidates != reparented.len() {
-        // FIXME: we must return 503 kind of response
-        tracing::info!("failed to reparent some candidates");
+    let reparented_all = reparenting_candidates == reparented.len();
+
+    if reparented_all {
+        // FIXME: we must return 503 kind of response in the end; do the restart anyways because
+        // otherwise the runtime state remains diverged
+        tracing::info!(
+            reparented = reparented.len(),
+            candidates = reparenting_candidates,
+            "failed to reparent all candidates; they will be retried after the restart",
+        );
     }
 
     reparented.sort_unstable();
@@ -1085,5 +1121,5 @@ pub(super) async fn complete(
     // FIXME: here everything has gone peachy, the tenant will be restarted next.
     // after restart and before returning the response, the gc blocking must be undone
 
-    Ok(reparented)
+    Ok((reparented, reparented_all))
 }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1280,6 +1280,7 @@ pub(super) async fn detach_and_reparent(
     }
 }
 
+/// Query against a locked `Tenant::timelines`.
 fn reparentable_timelines<'a, I>(
     timelines: I,
     detached: &'a Arc<Timeline>,

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -1251,17 +1251,10 @@ pub(super) async fn detach_and_reparent(
                     timeline.timeline_id
                 );
             }
-            Ok(None) => {
-                // lets just ignore this for now. one or all reparented timelines could had
-                // started deletion, and that is fine. deleting a timeline is the most likely
-                // reason for this.
-            }
             Err(je) if je.is_cancelled() => unreachable!("not used"),
-            Err(je) if je.is_panic() => {
-                // ignore; it's better to continue with a single reparenting failing (or even
-                // all of them) in order to get to the goal state. we will retry this after
-                // restart.
-            }
+            // just ignore failures now, we can retry
+            Ok(None) => {}
+            Err(je) if je.is_panic() => {}
             Err(je) => tracing::error!("unexpected join error: {je:?}"),
         }
     }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -987,17 +987,6 @@ pub(super) async fn complete(
         Deleted(TimelineId, Lsn),
     }
 
-    impl Ancestor {
-        fn as_branchpoint(&self) -> Option<(&Arc<Timeline>, &Lsn)> {
-            use Ancestor::*;
-
-            match self {
-                NotDetached(tl, lsn) | Detached(tl, lsn) => Some((tl, lsn)),
-                Deleted(..) => None,
-            }
-        }
-    }
-
     let (recorded_branchpoint, detach_is_ongoing) = {
         let access = detached.remote_client.initialized_upload_queue()?;
         let latest = access.latest_uploaded_index_part();
@@ -1045,153 +1034,154 @@ pub(super) async fn complete(
     // this is not perfect, but it avoids us a retry happening after a compaction or gc on restart
     // which could give us a completely wrong layer combination.
 
-    if let Ancestor::NotDetached(ancestor, ancestor_lsn) = &ancestor {
-        detached
-            .remote_client
-            .schedule_adding_existing_layers_to_index_detach_and_wait(
-                &layers,
-                (ancestor.timeline_id, *ancestor_lsn),
-            )
-            .await
-            .context("publish layers and detach ancestor")?;
+    let (ancestor, ancestor_lsn) = match ancestor {
+        Ancestor::NotDetached(ancestor, ancestor_lsn) => {
+            detached
+                .remote_client
+                .schedule_adding_existing_layers_to_index_detach_and_wait(
+                    &layers,
+                    (ancestor.timeline_id, ancestor_lsn),
+                )
+                .await
+                .context("publish layers and detach ancestor")?;
+
+            (ancestor, ancestor_lsn)
+        }
+        Ancestor::Detached(ancestor, ancestor_lsn) => (ancestor, ancestor_lsn),
+        Ancestor::Deleted(..) => {
+            return Ok((reparented_direct_children(detached, tenant)?, true));
+        }
+    };
+
+    assert!(detach_is_ongoing, "to reparent, gc must still be blocked");
+    let mut tasks = tokio::task::JoinSet::new();
+
+    fn fail_all_but_one() -> bool {
+        fail::fail_point!("timeline-detach-ancestor::allow_one_reparented", |_| true);
+        false
     }
 
-    let (reparented, reparented_all) =
-        if let Some((ancestor, ancestor_lsn)) = ancestor.as_branchpoint() {
-            assert!(detach_is_ongoing, "to reparent, gc must still be blocked");
-            let mut tasks = tokio::task::JoinSet::new();
+    let failpoint_sem = if fail_all_but_one() {
+        Some(Arc::new(tokio::sync::Semaphore::new(1)))
+    } else {
+        None
+    };
 
-            fn fail_all_but_one() -> bool {
-                fail::fail_point!("timeline-detach-ancestor::allow_one_reparented", |_| true);
-                false
+    // because we are now keeping the slot in progress, it is unlikely that there will be any
+    // timeline deletions during this time. if we raced one, then we'll just ignore it.
+    tenant
+        .timelines
+        .lock()
+        .unwrap()
+        .values()
+        .filter_map(|tl| {
+            if Arc::ptr_eq(tl, detached) {
+                return None;
             }
 
-            let failpoint_sem = if fail_all_but_one() {
-                Some(Arc::new(tokio::sync::Semaphore::new(1)))
+            let tl_ancestor = tl.ancestor_timeline.as_ref()?;
+            let is_same = Arc::ptr_eq(&ancestor, tl_ancestor);
+            let is_earlier = tl.get_ancestor_lsn() <= ancestor_lsn;
+
+            let is_deleting = tl
+                .delete_progress
+                .try_lock()
+                .map(|flow| !flow.is_not_started())
+                .unwrap_or(true);
+
+            if is_same && is_earlier && !is_deleting {
+                Some(tl.clone())
             } else {
                 None
-            };
+            }
+        })
+        .for_each(|timeline| {
+            // important in this scope: we are holding the Tenant::timelines lock
+            let span = tracing::info_span!("reparent", reparented=%timeline.timeline_id);
+            let new_parent = detached.timeline_id;
+            let failpoint_sem = failpoint_sem.clone();
 
-            // because we are now keeping the slot in progress, it is unlikely that there will be any
-            // timeline deletions during this time. if we raced one, then we'll just ignore it.
-            tenant
-                .timelines
-                .lock()
-                .unwrap()
-                .values()
-                .filter_map(|tl| {
-                    if Arc::ptr_eq(tl, detached) {
-                        return None;
-                    }
-
-                    let tl_ancestor = tl.ancestor_timeline.as_ref()?;
-                    let is_same = Arc::ptr_eq(&ancestor, tl_ancestor);
-                    let is_earlier = tl.get_ancestor_lsn() <= *ancestor_lsn;
-
-                    let is_deleting = tl
-                        .delete_progress
-                        .try_lock()
-                        .map(|flow| !flow.is_not_started())
-                        .unwrap_or(true);
-
-                    if is_same && is_earlier && !is_deleting {
-                        Some(tl.clone())
-                    } else {
-                        None
-                    }
-                })
-                .for_each(|timeline| {
-                    // important in this scope: we are holding the Tenant::timelines lock
-                    let span = tracing::info_span!("reparent", reparented=%timeline.timeline_id);
-                    let new_parent = detached.timeline_id;
-                    let failpoint_sem = failpoint_sem.clone();
-
-                    tasks.spawn(
-                        async move {
-                            let res = async {
-                                if let Some(failpoint_sem) = failpoint_sem {
-                                    let permit = failpoint_sem.acquire().await.map_err(|_| {
-                                        anyhow::anyhow!(
-                                        "failpoint: timeline-detach-ancestor::allow_one_reparented",
-                                    )
-                                    })?;
-                                    permit.forget();
-                                    failpoint_sem.close();
-                                }
-
-                                timeline
-                                    .remote_client
-                                    .schedule_reparenting_and_wait(&new_parent)
-                                    .await
-                            }
-                            .await;
-
-                            match res {
-                                Ok(()) => {
-                                    tracing::info!("reparented");
-                                    Some(timeline)
-                                }
-                                Err(e) => {
-                                    // with the use of tenant slot, timeline deletion is the most likely
-                                    // reason.
-                                    tracing::warn!("reparenting failed: {e:#}");
-                                    None
-                                }
-                            }
+            tasks.spawn(
+                async move {
+                    let res = async {
+                        if let Some(failpoint_sem) = failpoint_sem {
+                            let permit = failpoint_sem.acquire().await.map_err(|_| {
+                                anyhow::anyhow!(
+                                    "failpoint: timeline-detach-ancestor::allow_one_reparented",
+                                )
+                            })?;
+                            permit.forget();
+                            failpoint_sem.close();
                         }
-                        .instrument(span),
-                    );
-                });
 
-            let reparenting_candidates = tasks.len();
-            let mut reparented = Vec::with_capacity(tasks.len());
+                        timeline
+                            .remote_client
+                            .schedule_reparenting_and_wait(&new_parent)
+                            .await
+                    }
+                    .await;
 
-            while let Some(res) = tasks.join_next().await {
-                match res {
-                    Ok(Some(timeline)) => {
-                        reparented.push((timeline.ancestor_lsn, timeline.timeline_id));
+                    match res {
+                        Ok(()) => {
+                            tracing::info!("reparented");
+                            Some(timeline)
+                        }
+                        Err(e) => {
+                            // with the use of tenant slot, timeline deletion is the most likely
+                            // reason.
+                            tracing::warn!("reparenting failed: {e:#}");
+                            None
+                        }
                     }
-                    Ok(None) => {
-                        // lets just ignore this for now. one or all reparented timelines could had
-                        // started deletion, and that is fine. deleting a timeline is the most likely
-                        // reason for this.
-                    }
-                    Err(je) if je.is_cancelled() => unreachable!("not used"),
-                    Err(je) if je.is_panic() => {
-                        // ignore; it's better to continue with a single reparenting failing (or even
-                        // all of them) in order to get to the goal state. we will retry this after
-                        // restart.
-                    }
-                    Err(je) => tracing::error!("unexpected join error: {je:?}"),
                 }
+                .instrument(span),
+            );
+        });
+
+    let reparenting_candidates = tasks.len();
+    let mut reparented = Vec::with_capacity(tasks.len());
+
+    while let Some(res) = tasks.join_next().await {
+        match res {
+            Ok(Some(timeline)) => {
+                reparented.push((timeline.ancestor_lsn, timeline.timeline_id));
             }
-
-            let reparented_all = reparenting_candidates == reparented.len();
-
-            if reparented_all {
-                // FIXME: we must return 503 kind of response in the end; do the restart anyways because
-                // otherwise the runtime state remains diverged
-                tracing::info!(
-                    reparented = reparented.len(),
-                    candidates = reparenting_candidates,
-                    "failed to reparent all candidates; they will be retried after the restart",
-                );
-
-                // TODO: two-state Ok(return_value)?
-                (Vec::new(), false)
-            } else {
-                reparented.sort_unstable();
-
-                let reparented = reparented
-                    .into_iter()
-                    .map(|(_, timeline_id)| timeline_id)
-                    .collect();
-
-                (reparented, true)
+            Ok(None) => {
+                // lets just ignore this for now. one or all reparented timelines could had
+                // started deletion, and that is fine. deleting a timeline is the most likely
+                // reason for this.
             }
-        } else {
-            (reparented_direct_children(detached, tenant)?, true)
-        };
+            Err(je) if je.is_cancelled() => unreachable!("not used"),
+            Err(je) if je.is_panic() => {
+                // ignore; it's better to continue with a single reparenting failing (or even
+                // all of them) in order to get to the goal state. we will retry this after
+                // restart.
+            }
+            Err(je) => tracing::error!("unexpected join error: {je:?}"),
+        }
+    }
 
-    Ok((reparented, reparented_all))
+    let reparented_all = reparenting_candidates == reparented.len();
+
+    if reparented_all {
+        // FIXME: we must return 503 kind of response in the end; do the restart anyways because
+        // otherwise the runtime state remains diverged
+        tracing::info!(
+            reparented = reparented.len(),
+            candidates = reparenting_candidates,
+            "failed to reparent all candidates; they will be retried after the restart",
+        );
+
+        reparented.sort_unstable();
+
+        let reparented = reparented
+            .into_iter()
+            .map(|(_, timeline_id)| timeline_id)
+            .collect();
+
+        Ok((reparented, true))
+    } else {
+        // TODO: two-state Ok(return_value)?
+        Ok((Vec::new(), false))
+    }
 }

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use anyhow::Context;
 use pageserver_api::models::detach_ancestor::AncestorDetached;
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use utils::{completion, generation::Generation, http::error::ApiError, id::TimelineId, lsn::Lsn};
@@ -1054,16 +1055,15 @@ pub(super) async fn complete(
     assert!(detach_is_ongoing, "to reparent, gc must still be blocked");
     let mut tasks = tokio::task::JoinSet::new();
 
-    fn fail_all_but_one() -> bool {
-        fail::fail_point!("timeline-detach-ancestor::allow_one_reparented", |_| true);
-        false
-    }
-
-    let failpoint_sem = if fail_all_but_one() {
-        Some(Arc::new(tokio::sync::Semaphore::new(1)))
-    } else {
+    // Returns a single permit semaphore which will be used to make one reparenting succeed,
+    // others will fail as if those timelines had been stopped for whatever reason.
+    #[cfg(feature = "testing")]
+    let failpoint_sem = || -> Option<Arc<Semaphore>> {
+        fail::fail_point!("timeline-detach-ancestor::allow_one_reparented", |_| Some(
+            Arc::new(tokio::sync::Semaphore::new(1))
+        ));
         None
-    };
+    }();
 
     // because we are now keeping the slot in progress, it is unlikely that there will be any
     // timeline deletions during this time. if we raced one, then we'll just ignore it.
@@ -1097,18 +1097,19 @@ pub(super) async fn complete(
             // important in this scope: we are holding the Tenant::timelines lock
             let span = tracing::info_span!("reparent", reparented=%timeline.timeline_id);
             let new_parent = detached.timeline_id;
+            #[cfg(feature = "testing")]
             let failpoint_sem = failpoint_sem.clone();
 
             tasks.spawn(
                 async move {
                     let res = async {
+                        #[cfg(feature = "testing")]
                         if let Some(failpoint_sem) = failpoint_sem {
-                            let permit = failpoint_sem.acquire().await.map_err(|_| {
+                            let _permit = failpoint_sem.acquire().await.map_err(|_| {
                                 anyhow::anyhow!(
                                     "failpoint: timeline-detach-ancestor::allow_one_reparented",
                                 )
                             })?;
-                            permit.forget();
                             failpoint_sem.close();
                         }
 

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -670,9 +670,6 @@ pub(super) async fn prepare(
         .start_new_attempt(detached)
         .await?;
 
-    // FIXME: is the assumption that no one else is making these changes except us strong
-    // enough...? need a witness in the RemoteTimelineClient api?
-    //
     // if it wasn't persistently started already, mark the ancestor detach persistently started.
     detached
         .remote_client

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -2868,7 +2868,6 @@ impl Service {
         }
 
         // no shard needs to go first/last; the operation should be idempotent
-        // TODO: it would be great to ensure that all shards return the same error
         let mut results = self
             .tenant_for_shards(targets, |tenant_shard_id, node| {
                 futures::FutureExt::boxed(detach_one(
@@ -2887,6 +2886,7 @@ impl Service {
             .filter(|(_, res)| res != &any.1)
             .collect::<Vec<_>>();
         if !mismatching.is_empty() {
+            // this can be hit by races which should not happen because operation lock on cplane
             let matching = results.len() - mismatching.len();
             tracing::error!(
                 matching,

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -2842,6 +2842,7 @@ impl Service {
             );
 
             let client = PageserverClient::new(node.get_id(), node.base_url(), jwt.as_deref());
+
             client
                 .timeline_detach_ancestor(tenant_shard_id, timeline_id)
                 .await

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -837,7 +837,7 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         timeline_id: TimelineId,
         batch_size: int | None = None,
         **kwargs,
-    ) -> List[TimelineId]:
+    ) -> Set[TimelineId]:
         params = {}
         if batch_size is not None:
             params["batch_size"] = batch_size
@@ -848,7 +848,7 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         )
         self.verbose_error(res)
         json = res.json()
-        return list(map(TimelineId, json["reparented_timelines"]))
+        return set(map(TimelineId, json["reparented_timelines"]))
 
     def evict_layer(
         self, tenant_id: Union[TenantId, TenantShardId], timeline_id: TimelineId, layer_name: str

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -19,7 +19,7 @@ from fixtures.neon_fixtures import (
 )
 from fixtures.pageserver.http import HistoricLayerInfo, PageserverApiException
 from fixtures.pageserver.utils import wait_for_last_record_lsn, wait_timeline_detail_404
-from fixtures.remote_storage import LocalFsStorage, RemoteStorageKind, S3Storage
+from fixtures.remote_storage import LocalFsStorage, RemoteStorageKind
 from fixtures.utils import assert_pageserver_backups_equal, wait_until
 from requests import ReadTimeout
 
@@ -1124,9 +1124,6 @@ def test_retried_detach_ancestor_after_failed_reparenting(neon_env_builder: Neon
     http = http.without_status_retrying()
 
     http.configure_failpoints(("timeline-detach-ancestor::allow_one_reparented", "return"))
-
-    remote_storage = env.pageserver_remote_storage
-    assert isinstance(remote_storage, S3Storage)
 
     not_reparented: Set[TimelineId] = set()
     # tracked offset in the pageserver log which is at least at the most recent activation

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1049,9 +1049,7 @@ def test_sharded_tad_interleaved_after_partial_success(neon_env_builder: NeonEnv
             victim_http.configure_failpoints((pausepoint, "off"))
 
 
-def test_retried_detach_ancestor_after_failed_reparenting(
-    neon_env_builder: NeonEnvBuilder
-):
+def test_retried_detach_ancestor_after_failed_reparenting(neon_env_builder: NeonEnvBuilder):
     """
     Using a failpoint, force the completion step of timeline ancestor detach to fail after reparenting a single timeline.
     Retrying should try reparenting until all reparentings are done, all the time blocking gc.
@@ -1111,7 +1109,10 @@ def test_retried_detach_ancestor_after_failed_reparenting(
 
     for nth_round in range(len(timelines) - 1):
         log.info(f"{nth_round} round")
-        with pytest.raises(PageserverApiException, match=".*failed to reparent all candidate timelines, please retry") as exc:
+        with pytest.raises(
+            PageserverApiException,
+            match=".*failed to reparent all candidate timelines, please retry",
+        ) as exc:
             http.detach_ancestor(env.initial_tenant, detached)
         assert exc.value.status_code == 500
 
@@ -1168,7 +1169,9 @@ def test_retried_detach_ancestor_after_failed_reparenting(
     http.configure_failpoints(("timeline-detach-ancestor::complete_before_uploading", "return"))
 
     # almost final round, the failpoint is hit no longer, and everything completes
-    with pytest.raises(PageserverApiException, match=".* timeline-detach-ancestor::complete_before_uploading") as exc:
+    with pytest.raises(
+        PageserverApiException, match=".* timeline-detach-ancestor::complete_before_uploading"
+    ) as exc:
         http.detach_ancestor(env.initial_tenant, detached)
     assert exc.value.status_code == 500
     _, offset = env.pageserver.assert_log_contains(

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1163,13 +1163,16 @@ def test_retried_detach_ancestor_after_failed_reparenting(neon_env_builder: Neon
     # tracked offset in the pageserver log which is at least at the most recent activation
     offset = None
 
-    for nth_round in range(3):
+    def another_detach():
         with pytest.raises(
-            PageserverApiException,
-            match=".*failed to reparent all candidate timelines, please retry",
-        ) as exc:
-            http.detach_ancestor(env.initial_tenant, detached)
+                PageserverApiException,
+                match=".*failed to reparent all candidate timelines, please retry",
+            ) as exc:
+                http.detach_ancestor(env.initial_tenant, detached)
         assert exc.value.status_code == 500
+
+    for nth_round in range(3):
+        another_detach()
 
         assert (
             http.timeline_detail(env.initial_tenant, detached)["ancestor_timeline_id"] is None

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1221,7 +1221,7 @@ def test_retried_detach_ancestor_after_failed_reparenting(neon_env_builder: Neon
     assert metric == 0
 
 
-def test_deletion_after_timeline_ancestor_detach_before_completion(
+def test_timeline_is_deleted_before_timeline_detach_ancestor_completes(
     neon_env_builder: NeonEnvBuilder,
 ):
     env = neon_env_builder.init_start()

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -165,7 +165,7 @@ def test_ancestor_detach_branched_from(
     )
 
     all_reparented = client.detach_ancestor(env.initial_tenant, timeline_id)
-    assert all_reparented == []
+    assert all_reparented == set()
 
     if restart_after:
         env.pageserver.stop()
@@ -534,7 +534,7 @@ def test_compaction_induced_by_detaches_in_history(
 
     for _, timeline_id in skip_main:
         reparented = client.detach_ancestor(env.initial_tenant, timeline_id)
-        assert reparented == [], "we have no earlier branches at any level"
+        assert reparented == set(), "we have no earlier branches at any level"
 
     post_detach_l0s = list(filter(lambda x: x.l0, delta_layers(branch_timeline_id)))
     assert len(post_detach_l0s) == 5, "should had inherited 4 L0s, have 5 in total"
@@ -774,7 +774,7 @@ def test_sharded_timeline_detach_ancestor(neon_env_builder: NeonEnvBuilder):
         else:
             break
 
-    assert reparented == [], "too many retries (None) or unexpected reparentings"
+    assert reparented == set(), "too many retries (None) or unexpected reparentings"
 
     for shard_info in shards:
         node_id = int(shard_info["node_id"])
@@ -1203,7 +1203,7 @@ def test_retried_detach_ancestor_after_failed_reparenting(neon_env_builder: Neon
     http.configure_failpoints(("timeline-detach-ancestor::complete_before_uploading", "off"))
 
     reparented_resp = http.detach_ancestor(env.initial_tenant, detached)
-    assert reparented_resp == timelines
+    assert reparented_resp == set(timelines)
     # no need to quiesce_tenants anymore, because completion does that
 
     reparented, not_reparented = reparenting_progress(timelines)

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1262,6 +1262,9 @@ def test_timeline_is_deleted_before_timeline_detach_ancestor_completes(
 
             # FIXME: this should be 404 but because there is another Anyhow conversion it is 500
             assert exc.value.status_code == 500
+            env.pageserver.allowed_errors.append(
+                ".*Error processing HTTP request: InternalServerError\\(detached timeline was not found after restart"
+            )
     finally:
         http.configure_failpoints((failpoint, "off"))
 

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1073,6 +1073,8 @@ def test_retried_detach_ancestor_after_failed_reparenting(neon_env_builder: Neon
         }
     )
 
+    env.pageserver.allowed_errors.extend(SHUTDOWN_ALLOWED_ERRORS)
+
     env.pageserver.allowed_errors.extend(
         [
             ".* reparenting failed: failpoint: timeline-detach-ancestor::allow_one_reparented",

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1050,8 +1050,18 @@ def test_sharded_tad_interleaved_after_partial_success(neon_env_builder: NeonEnv
 
 def test_retried_detach_ancestor_after_failed_reparenting(neon_env_builder: NeonEnvBuilder):
     """
-    Using a failpoint, force the completion step of timeline ancestor detach to fail after reparenting a single timeline.
-    Retrying should try reparenting until all reparentings are done, all the time blocking gc.
+    Using a failpoint, force the completion step of timeline ancestor detach to
+    fail after reparenting a single timeline.
+
+    Retrying should try reparenting until all reparentings are done, all the
+    time blocking gc even across restarts (first round).
+
+    A completion failpoint is used to inhibit completion on second to last
+    round.
+
+    On last round, the completion uses a path where no reparentings can happen
+    because original ancestor is deleted, and there is a completion to unblock
+    gc without restart.
     """
 
     # to get the remote storage metrics

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1223,9 +1223,6 @@ def test_retried_detach_ancestor_after_failed_reparenting(neon_env_builder: Neon
 
 
 # TODO:
-# - after starting the operation, pageserver is shutdown, restarted
-# - after starting the operation, bottom-most timeline is deleted, pageserver is restarted, gc is inhibited
-# - deletion of reparented while reparenting should fail once, then succeed (?)
 # - branch near existing L1 boundary, image layers?
 # - investigate: why are layers started at uneven lsn? not just after branching, but in general.
 #


### PR DESCRIPTION
Building on the infrastructure added in #8516, implement persistent (index_part.json) based gc blocking for timelines. Persistent gc blocking adds another completion step, so the outline of the operation is now:

1. prepare (copy lsn prefix and remote copy layers)
2. detach and reparent (incl. restart if needed)
3. complete (unblock gc)

The added `index_part.json` change is modeled as a thing for which we could add more reasons for gc blocking. No manual way to start or stop gc blocking is provided.

Split off from #8430.

Cc: #6994 