### PR TITLE
fix: drain completed page_service connections

### DIFF
--- a/test_runner/regress/test_bad_connection.py
+++ b/test_runner/regress/test_bad_connection.py
@@ -11,7 +11,7 @@ from fixtures.neon_fixtures import NeonEnvBuilder
 def test_compute_pageserver_connection_stress(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_start()
     # FIXME currently all errors are logged uniformly
-    # env.pageserver.allowed_errors.append(".*simulated connection error.*") # this is never hit
+    env.pageserver.allowed_errors.append(".*simulated connection error.*") # this is never hit
 
     # the real reason (Simulated Connection Error) is on the next line, and we cannot filter this out.
     env.pageserver.allowed_errors.append(

--- a/test_runner/regress/test_bad_connection.py
+++ b/test_runner/regress/test_bad_connection.py
@@ -10,7 +10,6 @@ from fixtures.neon_fixtures import NeonEnvBuilder
 @pytest.mark.timeout(600)
 def test_compute_pageserver_connection_stress(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_start()
-    # FIXME currently all errors are logged uniformly
     env.pageserver.allowed_errors.append(".*simulated connection error.*") # this is never hit
 
     # the real reason (Simulated Connection Error) is on the next line, and we cannot filter this out.

--- a/test_runner/regress/test_bad_connection.py
+++ b/test_runner/regress/test_bad_connection.py
@@ -14,7 +14,9 @@ def test_compute_pageserver_connection_stress(neon_env_builder: NeonEnvBuilder):
     # env.pageserver.allowed_errors.append(".*simulated connection error.*") # this is never hit
 
     # the real reason (Simulated Connection Error) is on the next line, and we cannot filter this out.
-    env.pageserver.allowed_errors.append(".*ERROR error in page_service connection task: Postgres query error")
+    env.pageserver.allowed_errors.append(
+        ".*ERROR error in page_service connection task: Postgres query error"
+    )
 
     # Enable failpoint before starting everything else up so that we exercise the retry
     # on fetching basebackup

--- a/test_runner/regress/test_bad_connection.py
+++ b/test_runner/regress/test_bad_connection.py
@@ -10,7 +10,7 @@ from fixtures.neon_fixtures import NeonEnvBuilder
 @pytest.mark.timeout(600)
 def test_compute_pageserver_connection_stress(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_start()
-    env.pageserver.allowed_errors.append(".*simulated connection error.*") # this is never hit
+    env.pageserver.allowed_errors.append(".*simulated connection error.*")  # this is never hit
 
     # the real reason (Simulated Connection Error) is on the next line, and we cannot filter this out.
     env.pageserver.allowed_errors.append(


### PR DESCRIPTION
We've noticed increased memory usage with the latest release. Drain the joinset of `page_service` connection handlers to avoid leaking them until shutdown. An alternative would be to use a TaskTracker. TaskTracker was not discussed in original PR #8339 review, so not hot fixing it in here either.

