### PR TITLE
Add response tag to getpage request in V3 protocol version

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1460,13 +1460,17 @@ impl TryFrom<u8> for PagestreamBeMessageTag {
 // interface allows sending both LSNs, and let the pageserver do the right thing. There was no
 // difference in the responses between V1 and V2.
 //
-#[derive(Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PagestreamProtocolVersion {
     V2,
+    V3,
 }
+
+pub type RequestId = u64;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PagestreamExistsRequest {
+    pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub rel: RelTag,
@@ -1474,6 +1478,7 @@ pub struct PagestreamExistsRequest {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PagestreamNblocksRequest {
+    pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub rel: RelTag,
@@ -1481,6 +1486,7 @@ pub struct PagestreamNblocksRequest {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PagestreamGetPageRequest {
+    pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub rel: RelTag,
@@ -1489,6 +1495,7 @@ pub struct PagestreamGetPageRequest {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PagestreamDbSizeRequest {
+    pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub dbnode: u32,
@@ -1496,6 +1503,7 @@ pub struct PagestreamDbSizeRequest {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PagestreamGetSlruSegmentRequest {
+    pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub kind: u8,
@@ -1504,31 +1512,56 @@ pub struct PagestreamGetSlruSegmentRequest {
 
 #[derive(Debug)]
 pub struct PagestreamExistsResponse {
+    pub reqid: RequestId,
+    pub request_lsn: Lsn,
+    pub not_modified_since: Lsn,
+    pub rel: RelTag,
     pub exists: bool,
 }
 
 #[derive(Debug)]
 pub struct PagestreamNblocksResponse {
+    pub reqid: RequestId,
+    pub request_lsn: Lsn,
+    pub not_modified_since: Lsn,
+    pub rel: RelTag,
     pub n_blocks: u32,
 }
 
 #[derive(Debug)]
 pub struct PagestreamGetPageResponse {
+    pub reqid: RequestId,
+    pub request_lsn: Lsn,
+    pub not_modified_since: Lsn,
+    pub rel: RelTag,
+    pub blkno: u32,
     pub page: Bytes,
 }
 
 #[derive(Debug)]
 pub struct PagestreamGetSlruSegmentResponse {
+    pub reqid: RequestId,
+    pub request_lsn: Lsn,
+    pub not_modified_since: Lsn,
+    pub kind: u8,
+    pub segno: u32,
     pub segment: Bytes,
 }
 
 #[derive(Debug)]
 pub struct PagestreamErrorResponse {
+    pub reqid: RequestId,
+    pub request_lsn: Lsn,
+    pub not_modified_since: Lsn,
     pub message: String,
 }
 
 #[derive(Debug)]
 pub struct PagestreamDbSizeResponse {
+    pub reqid: RequestId,
+    pub request_lsn: Lsn,
+    pub not_modified_since: Lsn,
+    pub db_node: u32,
     pub db_size: i64,
 }
 
@@ -1552,6 +1585,7 @@ impl PagestreamFeMessage {
         match self {
             Self::Exists(req) => {
                 bytes.put_u8(0);
+                bytes.put_u64(req.reqid);
                 bytes.put_u64(req.request_lsn.0);
                 bytes.put_u64(req.not_modified_since.0);
                 bytes.put_u32(req.rel.spcnode);
@@ -1562,6 +1596,7 @@ impl PagestreamFeMessage {
 
             Self::Nblocks(req) => {
                 bytes.put_u8(1);
+                bytes.put_u64(req.reqid);
                 bytes.put_u64(req.request_lsn.0);
                 bytes.put_u64(req.not_modified_since.0);
                 bytes.put_u32(req.rel.spcnode);
@@ -1572,6 +1607,7 @@ impl PagestreamFeMessage {
 
             Self::GetPage(req) => {
                 bytes.put_u8(2);
+                bytes.put_u64(req.reqid);
                 bytes.put_u64(req.request_lsn.0);
                 bytes.put_u64(req.not_modified_since.0);
                 bytes.put_u32(req.rel.spcnode);
@@ -1583,6 +1619,7 @@ impl PagestreamFeMessage {
 
             Self::DbSize(req) => {
                 bytes.put_u8(3);
+                bytes.put_u64(req.reqid);
                 bytes.put_u64(req.request_lsn.0);
                 bytes.put_u64(req.not_modified_since.0);
                 bytes.put_u32(req.dbnode);
@@ -1590,6 +1627,7 @@ impl PagestreamFeMessage {
 
             Self::GetSlruSegment(req) => {
                 bytes.put_u8(4);
+                bytes.put_u64(req.reqid);
                 bytes.put_u64(req.request_lsn.0);
                 bytes.put_u64(req.not_modified_since.0);
                 bytes.put_u8(req.kind);
@@ -1600,19 +1638,31 @@ impl PagestreamFeMessage {
         bytes.into()
     }
 
-    pub fn parse<R: std::io::Read>(body: &mut R) -> anyhow::Result<PagestreamFeMessage> {
+    pub fn parse<R: std::io::Read>(
+        body: &mut R,
+        protocol_version: PagestreamProtocolVersion,
+    ) -> anyhow::Result<PagestreamFeMessage> {
         // these correspond to the NeonMessageTag enum in pagestore_client.h
         //
         // TODO: consider using protobuf or serde bincode for less error prone
         // serialization.
         let msg_tag = body.read_u8()?;
-
-        // these two fields are the same for every request type
-        let request_lsn = Lsn::from(body.read_u64::<BigEndian>()?);
-        let not_modified_since = Lsn::from(body.read_u64::<BigEndian>()?);
+        let (reqid, request_lsn, not_modified_since) = match protocol_version {
+            PagestreamProtocolVersion::V2 => (
+                0,
+                Lsn::from(body.read_u64::<BigEndian>()?),
+                Lsn::from(body.read_u64::<BigEndian>()?),
+            ),
+            PagestreamProtocolVersion::V3 => (
+                body.read_u64::<BigEndian>()?,
+                Lsn::from(body.read_u64::<BigEndian>()?),
+                Lsn::from(body.read_u64::<BigEndian>()?),
+            ),
+        };
 
         match msg_tag {
             0 => Ok(PagestreamFeMessage::Exists(PagestreamExistsRequest {
+                reqid,
                 request_lsn,
                 not_modified_since,
                 rel: RelTag {
@@ -1623,6 +1673,7 @@ impl PagestreamFeMessage {
                 },
             })),
             1 => Ok(PagestreamFeMessage::Nblocks(PagestreamNblocksRequest {
+                reqid,
                 request_lsn,
                 not_modified_since,
                 rel: RelTag {
@@ -1633,6 +1684,7 @@ impl PagestreamFeMessage {
                 },
             })),
             2 => Ok(PagestreamFeMessage::GetPage(PagestreamGetPageRequest {
+                reqid,
                 request_lsn,
                 not_modified_since,
                 rel: RelTag {
@@ -1644,12 +1696,14 @@ impl PagestreamFeMessage {
                 blkno: body.read_u32::<BigEndian>()?,
             })),
             3 => Ok(PagestreamFeMessage::DbSize(PagestreamDbSizeRequest {
+                reqid,
                 request_lsn,
                 not_modified_since,
                 dbnode: body.read_u32::<BigEndian>()?,
             })),
             4 => Ok(PagestreamFeMessage::GetSlruSegment(
                 PagestreamGetSlruSegmentRequest {
+                    reqid,
                     request_lsn,
                     not_modified_since,
                     kind: body.read_u8()?,
@@ -1662,43 +1716,114 @@ impl PagestreamFeMessage {
 }
 
 impl PagestreamBeMessage {
-    pub fn serialize(&self) -> Bytes {
+    pub fn serialize(&self, protocol_version: PagestreamProtocolVersion) -> Bytes {
         let mut bytes = BytesMut::new();
 
         use PagestreamBeMessageTag as Tag;
-        match self {
-            Self::Exists(resp) => {
-                bytes.put_u8(Tag::Exists as u8);
-                bytes.put_u8(resp.exists as u8);
-            }
+        match protocol_version {
+            PagestreamProtocolVersion::V2 => {
+                match self {
+                    Self::Exists(resp) => {
+                        bytes.put_u8(Tag::Exists as u8);
+                        bytes.put_u8(resp.exists as u8);
+                    }
 
-            Self::Nblocks(resp) => {
-                bytes.put_u8(Tag::Nblocks as u8);
-                bytes.put_u32(resp.n_blocks);
-            }
+                    Self::Nblocks(resp) => {
+                        bytes.put_u8(Tag::Nblocks as u8);
+                        bytes.put_u32(resp.n_blocks);
+                    }
 
-            Self::GetPage(resp) => {
-                bytes.put_u8(Tag::GetPage as u8);
-                bytes.put(&resp.page[..]);
-            }
+                    Self::GetPage(resp) => {
+                        bytes.put_u8(Tag::GetPage as u8);
+                        bytes.put(&resp.page[..])
+                    }
 
-            Self::Error(resp) => {
-                bytes.put_u8(Tag::Error as u8);
-                bytes.put(resp.message.as_bytes());
-                bytes.put_u8(0); // null terminator
-            }
-            Self::DbSize(resp) => {
-                bytes.put_u8(Tag::DbSize as u8);
-                bytes.put_i64(resp.db_size);
-            }
+                    Self::Error(resp) => {
+                        bytes.put_u8(Tag::Error as u8);
+                        bytes.put(resp.message.as_bytes());
+                        bytes.put_u8(0); // null terminator
+                    }
+                    Self::DbSize(resp) => {
+                        bytes.put_u8(Tag::DbSize as u8);
+                        bytes.put_i64(resp.db_size);
+                    }
 
-            Self::GetSlruSegment(resp) => {
-                bytes.put_u8(Tag::GetSlruSegment as u8);
-                bytes.put_u32((resp.segment.len() / BLCKSZ as usize) as u32);
-                bytes.put(&resp.segment[..]);
+                    Self::GetSlruSegment(resp) => {
+                        bytes.put_u8(Tag::GetSlruSegment as u8);
+                        bytes.put_u32((resp.segment.len() / BLCKSZ as usize) as u32);
+                        bytes.put(&resp.segment[..]);
+                    }
+                }
+            }
+            _ => {
+                match self {
+                    Self::Exists(resp) => {
+                        bytes.put_u8(Tag::Exists as u8);
+                        bytes.put_u64(resp.reqid);
+                        bytes.put_u64(resp.request_lsn.0);
+                        bytes.put_u64(resp.not_modified_since.0);
+                        bytes.put_u32(resp.rel.spcnode);
+                        bytes.put_u32(resp.rel.dbnode);
+                        bytes.put_u32(resp.rel.relnode);
+                        bytes.put_u8(resp.rel.forknum);
+                        bytes.put_u8(resp.exists as u8);
+                    }
+
+                    Self::Nblocks(resp) => {
+                        bytes.put_u8(Tag::Nblocks as u8);
+                        bytes.put_u64(resp.reqid);
+                        bytes.put_u64(resp.request_lsn.0);
+                        bytes.put_u64(resp.not_modified_since.0);
+                        bytes.put_u32(resp.rel.spcnode);
+                        bytes.put_u32(resp.rel.dbnode);
+                        bytes.put_u32(resp.rel.relnode);
+                        bytes.put_u8(resp.rel.forknum);
+                        bytes.put_u32(resp.n_blocks);
+                    }
+
+                    Self::GetPage(resp) => {
+                        bytes.put_u8(Tag::GetPage as u8);
+                        bytes.put_u64(resp.reqid);
+                        bytes.put_u64(resp.request_lsn.0);
+                        bytes.put_u64(resp.not_modified_since.0);
+                        bytes.put_u32(resp.rel.spcnode);
+                        bytes.put_u32(resp.rel.dbnode);
+                        bytes.put_u32(resp.rel.relnode);
+                        bytes.put_u8(resp.rel.forknum);
+                        bytes.put_u32(resp.blkno);
+                        bytes.put(&resp.page[..])
+                    }
+
+                    Self::Error(resp) => {
+                        bytes.put_u8(Tag::Error as u8);
+                        bytes.put_u64(resp.reqid);
+                        bytes.put_u64(resp.request_lsn.0);
+                        bytes.put_u64(resp.not_modified_since.0);
+                        bytes.put(resp.message.as_bytes());
+                        bytes.put_u8(0); // null terminator
+                    }
+                    Self::DbSize(resp) => {
+                        bytes.put_u8(Tag::DbSize as u8);
+                        bytes.put_u64(resp.reqid);
+                        bytes.put_u64(resp.request_lsn.0);
+                        bytes.put_u64(resp.not_modified_since.0);
+                        bytes.put_u32(resp.db_node);
+                        bytes.put_i64(resp.db_size);
+                    }
+
+                    Self::GetSlruSegment(resp) => {
+                        bytes.put_u8(Tag::GetSlruSegment as u8);
+                        bytes.put_u64(resp.reqid);
+                        bytes.put_u64(resp.request_lsn.0);
+                        bytes.put_u64(resp.not_modified_since.0);
+                        bytes.put_u8(resp.kind);
+                        bytes.put_u32(resp.segno);
+                        bytes.put_u32((resp.segment.len() / BLCKSZ as usize) as u32);
+                        bytes.put(&resp.segment[..]);
+                    }
+                }
             }
         }
-
         bytes.into()
     }
 
@@ -1710,38 +1835,109 @@ impl PagestreamBeMessage {
         let ok =
             match Tag::try_from(msg_tag).map_err(|tag: u8| anyhow::anyhow!("invalid tag {tag}"))? {
                 Tag::Exists => {
-                    let exists = buf.read_u8()?;
+                    let reqid = buf.read_u64::<BigEndian>()?;
+                    let request_lsn = Lsn(buf.read_u64::<BigEndian>()?);
+                    let not_modified_since = Lsn(buf.read_u64::<BigEndian>()?);
+                    let rel = RelTag {
+                        spcnode: buf.read_u32::<BigEndian>()?,
+                        dbnode: buf.read_u32::<BigEndian>()?,
+                        relnode: buf.read_u32::<BigEndian>()?,
+                        forknum: buf.read_u8()?,
+                    };
+                    let exists = buf.read_u8()? != 0;
                     Self::Exists(PagestreamExistsResponse {
-                        exists: exists != 0,
+                        reqid,
+                        request_lsn,
+                        not_modified_since,
+                        rel,
+                        exists,
                     })
                 }
                 Tag::Nblocks => {
+                    let reqid = buf.read_u64::<BigEndian>()?;
+                    let request_lsn = Lsn(buf.read_u64::<BigEndian>()?);
+                    let not_modified_since = Lsn(buf.read_u64::<BigEndian>()?);
+                    let rel = RelTag {
+                        spcnode: buf.read_u32::<BigEndian>()?,
+                        dbnode: buf.read_u32::<BigEndian>()?,
+                        relnode: buf.read_u32::<BigEndian>()?,
+                        forknum: buf.read_u8()?,
+                    };
                     let n_blocks = buf.read_u32::<BigEndian>()?;
-                    Self::Nblocks(PagestreamNblocksResponse { n_blocks })
+                    Self::Nblocks(PagestreamNblocksResponse {
+                        reqid,
+                        request_lsn,
+                        not_modified_since,
+                        rel,
+                        n_blocks,
+                    })
                 }
                 Tag::GetPage => {
+                    let reqid = buf.read_u64::<BigEndian>()?;
+                    let request_lsn = Lsn(buf.read_u64::<BigEndian>()?);
+                    let not_modified_since = Lsn(buf.read_u64::<BigEndian>()?);
+                    let rel = RelTag {
+                        spcnode: buf.read_u32::<BigEndian>()?,
+                        dbnode: buf.read_u32::<BigEndian>()?,
+                        relnode: buf.read_u32::<BigEndian>()?,
+                        forknum: buf.read_u8()?,
+                    };
+                    let blkno = buf.read_u32::<BigEndian>()?;
                     let mut page = vec![0; 8192]; // TODO: use MaybeUninit
                     buf.read_exact(&mut page)?;
-                    PagestreamBeMessage::GetPage(PagestreamGetPageResponse { page: page.into() })
+                    Self::GetPage(PagestreamGetPageResponse {
+                        reqid,
+                        request_lsn,
+                        not_modified_since,
+                        rel,
+                        blkno,
+                        page: page.into(),
+                    })
                 }
                 Tag::Error => {
+                    let reqid = buf.read_u64::<BigEndian>()?;
+                    let request_lsn = Lsn(buf.read_u64::<BigEndian>()?);
+                    let not_modified_since = Lsn(buf.read_u64::<BigEndian>()?);
                     let mut msg = Vec::new();
                     buf.read_until(0, &mut msg)?;
                     let cstring = std::ffi::CString::from_vec_with_nul(msg)?;
                     let rust_str = cstring.to_str()?;
-                    PagestreamBeMessage::Error(PagestreamErrorResponse {
+                    Self::Error(PagestreamErrorResponse {
+                        reqid,
+                        request_lsn,
+                        not_modified_since,
                         message: rust_str.to_owned(),
                     })
                 }
                 Tag::DbSize => {
+                    let reqid = buf.read_u64::<BigEndian>()?;
+                    let request_lsn = Lsn(buf.read_u64::<BigEndian>()?);
+                    let not_modified_since = Lsn(buf.read_u64::<BigEndian>()?);
+                    let db_node = buf.read_u32::<BigEndian>()?;
                     let db_size = buf.read_i64::<BigEndian>()?;
-                    Self::DbSize(PagestreamDbSizeResponse { db_size })
+                    Self::DbSize(PagestreamDbSizeResponse {
+                        reqid,
+                        request_lsn,
+                        not_modified_since,
+                        db_node,
+                        db_size,
+                    })
                 }
                 Tag::GetSlruSegment => {
+                    let reqid = buf.read_u64::<BigEndian>()?;
+                    let request_lsn = Lsn(buf.read_u64::<BigEndian>()?);
+                    let not_modified_since = Lsn(buf.read_u64::<BigEndian>()?);
+                    let kind = buf.read_u8()?;
+                    let segno = buf.read_u32::<BigEndian>()?;
                     let n_blocks = buf.read_u32::<BigEndian>()?;
                     let mut segment = vec![0; n_blocks as usize * BLCKSZ as usize];
                     buf.read_exact(&mut segment)?;
                     Self::GetSlruSegment(PagestreamGetSlruSegmentResponse {
+                        reqid,
+                        request_lsn,
+                        not_modified_since,
+                        kind,
+                        segno,
                         segment: segment.into(),
                     })
                 }
@@ -1780,6 +1976,7 @@ mod tests {
         // Test serialization/deserialization of PagestreamFeMessage
         let messages = vec![
             PagestreamFeMessage::Exists(PagestreamExistsRequest {
+                reqid: 0,
                 request_lsn: Lsn(4),
                 not_modified_since: Lsn(3),
                 rel: RelTag {
@@ -1790,6 +1987,7 @@ mod tests {
                 },
             }),
             PagestreamFeMessage::Nblocks(PagestreamNblocksRequest {
+                reqid: 0,
                 request_lsn: Lsn(4),
                 not_modified_since: Lsn(4),
                 rel: RelTag {
@@ -1800,6 +1998,7 @@ mod tests {
                 },
             }),
             PagestreamFeMessage::GetPage(PagestreamGetPageRequest {
+                reqid: 0,
                 request_lsn: Lsn(4),
                 not_modified_since: Lsn(3),
                 rel: RelTag {
@@ -1811,6 +2010,7 @@ mod tests {
                 blkno: 7,
             }),
             PagestreamFeMessage::DbSize(PagestreamDbSizeRequest {
+                reqid: 0,
                 request_lsn: Lsn(4),
                 not_modified_since: Lsn(3),
                 dbnode: 7,

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1561,7 +1561,7 @@ pub struct TenantHistorySize {
 
 impl PagestreamFeMessage {
     /// Serialize a compute -> pageserver message. This is currently only used in testing
-    /// tools. Always uses protocol version 2.
+    /// tools. Always uses protocol version 3.
     pub fn serialize(&self) -> Bytes {
         let mut bytes = BytesMut::new();
 
@@ -1748,7 +1748,7 @@ impl PagestreamBeMessage {
                     }
                 }
             }
-            _ => {
+            PagestreamProtocolVersion::V3 => {
                 match self {
                     Self::Exists(resp) => {
                         bytes.put_u8(Tag::Exists as u8);

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1460,6 +1460,11 @@ impl TryFrom<u8> for PagestreamBeMessageTag {
 // interface allows sending both LSNs, and let the pageserver do the right thing. There was no
 // difference in the responses between V1 and V2.
 //
+// V3 version of protocol adds request ID to all requests. This request ID is also included in response
+// as well as other fields from requests, which allows to verify that we receive response for our request.
+// We copy fields from request to response to make checking more reliable: request ID is formed from process ID
+// and local counter, so in principle there can be duplicated requests IDs if process PID is reused.
+//
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PagestreamProtocolVersion {
     V2,
@@ -1512,56 +1517,86 @@ pub struct PagestreamGetSlruSegmentRequest {
 
 #[derive(Debug)]
 pub struct PagestreamExistsResponse {
+    // Fields copied from the request, to aid debugging and to enable assertions in the
+    // compute to ensure that it doesn't mix up responses belonging to different
+    // requests.
     pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub rel: RelTag,
+
+    // Actual response
     pub exists: bool,
 }
 
 #[derive(Debug)]
 pub struct PagestreamNblocksResponse {
+    // Fields copied from the request, to aid debugging and to enable assertions in the
+    // compute to ensure that it doesn't mix up responses belonging to different
+    // requests.
     pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub rel: RelTag,
+
+    // Actual response
     pub n_blocks: u32,
 }
 
 #[derive(Debug)]
 pub struct PagestreamGetPageResponse {
+    // Fields copied from the request, to aid debugging and to enable assertions in the
+    // compute to ensure that it doesn't mix up responses belonging to different
+    // requests.
     pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub rel: RelTag,
+
+    // Actual response
     pub blkno: u32,
     pub page: Bytes,
 }
 
 #[derive(Debug)]
 pub struct PagestreamGetSlruSegmentResponse {
+    // Fields copied from the request, to aid debugging and to enable assertions in the
+    // compute to ensure that it doesn't mix up responses belonging to different
+    // requests.
     pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub kind: u8,
     pub segno: u32,
+
+    // Actual response
     pub segment: Bytes,
 }
 
 #[derive(Debug)]
 pub struct PagestreamErrorResponse {
+    // Fields copied from the request, to aid debugging and to enable assertions in the
+    // compute to ensure that it doesn't mix up responses belonging to different
+    // requests.
     pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
+
+    // Actual response
     pub message: String,
 }
 
 #[derive(Debug)]
 pub struct PagestreamDbSizeResponse {
+    // Fields copied from the request, to aid debugging and to enable assertions in the
+    // compute to ensure that it doesn't mix up responses belonging to different
+    // requests.
     pub reqid: RequestId,
     pub request_lsn: Lsn,
     pub not_modified_since: Lsn,
     pub db_node: u32,
+
+    // Actual response
     pub db_size: i64,
 }
 

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -2018,7 +2018,9 @@ mod tests {
         ];
         for msg in messages {
             let bytes = msg.serialize();
-            let reconstructed = PagestreamFeMessage::parse(&mut bytes.reader()).unwrap();
+            let reconstructed =
+                PagestreamFeMessage::parse(&mut bytes.reader(), PagestreamProtocolVersion::V3)
+                    .unwrap();
             assert!(msg == reconstructed);
         }
     }

--- a/pageserver/client/src/page_service.rs
+++ b/pageserver/client/src/page_service.rs
@@ -60,7 +60,7 @@ impl Client {
     ) -> anyhow::Result<PagestreamClient> {
         let copy_both: tokio_postgres::CopyBothDuplex<bytes::Bytes> = self
             .client
-            .copy_both_simple(&format!("pagestream_v2 {tenant_id} {timeline_id}"))
+            .copy_both_simple(&format!("pagestream_v3 {tenant_id} {timeline_id}"))
             .await?;
         let Client {
             cancel_on_client_drop,

--- a/pageserver/pagebench/src/cmd/getpage_latest_lsn.rs
+++ b/pageserver/pagebench/src/cmd/getpage_latest_lsn.rs
@@ -322,6 +322,7 @@ async fn main_impl(
                         .to_rel_block()
                         .expect("we filter non-rel-block keys out above");
                     PagestreamGetPageRequest {
+                        reqid: 0,
                         request_lsn: if rng.gen_bool(args.req_latest_probability) {
                             Lsn::MAX
                         } else {

--- a/pageserver/pagebench/src/cmd/getpage_latest_lsn.rs
+++ b/pageserver/pagebench/src/cmd/getpage_latest_lsn.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use camino::Utf8PathBuf;
 use pageserver_api::key::Key;
 use pageserver_api::keyspace::KeySpaceAccum;
-use pageserver_api::models::PagestreamGetPageRequest;
+use pageserver_api::models::{PagestreamGetPageRequest, PagestreamRequest};
 
 use pageserver_api::shard::TenantShardId;
 use tokio_util::sync::CancellationToken;
@@ -322,13 +322,15 @@ async fn main_impl(
                         .to_rel_block()
                         .expect("we filter non-rel-block keys out above");
                     PagestreamGetPageRequest {
-                        reqid: 0,
-                        request_lsn: if rng.gen_bool(args.req_latest_probability) {
-                            Lsn::MAX
-                        } else {
-                            r.timeline_lsn
+                        hdr: PagestreamRequest {
+                            reqid: 0,
+                            request_lsn: if rng.gen_bool(args.req_latest_probability) {
+                                Lsn::MAX
+                            } else {
+                                r.timeline_lsn
+                            },
+                            not_modified_since: r.timeline_lsn,
                         },
-                        not_modified_since: r.timeline_lsn,
                         rel: rel_tag,
                         blkno: block_no,
                     }

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -1845,6 +1845,7 @@ pub(crate) static LIVE_CONNECTIONS: Lazy<IntCounterPairVec> = Lazy::new(|| {
 
 #[derive(Clone, Copy, enum_map::Enum, IntoStaticStr)]
 pub(crate) enum ComputeCommandKind {
+    PageStreamV3,
     PageStreamV2,
     Basebackup,
     Fullbackup,

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -677,6 +677,7 @@ impl PageServerHandler {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn pagestream_read_message<IO>(
         pgb: &mut PostgresBackendReader<IO>,
         tenant_id: TenantId,

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1105,7 +1105,7 @@ impl PageServerHandler {
                         // print the all details to the log with {:#}, but for the client the
                         // error message is enough.  Do not log if shutting down, as the anyhow::Error
                         // here includes cancellation which is not an error.
-                        let full = utils::error::report_compact_sources(&e);
+                        let full = utils::error::report_compact_sources(&e.err);
                         span.in_scope(|| {
                             error!("error reading relation or page version: {full:#}")
                         });

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -552,12 +552,12 @@ impl std::fmt::Display for BatchedPageStreamError {
 }
 
 struct BatchedGetPageRequest {
-    rel: RelTag,
-    blkno: BlockNumber,
+	rel: RelTag,
+	blkno: BlockNumber,
     reqid: RequestId,
     request_lsn: Lsn,
     not_modified_since: Lsn,
-    timer: SmgrOpTimer,
+	timer: SmgrOpTimer,
 }
 
 enum BatchedFeMessage {
@@ -863,13 +863,8 @@ impl PageServerHandler {
                     shard,
                     effective_request_lsn,
                     pages: smallvec::smallvec![BatchedGetPageRequest {
-                        rel,
-                        blkno,
-                        reqid,
-                        request_lsn,
-                        not_modified_since,
-                        timer
-                    }],
+					    rel, blkno, reqid, request_lsn, not_modified_since, timer
+					}],
                 }
             }
         };
@@ -1232,7 +1227,7 @@ impl PageServerHandler {
                     request_span,
                     pipelining_config,
                     protocol_version,
-                    &ctx,
+					&ctx,
                 )
                 .await
             }
@@ -1245,7 +1240,7 @@ impl PageServerHandler {
                     timeline_handles,
                     request_span,
                     protocol_version,
-                    &ctx,
+					&ctx,
                 )
                 .await
             }
@@ -1763,32 +1758,29 @@ impl PageServerHandler {
         assert_eq!(results.len(), requests.len());
 
         // TODO: avoid creating the new Vec here
-        Vec::from_iter(
-            requests
-                .into_iter()
-                .zip(results.into_iter())
-                .map(|(req, res)| {
-                    res.map(|page| {
-                        (
-                            PagestreamBeMessage::GetPage(models::PagestreamGetPageResponse {
-                                reqid: req.reqid,
-                                request_lsn: req.request_lsn,
-                                not_modified_since: req.not_modified_since,
-                                rel: req.rel,
-                                blkno: req.blkno,
-                                page,
-                            }),
-                            req.timer,
-                        )
-                    })
-                    .map_err(|e| BatchedPageStreamError {
-                        err: PageStreamError::from(e),
-                        reqid: req.reqid,
-                        request_lsn: req.request_lsn,
-                        not_modified_since: req.not_modified_since,
-                    })
-                }),
-        )
+        Vec::from_iter(requests.into_iter().zip(results.into_iter()).map(
+            |(req, res)| {
+                res.map(|page| {
+                    (
+                        PagestreamBeMessage::GetPage(models::PagestreamGetPageResponse {
+                            reqid: req.reqid,
+                            request_lsn: req.request_lsn,
+                            not_modified_since: req.not_modified_since,
+                            rel: req.rel,
+                            blkno: req.blkno,
+                            page,
+                        }),
+                        req.timer,
+                    )
+                })
+                .map_err(|e| BatchedPageStreamError {
+                    err: PageStreamError::from(e),
+                    reqid: req.reqid,
+                    request_lsn: req.request_lsn,
+                    not_modified_since: req.not_modified_since,
+                })
+            },
+        ))
     }
 
     #[instrument(skip_all, fields(shard_id))]

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -2472,7 +2472,7 @@ mod tests {
             PageServiceCmd::PageStream(PageStreamCmd {
                 tenant_id,
                 timeline_id,
-                PagestreamProtocolVersion::V2,
+                protocol_version: PagestreamProtocolVersion::V2,
             })
         );
         let cmd = PageServiceCmd::parse(&format!("basebackup {tenant_id} {timeline_id}")).unwrap();

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -552,12 +552,12 @@ impl std::fmt::Display for BatchedPageStreamError {
 }
 
 struct BatchedGetPageRequest {
-	rel: RelTag,
-	blkno: BlockNumber,
+    rel: RelTag,
+    blkno: BlockNumber,
     reqid: RequestId,
     request_lsn: Lsn,
     not_modified_since: Lsn,
-	timer: SmgrOpTimer,
+    timer: SmgrOpTimer,
 }
 
 enum BatchedFeMessage {
@@ -863,8 +863,13 @@ impl PageServerHandler {
                     shard,
                     effective_request_lsn,
                     pages: smallvec::smallvec![BatchedGetPageRequest {
-					    rel, blkno, reqid, request_lsn, not_modified_since, timer
-					}],
+                        rel,
+                        blkno,
+                        reqid,
+                        request_lsn,
+                        not_modified_since,
+                        timer
+                    }],
                 }
             }
         };
@@ -1227,7 +1232,7 @@ impl PageServerHandler {
                     request_span,
                     pipelining_config,
                     protocol_version,
-					&ctx,
+                    &ctx,
                 )
                 .await
             }
@@ -1240,7 +1245,7 @@ impl PageServerHandler {
                     timeline_handles,
                     request_span,
                     protocol_version,
-					&ctx,
+                    &ctx,
                 )
                 .await
             }
@@ -1758,29 +1763,32 @@ impl PageServerHandler {
         assert_eq!(results.len(), requests.len());
 
         // TODO: avoid creating the new Vec here
-        Vec::from_iter(requests.into_iter().zip(results.into_iter()).map(
-            |(req, res)| {
-                res.map(|page| {
-                    (
-                        PagestreamBeMessage::GetPage(models::PagestreamGetPageResponse {
-                            reqid: req.reqid,
-                            request_lsn: req.request_lsn,
-                            not_modified_since: req.not_modified_since,
-                            rel: req.rel,
-                            blkno: req.blkno,
-                            page,
-                        }),
-                        req.timer,
-                    )
-                })
-                .map_err(|e| BatchedPageStreamError {
-                    err: PageStreamError::from(e),
-                    reqid: req.reqid,
-                    request_lsn: req.request_lsn,
-                    not_modified_since: req.not_modified_since,
-                })
-            },
-        ))
+        Vec::from_iter(
+            requests
+                .into_iter()
+                .zip(results.into_iter())
+                .map(|(req, res)| {
+                    res.map(|page| {
+                        (
+                            PagestreamBeMessage::GetPage(models::PagestreamGetPageResponse {
+                                reqid: req.reqid,
+                                request_lsn: req.request_lsn,
+                                not_modified_since: req.not_modified_since,
+                                rel: req.rel,
+                                blkno: req.blkno,
+                                page,
+                            }),
+                            req.timer,
+                        )
+                    })
+                    .map_err(|e| BatchedPageStreamError {
+                        err: PageStreamError::from(e),
+                        reqid: req.reqid,
+                        request_lsn: req.request_lsn,
+                        not_modified_since: req.not_modified_since,
+                    })
+                }),
+        )
     }
 
     #[instrument(skip_all, fields(shard_id))]

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -1138,9 +1138,9 @@ pg_init_libpagestore(void)
 							"Version of compute<->page server protocol",
 							NULL,
 							&neon_protocol_version,
-							2, /* use protocol version 2 */
-							2, /* min */
-							3, /* max */
+							2,	/* use protocol version 2 */
+							2,	/* min */
+							3,	/* max */
 							PGC_SU_BACKEND,
 							0,	/* no flags required */
 							NULL, NULL, NULL);

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -556,6 +556,9 @@ pageserver_connect(shardno_t shard_no, int elevel)
 
 		switch (neon_protocol_version)
 		{
+		case 3:
+			pagestream_query = psprintf("pagestream_v3 %s %s", neon_tenant, neon_timeline);
+			break;
 		case 2:
 			pagestream_query = psprintf("pagestream_v2 %s %s", neon_tenant, neon_timeline);
 			break;
@@ -1137,7 +1140,7 @@ pg_init_libpagestore(void)
 							&neon_protocol_version,
 							2, /* use protocol version 2 */
 							2, /* min */
-							2, /* max */
+							3, /* max */
 							PGC_SU_BACKEND,
 							0,	/* no flags required */
 							NULL, NULL, NULL);

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -93,6 +93,11 @@ typedef enum {
  *
  * These structs describe the V2 of these requests. (The old now-defunct V1
  * protocol contained just one LSN and a boolean 'latest' flag.)
+ *
+ * V3 version of protocol adds request ID to all requests. This request ID is also included in response
+ * as well as other fields from requests, which allows to verify that we receive response for our request.
+ * We copy fields from request to response to make checking more reliable: request ID is formed from process ID
+ * and local counter, so in principle there can be duplicated requests IDs if process PID is reused.
  */
 typedef NeonMessage NeonRequest;
 

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -49,10 +49,10 @@ typedef uint64 NeonRequestId;
 /* base struct for c-style inheritance */
 typedef struct
 {
-	NeonMessageTag	tag;
-	NeonRequestId	reqid;
-	XLogRecPtr		lsn;
-	XLogRecPtr		not_modified_since;
+	NeonMessageTag tag;
+	NeonRequestId reqid;
+	XLogRecPtr	lsn;
+	XLogRecPtr	not_modified_since;
 } NeonMessage;
 
 #define messageTag(m) (((const NeonMessage *)(m))->tag)
@@ -98,37 +98,37 @@ typedef NeonMessage NeonRequest;
 
 typedef struct
 {
-	NeonRequest 	req;
-	NRelFileInfo 	rinfo;
-	ForkNumber		forknum;
+	NeonRequest req;
+	NRelFileInfo rinfo;
+	ForkNumber	forknum;
 } NeonExistsRequest;
 
 typedef struct
 {
-	NeonRequest 	req;
-	NRelFileInfo 	rinfo;
-	ForkNumber		forknum;
+	NeonRequest req;
+	NRelFileInfo rinfo;
+	ForkNumber	forknum;
 } NeonNblocksRequest;
 
 typedef struct
 {
-	NeonRequest 	req;
-	Oid				dbNode;
+	NeonRequest req;
+	Oid			dbNode;
 } NeonDbSizeRequest;
 
 typedef struct
 {
-	NeonRequest		req;
-	NRelFileInfo 	rinfo;
-	ForkNumber		forknum;
-	BlockNumber 	blkno;
+	NeonRequest req;
+	NRelFileInfo rinfo;
+	ForkNumber	forknum;
+	BlockNumber blkno;
 } NeonGetPageRequest;
 
 typedef struct
 {
-	NeonRequest 	req;
-	SlruKind 		kind;
-	int      		segno;
+	NeonRequest req;
+	SlruKind	kind;
+	int			segno;
 } NeonGetSlruSegmentRequest;
 
 /* supertype of all the Neon*Response structs below */
@@ -136,52 +136,52 @@ typedef NeonMessage NeonResponse;
 
 typedef struct
 {
-	NeonResponse	resp;
-	NRelFileInfo	rinfo;
-	ForkNumber		forknum;
-	bool			exists;
+	NeonResponse resp;
+	NRelFileInfo rinfo;
+	ForkNumber	forknum;
+	bool		exists;
 } NeonExistsResponse;
 
 typedef struct
 {
-	NeonResponse	resp;
-	NRelFileInfo	rinfo;
-	ForkNumber		forknum;
-	uint32			n_blocks;
+	NeonResponse resp;
+	NRelFileInfo rinfo;
+	ForkNumber	forknum;
+	uint32		n_blocks;
 } NeonNblocksResponse;
 
 typedef struct
 {
-	NeonResponse	resp;
-	NRelFileInfo	rinfo;
-	ForkNumber		forknum;
-	BlockNumber 	blkno;
-	char			page[FLEXIBLE_ARRAY_MEMBER];
+	NeonResponse resp;
+	NRelFileInfo rinfo;
+	ForkNumber	forknum;
+	BlockNumber blkno;
+	char		page[FLEXIBLE_ARRAY_MEMBER];
 } NeonGetPageResponse;
 
 #define PS_GETPAGERESPONSE_SIZE (MAXALIGN(offsetof(NeonGetPageResponse, page) + BLCKSZ))
 
 typedef struct
 {
-	NeonResponse	resp;
-	Oid             dbNode;
-	int64			db_size;
+	NeonResponse resp;
+	Oid			dbNode;
+	int64		db_size;
 } NeonDbSizeResponse;
 
 typedef struct
 {
-	NeonResponse	resp;
-	char			message[FLEXIBLE_ARRAY_MEMBER]; /* null-terminated error
-													 * message */
+	NeonResponse resp;
+	char		message[FLEXIBLE_ARRAY_MEMBER]; /* null-terminated error
+												 * message */
 } NeonErrorResponse;
 
 typedef struct
 {
-	NeonResponse	resp;
-	SlruKind 		kind;
-	int      		segno;
-	int         	n_blocks;
-	char			data[BLCKSZ * SLRU_PAGES_PER_SEGMENT];
+	NeonResponse resp;
+	SlruKind	kind;
+	int			segno;
+	int			n_blocks;
+	char		data[BLCKSZ * SLRU_PAGES_PER_SEGMENT];
 } NeonGetSlruSegmentResponse;
 
 

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -44,10 +44,15 @@ typedef enum
 	T_NeonGetSlruSegmentResponse,
 } NeonMessageTag;
 
+typedef uint64 NeonRequestId;
+
 /* base struct for c-style inheritance */
 typedef struct
 {
-	NeonMessageTag tag;
+	NeonMessageTag	tag;
+	NeonRequestId	reqid;
+	XLogRecPtr		lsn;
+	XLogRecPtr		not_modified_since;
 } NeonMessage;
 
 #define messageTag(m) (((const NeonMessage *)(m))->tag)
@@ -66,6 +71,7 @@ typedef enum {
 	SLRU_MULTIXACT_MEMBERS,
 	SLRU_MULTIXACT_OFFSETS
 } SlruKind;
+
 
 /*--
  * supertype of all the Neon*Request structs below.
@@ -88,92 +94,94 @@ typedef enum {
  * These structs describe the V2 of these requests. (The old now-defunct V1
  * protocol contained just one LSN and a boolean 'latest' flag.)
  */
-typedef struct
-{
-	NeonMessageTag tag;
-	XLogRecPtr	lsn;
-	XLogRecPtr	not_modified_since;
-} NeonRequest;
+typedef NeonMessage NeonRequest;
 
 typedef struct
 {
-	NeonRequest req;
-	NRelFileInfo rinfo;
-	ForkNumber	forknum;
+	NeonRequest 	req;
+	NRelFileInfo 	rinfo;
+	ForkNumber		forknum;
 } NeonExistsRequest;
 
 typedef struct
 {
-	NeonRequest req;
-	NRelFileInfo rinfo;
-	ForkNumber	forknum;
+	NeonRequest 	req;
+	NRelFileInfo 	rinfo;
+	ForkNumber		forknum;
 } NeonNblocksRequest;
 
 typedef struct
 {
-	NeonRequest req;
-	Oid			dbNode;
+	NeonRequest 	req;
+	Oid				dbNode;
 } NeonDbSizeRequest;
 
 typedef struct
 {
-	NeonRequest req;
-	NRelFileInfo rinfo;
-	ForkNumber	forknum;
-	BlockNumber blkno;
+	NeonRequest		req;
+	NRelFileInfo 	rinfo;
+	ForkNumber		forknum;
+	BlockNumber 	blkno;
 } NeonGetPageRequest;
 
 typedef struct
 {
-	NeonRequest req;
-	SlruKind kind;
-	int      segno;
+	NeonRequest 	req;
+	SlruKind 		kind;
+	int      		segno;
 } NeonGetSlruSegmentRequest;
 
 /* supertype of all the Neon*Response structs below */
-typedef struct
-{
-	NeonMessageTag tag;
-} NeonResponse;
+typedef NeonMessage NeonResponse;
 
 typedef struct
 {
-	NeonMessageTag tag;
-	bool		exists;
+	NeonResponse	resp;
+	NRelFileInfo	rinfo;
+	ForkNumber		forknum;
+	bool			exists;
 } NeonExistsResponse;
 
 typedef struct
 {
-	NeonMessageTag tag;
-	uint32		n_blocks;
+	NeonResponse	resp;
+	NRelFileInfo	rinfo;
+	ForkNumber		forknum;
+	uint32			n_blocks;
 } NeonNblocksResponse;
 
 typedef struct
 {
-	NeonMessageTag tag;
-	char		page[FLEXIBLE_ARRAY_MEMBER];
+	NeonResponse	resp;
+	NRelFileInfo	rinfo;
+	ForkNumber		forknum;
+	BlockNumber 	blkno;
+	char			page[FLEXIBLE_ARRAY_MEMBER];
 } NeonGetPageResponse;
 
 #define PS_GETPAGERESPONSE_SIZE (MAXALIGN(offsetof(NeonGetPageResponse, page) + BLCKSZ))
 
 typedef struct
 {
-	NeonMessageTag tag;
-	int64		db_size;
+	NeonResponse	resp;
+	Oid             dbNode;
+	int64			db_size;
 } NeonDbSizeResponse;
 
 typedef struct
 {
-	NeonMessageTag tag;
-	char		message[FLEXIBLE_ARRAY_MEMBER]; /* null-terminated error
-												 * message */
+	NeonResponse	resp;
+	char			message[FLEXIBLE_ARRAY_MEMBER]; /* null-terminated error
+													 * message */
 } NeonErrorResponse;
 
 typedef struct
 {
-	NeonMessageTag tag;
-	int         n_blocks;
-	char		data[BLCKSZ * SLRU_PAGES_PER_SEGMENT];
+	NeonResponse	resp;
+	SlruKind 		kind;
+	int      		segno;
+	int         	n_blocks;
+	char			data[BLCKSZ * SLRU_PAGES_PER_SEGMENT];
 } NeonGetSlruSegmentResponse;
 
 

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -103,27 +103,27 @@ typedef NeonMessage NeonRequest;
 
 typedef struct
 {
-	NeonRequest req;
+	NeonRequest hdr;
 	NRelFileInfo rinfo;
 	ForkNumber	forknum;
 } NeonExistsRequest;
 
 typedef struct
 {
-	NeonRequest req;
+	NeonRequest hdr;
 	NRelFileInfo rinfo;
 	ForkNumber	forknum;
 } NeonNblocksRequest;
 
 typedef struct
 {
-	NeonRequest req;
+	NeonRequest hdr;
 	Oid			dbNode;
 } NeonDbSizeRequest;
 
 typedef struct
 {
-	NeonRequest req;
+	NeonRequest hdr;
 	NRelFileInfo rinfo;
 	ForkNumber	forknum;
 	BlockNumber blkno;
@@ -131,7 +131,7 @@ typedef struct
 
 typedef struct
 {
-	NeonRequest req;
+	NeonRequest hdr;
 	SlruKind	kind;
 	int			segno;
 } NeonGetSlruSegmentRequest;
@@ -141,26 +141,19 @@ typedef NeonMessage NeonResponse;
 
 typedef struct
 {
-	NeonResponse resp;
-	NRelFileInfo rinfo;
-	ForkNumber	forknum;
+	NeonExistsRequest req;
 	bool		exists;
 } NeonExistsResponse;
 
 typedef struct
 {
-	NeonResponse resp;
-	NRelFileInfo rinfo;
-	ForkNumber	forknum;
+	NeonNblocksRequest req;
 	uint32		n_blocks;
 } NeonNblocksResponse;
 
 typedef struct
 {
-	NeonResponse resp;
-	NRelFileInfo rinfo;
-	ForkNumber	forknum;
-	BlockNumber blkno;
+	NeonGetPageRequest req;
 	char		page[FLEXIBLE_ARRAY_MEMBER];
 } NeonGetPageResponse;
 
@@ -168,23 +161,20 @@ typedef struct
 
 typedef struct
 {
-	NeonResponse resp;
-	Oid			dbNode;
+	NeonDbSizeRequest req;
 	int64		db_size;
 } NeonDbSizeResponse;
 
 typedef struct
 {
-	NeonResponse resp;
+	NeonResponse req;
 	char		message[FLEXIBLE_ARRAY_MEMBER]; /* null-terminated error
 												 * message */
 } NeonErrorResponse;
 
 typedef struct
 {
-	NeonResponse resp;
-	SlruKind	kind;
-	int			segno;
+	NeonGetSlruSegmentRequest req;
 	int			n_blocks;
 	char		data[BLCKSZ * SLRU_PAGES_PER_SEGMENT];
 } NeonGetSlruSegmentResponse;

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -364,6 +364,7 @@ compact_prefetch_buffers(void)
 		target_slot->shard_no = source_slot->shard_no;
 		target_slot->status = source_slot->status;
 		target_slot->response = source_slot->response;
+		target_slot->reqid = source_slot->reqid;
 		target_slot->request_lsns = source_slot->request_lsns;
 		target_slot->my_ring_index = empty_ring_index;
 
@@ -2373,7 +2374,7 @@ neon_exists(SMgrRelation reln, ForkNumber forkNum)
 					if (resp->reqid != request.req.reqid ||
 						resp->lsn != request.req.lsn ||
 						resp->not_modified_since != request.req.not_modified_since ||
-						RelFileInfoEquals(exists_resp->rinfo, request.rinfo) ||
+						!RelFileInfoEquals(exists_resp->rinfo, request.rinfo) ||
 						exists_resp->forknum != forkNum)
 					{
 						NEON_PANIC_CONNECTION_STATE(-1, PANIC,
@@ -3029,7 +3030,7 @@ Retry:
 					if (resp->reqid != slot->reqid ||
 						resp->lsn != slot->request_lsns.request_lsn ||
 						resp->not_modified_since != slot->request_lsns.not_modified_since ||
-						RelFileInfoEquals(getpage_resp->rinfo, rinfo) ||
+						!RelFileInfoEquals(getpage_resp->rinfo, rinfo) ||
 						getpage_resp->forknum != forkNum ||
 						getpage_resp->blkno != base_blockno + i)
 					{
@@ -3561,7 +3562,7 @@ neon_nblocks(SMgrRelation reln, ForkNumber forknum)
 					if (resp->reqid != request.req.reqid ||
 						resp->lsn != request.req.lsn ||
 						resp->not_modified_since != request.req.not_modified_since ||
-						RelFileInfoEquals(relsize_resp->rinfo, request.rinfo) ||
+						!RelFileInfoEquals(relsize_resp->rinfo, request.rinfo) ||
 						relsize_resp->forknum != forknum)
 					{
 						NEON_PANIC_CONNECTION_STATE(-1, PANIC,

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -120,6 +120,9 @@ static bool (*old_redo_read_buffer_filter) (XLogReaderState *record, uint8 block
 
 static BlockNumber neon_nblocks(SMgrRelation reln, ForkNumber forknum);
 
+static uint32 local_request_counter;
+#define GENERATE_REQUEST_ID() (((NeonRequestId)MyProcPid << 32) | ++local_request_counter)
+
 /*
  * Prefetch implementation:
  *
@@ -188,14 +191,10 @@ typedef struct PrefetchRequest
 	uint8		status;		/* see PrefetchStatus for valid values */
 	uint8		flags;		/* see PrefetchRequestFlags */
 	neon_request_lsns request_lsns;
+	NeonRequestId reqid;
 	NeonResponse *response;		/* may be null */
 	uint64		my_ring_index;
 } PrefetchRequest;
-
-StaticAssertDecl(sizeof(PrefetchRequest) == 64,
-				 "We prefer to have a power-of-2 size for this struct. Please"
-				 " try to find an alternative solution before reaching to"
-				 " increase the expected size here");
 
 /* prefetch buffer lookup hash table */
 
@@ -797,6 +796,7 @@ prefetch_do_request(PrefetchRequest *slot, neon_request_lsns *force_request_lsns
 
 	NeonGetPageRequest request = {
 		.req.tag = T_NeonGetPageRequest,
+		.req.reqid = GENERATE_REQUEST_ID(),
 		/* lsn and not_modified_since are filled in below */
 		.rinfo = BufTagGetNRelFileInfo(slot->buftag),
 		.forknum = slot->buftag.forkNum,
@@ -804,6 +804,8 @@ prefetch_do_request(PrefetchRequest *slot, neon_request_lsns *force_request_lsns
 	};
 
 	Assert(mySlotNo == MyPState->ring_unused);
+
+	slot->reqid = request.req.reqid;
 
 	if (force_request_lsns)
 		slot->request_lsns = *force_request_lsns;
@@ -1177,6 +1179,10 @@ nm_pack_request(NeonRequest *msg)
 	initStringInfo(&s);
 
 	pq_sendbyte(&s, msg->tag);
+	if (neon_protocol_version >= 3)
+	{
+		pq_sendint64(&s, msg->reqid);
+	}
 	pq_sendint64(&s, msg->lsn);
 	pq_sendint64(&s, msg->not_modified_since);
 
@@ -1254,8 +1260,16 @@ NeonResponse *
 nm_unpack_response(StringInfo s)
 {
 	NeonMessageTag tag = pq_getmsgbyte(s);
+	NeonResponse resp_hdr = {0}; /* make valgrind happy */
 	NeonResponse *resp = NULL;
 
+	resp_hdr.tag = tag;
+	if (neon_protocol_version >= 3)
+	{
+		resp_hdr.reqid = pq_getmsgint64(s);
+		resp_hdr.lsn = pq_getmsgint64(s);
+		resp_hdr.not_modified_since = pq_getmsgint64(s);
+	}
 	switch (tag)
 	{
 			/* pagestore -> pagestore_client */
@@ -1263,7 +1277,14 @@ nm_unpack_response(StringInfo s)
 			{
 				NeonExistsResponse *msg_resp = palloc0(sizeof(NeonExistsResponse));
 
-				msg_resp->tag = tag;
+				if (neon_protocol_version >= 3)
+				{
+					NInfoGetSpcOid(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					NInfoGetDbOid(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					NInfoGetRelNumber(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					msg_resp->forknum = pq_getmsgbyte(s);
+				}
+				msg_resp->resp = resp_hdr;
 				msg_resp->exists = pq_getmsgbyte(s);
 				pq_getmsgend(s);
 
@@ -1275,7 +1296,14 @@ nm_unpack_response(StringInfo s)
 			{
 				NeonNblocksResponse *msg_resp = palloc0(sizeof(NeonNblocksResponse));
 
-				msg_resp->tag = tag;
+				if (neon_protocol_version >= 3)
+				{
+					NInfoGetSpcOid(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					NInfoGetDbOid(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					NInfoGetRelNumber(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					msg_resp->forknum = pq_getmsgbyte(s);
+				}
+				msg_resp->resp = resp_hdr;
 				msg_resp->n_blocks = pq_getmsgint(s, 4);
 				pq_getmsgend(s);
 
@@ -1288,12 +1316,20 @@ nm_unpack_response(StringInfo s)
 				NeonGetPageResponse *msg_resp;
 
 				msg_resp = MemoryContextAllocZero(MyPState->bufctx, PS_GETPAGERESPONSE_SIZE);
-				msg_resp->tag = tag;
+				if (neon_protocol_version >= 3)
+				{
+					NInfoGetSpcOid(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					NInfoGetDbOid(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					NInfoGetRelNumber(msg_resp->rinfo) = pq_getmsgint(s, 4);
+					msg_resp->forknum = pq_getmsgbyte(s);
+					msg_resp->blkno = pq_getmsgint(s, 4);
+				}
+				msg_resp->resp = resp_hdr;
 				/* XXX:	should be varlena */
 				memcpy(msg_resp->page, pq_getmsgbytes(s, BLCKSZ), BLCKSZ);
 				pq_getmsgend(s);
 
-				Assert(msg_resp->tag == T_NeonGetPageResponse);
+				Assert(msg_resp->resp.tag == T_NeonGetPageResponse);
 
 				resp = (NeonResponse *) msg_resp;
 				break;
@@ -1303,7 +1339,11 @@ nm_unpack_response(StringInfo s)
 			{
 				NeonDbSizeResponse *msg_resp = palloc0(sizeof(NeonDbSizeResponse));
 
-				msg_resp->tag = tag;
+				if (neon_protocol_version >= 3)
+				{
+					msg_resp->dbNode = pq_getmsgint(s, 4);
+				}
+				msg_resp->resp = resp_hdr;
 				msg_resp->db_size = pq_getmsgint64(s);
 				pq_getmsgend(s);
 
@@ -1321,7 +1361,7 @@ nm_unpack_response(StringInfo s)
 				msglen = strlen(msgtext);
 
 				msg_resp = palloc0(sizeof(NeonErrorResponse) + msglen + 1);
-				msg_resp->tag = tag;
+				msg_resp->resp = resp_hdr;
 				memcpy(msg_resp->message, msgtext, msglen + 1);
 				pq_getmsgend(s);
 
@@ -1332,9 +1372,17 @@ nm_unpack_response(StringInfo s)
 		case T_NeonGetSlruSegmentResponse:
 		    {
 				NeonGetSlruSegmentResponse *msg_resp;
-				int n_blocks = pq_getmsgint(s, 4);
+				int n_blocks;
 				msg_resp = palloc(sizeof(NeonGetSlruSegmentResponse));
-				msg_resp->tag = tag;
+
+				if (neon_protocol_version >= 3)
+				{
+					msg_resp->kind = pq_getmsgbyte(s);
+					msg_resp->segno = pq_getmsgint(s, 4);
+				}
+				msg_resp->resp = resp_hdr;
+
+				n_blocks = pq_getmsgint(s, 4);
 				msg_resp->n_blocks = n_blocks;
 				memcpy(msg_resp->data, pq_getmsgbytes(s, n_blocks * BLCKSZ), n_blocks * BLCKSZ);
 				pq_getmsgend(s);
@@ -2306,6 +2354,7 @@ neon_exists(SMgrRelation reln, ForkNumber forkNum)
 	{
 		NeonExistsRequest request = {
 			.req.tag = T_NeonExistsRequest,
+			.req.reqid = GENERATE_REQUEST_ID(),
 			.req.lsn = request_lsns.request_lsn,
 			.req.not_modified_since = request_lsns.not_modified_since,
 			.rinfo = InfoFromSMgrRel(reln),
@@ -2313,31 +2362,59 @@ neon_exists(SMgrRelation reln, ForkNumber forkNum)
 		};
 
 		resp = page_server_request(&request);
+
+		switch (resp->tag)
+		{
+			case T_NeonExistsResponse:
+			{
+				NeonExistsResponse* exists_resp = (NeonExistsResponse *) resp;
+				if (neon_protocol_version >= 3)
+				{
+					if (resp->reqid != request.req.reqid ||
+						resp->lsn != request.req.lsn ||
+						resp->not_modified_since != request.req.not_modified_since ||
+						RelFileInfoEquals(exists_resp->rinfo, request.rinfo) ||
+						exists_resp->forknum != forkNum)
+					{
+						NEON_PANIC_CONNECTION_STATE(-1, PANIC,
+													"Unexpect response {reqid=%lx,lsn=%X/%08X, since=%X/%08X, rel=%u/%u/%u.%u} to exits request {reqid=%lx,lsn=%X/%08X, since=%X/%08X, rel=%u/%u/%u.%u}",
+													resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since), RelFileInfoFmt(exists_resp->rinfo), exists_resp->forknum,
+													request.req.reqid, LSN_FORMAT_ARGS(request.req.lsn), LSN_FORMAT_ARGS(request.req.not_modified_since), RelFileInfoFmt(request.rinfo), forkNum);
+					}
+				}
+				exists = exists_resp->exists;
+				break;
+			}
+			case T_NeonErrorResponse:
+				if (neon_protocol_version >= 3)
+				{
+					if (resp->reqid != request.req.reqid ||
+						resp->lsn != request.req.lsn ||
+						resp->not_modified_since != request.req.not_modified_since)
+					{
+						elog(WARNING, NEON_TAG "Error message {reqid=%lx,lsn=%X/%08X, since=%X/%08X} doesn't match exists request {reqid=%lx,lsn=%X/%08X, since=%X/%08X}",
+							 resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since),
+							 request.req.reqid, LSN_FORMAT_ARGS(request.req.lsn), LSN_FORMAT_ARGS(request.req.not_modified_since));
+					}
+				}
+				ereport(ERROR,
+						(errcode(ERRCODE_IO_ERROR),
+						 errmsg(NEON_TAG "[reqid %lx] could not read relation existence of rel %u/%u/%u.%u from page server at lsn %X/%08X",
+								resp->reqid,
+								RelFileInfoFmt(InfoFromSMgrRel(reln)),
+								forkNum,
+								LSN_FORMAT_ARGS(request_lsns.effective_request_lsn)),
+						 errdetail("page server returned error: %s",
+								   ((NeonErrorResponse *) resp)->message)));
+				break;
+
+			default:
+				NEON_PANIC_CONNECTION_STATE(-1, PANIC,
+											"Expected Exists (0x%02x) or Error (0x%02x) response to ExistsRequest, but got 0x%02x",
+											T_NeonExistsResponse, T_NeonErrorResponse, resp->tag);
+		}
+		pfree(resp);
 	}
-
-	switch (resp->tag)
-	{
-		case T_NeonExistsResponse:
-			exists = ((NeonExistsResponse *) resp)->exists;
-			break;
-
-		case T_NeonErrorResponse:
-			ereport(ERROR,
-					(errcode(ERRCODE_IO_ERROR),
-					 errmsg(NEON_TAG "could not read relation existence of rel %u/%u/%u.%u from page server at lsn %X/%08X",
-							RelFileInfoFmt(InfoFromSMgrRel(reln)),
-							forkNum,
-							LSN_FORMAT_ARGS(request_lsns.effective_request_lsn)),
-					 errdetail("page server returned error: %s",
-							   ((NeonErrorResponse *) resp)->message)));
-			break;
-
-		default:
-			NEON_PANIC_CONNECTION_STATE(-1, PANIC,
-										"Expected Exists (0x%02x) or Error (0x%02x) response to ExistsRequest, but got 0x%02x",
-										T_NeonExistsResponse, T_NeonErrorResponse, resp->tag);
-	}
-	pfree(resp);
 	return exists;
 }
 
@@ -2945,15 +3022,43 @@ Retry:
 		switch (resp->tag)
 		{
 			case T_NeonGetPageResponse:
-				memcpy(buffer, ((NeonGetPageResponse *) resp)->page, BLCKSZ);
+			{
+				NeonGetPageResponse* getpage_resp = (NeonGetPageResponse *) resp;
+				if (neon_protocol_version >= 3)
+				{
+					if (resp->reqid != slot->reqid ||
+						resp->lsn != slot->request_lsns.request_lsn ||
+						resp->not_modified_since != slot->request_lsns.not_modified_since ||
+						RelFileInfoEquals(getpage_resp->rinfo, rinfo) ||
+						getpage_resp->forknum != forkNum ||
+						getpage_resp->blkno != base_blockno + i)
+					{
+						NEON_PANIC_CONNECTION_STATE(-1, PANIC,
+													"Unexpect response {reqid=%lx,lsn=%X/%08X, since=%X/%08X, rel=%u/%u/%u.%u, block=%u} to get page request {reqid=%lx,lsn=%X/%08X, since=%X/%08X, rel=%u/%u/%u.%u, block=%u}",
+													resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since), RelFileInfoFmt(getpage_resp->rinfo), getpage_resp->forknum, getpage_resp->blkno,
+													slot->reqid, LSN_FORMAT_ARGS(slot->request_lsns.request_lsn), LSN_FORMAT_ARGS(slot->request_lsns.not_modified_since), RelFileInfoFmt(rinfo), forkNum, base_blockno + i);
+					}
+				}
+				memcpy(buffer, getpage_resp->page, BLCKSZ);
 				lfc_write(rinfo, forkNum, blockno, buffer);
 				break;
-
+			}
 			case T_NeonErrorResponse:
+				if (neon_protocol_version >= 3)
+				{
+					if (resp->reqid != slot->reqid ||
+						resp->lsn != slot->request_lsns.request_lsn ||
+						resp->not_modified_since != slot->request_lsns.not_modified_since)
+					{
+						elog(WARNING, NEON_TAG "Error message {reqid=%lx,lsn=%X/%08X, since=%X/%08X} doesn't match get relsize request {reqid=%lx,lsn=%X/%08X, since=%X/%08X}",
+							 resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since),
+							 slot->reqid, LSN_FORMAT_ARGS(slot->request_lsns.request_lsn), LSN_FORMAT_ARGS(slot->request_lsns.not_modified_since));
+					}
+				}
 				ereport(ERROR,
 						(errcode(ERRCODE_IO_ERROR),
-						 errmsg(NEON_TAG "[shard %d] could not read block %u in rel %u/%u/%u.%u from page server at lsn %X/%08X",
-								slot->shard_no, blockno, RelFileInfoFmt(rinfo),
+						 errmsg(NEON_TAG "[shard %d, reqid %lx] could not read block %u in rel %u/%u/%u.%u from page server at lsn %X/%08X",
+								slot->shard_no, resp->reqid, blockno, RelFileInfoFmt(rinfo),
 								forkNum, LSN_FORMAT_ARGS(reqlsns->effective_request_lsn)),
 						 errdetail("page server returned error: %s",
 								   ((NeonErrorResponse *) resp)->message)));
@@ -3437,6 +3542,7 @@ neon_nblocks(SMgrRelation reln, ForkNumber forknum)
 	{
 		NeonNblocksRequest request = {
 			.req.tag = T_NeonNblocksRequest,
+			.req.reqid = GENERATE_REQUEST_ID(),
 			.req.lsn = request_lsns.request_lsn,
 			.req.not_modified_since = request_lsns.not_modified_since,
 			.rinfo = InfoFromSMgrRel(reln),
@@ -3444,39 +3550,67 @@ neon_nblocks(SMgrRelation reln, ForkNumber forknum)
 		};
 
 		resp = page_server_request(&request);
+
+		switch (resp->tag)
+		{
+			case T_NeonNblocksResponse:
+			{
+				NeonNblocksResponse * relsize_resp = (NeonNblocksResponse *) resp;
+				if (neon_protocol_version >= 3)
+				{
+					if (resp->reqid != request.req.reqid ||
+						resp->lsn != request.req.lsn ||
+						resp->not_modified_since != request.req.not_modified_since ||
+						RelFileInfoEquals(relsize_resp->rinfo, request.rinfo) ||
+						relsize_resp->forknum != forknum)
+					{
+						NEON_PANIC_CONNECTION_STATE(-1, PANIC,
+													"Unexpect response {reqid=%lx,lsn=%X/%08X, since=%X/%08X, rel=%u/%u/%u.%u} to get relsize request {reqid=%lx,lsn=%X/%08X, since=%X/%08X, rel=%u/%u/%u.%u}",
+													resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since), RelFileInfoFmt(relsize_resp->rinfo), relsize_resp->forknum,
+													request.req.reqid, LSN_FORMAT_ARGS(request.req.lsn), LSN_FORMAT_ARGS(request.req.not_modified_since), RelFileInfoFmt(request.rinfo), forknum);
+					}
+				}
+				n_blocks = relsize_resp->n_blocks;
+				break;
+			}
+			case T_NeonErrorResponse:
+				if (neon_protocol_version >= 3)
+				{
+					if (resp->reqid != request.req.reqid ||
+						resp->lsn != request.req.lsn ||
+						resp->not_modified_since != request.req.not_modified_since)
+					{
+						elog(WARNING, NEON_TAG "Error message {reqid=%lx,lsn=%X/%08X, since=%X/%08X} doesn't match get relsize request {reqid=%lx,lsn=%X/%08X, since=%X/%08X}",
+							 resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since),
+							 request.req.reqid, LSN_FORMAT_ARGS(request.req.lsn), LSN_FORMAT_ARGS(request.req.not_modified_since));
+					}
+				}
+				ereport(ERROR,
+						(errcode(ERRCODE_IO_ERROR),
+						 errmsg(NEON_TAG "[reqid %lx] could not read relation size of rel %u/%u/%u.%u from page server at lsn %X/%08X",
+								resp->reqid,
+								RelFileInfoFmt(InfoFromSMgrRel(reln)),
+								forknum,
+								LSN_FORMAT_ARGS(request_lsns.effective_request_lsn)),
+						 errdetail("page server returned error: %s",
+								   ((NeonErrorResponse *) resp)->message)));
+				break;
+
+			default:
+				NEON_PANIC_CONNECTION_STATE(-1, PANIC,
+											"Expected Nblocks (0x%02x) or Error (0x%02x) response to NblocksRequest, but got 0x%02x",
+											T_NeonNblocksResponse, T_NeonErrorResponse, resp->tag);
+		}
+		update_cached_relsize(InfoFromSMgrRel(reln), forknum, n_blocks);
+
+		neon_log(SmgrTrace, "neon_nblocks: rel %u/%u/%u fork %u (request LSN %X/%08X): %u blocks",
+				 RelFileInfoFmt(InfoFromSMgrRel(reln)),
+				 forknum,
+				 LSN_FORMAT_ARGS(request_lsns.effective_request_lsn),
+				 n_blocks);
+
+		pfree(resp);
 	}
-
-	switch (resp->tag)
-	{
-		case T_NeonNblocksResponse:
-			n_blocks = ((NeonNblocksResponse *) resp)->n_blocks;
-			break;
-
-		case T_NeonErrorResponse:
-			ereport(ERROR,
-					(errcode(ERRCODE_IO_ERROR),
-					 errmsg(NEON_TAG "could not read relation size of rel %u/%u/%u.%u from page server at lsn %X/%08X",
-							RelFileInfoFmt(InfoFromSMgrRel(reln)),
-							forknum,
-							LSN_FORMAT_ARGS(request_lsns.effective_request_lsn)),
-					 errdetail("page server returned error: %s",
-							   ((NeonErrorResponse *) resp)->message)));
-			break;
-
-		default:
-			NEON_PANIC_CONNECTION_STATE(-1, PANIC,
-										"Expected Nblocks (0x%02x) or Error (0x%02x) response to NblocksRequest, but got 0x%02x",
-										T_NeonNblocksResponse, T_NeonErrorResponse, resp->tag);
-	}
-	update_cached_relsize(InfoFromSMgrRel(reln), forknum, n_blocks);
-
-	neon_log(SmgrTrace, "neon_nblocks: rel %u/%u/%u fork %u (request LSN %X/%08X): %u blocks",
-			 RelFileInfoFmt(InfoFromSMgrRel(reln)),
-			 forknum,
-			 LSN_FORMAT_ARGS(request_lsns.effective_request_lsn),
-			 n_blocks);
-
-	pfree(resp);
 	return n_blocks;
 }
 
@@ -3497,39 +3631,67 @@ neon_dbsize(Oid dbNode)
 	{
 		NeonDbSizeRequest request = {
 			.req.tag = T_NeonDbSizeRequest,
+			.req.reqid = GENERATE_REQUEST_ID(),
 			.req.lsn = request_lsns.request_lsn,
 			.req.not_modified_since = request_lsns.not_modified_since,
 			.dbNode = dbNode,
 		};
 
 		resp = page_server_request(&request);
+
+		switch (resp->tag)
+		{
+			case T_NeonDbSizeResponse:
+			{
+				NeonDbSizeResponse* dbsize_resp = (NeonDbSizeResponse *) resp;
+				if (neon_protocol_version >= 3)
+				{
+					if (resp->reqid != request.req.reqid ||
+						resp->lsn != request.req.lsn ||
+						resp->not_modified_since != request.req.not_modified_since ||
+						dbsize_resp->dbNode != dbNode)
+					{
+						NEON_PANIC_CONNECTION_STATE(-1, PANIC,
+													"Unexpect response {reqid=%lx,lsn=%X/%08X, since=%X/%08X, dbNode=%u} to get DB size request {reqid=%lx,lsn=%X/%08X, since=%X/%08X, dbNode=%u}",
+													resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since), dbsize_resp->dbNode,
+													request.req.reqid, LSN_FORMAT_ARGS(request.req.lsn), LSN_FORMAT_ARGS(request.req.not_modified_since), dbNode);
+					}
+				}
+				db_size = dbsize_resp->db_size;
+				break;
+			}
+			case T_NeonErrorResponse:
+				if (neon_protocol_version >= 3)
+				{
+					if (resp->reqid != request.req.reqid ||
+						resp->lsn != request.req.lsn ||
+						resp->not_modified_since != request.req.not_modified_since)
+					{
+						elog(WARNING, NEON_TAG "Error message {reqid=%lx,lsn=%X/%08X, since=%X/%08X} doesn't match get DB size request {reqid=%lx,lsn=%X/%08X, since=%X/%08X}",
+							 resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since),
+							 request.req.reqid, LSN_FORMAT_ARGS(request.req.lsn), LSN_FORMAT_ARGS(request.req.not_modified_since));
+					}
+				}
+				ereport(ERROR,
+						(errcode(ERRCODE_IO_ERROR),
+						 errmsg(NEON_TAG "[reqid %lx] could not read db size of db %u from page server at lsn %X/%08X",
+								resp->reqid,
+								dbNode, LSN_FORMAT_ARGS(request_lsns.effective_request_lsn)),
+						 errdetail("page server returned error: %s",
+								   ((NeonErrorResponse *) resp)->message)));
+				break;
+
+			default:
+				NEON_PANIC_CONNECTION_STATE(-1, PANIC,
+											"Expected DbSize (0x%02x) or Error (0x%02x) response to DbSizeRequest, but got 0x%02x",
+											T_NeonDbSizeResponse, T_NeonErrorResponse, resp->tag);
+		}
+
+		neon_log(SmgrTrace, "neon_dbsize: db %u (request LSN %X/%08X): %ld bytes",
+				 dbNode, LSN_FORMAT_ARGS(request_lsns.effective_request_lsn), db_size);
+
+		pfree(resp);
 	}
-
-	switch (resp->tag)
-	{
-		case T_NeonDbSizeResponse:
-			db_size = ((NeonDbSizeResponse *) resp)->db_size;
-			break;
-
-		case T_NeonErrorResponse:
-			ereport(ERROR,
-					(errcode(ERRCODE_IO_ERROR),
-					 errmsg(NEON_TAG "could not read db size of db %u from page server at lsn %X/%08X",
-							dbNode, LSN_FORMAT_ARGS(request_lsns.effective_request_lsn)),
-					 errdetail("page server returned error: %s",
-							   ((NeonErrorResponse *) resp)->message)));
-			break;
-
-		default:
-			NEON_PANIC_CONNECTION_STATE(-1, PANIC,
-										"Expected DbSize (0x%02x) or Error (0x%02x) response to DbSizeRequest, but got 0x%02x",
-										T_NeonDbSizeResponse, T_NeonErrorResponse, resp->tag);
-	}
-
-	neon_log(SmgrTrace, "neon_dbsize: db %u (request LSN %X/%08X): %ld bytes",
-			 dbNode, LSN_FORMAT_ARGS(request_lsns.effective_request_lsn), db_size);
-
-	pfree(resp);
 	return db_size;
 }
 
@@ -3862,6 +4024,7 @@ neon_read_slru_segment(SMgrRelation reln, const char* path, int segno, void* buf
 
 	request = (NeonGetSlruSegmentRequest) {
 		.req.tag = T_NeonGetSlruSegmentRequest,
+		.req.reqid = GENERATE_REQUEST_ID(),
 		.req.lsn = request_lsn,
 		.req.not_modified_since = not_modified_since,
 		.kind = kind,
@@ -3880,14 +4043,42 @@ neon_read_slru_segment(SMgrRelation reln, const char* path, int segno, void* buf
 	switch (resp->tag)
 	{
 		case T_NeonGetSlruSegmentResponse:
-			n_blocks = ((NeonGetSlruSegmentResponse *) resp)->n_blocks;
-			memcpy(buffer, ((NeonGetSlruSegmentResponse *) resp)->data, n_blocks*BLCKSZ);
+		{
+			NeonGetSlruSegmentResponse* slru_resp = (NeonGetSlruSegmentResponse *) resp;
+			if (neon_protocol_version >= 3)
+			{
+				if (resp->reqid != request.req.reqid ||
+					resp->lsn != request.req.lsn ||
+					resp->not_modified_since != request.req.not_modified_since ||
+					slru_resp->kind != kind ||
+					slru_resp->segno != segno)
+				{
+					NEON_PANIC_CONNECTION_STATE(-1, PANIC,
+												"Unexpect response {reqid=%lx,lsn=%X/%08X, since=%X/%08X, kind=%u, segno=%u} to get SLRU segment request {reqid=%lx,lsn=%X/%08X, since=%X/%08X, kind=%u, segno=%u}",
+												resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since), slru_resp->kind, slru_resp->segno,
+												request.req.reqid, LSN_FORMAT_ARGS(request.req.lsn), LSN_FORMAT_ARGS(request.req.not_modified_since), kind, segno);
+				}
+			}
+			n_blocks = slru_resp->n_blocks;
+			memcpy(buffer, slru_resp->data, n_blocks*BLCKSZ);
 			break;
-
+		}
 		case T_NeonErrorResponse:
+			if (neon_protocol_version >= 3)
+			{
+				if (resp->reqid != request.req.reqid ||
+					resp->lsn != request.req.lsn ||
+					resp->not_modified_since != request.req.not_modified_since)
+				{
+					elog(WARNING, NEON_TAG "Error message {reqid=%lx,lsn=%X/%08X, since=%X/%08X} doesn't match get SLRU segment request {reqid=%lx,lsn=%X/%08X, since=%X/%08X}",
+						 resp->reqid, LSN_FORMAT_ARGS(resp->lsn), LSN_FORMAT_ARGS(resp->not_modified_since),
+						 request.req.reqid, LSN_FORMAT_ARGS(request.req.lsn), LSN_FORMAT_ARGS(request.req.not_modified_since));
+				}
+			}
 			ereport(ERROR,
 					(errcode(ERRCODE_IO_ERROR),
-					 errmsg(NEON_TAG "could not read SLRU %d segment %d at lsn %X/%08X",
+					 errmsg(NEON_TAG "[reqid %lx] could not read SLRU %d segment %d at lsn %X/%08X",
+							resp->reqid,
 							kind,
 							segno,
 							LSN_FORMAT_ARGS(request_lsn)),
@@ -4028,6 +4219,7 @@ neon_extend_rel_size(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber blkno, 
 		NeonNblocksRequest request = {
 			.req = (NeonRequest) {
 				.tag = T_NeonNblocksRequest,
+				.reqid = GENERATE_REQUEST_ID(),
 				.lsn = end_recptr,
 				.not_modified_since = end_recptr,
 			},


### PR DESCRIPTION
## Problem

We have several serious data corruption incidents caused by mismatch of get-age requests:
https://neondb.slack.com/archives/C07FJS4QF7V/p1723032720164359

We hope that the problem is fixed now. But it is better to prevent such kind of problems in future.

Part of https://github.com/neondatabase/cloud/issues/16472

## Summary of changes

This PR introduce new V3 version of compute<->pageserver protocol, adding tag to getpage response.
So now compute is able to check if it really gets response to the requested page.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
