### PR TITLE
Revert "Add package-mode=false to poetry."

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [tool.poetry]
+name = "neon"
+version = "0.1.0"
 description = ""
 authors = []
-package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Reverts neondatabase/neon#8609

Poetry 1.3.2 doesn't have support for a `package-mode` parameter, and requires (!) name and version fields to be present. We claim to support Poetry >= 1.3 in our readme.