### PR TITLE
fix(pageserver): use default io-engine from conf to resolve clippy warnings

### DIFF
--- a/pageserver/benches/bench_ingest.rs
+++ b/pageserver/benches/bench_ingest.rs
@@ -11,7 +11,7 @@ use pageserver::{
     repository::Value,
     task_mgr::TaskKind,
     tenant::storage_layer::InMemoryLayer,
-    virtual_file::{self, api::IoEngineKind},
+    virtual_file,
 };
 use pageserver_api::{key::Key, shard::TenantShardId};
 use utils::{
@@ -149,7 +149,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let conf: &'static PageServerConf = Box::leak(Box::new(
         pageserver::config::PageServerConf::dummy_conf(temp_dir.path().to_path_buf()),
     ));
-    virtual_file::init(16384, IoEngineKind::TokioEpollUring);
+    virtual_file::init(16384, conf.virtual_file_io_engine);
     page_cache::init(conf.page_cache_size);
 
     {


### PR DESCRIPTION
On non-linux platform (e.g MacOS), clippy will fail for `bench_ingest`:

```
error[E0599]: no variant or associated item named `TokioEpollUring` found for enum `pageserver::virtual_file::api::IoEngineKind` in the current scope
   --> pageserver/benches/bench_ingest.rs:152:45
    |
152 |     virtual_file::init(16384, IoEngineKind::TokioEpollUring);
    |                                             ^^^^^^^^^^^^^^^ variant or associated item not found in `IoEngineKind`
```

This PR fixes this by using the io-engine from pagerserver config, which will be still use `tokio-epoll-uring` on linux target as desired.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
