### PR TITLE
proxy: improve performance of leaky-bucket

### DIFF
--- a/proxy/src/rate_limiter.rs
+++ b/proxy/src/rate_limiter.rs
@@ -5,6 +5,4 @@ pub use limit_algorithm::{
 };
 pub use limiter::{BucketRateLimiter, GlobalRateLimiter, RateBucketInfo, WakeComputeRateLimiter};
 mod leaky_bucket;
-pub use leaky_bucket::{
-    EndpointRateLimiter, LeakyBucketConfig, LeakyBucketRateLimiter, LeakyBucketState,
-};
+pub use leaky_bucket::{EndpointRateLimiter, LeakyBucketConfig, LeakyBucketRateLimiter};

--- a/proxy/src/rate_limiter/leaky_bucket.rs
+++ b/proxy/src/rate_limiter/leaky_bucket.rs
@@ -86,7 +86,7 @@ struct LeakyBucketConfigInner {
 
 impl From<LeakyBucketConfig> for LeakyBucketConfigInner {
     fn from(config: LeakyBucketConfig) -> Self {
-        // seconds-per-request = 1/(request-per-second)
+        // seconds_per_request = 1/(request_per_second)
         let spr = config.rps.recip();
         Self {
             time_cost: Duration::from_secs_f64(spr),
@@ -98,7 +98,7 @@ impl From<LeakyBucketConfig> for LeakyBucketConfigInner {
 struct LeakyBucketState {
     /// Bucket is represented by `start..end` where `start = end - config.bucket_width`.
     ///
-    /// At any given time, `end-now` represents the number of tokens in the bucket, multiplied by the "time_cost".
+    /// At any given time, `end - now` represents the number of tokens in the bucket, multiplied by the "time_cost".
     /// Adding `n` tokens to the bucket is done by moving `end` forward by `n * config.time_cost`.
     /// If `now < start`, the bucket is considered filled and cannot accept any more tokens.
     /// Draining the bucket will happen naturally as `now` moves forward.


### PR DESCRIPTION
## Problem

I discovered the GCRA this weekend, and I thought about my leaky-bucket impl.

## Summary of changes

Slightly improve the design of my leaky-bucket to be closer to GCRA. It's all functionally equivalent, but slightly more performant than before (maybe 2x from 600ns to 300ns).

I wanted to try and make the impl use an AtomicU64 instead of Instant, but the atomic impl had worse tail-latencies and no better average latencies, so I kept the mutex-based impl.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
