### PR TITLE
Implement archival_config timeline endpoint in the storage controller

### DIFF
--- a/pageserver/client/src/mgmt_api.rs
+++ b/pageserver/client/src/mgmt_api.rs
@@ -419,6 +419,24 @@ impl Client {
         }
     }
 
+    pub async fn timeline_archival_config(
+        &self,
+        tenant_shard_id: TenantShardId,
+        timeline_id: TimelineId,
+        req: &TimelineArchivalConfigRequest,
+    ) -> Result<()> {
+        let uri = format!(
+            "{}/v1/tenant/{tenant_shard_id}/timeline/{timeline_id}/archival_config",
+            self.mgmt_api_endpoint
+        );
+
+        self.request(Method::POST, &uri, req)
+            .await?
+            .json()
+            .await
+            .map_err(Error::ReceiveBody)
+    }
+
     pub async fn timeline_detach_ancestor(
         &self,
         tenant_shard_id: TenantShardId,

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -345,11 +345,11 @@ async fn handle_tenant_timeline_archival_config(
 
     let create_req = json_request::<TimelineArchivalConfigRequest>(&mut req).await?;
 
-    let res = service
+    service
         .tenant_timeline_archival_config(tenant_id, timeline_id, create_req)
         .await?;
 
-    json_response(StatusCode::OK, res)
+    json_response(StatusCode::OK, ())
 }
 
 async fn handle_tenant_timeline_detach_ancestor(

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -16,7 +16,8 @@ use pageserver_api::controller_api::{
     TenantCreateRequest,
 };
 use pageserver_api::models::{
-    TenantConfigRequest, TenantLocationConfigRequest, TenantShardSplitRequest, TenantTimeTravelRequest, TimelineArchivalConfigRequest, TimelineCreateRequest
+    TenantConfigRequest, TenantLocationConfigRequest, TenantShardSplitRequest,
+    TenantTimeTravelRequest, TimelineArchivalConfigRequest, TimelineCreateRequest,
 };
 use pageserver_api::shard::TenantShardId;
 use pageserver_client::mgmt_api;

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -1179,7 +1179,7 @@ pub fn make_router(
             )
         })
         .post(
-            "/v1/tenant/:tenant_shard_id/timeline/:timeline_id/archival_config",
+            "/v1/tenant/:tenant_id/timeline/:timeline_id/archival_config",
             |r| {
                 tenant_service_handler(
                     r,

--- a/storage_controller/src/pageserver_client.rs
+++ b/storage_controller/src/pageserver_client.rs
@@ -1,9 +1,6 @@
 use pageserver_api::{
     models::{
-        detach_ancestor::AncestorDetached, LocationConfig, LocationConfigListResponse,
-        PageserverUtilization, SecondaryProgress, TenantScanRemoteStorageResponse,
-        TenantShardSplitRequest, TenantShardSplitResponse, TimelineCreateRequest, TimelineInfo,
-        TopTenantShardsRequest, TopTenantShardsResponse,
+        detach_ancestor::AncestorDetached, LocationConfig, LocationConfigListResponse, PageserverUtilization, SecondaryProgress, TenantScanRemoteStorageResponse, TenantShardSplitRequest, TenantShardSplitResponse, TimelineArchivalConfigRequest, TimelineCreateRequest, TimelineInfo, TopTenantShardsRequest, TopTenantShardsResponse
     },
     shard::TenantShardId,
 };
@@ -224,6 +221,22 @@ impl PageserverClient {
             crate::metrics::Method::Get,
             &self.node_id_label,
             self.inner.timeline_list(tenant_shard_id).await
+        )
+    }
+
+    pub(crate) async fn timeline_archival_config(
+        &self,
+        tenant_shard_id: TenantShardId,
+        timeline_id: TimelineId,
+        req: &TimelineArchivalConfigRequest,
+    ) -> Result<()> {
+        measured_request!(
+            "timeline_archival_config",
+            crate::metrics::Method::Post,
+            &self.node_id_label,
+            self.inner
+                .timeline_archival_config(tenant_shard_id, timeline_id, req)
+                .await
         )
     }
 

--- a/storage_controller/src/pageserver_client.rs
+++ b/storage_controller/src/pageserver_client.rs
@@ -1,6 +1,9 @@
 use pageserver_api::{
     models::{
-        detach_ancestor::AncestorDetached, LocationConfig, LocationConfigListResponse, PageserverUtilization, SecondaryProgress, TenantScanRemoteStorageResponse, TenantShardSplitRequest, TenantShardSplitResponse, TimelineArchivalConfigRequest, TimelineCreateRequest, TimelineInfo, TopTenantShardsRequest, TopTenantShardsResponse
+        detach_ancestor::AncestorDetached, LocationConfig, LocationConfigListResponse,
+        PageserverUtilization, SecondaryProgress, TenantScanRemoteStorageResponse,
+        TenantShardSplitRequest, TenantShardSplitResponse, TimelineArchivalConfigRequest,
+        TimelineCreateRequest, TimelineInfo, TopTenantShardsRequest, TopTenantShardsResponse,
     },
     shard::TenantShardId,
 };

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -2974,7 +2974,7 @@ impl Service {
             node: Node,
             jwt: Option<String>,
             req: TimelineArchivalConfigRequest,
-        ) -> Result<ShardNumber, ApiError> {
+        ) -> Result<(), ApiError> {
             tracing::info!(
                 "Setting archival config of timeline on shard {tenant_shard_id}/{timeline_id}, attached to node {node}",
             );
@@ -3000,7 +3000,6 @@ impl Service {
                         other => passthrough_api_error(&node, other),
                     }
                 })
-                .map(|_| tenant_shard_id.shard_number)
         }
 
         // no shard needs to go first/last; the operation should be idempotent

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -2955,8 +2955,8 @@ impl Service {
                 req: TimelineArchivalConfigRequest,
             ) -> Result<(), ApiError> {
                 tracing::info!(
-                "Setting archival config of timeline on shard {tenant_shard_id}/{timeline_id}, attached to node {node}",
-            );
+                    "Setting archival config of timeline on shard {tenant_shard_id}/{timeline_id}, attached to node {node}",
+                );
 
                 let client = PageserverClient::new(node.get_id(), node.base_url(), jwt.as_deref());
                 client

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -3016,7 +3016,7 @@ impl Service {
                 ))
             })
             .await?;
-        assert!(results.len() > 0, "must have at least one result");
+        assert!(!results.is_empty(), "must have at least one result");
 
         Ok(())
     }

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -2940,84 +2940,48 @@ impl Service {
         )
         .await;
 
-        self.ensure_attached_wait(tenant_id).await?;
-
-        let targets = {
-            let locked = self.inner.read().unwrap();
-            let mut targets = Vec::new();
-
-            for (tenant_shard_id, shard) in
-                locked.tenants.range(TenantShardId::tenant_range(tenant_id))
-            {
-                let node_id = shard.intent.get_attached().ok_or_else(|| {
-                    ApiError::InternalServerError(anyhow::anyhow!("Shard not scheduled"))
-                })?;
-                let node = locked
-                    .nodes
-                    .get(&node_id)
-                    .expect("Pageservers may not be deleted while referenced");
-
-                targets.push((*tenant_shard_id, node.clone()));
+        self.tenant_remote_mutation(tenant_id, move |targets| async move {
+            if targets.is_empty() {
+                return Err(ApiError::NotFound(
+                    anyhow::anyhow!("Tenant not found").into(),
+                ));
             }
-            targets
-        };
 
-        if targets.is_empty() {
-            return Err(ApiError::NotFound(
-                anyhow::anyhow!("Tenant not found").into(),
-            ));
-        }
-
-        async fn config_one(
-            tenant_shard_id: TenantShardId,
-            timeline_id: TimelineId,
-            node: Node,
-            jwt: Option<String>,
-            req: TimelineArchivalConfigRequest,
-        ) -> Result<(), ApiError> {
-            tracing::info!(
+            async fn config_one(
+                tenant_shard_id: TenantShardId,
+                timeline_id: TimelineId,
+                node: Node,
+                jwt: Option<String>,
+                req: TimelineArchivalConfigRequest,
+            ) -> Result<(), ApiError> {
+                tracing::info!(
                 "Setting archival config of timeline on shard {tenant_shard_id}/{timeline_id}, attached to node {node}",
             );
 
-            let client = PageserverClient::new(node.get_id(), node.base_url(), jwt.as_deref());
-            client
-                .timeline_archival_config(tenant_shard_id, timeline_id, &req)
-                .await
-                .map_err(|e| {
-                    use mgmt_api::Error;
+                let client = PageserverClient::new(node.get_id(), node.base_url(), jwt.as_deref());
+                client
+                    .timeline_archival_config(tenant_shard_id, timeline_id, &req)
+                    .await
+                    .map_err(|e| passthrough_api_error(&node, e))
+            }
 
-                    match e {
-                        // no ancestor (ever)
-                        Error::ApiError(StatusCode::CONFLICT, msg) => ApiError::Conflict(format!(
-                            "{node}: {}",
-                            msg.strip_prefix("Conflict: ").unwrap_or(&msg)
-                        )),
-                        // too many ancestors
-                        Error::ApiError(StatusCode::BAD_REQUEST, msg) => {
-                            ApiError::BadRequest(anyhow::anyhow!("{node}: {msg}"))
-                        }
-                        // rest can be mapped
-                        other => passthrough_api_error(&node, other),
-                    }
+            // no shard needs to go first/last; the operation should be idempotent
+            // TODO: it would be great to ensure that all shards return the same error
+            let results = self
+                .tenant_for_shards(targets, |tenant_shard_id, node| {
+                    futures::FutureExt::boxed(config_one(
+                        tenant_shard_id,
+                        timeline_id,
+                        node,
+                        self.config.jwt_token.clone(),
+                        req.clone(),
+                    ))
                 })
-        }
+                .await?;
+            assert!(!results.is_empty(), "must have at least one result");
 
-        // no shard needs to go first/last; the operation should be idempotent
-        // TODO: it would be great to ensure that all shards return the same error
-        let results = self
-            .tenant_for_shards(targets, |tenant_shard_id, node| {
-                futures::FutureExt::boxed(config_one(
-                    tenant_shard_id,
-                    timeline_id,
-                    node,
-                    self.config.jwt_token.clone(),
-                    req.clone(),
-                ))
-            })
-            .await?;
-        assert!(!results.is_empty(), "must have at least one result");
-
-        Ok(())
+            Ok(())
+        }).await?
     }
 
     pub(crate) async fn tenant_timeline_detach_ancestor(

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -32,13 +32,9 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
 
     # for a non existing tenant:
     invalid_tenant_id = TenantId.generate()
-    if unsharded:
-        not_found_pattern = f"NotFound: tenant {invalid_tenant_id}"
-    else:
-        not_found_pattern = "NotFound: Tenant not found"
     with pytest.raises(
         PageserverApiException,
-        match=not_found_pattern,
+        match="NotFound: [tT]enant",
     ) as exc:
         ps_http.timeline_archival_config(
             invalid_tenant_id,

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -23,8 +23,8 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
     invalid_timeline_id = TimelineId.generate()
     with pytest.raises(PageserverApiException, match="timeline not found") as exc:
         ps_http.timeline_archival_config(
-            tenant_id=env.initial_tenant,
-            timeline_id=invalid_timeline_id,
+            env.initial_tenant,
+            invalid_timeline_id,
             state=TimelineArchivalState.ARCHIVED,
         )
 
@@ -41,8 +41,8 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
         match=not_found_pattern,
     ) as exc:
         ps_http.timeline_archival_config(
-            tenant_id=invalid_tenant_id,
-            timeline_id=invalid_timeline_id,
+            invalid_tenant_id,
+            invalid_timeline_id,
             state=TimelineArchivalState.ARCHIVED,
         )
 
@@ -61,8 +61,8 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
         match="Cannot archive timeline which has non-archived child timelines",
     ) as exc:
         ps_http.timeline_archival_config(
-            tenant_id=env.initial_tenant,
-            timeline_id=parent_timeline_id,
+            env.initial_tenant,
+            parent_timeline_id,
             state=TimelineArchivalState.ARCHIVED,
         )
 
@@ -70,27 +70,27 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
 
     if shard_count != 0:
         leaf_detail = ps_http.timeline_detail(
-            tenant_id=env.initial_tenant,
+            env.initial_tenant,
             timeline_id=leaf_timeline_id,
         )
         assert leaf_detail["is_archived"] is False
 
     # Test that archiving the leaf timeline and then the parent works
     ps_http.timeline_archival_config(
-        tenant_id=env.initial_tenant,
-        timeline_id=leaf_timeline_id,
+        env.initial_tenant,
+        leaf_timeline_id,
         state=TimelineArchivalState.ARCHIVED,
     )
     if shard_count != 0:
         leaf_detail = ps_http.timeline_detail(
-            tenant_id=env.initial_tenant,
-            timeline_id=leaf_timeline_id,
+            env.initial_tenant,
+            leaf_timeline_id,
         )
         assert leaf_detail["is_archived"] is True
 
     ps_http.timeline_archival_config(
-        tenant_id=env.initial_tenant,
-        timeline_id=parent_timeline_id,
+        env.initial_tenant,
+        parent_timeline_id,
         state=TimelineArchivalState.ARCHIVED,
     )
 
@@ -100,20 +100,20 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
         match="ancestor is archived",
     ) as exc:
         ps_http.timeline_archival_config(
-            tenant_id=env.initial_tenant,
-            timeline_id=leaf_timeline_id,
+            env.initial_tenant,
+            leaf_timeline_id,
             state=TimelineArchivalState.UNARCHIVED,
         )
 
     # Unarchive works for the leaf if the parent gets unarchived first
     ps_http.timeline_archival_config(
-        tenant_id=env.initial_tenant,
-        timeline_id=parent_timeline_id,
+        env.initial_tenant,
+        parent_timeline_id,
         state=TimelineArchivalState.UNARCHIVED,
     )
 
     ps_http.timeline_archival_config(
-        tenant_id=env.initial_tenant,
-        timeline_id=leaf_timeline_id,
+        env.initial_tenant,
+        leaf_timeline_id,
         state=TimelineArchivalState.UNARCHIVED,
     )

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -68,7 +68,6 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
 
     assert exc.value.status_code == 412 if unsharded else 409
 
-    # Test timeline_detail
     if shard_count != 0:
         leaf_detail = ps_http.timeline_detail(
             tenant_id=env.initial_tenant,

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -68,12 +68,11 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
 
     assert exc.value.status_code == 412 if unsharded else 409
 
-    if shard_count != 0:
-        leaf_detail = ps_http.timeline_detail(
-            env.initial_tenant,
-            timeline_id=leaf_timeline_id,
-        )
-        assert leaf_detail["is_archived"] is False
+    leaf_detail = ps_http.timeline_detail(
+        env.initial_tenant,
+        timeline_id=leaf_timeline_id,
+    )
+    assert leaf_detail["is_archived"] is False
 
     # Test that archiving the leaf timeline and then the parent works
     ps_http.timeline_archival_config(
@@ -81,12 +80,11 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
         leaf_timeline_id,
         state=TimelineArchivalState.ARCHIVED,
     )
-    if shard_count != 0:
-        leaf_detail = ps_http.timeline_detail(
-            env.initial_tenant,
-            leaf_timeline_id,
-        )
-        assert leaf_detail["is_archived"] is True
+    leaf_detail = ps_http.timeline_detail(
+        env.initial_tenant,
+        leaf_timeline_id,
+    )
+    assert leaf_detail["is_archived"] is True
 
     ps_http.timeline_archival_config(
         env.initial_tenant,

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -1,24 +1,21 @@
 import pytest
 from fixtures.common_types import TenantId, TimelineArchivalState, TimelineId
 from fixtures.neon_fixtures import (
-    NeonEnv,
+    NeonEnvBuilder,
 )
 from fixtures.pageserver.http import PageserverApiException
 
 
-def test_timeline_archive(neon_simple_env: NeonEnv):
-    env = neon_simple_env
-
-    env.pageserver.allowed_errors.extend(
-        [
-            ".*Timeline .* was not found.*",
-            ".*timeline not found.*",
-            ".*Cannot archive timeline which has unarchived child timelines.*",
-            ".*Precondition failed: Requested tenant is missing.*",
-        ]
-    )
-
-    ps_http = env.pageserver.http_client()
+@pytest.mark.parametrize("shard_count", [0, 4])
+def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
+    unsharded = shard_count == 0
+    if unsharded:
+        env = neon_env_builder.init_start()
+        ps_http = env.pageserver.http_client()
+    else:
+        neon_env_builder.num_pageservers = shard_count
+        env = neon_env_builder.init_start(initial_tenant_shard_count=shard_count)
+        ps_http = env.storage_controller.pageserver_api()
 
     # first try to archive non existing timeline
     # for existing tenant:
@@ -34,9 +31,13 @@ def test_timeline_archive(neon_simple_env: NeonEnv):
 
     # for non existing tenant:
     invalid_tenant_id = TenantId.generate()
+    if unsharded:
+        not_found_pattern = f"NotFound: tenant {invalid_tenant_id}"
+    else:
+        not_found_pattern = "NotFound: Tenant not found"
     with pytest.raises(
         PageserverApiException,
-        match=f"NotFound: tenant {invalid_tenant_id}",
+        match=not_found_pattern,
     ) as exc:
         ps_http.timeline_archival_config(
             tenant_id=invalid_tenant_id,
@@ -48,34 +49,31 @@ def test_timeline_archive(neon_simple_env: NeonEnv):
 
     # construct pair of branches to validate that pageserver prohibits
     # archival of ancestor timelines when they have non-archived child branches
-    parent_timeline_id = env.neon_cli.create_branch("test_ancestor_branch_archive_parent", "empty")
+    parent_timeline_id = env.neon_cli.create_branch("test_ancestor_branch_archive_parent")
 
     leaf_timeline_id = env.neon_cli.create_branch(
         "test_ancestor_branch_archive_branch1", "test_ancestor_branch_archive_parent"
     )
 
-    timeline_path = env.pageserver.timeline_dir(env.initial_tenant, parent_timeline_id)
-
     with pytest.raises(
         PageserverApiException,
         match="Cannot archive timeline which has non-archived child timelines",
     ) as exc:
-        assert timeline_path.exists()
-
         ps_http.timeline_archival_config(
             tenant_id=env.initial_tenant,
             timeline_id=parent_timeline_id,
             state=TimelineArchivalState.ARCHIVED,
         )
 
-    assert exc.value.status_code == 412
+    assert exc.value.status_code == 412 if unsharded else 409
 
     # Test timeline_detail
-    leaf_detail = ps_http.timeline_detail(
-        tenant_id=env.initial_tenant,
-        timeline_id=leaf_timeline_id,
-    )
-    assert leaf_detail["is_archived"] is False
+    if shard_count != 0:
+        leaf_detail = ps_http.timeline_detail(
+            tenant_id=env.initial_tenant,
+            timeline_id=leaf_timeline_id,
+        )
+        assert leaf_detail["is_archived"] is False
 
     # Test that archiving the leaf timeline and then the parent works
     ps_http.timeline_archival_config(
@@ -83,11 +81,12 @@ def test_timeline_archive(neon_simple_env: NeonEnv):
         timeline_id=leaf_timeline_id,
         state=TimelineArchivalState.ARCHIVED,
     )
-    leaf_detail = ps_http.timeline_detail(
-        tenant_id=env.initial_tenant,
-        timeline_id=leaf_timeline_id,
-    )
-    assert leaf_detail["is_archived"] is True
+    if shard_count != 0:
+        leaf_detail = ps_http.timeline_detail(
+            tenant_id=env.initial_tenant,
+            timeline_id=leaf_timeline_id,
+        )
+        assert leaf_detail["is_archived"] is True
 
     ps_http.timeline_archival_config(
         tenant_id=env.initial_tenant,
@@ -100,8 +99,6 @@ def test_timeline_archive(neon_simple_env: NeonEnv):
         PageserverApiException,
         match="ancestor is archived",
     ) as exc:
-        assert timeline_path.exists()
-
         ps_http.timeline_archival_config(
             tenant_id=env.initial_tenant,
             timeline_id=leaf_timeline_id,

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -66,7 +66,7 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
             state=TimelineArchivalState.ARCHIVED,
         )
 
-    assert exc.value.status_code == 412 if unsharded else 409
+    assert exc.value.status_code == 412
 
     leaf_detail = ps_http.timeline_detail(
         env.initial_tenant,


### PR DESCRIPTION
Implement the timeline specific `archival_config` endpoint also in the storage controller.

It's mostly a copy-paste of the detach handler: the task is the same: do the same operation on all shards.

Part of #8088.