### PR TITLE
Automatically prepare/restore Aurora and RDS databases from pg_dump in benchmarking workflow

### DIFF
--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -66,16 +66,20 @@ jobs:
         "
     
     - name: Check if restore is already done
+      id: check-restore-done
       env:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}
       run: |
+        skip = false
         if ${PG_BINARIES}/psql "${{ env.BENCHMARK_CONNSTR }}" -tAc "SELECT 1 FROM benchmark_restore_status WHERE databasename='${{ env.DATABASE_NAME }}' AND restore_done=true;" | grep -q 1; then
           echo "Restore already done for database ${{ env.DATABASE_NAME }} on platform ${{ env.PLATFORM }}. Skipping this database."
-          exit 0
+          skip = true
         fi
+        echo "skip=${skip}" | tee -a $GITHUB_OUTPUT
 
     - name: Check and create database if it does not exist
+      if: steps.check-restore-done.outputs.skip != 'true'
       env:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}
@@ -89,6 +93,7 @@ jobs:
         fi
 
     - name: Download dump from S3 to /tmp/dumps
+      if: steps.check-restore-done.outputs.skip != 'true'
       env:
         DATABASE_NAME: ${{ matrix.database }}
       run: |
@@ -96,6 +101,7 @@ jobs:
         aws s3 cp s3://neon-github-dev/performance/pgdumps/$DATABASE_NAME/$DATABASE_NAME.pg_dump /tmp/dumps/ 
 
     - name: Replace database name in connection string
+      if: steps.check-restore-done.outputs.skip != 'true'
       id: replace-dbname
       env:
         DATABASE_NAME: ${{ matrix.database }}
@@ -106,6 +112,7 @@ jobs:
         echo "database_connstr=${new_connstr}" >> $GITHUB_OUTPUT  
 
     - name: Restore dump
+      if: steps.check-restore-done.outputs.skip != 'true'
       env:
         DATABASE_NAME: ${{ matrix.database }}
         DATABASE_CONNSTR: ${{ steps.replace-dbname.outputs.database_connstr }}
@@ -116,6 +123,7 @@ jobs:
         -d "${DATABASE_CONNSTR}" /tmp/dumps/${DATABASE_NAME}.pg_dump
 
     - name: Update benchmark_restore_status table
+      if: steps.check-restore-done.outputs.skip != 'true'
       env:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -17,7 +17,7 @@ jobs:
         # the following hard-coded connection string which contains a password is just used for testing the workflow
         # and project will be immediately deleted after the workflow is running
         # so please don't worry about the "security issue" for now
-        - BENCHMARK_CONNSTR: "postgresql://neondb_owner:4czu1xJeBkdN@ep-noisy-frost-w2k417od.us-east-2.aws.neon.build/neondb?sslmode=require"
+        - BENCHMARK_CONNSTR: "postgresql://neondb_owner@ep-noisy-frost-w2k417od.us-east-2.aws.neon.build/neondb?sslmode=require"
     env:
       BENCHMARK_CONNSTR: ${{ matrix.BENCHMARK_CONNSTR }}
       LD_LIBRARY_PATH: /tmp/neon/pg_install/v16/lib

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -20,6 +20,7 @@ jobs:
         - BENCHMARK_CONNSTR: "postgresql://neondb_owner:4czu1xJeBkdN@ep-noisy-frost-w2k417od.us-east-2.aws.neon.build/neondb?sslmode=require"
     env:
       BENCHMARK_CONNSTR: ${{ matrix.BENCHMARK_CONNSTR }}
+      LD_LIBRARY_PATH: /tmp/neon/pg_install/v16/lib
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -1,0 +1,45 @@
+name: Prepare benchmarking databases by restoring dumps
+
+on:
+  workflow_call:
+    # no inputs needed
+    
+defaults:
+  run:
+    shell: bash -euxo pipefail {0}
+
+jobs:
+  setup-databases:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # the following hard-coded connection string which contains a password is just used for testing the workflow
+        # and project will be immediately deleted after the workflow is running
+        # so please don't worry about the "security issue" for now
+        - BENCHMARK_CONNSTR: "postgresql://neondb_owner:4czu1xJeBkdN@ep-noisy-frost-w2k417od.us-east-2.aws.neon.build/neondb?sslmode=require"
+    env:
+      BENCHMARK_CONNSTR: ${{ matrix.BENCHMARK_CONNSTR }}
+
+    runs-on: [ self-hosted, us-east-2, x64 ]
+    container:
+      image: 369495373322.dkr.ecr.eu-central-1.amazonaws.com/build-tools:pinned
+      options: --init
+
+    steps:
+    - name: Download Neon artifact
+      uses: ./.github/actions/download
+      with:
+        name: neon-${{ runner.os }}-${{ runner.arch }}-release-artifact
+        path: /tmp/neon/
+        prefix: latest
+
+    # we create a table that has one row for each database that we want to restore with the status whether the restore is done    
+    - name: Create benchmark_restore_status table if it does not exist
+      run: |
+        /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
+        CREATE TABLE IF NOT EXISTS benchmark_restore_status (
+        databasename text,
+        restore_done boolean
+        );
+        "

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -71,10 +71,10 @@ jobs:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}
       run: |
-        skip = false
+        skip=false
         if ${PG_BINARIES}/psql "${{ env.BENCHMARK_CONNSTR }}" -tAc "SELECT 1 FROM benchmark_restore_status WHERE databasename='${{ env.DATABASE_NAME }}' AND restore_done=true;" | grep -q 1; then
           echo "Restore already done for database ${{ env.DATABASE_NAME }} on platform ${{ env.PLATFORM }}. Skipping this database."
-          skip = true
+          skip=true
         fi
         echo "skip=${skip}" | tee -a $GITHUB_OUTPUT
 
@@ -107,8 +107,16 @@ jobs:
         DATABASE_NAME: ${{ matrix.database }}
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
       run: |
-        current_dbname=$(echo "${BENCHMARK_CONNSTR}" | sed 's|.*/||' | sed 's|?.*||')
-        new_connstr=$(echo "${BENCHMARK_CONNSTR}" | sed "s|/${current_dbname}\([/?]\)|/${DATABASE_NAME}\1|")
+        # Extract the part before the database name
+        base_connstr="${BENCHMARK_CONNSTR%/*}"
+        # Extract the query parameters (if any) after the database name
+        query_params="${BENCHMARK_CONNSTR#*\?}"
+        # Reconstruct the new connection string
+        if [ "$query_params" != "$BENCHMARK_CONNSTR" ]; then
+          new_connstr="${base_connstr}/${DATABASE_NAME}?${query_params}"
+        else
+          new_connstr="${base_connstr}/${DATABASE_NAME}"
+        fi
         echo "database_connstr=${new_connstr}" >> $GITHUB_OUTPUT  
 
     - name: Restore dump

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -17,7 +17,6 @@ jobs:
         database: [ clickbench, tpch, userexample ]
   
     env:
-      BENCHMARK_CONNSTR: ${{ matrix.BENCHMARK_CONNSTR }}
       LD_LIBRARY_PATH: /tmp/neon/pg_install/v16/lib
       PLATFORM: ${{ matrix.platform }}
 
@@ -60,7 +59,7 @@ jobs:
       run: |
         /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
         CREATE TABLE IF NOT EXISTS benchmark_restore_status (
-        databasename text,
+        databasename text primary key,
         restore_done boolean
         );
         "
@@ -94,3 +93,32 @@ jobs:
       run: |
         mkdir -p /tmp/dumps
         aws s3 cp s3://neon-github-dev/performance/pgdumps/$DATABASE_NAME/$DATABASE_NAME.pg_dump /tmp/dumps/ 
+
+    - name: Replace database name in connection string
+      id: replace-dbname
+      env:
+        DATABASE_NAME: ${{ matrix.database }}
+        BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
+      run: |
+        current_dbname=$(echo "${BENCHMARK_CONNSTR}" | sed 's|.*/||' | sed 's|?.*||')
+        new_connstr=$(echo "${BENCHMARK_CONNSTR}" | sed "s|/${current_dbname}\([/?]\)|/${DATABASE_NAME}\1|")
+        echo "database_connstr=${new_connstr}" >> $GITHUB_OUTPUT  
+
+    - name: Restore dump
+      env:
+        DATABASE_NAME: ${{ matrix.database }}
+        DATABASE_CONNSTR: ${{ steps.replace-dbname.outputs.database_connstr }}
+        PGOPTIONS: "-c maintenance_work_mem=8388608 -c max_parallel_maintenance_workers=7"
+      run: |
+        /tmp/neon/pg_install/v16/bin/pg_restore --clean --if-exists --no-owner --jobs=4 \
+        -d "${DATABASE_CONNSTR}" /tmp/dumps/${DATABASE_NAME}.pg_dump
+
+    - name: Update benchmark_restore_status table
+      env:
+        BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
+        DATABASE_NAME: ${{ matrix.database }}
+      run: |
+        /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
+        INSERT INTO benchmark_restore_status (databasename, restore_done) VALUES ('${{ env.DATABASE_NAME }}', true)
+        ON CONFLICT (databasename) DO UPDATE SET restore_done = true;
+        "

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -57,12 +57,16 @@ jobs:
       env:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}
+      # to avoid a race condition of multiple jobs trying to create the table at the same time, 
+      # we use an advisory lock
       run: |
         ${PG_BINARIES}/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
+        SELECT pg_advisory_lock(4711);  
         CREATE TABLE IF NOT EXISTS benchmark_restore_status (
         databasename text primary key,
         restore_done boolean
         );
+        SELECT pg_advisory_unlock(4711);
         "
     
     - name: Check if restore is already done
@@ -126,9 +130,12 @@ jobs:
         DATABASE_CONNSTR: ${{ steps.replace-dbname.outputs.database_connstr }}
         # the following works only with larger computes: 
         # PGOPTIONS: "-c maintenance_work_mem=8388608 -c max_parallel_maintenance_workers=7"
+        # we add the || true because:
+        # the dumps were created with Neon and contain neon extensions that are not 
+        # available in RDS, so we will always report an error, but we can ignore it
       run: |
         ${PG_BINARIES}/pg_restore --clean --if-exists --no-owner --jobs=4 \
-        -d "${DATABASE_CONNSTR}" /tmp/dumps/${DATABASE_NAME}.pg_dump
+        -d "${DATABASE_CONNSTR}" /tmp/dumps/${DATABASE_NAME}.pg_dump || true
 
     - name: Update benchmark_restore_status table
       if: steps.check-restore-done.outputs.skip != 'true'

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -13,12 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-        # the following connection string is a temporary one to test the workflow
-        # and will be replaced by real RDS connection string once the workflow test is successful
-        - platform: aws-rds-postgres
-        - platform: aws-aurora-serverless-v2-postgres
-
+        platform: [ aws-rds-postgres ] # platform: aws-aurora-serverless-v2-postgres FIXME!
+        database: [ clickbench, tpch, userexample ]
+  
     env:
       BENCHMARK_CONNSTR: ${{ matrix.BENCHMARK_CONNSTR }}
       LD_LIBRARY_PATH: /tmp/neon/pg_install/v16/lib
@@ -35,10 +32,10 @@ jobs:
       run: |
         case "${PLATFORM}" in
           aws-rds-postgres)
-            CONNSTR=${{ secrets.BODOBOLERO_TEMPORARY_CONNSTR }} # FIXME! todo this is just for testing during the workflow development
+            CONNSTR=${{ secrets.BODOBOLERO_TEMPORARY_CONNSTR }} # FIXME! todo this is just for testing during the workflow development later use secrets.BENCHMARK_RDS_POSTGRES_CONNSTR
             ;;
           aws-aurora-serverless-v2-postgres)
-            CONNSTR=${{ secrets.BODOBOLERO_TEMPORARY_CONNSTR }} # FIXME! todo this is just for testing during the workflow development, but is a good test for idempotency, second run should do nothing
+            CONNSTR=${{ secrets.BENCHMARK_RDS_AURORA_CONNSTR }} 
             ;;
           *)
             echo >&2 "Unknown PLATFORM=${PLATFORM}"
@@ -59,6 +56,7 @@ jobs:
     - name: Create benchmark_restore_status table if it does not exist
       env:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
+        DATABASE_NAME: ${{ matrix.database }}
       run: |
         /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
         CREATE TABLE IF NOT EXISTS benchmark_restore_status (
@@ -66,3 +64,33 @@ jobs:
         restore_done boolean
         );
         "
+    
+    - name: Check if restore is already done
+      env:
+        BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
+        DATABASE_NAME: ${{ matrix.database }}
+      run: |
+        if /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -tAc "SELECT 1 FROM benchmark_restore_status WHERE databasename='${{ env.DATABASE_NAME }}' AND restore_done=true;" | grep -q 1; then
+          echo "Restore already done for database ${{ env.DATABASE_NAME }} on platform ${{ env.PLATFORM }}. Skipping this database."
+          exit 0
+        fi
+
+    - name: Check and create database if it does not exist
+      env:
+        BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
+        DATABASE_NAME: ${{ matrix.database }}
+      run: |
+        DB_EXISTS=$(/tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -tAc "SELECT 1 FROM pg_database WHERE datname='${{ env.DATABASE_NAME }}'")
+        if [ "$DB_EXISTS" != "1" ]; then
+          echo "Database ${{ env.DATABASE_NAME }} does not exist. Creating it..."
+          /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "CREATE DATABASE \"${{ env.DATABASE_NAME }}\";"
+        else
+          echo "Database ${{ env.DATABASE_NAME }} already exists."
+        fi
+
+    - name: Download dump from S3 to /tmp/dumps
+      env:
+        DATABASE_NAME: ${{ matrix.database }}
+      run: |
+        mkdir -p /tmp/dumps
+        aws s3 cp s3://neon-github-dev/performance/pgdumps/$DATABASE_NAME/$DATABASE_NAME.pg_dump /tmp/dumps/ 

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -14,13 +14,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # the following hard-coded connection string which contains a password is just used for testing the workflow
-        # and project will be immediately deleted after the workflow is running
-        # so please don't worry about the "security issue" for now
-        - BENCHMARK_CONNSTR: "postgresql://neondb_owner@ep-noisy-frost-w2k417od.us-east-2.aws.neon.build/neondb?sslmode=require"
+        # the following connection string is a temporary one to test the workflow
+        # and will be replaced by real RDS connection string once the workflow test is successful
+        - platform: aws-rds-postgres
+        - platform: aws-aurora-serverless-v2-postgres
+
     env:
       BENCHMARK_CONNSTR: ${{ matrix.BENCHMARK_CONNSTR }}
       LD_LIBRARY_PATH: /tmp/neon/pg_install/v16/lib
+      PLATFORM: ${{ matrix.platform }}
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
@@ -28,6 +30,24 @@ jobs:
       options: --init
 
     steps:
+    - name: Set up Connection String
+      id: set-up-prep-connstr
+      run: |
+        case "${PLATFORM}" in
+          aws-rds-postgres)
+            CONNSTR=${{ secrets.BODOBOLERO_TEMPORARY_CONNSTR }} # FIXME! todo this is just for testing during the workflow development
+            ;;
+          aws-aurora-serverless-v2-postgres)
+            CONNSTR=${{ secrets.BODOBOLERO_TEMPORARY_CONNSTR }} # FIXME! todo this is just for testing during the workflow development, but is a good test for idempotency, second run should do nothing
+            ;;
+          *)
+            echo >&2 "Unknown PLATFORM=${PLATFORM}"
+            exit 1
+            ;;
+        esac
+
+        echo "connstr=${CONNSTR}" >> $GITHUB_OUTPUT  
+
     - name: Download Neon artifact
       uses: ./.github/actions/download
       with:
@@ -37,6 +57,8 @@ jobs:
 
     # we create a table that has one row for each database that we want to restore with the status whether the restore is done    
     - name: Create benchmark_restore_status table if it does not exist
+      env:
+        BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
       run: |
         /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
         CREATE TABLE IF NOT EXISTS benchmark_restore_status (

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ aws-rds-postgres ] # platform: aws-aurora-serverless-v2-postgres FIXME!
+        platform: [ aws-rds-postgres, aws-aurora-serverless-v2-postgres ] 
         database: [ clickbench, tpch, userexample ]
   
     env:
@@ -32,7 +32,7 @@ jobs:
       run: |
         case "${PLATFORM}" in
           aws-rds-postgres)
-            CONNSTR=${{ secrets.BODOBOLERO_TEMPORARY_CONNSTR }} # FIXME! todo this is just for testing during the workflow development later use secrets.BENCHMARK_RDS_POSTGRES_CONNSTR
+            CONNSTR=${{ secrets.BENCHMARK_RDS_POSTGRES_CONNSTR }} 
             ;;
           aws-aurora-serverless-v2-postgres)
             CONNSTR=${{ secrets.BENCHMARK_RDS_AURORA_CONNSTR }} 

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       LD_LIBRARY_PATH: /tmp/neon/pg_install/v16/lib
       PLATFORM: ${{ matrix.platform }}
+      PG_BINARIES: ${PG_BINARIES}
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:
@@ -57,7 +58,7 @@ jobs:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}
       run: |
-        /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
+        ${PG_BINARIES}/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
         CREATE TABLE IF NOT EXISTS benchmark_restore_status (
         databasename text primary key,
         restore_done boolean
@@ -69,7 +70,7 @@ jobs:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}
       run: |
-        if /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -tAc "SELECT 1 FROM benchmark_restore_status WHERE databasename='${{ env.DATABASE_NAME }}' AND restore_done=true;" | grep -q 1; then
+        if ${PG_BINARIES}/psql "${{ env.BENCHMARK_CONNSTR }}" -tAc "SELECT 1 FROM benchmark_restore_status WHERE databasename='${{ env.DATABASE_NAME }}' AND restore_done=true;" | grep -q 1; then
           echo "Restore already done for database ${{ env.DATABASE_NAME }} on platform ${{ env.PLATFORM }}. Skipping this database."
           exit 0
         fi
@@ -79,10 +80,10 @@ jobs:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}
       run: |
-        DB_EXISTS=$(/tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -tAc "SELECT 1 FROM pg_database WHERE datname='${{ env.DATABASE_NAME }}'")
+        DB_EXISTS=$(${PG_BINARIES}/psql "${{ env.BENCHMARK_CONNSTR }}" -tAc "SELECT 1 FROM pg_database WHERE datname='${{ env.DATABASE_NAME }}'")
         if [ "$DB_EXISTS" != "1" ]; then
           echo "Database ${{ env.DATABASE_NAME }} does not exist. Creating it..."
-          /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "CREATE DATABASE \"${{ env.DATABASE_NAME }}\";"
+          ${PG_BINARIES}/psql "${{ env.BENCHMARK_CONNSTR }}" -c "CREATE DATABASE \"${{ env.DATABASE_NAME }}\";"
         else
           echo "Database ${{ env.DATABASE_NAME }} already exists."
         fi
@@ -108,9 +109,10 @@ jobs:
       env:
         DATABASE_NAME: ${{ matrix.database }}
         DATABASE_CONNSTR: ${{ steps.replace-dbname.outputs.database_connstr }}
-        # the following works only with larger computes: PGOPTIONS: "-c maintenance_work_mem=8388608 -c max_parallel_maintenance_workers=7"
+        # the following works only with larger computes: 
+        # PGOPTIONS: "-c maintenance_work_mem=8388608 -c max_parallel_maintenance_workers=7"
       run: |
-        /tmp/neon/pg_install/v16/bin/pg_restore --clean --if-exists --no-owner --jobs=4 \
+        ${PG_BINARIES}/pg_restore --clean --if-exists --no-owner --jobs=4 \
         -d "${DATABASE_CONNSTR}" /tmp/dumps/${DATABASE_NAME}.pg_dump
 
     - name: Update benchmark_restore_status table
@@ -118,7 +120,7 @@ jobs:
         BENCHMARK_CONNSTR: ${{ steps.set-up-prep-connstr.outputs.connstr }}
         DATABASE_NAME: ${{ matrix.database }}
       run: |
-        /tmp/neon/pg_install/v16/bin/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
+        ${PG_BINARIES}/psql "${{ env.BENCHMARK_CONNSTR }}" -c "
         INSERT INTO benchmark_restore_status (databasename, restore_done) VALUES ('${{ env.DATABASE_NAME }}', true)
         ON CONFLICT (databasename) DO UPDATE SET restore_done = true;
         "

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       LD_LIBRARY_PATH: /tmp/neon/pg_install/v16/lib
       PLATFORM: ${{ matrix.platform }}
-      PG_BINARIES: ${PG_BINARIES}
+      PG_BINARIES: /tmp/neon/pg_install/v16/bin
 
     runs-on: [ self-hosted, us-east-2, x64 ]
     container:

--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -108,7 +108,7 @@ jobs:
       env:
         DATABASE_NAME: ${{ matrix.database }}
         DATABASE_CONNSTR: ${{ steps.replace-dbname.outputs.database_connstr }}
-        PGOPTIONS: "-c maintenance_work_mem=8388608 -c max_parallel_maintenance_workers=7"
+        # the following works only with larger computes: PGOPTIONS: "-c maintenance_work_mem=8388608 -c max_parallel_maintenance_workers=7"
       run: |
         /tmp/neon/pg_install/v16/bin/pg_restore --clean --if-exists --no-owner --jobs=4 \
         -d "${DATABASE_CONNSTR}" /tmp/dumps/${DATABASE_NAME}.pg_dump

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -280,9 +280,9 @@ jobs:
                       { "pg_version": 16, "region_id": "'"$region_id_default"'", "platform": "neonvm-captest-sharding-reuse", "db_size": "50gb","runner": '"$runner_default"', "image": "'"$image_default"'" }]
         }'
 
-        if [ "$(date +%A)" = "Saturday" ]; then
-          matrix=$(echo "$matrix" | jq '.include += [{ "pg_version": 14, "region_id": "'"$region_id_default"'", "platform": "rds-postgres", "db_size": "10gb","runner": '"$runner_default"', "image": "'"$image_default"'" },
-                                                     { "pg_version": 14, "region_id": "'"$region_id_default"'", "platform": "rds-aurora", "db_size": "10gb","runner": '"$runner_default"', "image": "'"$image_default"'" }]')
+        if [ "$(date +%A)" = "Saturday" ] || [ ${RUN_AWS_RDS_AND_AURORA} = "true" ]; then
+          matrix=$(echo "$matrix" | jq '.include += [{ "pg_version": 16, "region_id": "'"$region_id_default"'", "platform": "rds-postgres", "db_size": "10gb","runner": '"$runner_default"', "image": "'"$image_default"'" },
+                                                     { "pg_version": 16, "region_id": "'"$region_id_default"'", "platform": "rds-aurora", "db_size": "10gb","runner": '"$runner_default"', "image": "'"$image_default"'" }]')
         fi
 
         echo "matrix=$(echo "$matrix" | jq --compact-output '.')" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -281,7 +281,8 @@ jobs:
         }'
 
         if [ "$(date +%A)" = "Saturday" ]; then
-          matrix=$(echo "$matrix" | jq '.include += [{ "pg_version": 14, "region_id": "'"$region_id_default"'", "platform": "rds-postgres", "db_size": "10gb","runner": '"$runner_default"', "image": "'"$image_default"'" }]')
+          matrix=$(echo "$matrix" | jq '.include += [{ "pg_version": 14, "region_id": "'"$region_id_default"'", "platform": "rds-postgres", "db_size": "10gb","runner": '"$runner_default"', "image": "'"$image_default"'" },
+                                                     { "pg_version": 14, "region_id": "'"$region_id_default"'", "platform": "rds-aurora", "db_size": "10gb","runner": '"$runner_default"', "image": "'"$image_default"'" }]')
         fi
 
         echo "matrix=$(echo "$matrix" | jq --compact-output '.')" >> $GITHUB_OUTPUT
@@ -728,7 +729,7 @@ jobs:
             ENV_PLATFORM=RDS_AURORA_TPCH
             ;;
           rds-postgres)
-            ENV_PLATFORM=RDS_AURORA_TPCH
+            ENV_PLATFORM=RDS_POSTGRES_TPCH
             ;;
           *)
             echo >&2 "Unknown PLATFORM=${PLATFORM}. Allowed only 'neonvm-captest-reuse', 'rds-aurora', or 'rds-postgres'"

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -60,6 +60,7 @@ jobs:
       contents: write
       statuses: write
       id-token: write # Required for OIDC authentication in azure runners
+    needs: [ prepare_AWS_RDS_databases ] # FIXME! this is a fake dependency that we need to remove before merging the workflow
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -608,7 +608,7 @@ jobs:
 
     env:
       POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install
-      DEFAULT_PG_VERSION: 14
+      DEFAULT_PG_VERSION: 16
       TEST_OUTPUT: /tmp/test_output
       TEST_OLAP_COLLECT_EXPLAIN: ${{ github.event.inputs.collect_olap_explain }}
       TEST_OLAP_COLLECT_PG_STAT_STATEMENTS: ${{ github.event.inputs.collect_pg_stat_statements }}
@@ -660,6 +660,7 @@ jobs:
         run_in_parallel: false
         save_perf_report: ${{ env.SAVE_PERF_REPORT }}
         extra_params: -m remote_cluster --timeout 21600 -k test_clickbench
+        pg_version: ${{ env.DEFAULT_PG_VERSION }}
       env:
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
@@ -697,7 +698,7 @@ jobs:
 
     env:
       POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install
-      DEFAULT_PG_VERSION: 14
+      DEFAULT_PG_VERSION: 16
       TEST_OUTPUT: /tmp/test_output
       BUILD_TYPE: remote
       SAVE_PERF_REPORT: ${{ github.event.inputs.save_perf_report || ( github.ref_name == 'main' ) }}
@@ -755,6 +756,7 @@ jobs:
         run_in_parallel: false
         save_perf_report: ${{ env.SAVE_PERF_REPORT }}
         extra_params: -m remote_cluster --timeout 21600 -k test_tpch
+        pg_version: ${{ env.DEFAULT_PG_VERSION }}
       env:
         VIP_VAP_ACCESS_TOKEN: "${{ secrets.VIP_VAP_ACCESS_TOKEN }}"
         PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
@@ -784,7 +786,7 @@ jobs:
 
     env:
       POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install
-      DEFAULT_PG_VERSION: 14
+      DEFAULT_PG_VERSION: 16
       TEST_OUTPUT: /tmp/test_output
       BUILD_TYPE: remote
       SAVE_PERF_REPORT: ${{ github.event.inputs.save_perf_report || ( github.ref_name == 'main' ) }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -321,9 +321,13 @@ jobs:
 
         echo "matrix=$(echo "$matrix" | jq --compact-output '.')" >> $GITHUB_OUTPUT
 
+  prepare_AWS_RDS_databases:
+    uses: ./.github/workflows/_benchmarking_preparation.yml
+    secrets: inherit
+  
   pgbench-compare:
     if: ${{ github.event.inputs.run_only_pgvector_tests == 'false' || github.event.inputs.run_only_pgvector_tests == null }}
-    needs: [ generate-matrices ]
+    needs: [ generate-matrices, prepare_AWS_RDS_databases ]
     permissions:
       contents: write
       statuses: write
@@ -595,7 +599,7 @@ jobs:
     # *_CLICKBENCH_CONNSTR: Genuine ClickBench DB with ~100M rows
     # *_CLICKBENCH_10M_CONNSTR: DB with the first 10M rows of ClickBench DB
     if: ${{ !cancelled() && (github.event.inputs.run_only_pgvector_tests == 'false' || github.event.inputs.run_only_pgvector_tests == null) }}
-    needs: [ generate-matrices, pgbench-compare ]
+    needs: [ generate-matrices, pgbench-compare, prepare_AWS_RDS_databases ]
 
     strategy:
       fail-fast: false
@@ -684,7 +688,7 @@ jobs:
     #
     # *_TPCH_S10_CONNSTR: DB generated with scale factor 10 (~10 GB)
     if: ${{ !cancelled() && (github.event.inputs.run_only_pgvector_tests == 'false' || github.event.inputs.run_only_pgvector_tests == null) }}
-    needs: [ generate-matrices, clickbench-compare ]
+    needs: [ generate-matrices, clickbench-compare, prepare_AWS_RDS_databases ]
 
     strategy:
       fail-fast: false
@@ -771,7 +775,7 @@ jobs:
 
   user-examples-compare:
     if: ${{ !cancelled() && (github.event.inputs.run_only_pgvector_tests == 'false' || github.event.inputs.run_only_pgvector_tests == null) }}
-    needs: [ generate-matrices, tpch-compare ]
+    needs: [ generate-matrices, tpch-compare, prepare_AWS_RDS_databases ]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -60,7 +60,6 @@ jobs:
       contents: write
       statuses: write
       id-token: write # Required for OIDC authentication in azure runners
-    needs: [ prepare_AWS_RDS_databases ] # FIXME! this is a fake dependency that we need to remove before merging the workflow
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

We use infrastructure as code (TF) to deploy AWS Aurora and AWS RDS Postgres database clusters.
Whenever we have a change in TF (e.g. **every year** to upgrade to a higher Postgres version or when we change the cluster configuration) TF will apply the change and create a new AWS database cluster.

However our benchmarking testcase also expects databases in these clusters and tables loaded with data.
So we add auto-detection - if the AWS RDS instances are "empty" we create the necessary databases and restore a pg_dump.

**Important Notes:** 

- These steps are NOT run in each benchmarking run, but only after a new RDS instance has been deployed.
- the benchmarking workflows use GitHub secrets to find the connection string for the database. These secrets still need to be (manually or programmatically using git cli) updated if some port of the connection string (e.g. user, password or hostname) changes.

## Summary of changes

In each benchmarking run check if
- database has already been created - if not create it
- database has already been restored - if not restore it

Supported databases
- tpch
- clickbench
- user example

Supported platforms:
- AWS RDS Postgres
- AWS Aurora serverless Postgres

Sample workflow run - but this one uses Neon database to test the restore step and not real AWS databases

https://github.com/neondatabase/neon/actions/runs/10321441086/job/28574350581

Sample workflow run - with real AWS database clusters
https://github.com/neondatabase/neon/actions/runs/10346816389/job/28635997653

Verification in second run - with real AWS database clusters - that second time the restore is skipped
https://github.com/neondatabase/neon/actions/runs/10348469517/job/28640778223

