### PR TITLE
CI(build-neon): fix accidental neon rebuild on `cargo test`

### DIFF
--- a/.github/workflows/_build-and-test-locally.yml
+++ b/.github/workflows/_build-and-test-locally.yml
@@ -208,7 +208,7 @@ jobs:
           export LD_LIBRARY_PATH
 
           #nextest does not yet support running doctests
-          cargo test --doc $CARGO_FLAGS $CARGO_FEATURES
+          ${cov_prefix} cargo test --doc $CARGO_FLAGS $CARGO_FEATURES
 
           for io_engine in std-fs tokio-epoll-uring ; do
             NEON_PAGESERVER_UNIT_TEST_VIRTUAL_FILE_IOENGINE=$io_engine ${cov_prefix} cargo nextest run $CARGO_FLAGS $CARGO_FEATURES


### PR DESCRIPTION
## Problem

During `Run rust tests` (for debug builds) step, we accidentally rebuild neon twice (by `cargo test --doc` and by `cargo nextest run`).
It happens because we don't set `cov_prefix` for the `cargo test --doc` command, which triggers rebuilding with different build flags, and one more rebuild by `cargo nextest run`.

Before: [~8m](https://github.com/neondatabase/neon/actions/runs/10381803834/job/28743853594#step:19:49)
After: [~5m](https://github.com/neondatabase/neon/actions/runs/10382892422/job/28746805737?pr=8721#step:19:49)


## Summary of changes
- Set `cov_prefix` for `cargo test --doc` to prevent unneeded rebuilds

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
