### PR TITLE
fix(neon): disable create tablespace stmt

### DIFF
--- a/pgxn/neon/control_plane_connector.c
+++ b/pgxn/neon/control_plane_connector.c
@@ -807,7 +807,7 @@ NeonProcessUtility(
 			if (!RegressTestMode)
 			{
 				ereport(ERROR,
-					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					errmsg("CREATE TABLESPACE statements are not supported by Neon.")));
 			}
    			break;

--- a/pgxn/neon/control_plane_connector.c
+++ b/pgxn/neon/control_plane_connector.c
@@ -808,7 +808,7 @@ NeonProcessUtility(
 			{
 				ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("CREATE TABLESPACE statements are not supported by Neon.")));
+					errmsg("CREATE TABLESPACE is not supported on Neon")));
 			}
    			break;
 		default:

--- a/pgxn/neon/control_plane_connector.c
+++ b/pgxn/neon/control_plane_connector.c
@@ -802,6 +802,11 @@ NeonProcessUtility(
 		case T_DropRoleStmt:
 			HandleDropRole(castNode(DropRoleStmt, parseTree));
 			break;
+		case T_CreateTableSpaceStmt:
+   			ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+                 errmsg("CREATE TABLESPACE statements are not supported by Neon.")));
+   			break;
 		default:
 			break;
 	}

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -152,7 +152,7 @@ def test_pg_regress(
     (runpath / "testtablespace").mkdir(parents=True)
 
     # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql("SET neon.regress_test_mode = true", dbname=DBNAME)
+    endpoint.safe_psql("SET neon.regress_test_mode = true", database=DBNAME)
 
     # Compute all the file locations that pg_regress will need.
     build_path = pg_distrib_dir / f"build/{env.pg_version.v_prefixed}/src/test/regress"
@@ -218,7 +218,7 @@ def test_isolation(
     (runpath / "testtablespace").mkdir(parents=True)
 
     # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql("SET neon.regress_test_mode = true", dbname=DBNAME)
+    endpoint.safe_psql("SET neon.regress_test_mode = true", database=DBNAME)
 
     # Compute all the file locations that pg_isolation_regress will need.
     build_path = pg_distrib_dir / f"build/{env.pg_version.v_prefixed}/src/test/isolation"
@@ -282,7 +282,7 @@ def test_sql_regress(
     (runpath / "testtablespace").mkdir(parents=True)
 
     # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql("SET neon.regress_test_mode = true", dbname=DBNAME)
+    endpoint.safe_psql("SET neon.regress_test_mode = true", database=DBNAME)
 
     # Compute all the file locations that pg_regress will need.
     # This test runs neon specific tests

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -151,6 +151,9 @@ def test_pg_regress(
     runpath = test_output_dir / "regress"
     (runpath / "testtablespace").mkdir(parents=True)
 
+    # Enable the test mode, so that we don't need to patch the test cases.
+    endpoint.safe_psql(f"SET neon.regress_test_mode = true")
+
     # Compute all the file locations that pg_regress will need.
     build_path = pg_distrib_dir / f"build/{env.pg_version.v_prefixed}/src/test/regress"
     src_path = base_dir / f"vendor/postgres-{env.pg_version.v_prefixed}/src/test/regress"
@@ -213,6 +216,9 @@ def test_isolation(
     # Create some local directories for pg_isolation_regress to run in.
     runpath = test_output_dir / "regress"
     (runpath / "testtablespace").mkdir(parents=True)
+
+    # Enable the test mode, so that we don't need to patch the test cases.
+    endpoint.safe_psql(f"SET neon.regress_test_mode = true")
 
     # Compute all the file locations that pg_isolation_regress will need.
     build_path = pg_distrib_dir / f"build/{env.pg_version.v_prefixed}/src/test/isolation"

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -152,7 +152,7 @@ def test_pg_regress(
     (runpath / "testtablespace").mkdir(parents=True)
 
     # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql(f"SET neon.regress_test_mode = true")
+    endpoint.safe_psql("SET neon.regress_test_mode = true", dbname=DBNAME)
 
     # Compute all the file locations that pg_regress will need.
     build_path = pg_distrib_dir / f"build/{env.pg_version.v_prefixed}/src/test/regress"
@@ -218,7 +218,7 @@ def test_isolation(
     (runpath / "testtablespace").mkdir(parents=True)
 
     # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql(f"SET neon.regress_test_mode = true")
+    endpoint.safe_psql("SET neon.regress_test_mode = true", dbname=DBNAME)
 
     # Compute all the file locations that pg_isolation_regress will need.
     build_path = pg_distrib_dir / f"build/{env.pg_version.v_prefixed}/src/test/isolation"
@@ -282,7 +282,7 @@ def test_sql_regress(
     (runpath / "testtablespace").mkdir(parents=True)
 
     # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql(f"SET neon.regress_test_mode = true")
+    endpoint.safe_psql("SET neon.regress_test_mode = true", dbname=DBNAME)
 
     # Compute all the file locations that pg_regress will need.
     # This test runs neon specific tests

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -275,6 +275,9 @@ def test_sql_regress(
     runpath = test_output_dir / "regress"
     (runpath / "testtablespace").mkdir(parents=True)
 
+    # Enable the test mode, so that we don't need to patch the test cases.
+    endpoint.safe_psql(f"SET neon.regress_test_mode = true")
+
     # Compute all the file locations that pg_regress will need.
     # This test runs neon specific tests
     build_path = pg_distrib_dir / f"build/v{env.pg_version}/src/test/regress"

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -144,15 +144,18 @@ def test_pg_regress(
     )
 
     # Connect to postgres and create a database called "regression".
-    endpoint = env.endpoints.create_start("main")
+    endpoint = env.endpoints.create_start(
+        "main",
+        config_lines=[
+            # Enable the test mode, so that we don't need to patch the test cases.
+            "neon.regress_test_mode = true",
+        ],
+    )
     endpoint.safe_psql(f"CREATE DATABASE {DBNAME}")
 
     # Create some local directories for pg_regress to run in.
     runpath = test_output_dir / "regress"
     (runpath / "testtablespace").mkdir(parents=True)
-
-    # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql("SET neon.regress_test_mode = true", database=DBNAME)
 
     # Compute all the file locations that pg_regress will need.
     build_path = pg_distrib_dir / f"build/{env.pg_version.v_prefixed}/src/test/regress"
@@ -210,15 +213,19 @@ def test_isolation(
 
     # Connect to postgres and create a database called "regression".
     # isolation tests use prepared transactions, so enable them
-    endpoint = env.endpoints.create_start("main", config_lines=["max_prepared_transactions=100"])
+    endpoint = env.endpoints.create_start(
+        "main",
+        config_lines=[
+            "max_prepared_transactions=100",
+            # Enable the test mode, so that we don't need to patch the test cases.
+            "neon.regress_test_mode = true",
+        ],
+    )
     endpoint.safe_psql(f"CREATE DATABASE {DBNAME}")
 
     # Create some local directories for pg_isolation_regress to run in.
     runpath = test_output_dir / "regress"
     (runpath / "testtablespace").mkdir(parents=True)
-
-    # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql("SET neon.regress_test_mode = true", database=DBNAME)
 
     # Compute all the file locations that pg_isolation_regress will need.
     build_path = pg_distrib_dir / f"build/{env.pg_version.v_prefixed}/src/test/isolation"
@@ -274,15 +281,18 @@ def test_sql_regress(
     )
 
     # Connect to postgres and create a database called "regression".
-    endpoint = env.endpoints.create_start("main")
+    endpoint = env.endpoints.create_start(
+        "main",
+        config_lines=[
+            # Enable the test mode, so that we don't need to patch the test cases.
+            "neon.regress_test_mode = true",
+        ],
+    )
     endpoint.safe_psql(f"CREATE DATABASE {DBNAME}")
 
     # Create some local directories for pg_regress to run in.
     runpath = test_output_dir / "regress"
     (runpath / "testtablespace").mkdir(parents=True)
-
-    # Enable the test mode, so that we don't need to patch the test cases.
-    endpoint.safe_psql("SET neon.regress_test_mode = true", database=DBNAME)
 
     # Compute all the file locations that pg_regress will need.
     # This test runs neon specific tests


### PR DESCRIPTION
## Problem

part of https://github.com/neondatabase/neon/issues/8653

## Summary of changes

Disable create tablespace stmt. It turns out it requires much less effort to do the regress test mode flag than patching the test cases, and given that we might need to support tablespaces in the future, I decided to add a new flag `regress_test_mode` to change the behavior of create tablespace.

Tested manually that without setting regress_test_mode, create tablespace will be rejected.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
