### PR TITLE
storcon_cli: don't clobber heatmap interval when setting eviction

### DIFF
--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -622,6 +622,7 @@ async fn main() -> anyhow::Result<()> {
                                 threshold: threshold.into(),
                             },
                         )),
+                        heatmap_period: Some("300s".to_string()),
                         ..Default::default()
                     },
                 })


### PR DESCRIPTION
## Problem

This command is kind of a hack, used when we're migrating large tenants and want to get their resident size down.  It sets the tenant config to a fixed value, which omitted heatmap_period, so caused secondaries to get out of date.

## Summary of changes

- Set heatmap period to the same 300s default that we use elsewhere when updating eviction settings

This is not as elegant as some general purpose partial modification of the config, but it practically makes the command safer to use.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
