### PR TITLE
Benchmarking tests: automatically restore Neon reuse databases, too and migrate to pg16

### DIFF
--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ aws-rds-postgres, aws-aurora-serverless-v2-postgres ] 
+        platform: [ aws-rds-postgres, aws-aurora-serverless-v2-postgres, neon ] 
         database: [ clickbench, tpch, userexample ]
   
     env:
@@ -31,6 +31,9 @@ jobs:
       id: set-up-prep-connstr
       run: |
         case "${PLATFORM}" in
+          neon)
+            CONNSTR=${{ secrets.BENCHMARK_CAPTEST_CONNSTR }} 
+            ;;
           aws-rds-postgres)
             CONNSTR=${{ secrets.BENCHMARK_RDS_POSTGRES_CONNSTR }} 
             ;;


### PR DESCRIPTION

## Problem

We use a set of **Neon** reuse databases in benchmarking.yml which are still using pg14.
Because we want to compare apples to apples and have migrated the AWS reuse clusters to pg16 we should also use pg16 for Neon.

## Summary of changes

- Automatically restore the test databases for Neon project

