### PR TITLE
storage controller: read from database in validate API

### DIFF
--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -101,7 +101,7 @@ async fn handle_validate(mut req: Request<Body>) -> Result<Response<Body>, ApiEr
 
     let validate_req = json_request::<ValidateRequest>(&mut req).await?;
     let state = get_state(&req);
-    json_response(StatusCode::OK, state.service.validate(validate_req))
+    json_response(StatusCode::OK, state.service.validate(validate_req).await?)
 }
 
 /// Call into this before attaching a tenant to a pageserver, to acquire a generation number

--- a/storage_controller/src/reconciler.rs
+++ b/storage_controller/src/reconciler.rs
@@ -17,6 +17,7 @@ use utils::failpoint_support;
 use utils::generation::Generation;
 use utils::id::{NodeId, TimelineId};
 use utils::lsn::Lsn;
+use utils::pausable_failpoint;
 use utils::sync::gate::GateGuard;
 
 use crate::compute_hook::{ComputeHook, NotifyError};
@@ -592,6 +593,8 @@ impl Reconciler {
             .await;
             notify_attempts += 1;
         }
+
+        pausable_failpoint!("reconciler-live-migrate-post-notify");
 
         // Downgrade the origin to secondary.  If the tenant's policy is PlacementPolicy::Attached(0), then
         // this location will be deleted in the general case reconciliation that runs after this.

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -3213,7 +3213,7 @@ impl Service {
             // run concurrently with reconciliations, and it is not guaranteed that the node we find here
             // will still be the latest when we're done: we will check generations again at the end of
             // this function to handle that.
-            let generations = self.persistence.peek_generations(tenant_id).await?;
+            let generations = self.persistence.tenant_generations(tenant_id).await?;
 
             if generations
                 .iter()
@@ -3270,7 +3270,7 @@ impl Service {
         // Post-check: are all the generations of all the shards the same as they were initially?  This proves that
         // our remote operation executed on the latest generation and is therefore persistent.
         {
-            let latest_generations = self.persistence.peek_generations(tenant_id).await?;
+            let latest_generations = self.persistence.tenant_generations(tenant_id).await?;
             if latest_generations
                 .into_iter()
                 .map(

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -1887,10 +1887,6 @@ impl Service {
 
         // Database calls to confirm validity for anything that passed the in-memory check.  We must do this
         // in case of controller split-brain, where some other controller process might have incremented the generation.
-        let mut response = ValidateResponse {
-            tenants: Vec::new(),
-        };
-
         let db_generations = self
             .persistence
             .shard_generations(in_memory_result.iter().filter_map(|i| {
@@ -1903,6 +1899,9 @@ impl Service {
             .await?;
         let db_generations = db_generations.into_iter().collect::<HashMap<_, _>>();
 
+        let mut response = ValidateResponse {
+            tenants: Vec::new(),
+        };
         for (tenant_shard_id, validate_generation, valid) in in_memory_result.into_iter() {
             let valid = if valid {
                 let db_generation = db_generations.get(&tenant_shard_id);

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -1871,6 +1871,14 @@ impl Service {
                     );
 
                     in_memory_result.push((req_tenant.id, Generation::new(req_tenant.gen), valid));
+                } else {
+                    // This is legal: for example during a shard split the pageserver may still
+                    // have deletions in its queue from the old pre-split shard, or after deletion
+                    // of a tenant that was busy with compaction/gc while being deleted.
+                    tracing::info!(
+                        "Refusing deletion validation for missing shard {}",
+                        req_tenant.id
+                    );
                 }
             }
 


### PR DESCRIPTION
## Problem

The initial implementation of the validate API treats the in-memory generations as authoritative.
- This is true when only one storage controller is running, but if a rogue controller was running that hadn't been shut down properly, and some pageserver requests were routed to that bad controller, it could incorrectly return valid=true for stale generations.
- The generation in the main in-memory map gets out of date while a live migration is in flight, and if the origin location for the migration tries to do some deletions even though it is in AttachedStale (for example because it had already started compaction), these might be wrongly validated + executed.

## Summary of changes

- Continue to do the in-memory check: if this returns valid=false it is sufficient to reject requests.
- When valid=true, do an additional read from the database to confirm the generation is fresh.
- Revise behavior for validation on missing shards: this used to always return valid=true as a convenience for deletions and shard splits, so that pageservers weren't prevented from completing any enqueued deletions for these shards after they're gone.  However, this becomes unsafe when we consider split brain scenarios.  We could reinstate this in future if we wanted to store some tombstones for deleted shards.
- Update test_scrubber_physical_gc to cope with the behavioral change: they must now explicitly flush the deletion queue before splits, to avoid tripping up on deletions that are enqueued at the time of the split (these tests assert "scrubber deletes nothing", which check fails if the split leaves behind some remote objects that are legitimately GC'able)
- Add `test_storage_controller_validate_during_migration`, which uses failpoints to create a situation where incorrect generation validation during a live migration could result in a corruption

The rate of validate calls for tenants is pretty low: it happens as a consequence deletions from GC and compaction, which are both concurrency-limited on the pageserver side.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
