### PR TITLE
storcon: deny external node configuration if an operation is ongoing

### DIFF
--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -313,20 +313,17 @@ pub struct MetadataHealthUpdateRequest {
 pub struct MetadataHealthUpdateResponse {}
 
 #[derive(Serialize, Deserialize, Debug)]
-
 pub struct MetadataHealthListUnhealthyResponse {
     pub unhealthy_tenant_shards: Vec<TenantShardId>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-
 pub struct MetadataHealthListOutdatedRequest {
     #[serde(with = "humantime_serde")]
     pub not_scrubbed_for: Duration,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-
 pub struct MetadataHealthListOutdatedResponse {
     pub health_records: Vec<MetadataHealthRecord>,
 }

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -500,7 +500,7 @@ async fn handle_node_configure(mut req: Request<Body>) -> Result<Response<Body>,
         StatusCode::OK,
         state
             .service
-            .node_configure(
+            .external_node_configure(
                 config_req.node_id,
                 config_req.availability.map(NodeAvailability::from),
                 config_req.scheduling,

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5990,7 +5990,7 @@ impl Service {
                 .await_waiters_remainder(waiters, SHORT_RECONCILE_TIMEOUT)
                 .await;
 
-            failpoint_support::sleep_millis_async!("sleepy-drain-loop");
+            failpoint_support::sleep_millis_async!("sleepy-drain-loop", &cancel);
         }
 
         while !waiters.is_empty() {

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5037,25 +5037,19 @@ impl Service {
     }
 
     pub(crate) async fn cancel_node_drain(&self, node_id: NodeId) -> Result<(), ApiError> {
-        let (node_available, node_policy) = {
+        let node_available = {
             let locked = self.inner.read().unwrap();
             let nodes = &locked.nodes;
             let node = nodes.get(&node_id).ok_or(ApiError::NotFound(
                 anyhow::anyhow!("Node {} not registered", node_id).into(),
             ))?;
 
-            (node.is_available(), node.get_scheduling())
+            node.is_available()
         };
 
         if !node_available {
             return Err(ApiError::ResourceUnavailable(
                 format!("Node {node_id} is currently unavailable").into(),
-            ));
-        }
-
-        if !matches!(node_policy, NodeSchedulingPolicy::Draining) {
-            return Err(ApiError::PreconditionFailed(
-                format!("Node {node_id} has no drain in progress").into(),
             ));
         }
 
@@ -5172,25 +5166,19 @@ impl Service {
     }
 
     pub(crate) async fn cancel_node_fill(&self, node_id: NodeId) -> Result<(), ApiError> {
-        let (node_available, node_policy) = {
+        let node_available = {
             let locked = self.inner.read().unwrap();
             let nodes = &locked.nodes;
             let node = nodes.get(&node_id).ok_or(ApiError::NotFound(
                 anyhow::anyhow!("Node {} not registered", node_id).into(),
             ))?;
 
-            (node.is_available(), node.get_scheduling())
+            node.is_available()
         };
 
         if !node_available {
             return Err(ApiError::ResourceUnavailable(
                 format!("Node {node_id} is currently unavailable").into(),
-            ));
-        }
-
-        if !matches!(node_policy, NodeSchedulingPolicy::Filling) {
-            return Err(ApiError::PreconditionFailed(
-                format!("Node {node_id} has no fill in progress").into(),
             ));
         }
 

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2129,3 +2129,9 @@ def test_storage_controller_ps_restarted_during_drain(neon_env_builder: NeonEnvB
         env.storage_controller.node_configure(attached.id, {"availability": "Offline"})
 
     env.storage_controller.cancel_node_drain(attached.id)
+
+    def reconfigure_node_again():
+        env.storage_controller.node_configure(attached.id, {"scheduling": "Pause"})
+
+    # allow for small delay between actually having cancelled and being able reconfigure again
+    wait_until(4, 0.5, reconfigure_node_again)

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2099,7 +2099,6 @@ def test_storage_controller_ps_restarted_during_drain(neon_env_builder: NeonEnvB
 
     env = neon_env_builder.init_start()
 
-    # make sure there is no secondary, so we will have something to drain
     env.storage_controller.tenant_policy_update(env.initial_tenant, {"placement": {"Attached": 1}})
     env.storage_controller.reconcile_until_idle()
 

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2092,6 +2092,7 @@ def test_storage_controller_step_down(neon_env_builder: NeonEnvBuilder):
         == 0
     )
 
+
 def test_storage_controller_ps_restarted_during_drain(neon_env_builder: NeonEnvBuilder):
     # single unsharded tenant, two locations
     neon_env_builder.num_pageservers = 2
@@ -2125,9 +2126,15 @@ def test_storage_controller_ps_restarted_during_drain(neon_env_builder: NeonEnvB
     first.restart()
 
     # we are unable to reconfigure node while the operation is still ongoing
-    with pytest.raises(StorageControllerApiException, match="Precondition failed: Ongoing background operation forbids configuring: drain.*"):
+    with pytest.raises(
+        StorageControllerApiException,
+        match="Precondition failed: Ongoing background operation forbids configuring: drain.*",
+    ):
         env.storage_controller.node_configure(first.id, {"scheduling": "Pause"})
-    with pytest.raises(StorageControllerApiException, match="Precondition failed: Ongoing background operation forbids configuring: drain.*"):
+    with pytest.raises(
+        StorageControllerApiException,
+        match="Precondition failed: Ongoing background operation forbids configuring: drain.*",
+    ):
         env.storage_controller.node_configure(first.id, {"availability": "Offline"})
 
     env.storage_controller.cancel_node_drain(first.id)

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2120,8 +2120,6 @@ def test_storage_controller_ps_restarted_during_drain(neon_env_builder: NeonEnvB
 
     wait_until(10, 0.5, first_is_draining)
 
-    # restarting or the re-attach request from ps does not cancel drain
-    # but it makes it so that it cannot be cancelled from the api, bug?
     first.restart()
 
     # we are unable to reconfigure node while the operation is still ongoing

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2130,5 +2130,4 @@ def test_storage_controller_ps_restarted_during_drain(neon_env_builder: NeonEnvB
     with pytest.raises(StorageControllerApiException, match="Precondition failed: Ongoing background operation forbids configuring: drain.*"):
         env.storage_controller.node_configure(first.id, {"availability": "Offline"})
 
-    # fails, because the check for schedulingpolicy happens before the operation check
-    # env.storage_controller.cancel_node_drain(first.id)
+    env.storage_controller.cancel_node_drain(first.id)


### PR DESCRIPTION
Per #8674, disallow node configuration while drain/fill are ongoing. Implement it by adding a only-http wrapper `Service::external_node_configure` which checks for operation existing before configuring.

Additionally:
- allow cancelling drain/fill after a pageserver has restarted and transitioned to WarmingUp

Fixes: #8674