### PR TITLE
feat(pageserver): support split delta layers

### DIFF
--- a/pageserver/src/tenant/storage_layer/split_writer.rs
+++ b/pageserver/src/tenant/storage_layer/split_writer.rs
@@ -157,9 +157,8 @@ impl SplitDeltaLayerWriter {
         tline: &Arc<Timeline>,
         ctx: &RequestContext,
     ) -> anyhow::Result<()> {
-        // The current estimation is an upper bound of the space that the key/image could take
-        // because we did not consider compression in this estimation. The resulting image layer
-        // could be smaller than the target size.
+        // The current estimation is key size plus LSN size plus value size estimation. This is not an accurate
+        // number, and therefore the final layer size could be a little bit larger or smaller than the target.
         let addition_size_estimation = KEY_SIZE as u64 + 8 /* LSN u64 size */ + 80 /* value size estimation */;
         if self.inner.num_keys() >= 1
             && self.inner.estimated_size() + addition_size_estimation >= self.target_layer_size

--- a/pageserver/src/tenant/storage_layer/split_writer.rs
+++ b/pageserver/src/tenant/storage_layer/split_writer.rs
@@ -100,6 +100,7 @@ impl SplitImageLayerWriter {
     }
 
     /// When split writer fails, the caller should call this function and handle partially generated layers.
+    #[allow(dead_code)]
     pub(crate) async fn take(self) -> anyhow::Result<(Vec<ResidentLayer>, ImageLayerWriter)> {
         Ok((self.generated_layers, self.inner))
     }
@@ -195,6 +196,7 @@ impl SplitDeltaLayerWriter {
     }
 
     /// When split writer fails, the caller should call this function and handle partially generated layers.
+    #[allow(dead_code)]
     pub(crate) async fn take(self) -> anyhow::Result<(Vec<ResidentLayer>, DeltaLayerWriter)> {
         Ok((self.generated_layers, self.inner))
     }


### PR DESCRIPTION
## Problem

part of https://github.com/neondatabase/neon/issues/8002

## Summary of changes

Similar to https://github.com/neondatabase/neon/pull/8574, we add auto-split support for delta layers. Tests are reused from image layer split writers.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
