### PR TITLE
refactor(layer load API): all errors are permanent

### DIFF
--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -43,7 +43,7 @@ use crate::tenant::vectored_blob_io::{
 use crate::tenant::{PageReconstructError, Timeline};
 use crate::virtual_file::{self, VirtualFile};
 use crate::{IMAGE_FILE_MAGIC, STORAGE_FORMAT_VERSION, TEMP_FILE_SUFFIX};
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use bytes::{Bytes, BytesMut};
 use camino::{Utf8Path, Utf8PathBuf};
 use hex;
@@ -69,7 +69,6 @@ use utils::{
     lsn::Lsn,
 };
 
-use super::layer::LoadError;
 use super::layer_name::ImageLayerName;
 use super::{
     AsLayerDesc, Layer, LayerName, PersistentLayerDesc, ResidentLayer, ValuesReconstructState,
@@ -385,33 +384,23 @@ impl ImageLayerInner {
         summary: Option<Summary>,
         max_vectored_read_bytes: Option<MaxVectoredReadBytes>,
         ctx: &RequestContext,
-    ) -> Result<Self, LoadError> {
-        let file = match VirtualFile::open(path, ctx).await {
-            Ok(file) => file,
-            Err(e) => {
-                return Err(LoadError::Io(
-                    anyhow::Error::new(e).context("open layer file"),
-                ));
-            }
-        };
+    ) -> anyhow::Result<Self> {
+        let file = VirtualFile::open(path, ctx)
+            .await
+            .context("open layer file")?;
         let file_id = page_cache::next_file_id();
         let block_reader = FileBlockReader::new(&file, file_id);
-        let summary_blk = match block_reader.read_blk(0, ctx).await {
-            Ok(blk) => blk,
-            Err(e) => {
-                return Err(LoadError::Io(
-                    anyhow::Error::new(e).context("read first block"),
-                ));
-            }
-        };
+        let summary_blk = block_reader
+            .read_blk(0, ctx)
+            .await
+            .context("read first block")?;
 
         // length is the only way how this could fail, so it's not actually likely at all unless
         // read_blk returns wrong sized block.
         //
         // TODO: confirm and make this into assertion
-        let actual_summary = Summary::des_prefix(summary_blk.as_ref())
-            .context("deserialize first block")
-            .map_err(LoadError::Corruption)?;
+        let actual_summary =
+            Summary::des_prefix(summary_blk.as_ref()).context("deserialize first block")?;
 
         if let Some(mut expected_summary) = summary {
             // production code path
@@ -421,11 +410,11 @@ impl ImageLayerInner {
             expected_summary.timeline_id = actual_summary.timeline_id;
 
             if actual_summary != expected_summary {
-                return Err(LoadError::Corruption(anyhow::anyhow!(
+                bail!(
                     "in-file summary does not match expected summary. actual = {:?} expected = {:?}",
                     actual_summary,
                     expected_summary
-                )));
+                );
             }
         }
 

--- a/pageserver/src/tenant/storage_layer/layer.rs
+++ b/pageserver/src/tenant/storage_layer/layer.rs
@@ -1650,14 +1650,6 @@ impl Drop for DownloadedLayer {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum LoadError {
-    #[error(transparent)]
-    Io(anyhow::Error),
-    #[error(transparent)]
-    Corruption(anyhow::Error),
-}
-
 impl DownloadedLayer {
     /// Initializes the `DeltaLayerInner` or `ImageLayerInner` within [`LayerKind`], or fails to
     /// initialize it permanently.
@@ -1669,7 +1661,7 @@ impl DownloadedLayer {
         &'a self,
         owner: &Arc<LayerInner>,
         ctx: &RequestContext,
-    ) -> Result<&'a LayerKind, LoadError> {
+    ) -> anyhow::Result<&'a LayerKind> {
         let init = || async {
             assert_eq!(
                 Weak::as_ptr(&self.owner),
@@ -1758,7 +1750,6 @@ impl DownloadedLayer {
         match self
             .get(owner, ctx)
             .await
-            .context("get layer") /* TODO avoid this */
             .map_err(GetVectoredError::Other)?
         {
             Delta(d) => {

--- a/test_runner/regress/test_broken_timeline.py
+++ b/test_runner/regress/test_broken_timeline.py
@@ -32,7 +32,7 @@ def test_local_corruption(neon_env_builder: NeonEnvBuilder):
             ".*will not become active. Current state: Broken.*",
             ".*failed to load metadata.*",
             ".*load failed.*load local timeline.*",
-            ".*layer loading failed permanently: load layer: .*",
+            ".*: layer load failed, assuming permanent failure:.*",
         ]
     )
 


### PR DESCRIPTION
I am not aware of a case of "transient" VirtualFile errors as mentioned in https://github.com/neondatabase/neon/pull/5880

Private DM with Joonas discussing this: https://neondb.slack.com/archives/D049K7HJ9JM/p1721836424615799