### PR TITLE
storcon: handle heartbeater shutdown gracefully

### DIFF
--- a/storage_controller/src/heartbeater.rs
+++ b/storage_controller/src/heartbeater.rs
@@ -87,9 +87,12 @@ impl Heartbeater {
                 pageservers,
                 reply: sender,
             })
-            .unwrap();
+            .map_err(|_| HeartbeaterError::Cancel)?;
 
-        receiver.await.unwrap()
+        receiver
+            .await
+            .map_err(|_| HeartbeaterError::Cancel)
+            .and_then(|x| x)
     }
 }
 


### PR DESCRIPTION
if a heartbeat happens during shutdown, then the task is already cancelled and will not be sending responses.

Fixes: #8766