### PR TITLE
Add package-mode=false to poetry.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [tool.poetry]
-name = "neon"
-version = "0.1.0"
 description = ""
 authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
We don't use it for packaging, and 'poetry install' will soon error otherwise.
