### PR TITLE
Benchmarking: need to checkout actions to download Neon artifacts

### DIFF
--- a/.github/workflows/_benchmarking_preparation.yml
+++ b/.github/workflows/_benchmarking_preparation.yml
@@ -48,6 +48,8 @@ jobs:
 
         echo "connstr=${CONNSTR}" >> $GITHUB_OUTPUT  
 
+    - uses: actions/checkout@v4
+
     - name: Download Neon artifact
       uses: ./.github/actions/download
       with:


### PR DESCRIPTION
## Problem

Database preparation workflow needs Neon artifacts but does not checkout necessary download action.

We were lucke in a few runs like this one
https://github.com/neondatabase/neon/actions/runs/10413970941/job/28870668020

but this is flaky and a race condition which failed here

https://github.com/neondatabase/neon/actions/runs/10446395644/job/28923749772#step:4:1



## Summary of changes

Checkout code (including actions) before invoking download action

Successful test run https://github.com/neondatabase/neon/actions/runs/10469356296/job/28992200694

