### PR TITLE
pageserver: shutdown all walredo managers 8s into shutdown

### DIFF
--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -139,7 +139,7 @@ pub async fn shutdown_pageserver(
             info!(count=%futs.len(), "built FuturesUnordered");
             let mut last_log_at = std::time::Instant::now();
             while let Some(()) = rt.block_on(futs.next()) {
-                if last_log_at.elapsed() > Duration::from_secs(1) {
+                if last_log_at.elapsed() > Duration::from_millis(100) {
                     info!(remaining=%futs.len(), "progress");
                     last_log_at = std::time::Instant::now();
                 }

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -112,6 +112,7 @@ pub async fn shutdown_pageserver(
                 .enable_all()
                 .build()
                 .unwrap();
+            let _entered = rt.enter();
             let _entered = walredo_extraordinary_shutdown_thread_span.enter();
             if let Ok(()) = rt.block_on(tokio::time::timeout(
                 Duration::from_secs(8),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -354,7 +354,7 @@ impl Drop for WalRedoManager {
     }
 }
 
-/// Global registro of all walredo managers so that [`crate::shutdown_pageserver`] can shut down
+/// Global registry of all walredo managers so that [`crate::shutdown_pageserver`] can shut down
 /// the walredo processes outside of the regular order.
 ///
 /// This is necessary to work around a systemd bug where it freezes if there are

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -384,12 +384,13 @@ impl From<harness::TestRedoManager> for WalRedoManager {
 }
 
 impl WalRedoManager {
-    pub(crate) async fn shutdown(&self) {
+    pub(crate) async fn shutdown(&self) -> bool {
         match self {
             Self::Prod(_, mgr) => mgr.shutdown().await,
             #[cfg(test)]
             Self::Test(_) => {
                 // Not applicable to test redo manager
+                true
             }
         }
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -76,6 +76,7 @@ use crate::{
         metadata::TimelineMetadata,
         storage_layer::PersistentLayerDesc,
     },
+    walredo,
 };
 use crate::{
     context::{DownloadBehavior, RequestContext},
@@ -1000,7 +1001,10 @@ impl Timeline {
             .for_get_kind(GetKind::Singular)
             .observe(elapsed.as_secs_f64());
 
-        if cfg!(feature = "testing") && res.is_err() {
+        if cfg!(feature = "testing")
+            && res.is_err()
+            && !matches!(res, Err(PageReconstructError::Cancelled))
+        {
             // it can only be walredo issue
             use std::fmt::Write;
 
@@ -5466,20 +5470,22 @@ impl Timeline {
                 } else {
                     trace!("found {} WAL records that will init the page for {} at {}, performing WAL redo", data.records.len(), key, request_lsn);
                 };
-
-                let img = match self
+                let res = self
                     .walredo_mgr
                     .as_ref()
                     .context("timeline has no walredo manager")
                     .map_err(PageReconstructError::WalRedo)?
                     .request_redo(key, request_lsn, data.img, data.records, self.pg_version)
-                    .await
-                    .context("reconstruct a page image")
-                {
+                    .await;
+                let img = match res {
                     Ok(img) => img,
-                    Err(e) => return Err(PageReconstructError::WalRedo(e)),
+                    Err(walredo::Error::Cancelled) => return Err(PageReconstructError::Cancelled),
+                    Err(walredo::Error::Other(e)) => {
+                        return Err(PageReconstructError::WalRedo(
+                            e.context("reconstruct a page image"),
+                        ))
+                    }
                 };
-
                 Ok(img)
             }
         }


### PR DESCRIPTION
# Motivation

The working theory for hung systemd during PS deploy (https://github.com/neondatabase/cloud/issues/11387) is that leftover walredo processes trigger a race condition.

In https://github.com/neondatabase/neon/pull/8150 I arranged that a clean Tenant shutdown does actually kill its walredo processes.

But many prod machines don't manage to shut down all their tenants until the 10s systemd timeout hits and, presumably, triggers the race condition in systemd / the Linux kernel that causes the frozen systemd

# Solution

This PR bolts on a rather ugly mechanism to shut down tenant managers out of order 8s after we've received the SIGTERM from systemd.

# Changes

- add a global registry of `Weak<WalRedoManager>`
- add a special thread spawned during `shutdown_pageserver` that sleeps for 8s, then shuts down all redo managers in the registry and prevents new redo managers from being created
- propagate the new failure mode of tenant spawning throughout the code base
- make sure shut down tenant manager results in PageReconstructError::Cancelled so that if Timeline::get calls come in after the shutdown, they do the right thing

