### PR TITLE
bench: lower attach concurrency

### DIFF
--- a/test_runner/fixtures/pageserver/many_tenants.py
+++ b/test_runner/fixtures/pageserver/many_tenants.py
@@ -65,7 +65,7 @@ def single_timeline(
             override_storage_controller_generation=True,
         )
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=22) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         executor.map(attach, tenants)
 
     # Benchmarks will start the pageserver explicitly themselves


### PR DESCRIPTION
it has been observed that we get transaction serialization issues otherwise.

evidence: https://neon-github-public-dev.s3.amazonaws.com/reports/main/10402057346/index.html#suites/c62b105f3a4f00dd6be4ad88810e0e02/7c03011d9dbd5ec4/

Slack thread: <https://neondb.slack.com/archives/C060CNA47S9/p1723722430992019>

Alternatively we could:
- first issue attach hooks sequentially then attach concurrently
- just not do it at all (unsure why we even bother with overriding the generations)