### PR TITLE
feat(compute): Introduce new compute_subscriptions_count metric

### DIFF
--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -356,6 +356,17 @@ files:
           from pg_replication_slots
           where slot_type = 'logical';
 
+      - metric_name: compute_subscriptions_count
+        type: gauge
+        help: 'Number of logical replication subscriptions grouped by enabled/disabled'
+        key_labels:
+          - enabled
+        values: [subscriptions_count]
+        query: |
+          select subenabled::text as enabled, count(*) as subscriptions_count
+          from pg_subscription
+          group by subenabled;
+
       - metric_name: retained_wal
         type: gauge
         help: 'Retained WAL in inactive replication slots'


### PR DESCRIPTION
## Problem

We need some metric to sneak peek into how many people use inbound logical replication (Neon is subscriber).

## Summary of changes

This commit adds a new metric `compute_subscriptions_count`, which is number of subscriptions grouped by enabled/disabled state.

Resolves: neondatabase/cloud#16146

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
