### PR TITLE
Fix sql-exporter-autoscaling for pg < 16

### DIFF
--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -404,7 +404,7 @@ files:
             x::text as duration_seconds,
             neon.approximate_working_set_size_seconds(x) as size
           from
-            (select generate_series * 60 as x from generate_series(1, 60));
+            (select generate_series * 60 as x from generate_series(1, 60)) as t (x);
 build: |
   # Build cgroup-tools
   #


### PR DESCRIPTION
The `lfc_approximate_working_set_size_windows` query [was failing](https://neonprod.grafana.net/goto/VGdu2QuIg?orgId=1) on pg15 (and presumably pg14) with

    pq: subquery in FROM must have an alias

Because aliases in that position became optional only in pg16.

Some context here: https://neondb.slack.com/archives/C04DGM6SMTM/p1721970322601679?thread_ts=1721921122.528849