### PR TITLE
create test-tools image with added packages postgres-client and postgres based on build-tools

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -187,7 +187,7 @@ runs:
           fi
 
           for q in "${QUERIES[@]}"; do
-            ${POSTGRES_DISTRIB_DIR}/v${DEFAULT_PG_VERSION}/bin/psql ${BENCHMARK_CONNSTR} -c "${q}"
+            psql ${BENCHMARK_CONNSTR} -c "${q}"
           done
         fi
 

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -452,7 +452,7 @@ jobs:
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
+      image: neondatabase/test-tools:cfad3e1e4ca5865e09d807830a68c63a513904cbe79376e6d6cfd69c1a1b26fb
       options: --init
 
     steps:

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -78,7 +78,7 @@ jobs:
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
+      image: neondatabase/test-tools:cfad3e1e4ca5865e09d807830a68c63a513904cbe79376e6d6cfd69c1a1b26fb
       options: --init
 
     steps:
@@ -155,7 +155,7 @@ jobs:
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
+      image: neondatabase/test-tools:cfad3e1e4ca5865e09d807830a68c63a513904cbe79376e6d6cfd69c1a1b26fb
       options: --init
 
     steps:
@@ -316,7 +316,7 @@ jobs:
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
+      image: neondatabase/test-tools:cfad3e1e4ca5865e09d807830a68c63a513904cbe79376e6d6cfd69c1a1b26fb
       options: --init
 
     # Increase timeout to 8h, default timeout is 6h
@@ -458,24 +458,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # until https://github.com/neondatabase/neon/issues/8275 is fixed we temporarily install postgresql-16
-    # instead of using Neon artifacts containing pgbench
-    - name: Install postgresql-16 where pytest expects it
-      run: |
-        cd /home/nonroot
-        wget -q https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/libpq5_16.3-1.pgdg110%2B1_amd64.deb
-        wget -q https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-client-16_16.3-1.pgdg110%2B1_amd64.deb
-        wget -q https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-16_16.3-1.pgdg110%2B1_amd64.deb 
-        dpkg -x libpq5_16.3-1.pgdg110+1_amd64.deb pg
-        dpkg -x postgresql-client-16_16.3-1.pgdg110+1_amd64.deb pg
-        dpkg -x postgresql-16_16.3-1.pgdg110+1_amd64.deb pg
-        mkdir -p /tmp/neon/pg_install/v16/bin
-        ln -s /home/nonroot/pg/usr/lib/postgresql/16/bin/pgbench /tmp/neon/pg_install/v16/bin/pgbench  
-        ln -s /home/nonroot/pg/usr/lib/postgresql/16/bin/psql /tmp/neon/pg_install/v16/bin/psql  
-        ln -s /home/nonroot/pg/usr/lib/x86_64-linux-gnu /tmp/neon/pg_install/v16/lib 
-        /tmp/neon/pg_install/v16/bin/pgbench --version
-        /tmp/neon/pg_install/v16/bin/psql --version
-
     - name: Set up Connection String
       id: set-up-connstr
       run: |
@@ -562,7 +544,7 @@ jobs:
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
+      image: neondatabase/test-tools:cfad3e1e4ca5865e09d807830a68c63a513904cbe79376e6d6cfd69c1a1b26fb
       options: --init
 
     steps:
@@ -650,7 +632,7 @@ jobs:
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
+      image: neondatabase/test-tools:cfad3e1e4ca5865e09d807830a68c63a513904cbe79376e6d6cfd69c1a1b26fb
       options: --init
 
     steps:
@@ -736,7 +718,7 @@ jobs:
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
-      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
+      image: neondatabase/test-tools:cfad3e1e4ca5865e09d807830a68c63a513904cbe79376e6d6cfd69c1a1b26fb
       options: --init
 
     steps:

--- a/.github/workflows/build-build-tools-image.yml
+++ b/.github/workflows/build-build-tools-image.yml
@@ -99,7 +99,7 @@ jobs:
           cache-from: type=registry,ref=cache.neon.build/test-tools:cache-${{ matrix.arch }}
           cache-to: ${{ github.ref_name == 'main' && format('type=registry,ref=cache.neon.build/test-tools:cache-{0},mode=max', matrix.arch) || '' }}
           build-args: |
-            BUILD_TOOLS_BASE_IMAGE=neondatabase/build-tools:${{ github.sha }}-${{ matrix.arch }}
+            BUILD_TOOLS_BASE_IMAGE=neondatabase/build-tools:${{ inputs.image-tag }}-${{ matrix.arch }}
           tags: neondatabase/test-tools:${{ inputs.image-tag }}-${{ matrix.arch }}    
 
       - name: Remove custom docker config directory

--- a/.github/workflows/build-build-tools-image.yml
+++ b/.github/workflows/build-build-tools-image.yml
@@ -129,6 +129,3 @@ jobs:
           docker buildx imagetools create -t neondatabase/${{ matrix.tool }}:${IMAGE_TAG} \
                                              neondatabase/${{ matrix.tool }}:${IMAGE_TAG}-x64 \
                                              neondatabase/${{ matrix.tool }}:${IMAGE_TAG}-arm64                                           
-                                          
-
-          

--- a/.github/workflows/build-build-tools-image.yml
+++ b/.github/workflows/build-build-tools-image.yml
@@ -124,7 +124,7 @@ jobs:
           username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
-      - name: Create multi-arch tool image
+      - name: Create multi-arch ${{ matrix.tool }} image
         run: |
           docker buildx imagetools create -t neondatabase/${{ matrix.tool }}:${IMAGE_TAG} \
                                              neondatabase/${{ matrix.tool }}:${IMAGE_TAG}-x64 \

--- a/.github/workflows/build-build-tools-image.yml
+++ b/.github/workflows/build-build-tools-image.yml
@@ -89,6 +89,19 @@ jobs:
           cache-to: ${{ github.ref_name == 'main' && format('type=registry,ref=cache.neon.build/build-tools:cache-{0},mode=max', matrix.arch) || '' }}
           tags: neondatabase/build-tools:${{ inputs.image-tag }}-${{ matrix.arch }}
 
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          provenance: false
+          push: true
+          pull: true
+          file: Dockerfile.test-tools
+          cache-from: type=registry,ref=cache.neon.build/test-tools:cache-${{ matrix.arch }}
+          cache-to: ${{ github.ref_name == 'main' && format('type=registry,ref=cache.neon.build/test-tools:cache-{0},mode=max', matrix.arch) || '' }}
+          build-args: |
+            BUILD_TOOLS_BASE_IMAGE=neondatabase/build-tools:${{ github.sha }}-${{ matrix.arch }}
+          tags: neondatabase/test-tools:${{ inputs.image-tag }}-${{ matrix.arch }}    
+
       - name: Remove custom docker config directory
         if: always()
         run: |
@@ -97,6 +110,10 @@ jobs:
   merge-images:
     needs: [ build-image ]
     runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        tool: [ build-tools, test-tools ]
 
     env:
       IMAGE_TAG: ${{ inputs.image-tag }}
@@ -107,8 +124,11 @@ jobs:
           username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
-      - name: Create multi-arch image
+      - name: Create multi-arch tool image
         run: |
-          docker buildx imagetools create -t neondatabase/build-tools:${IMAGE_TAG} \
-                                             neondatabase/build-tools:${IMAGE_TAG}-x64 \
-                                             neondatabase/build-tools:${IMAGE_TAG}-arm64
+          docker buildx imagetools create -t neondatabase/${{ matrix.tool }}:${IMAGE_TAG} \
+                                             neondatabase/${{ matrix.tool }}:${IMAGE_TAG}-x64 \
+                                             neondatabase/${{ matrix.tool }}:${IMAGE_TAG}-arm64                                           
+                                          
+
+          

--- a/Dockerfile.build-tools
+++ b/Dockerfile.build-tools
@@ -124,18 +124,6 @@ RUN for package in Capture::Tiny DateTime Devel::Cover Digest::MD5 File::Spec JS
     && make install \
     && rm -rf ../lcov.tar.gz
 
-# postgresql (depends on  curl)
-# needed in some tests because neon artifacts cannot be used 
-# in combination with staticaclly built openssl
-# due to https://github.com/neondatabase/neon/issues/8275
-ENV PG_VERSION=16
-RUN set -e \
-    && curl -fsSL 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | apt-key add - \
-    && echo 'deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
-    && apt update \
-    && apt install -y postgresql-client-${PG_VERSION} postgresql-${PG_VERSION} \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 # Compile and install the static OpenSSL library
 ENV OPENSSL_VERSION=1.1.1w
 ENV OPENSSL_PREFIX=/usr/local/openssl

--- a/Dockerfile.build-tools
+++ b/Dockerfile.build-tools
@@ -124,16 +124,16 @@ RUN for package in Capture::Tiny DateTime Devel::Cover Digest::MD5 File::Spec JS
     && make install \
     && rm -rf ../lcov.tar.gz
 
-# postgresql-client (depends on  curl)
-# needed in some tests because neon artifcacts cannot be used 
+# postgresql (depends on  curl)
+# needed in some tests because neon artifacts cannot be used 
 # in combination with staticaclly built openssl
 # due to https://github.com/neondatabase/neon/issues/8275
-ENV PGCLIENT_VERSION=16
+ENV PG_VERSION=16
 RUN set -e \
     && curl -fsSL 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | apt-key add - \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt update \
-    && apt install -y postgresql-client-${PGCLIENT_VERSION} postgresql-contrib-${PGCLIENT_VERSION} \
+    && apt install -y postgresql-client-${PG_VERSION} postgresql-${PG_VERSION} \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Compile and install the static OpenSSL library

--- a/Dockerfile.build-tools
+++ b/Dockerfile.build-tools
@@ -133,7 +133,7 @@ RUN set -e \
     && curl -fsSL 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | apt-key add - \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt update \
-    && apt install -y postgresql-client-${PGCLIENT_VERSION} postgresql-contrib-${PGCLIENT_VERSION}\
+    && apt install -y postgresql-client-${PGCLIENT_VERSION} postgresql-contrib-${PGCLIENT_VERSION} \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Compile and install the static OpenSSL library

--- a/Dockerfile.build-tools
+++ b/Dockerfile.build-tools
@@ -124,6 +124,18 @@ RUN for package in Capture::Tiny DateTime Devel::Cover Digest::MD5 File::Spec JS
     && make install \
     && rm -rf ../lcov.tar.gz
 
+# postgresql-client (depends on  curl)
+# needed in some tests because neon artifcacts cannot be used 
+# in combination with staticaclly built openssl
+# due to https://github.com/neondatabase/neon/issues/8275
+ENV PGCLIENT_VERSION=16
+RUN set -e \
+    && curl -fsSL 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | apt-key add - \
+    && echo 'deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+    && apt update \
+    && apt install -y postgresql-client-${PGCLIENT_VERSION} \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Compile and install the static OpenSSL library
 ENV OPENSSL_VERSION=1.1.1w
 ENV OPENSSL_PREFIX=/usr/local/openssl

--- a/Dockerfile.build-tools
+++ b/Dockerfile.build-tools
@@ -133,7 +133,7 @@ RUN set -e \
     && curl -fsSL 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | apt-key add - \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt update \
-    && apt install -y postgresql-client-${PGCLIENT_VERSION} \
+    && apt install -y postgresql-client-${PGCLIENT_VERSION} postgresql-contrib-${PGCLIENT_VERSION}\
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Compile and install the static OpenSSL library

--- a/Dockerfile.test-tools
+++ b/Dockerfile.test-tools
@@ -15,7 +15,7 @@ RUN set -e \
     && curl -fsSL 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | apt-key add - \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
     && apt update \
-    && apt install -y postgresql-client-${PG_VERSION} postgresql-${PG_VERSION} \
+    && apt install -y postgresql-${PG_VERSION} \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Switch back to nonroot user

--- a/Dockerfile.test-tools
+++ b/Dockerfile.test-tools
@@ -1,0 +1,24 @@
+# based on build-tools but adds postgresql-client and postgresql packages
+ARG BUILD_TOOLS_BASE_IMAGE
+
+FROM ${BUILD_TOOLS_BASE_IMAGE}
+
+# Switch to root user
+USER root
+
+# postgresql (depends on  curl)
+# needed in some tests because neon artifacts cannot be used 
+# in combination with staticaclly built openssl
+# due to https://github.com/neondatabase/neon/issues/8275
+ENV PG_VERSION=16
+RUN set -e \
+    && curl -fsSL 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | apt-key add - \
+    && echo 'deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+    && apt update \
+    && apt install -y postgresql-client-${PG_VERSION} postgresql-${PG_VERSION} \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Switch back to nonroot user
+USER nonroot:nonroot
+WORKDIR /home/nonroot
+

--- a/Dockerfile.test-tools
+++ b/Dockerfile.test-tools
@@ -1,4 +1,5 @@
-# based on build-tools but adds postgresql-client and postgresql packages
+# based on build-tools but adds additional components only needed for testing but not for build
+# for example: postgresql package
 ARG BUILD_TOOLS_BASE_IMAGE
 
 FROM ${BUILD_TOOLS_BASE_IMAGE}
@@ -10,7 +11,7 @@ USER root
 # needed in some tests because neon artifacts cannot be used 
 # in combination with staticaclly built openssl
 # due to https://github.com/neondatabase/neon/issues/8275
-ENV PG_VERSION=16
+ARG PG_VERSION=16
 RUN set -e \
     && curl -fsSL 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' | apt-key add - \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \


### PR DESCRIPTION
# On hold

neon test fixtures rely on postgres binaries in neon/pg_install/<version>/bin directory.
For this reason we put this change on hold and will try another approach:
Build pgbench (which is multithreaded) with dynamically linked openssl because it is probably the only postgres binary on the client side that is multi-threaded and statically linked openssl does not support multithreading.

## Problem

Some github test workflows running in build-tools container need postgresql-client (psql, pgbench).

Neon artifcacts cannot be used 
in combination with staticaclly built openssl
due to https://github.com/neondatabase/neon/issues/8275

## Summary of changes

Create a new test-tools container.
Add vanilla postgresql (including postgresql-client) to test-tools

## Log that it works

```bash
docker run -it --rm  neondatabase/test-tools:cfad3e1e4ca5865e09d807830a68c63a513904cbe79376e6d6cfd69c1a1b26fb-arm64
nonroot@7f5eefee03d9:~$ psql --version
psql (PostgreSQL) 16.3 (Debian 16.3-1.pgdg110+1)
nonroot@7f5eefee03d9:~$ pgbench --version
pgbench (PostgreSQL) 16.3 (Debian 16.3-1.pgdg110+1)
nonroot@7f5eefee03d9:~$ whoami
nonroot
```
