### PR TITLE
fix(sql-exporter): Fix typo in gauge metric type

### DIFF
--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -329,12 +329,10 @@ files:
         type: gauge
         help: 'Number of snapshot files in pg_logical/snapshot'
         key_labels:
-          - tenant_id
           - timeline_id
         values: [num_logical_snapshot_files]
         query: |
           SELECT
-            (SELECT setting FROM pg_settings WHERE name = 'neon.tenant_id') AS tenant_id,
             (SELECT setting FROM pg_settings WHERE name = 'neon.timeline_id') AS timeline_id,
             -- Postgres creates temporary snapshot files of the form %X-%X.snap.%d.tmp. These
             -- temporary snapshot files are renamed to the actual snapshot files after they are

--- a/vm-image-spec.yaml
+++ b/vm-image-spec.yaml
@@ -326,7 +326,7 @@ files:
           SELECT checkpoints_timed FROM pg_stat_bgwriter;
 
       - metric_name: compute_logical_snapshot_files
-        type: guage
+        type: gauge
         help: 'Number of snapshot files in pg_logical/snapshot'
         key_labels:
           - tenant_id


### PR DESCRIPTION
In f4b3c317f there was a typo, and I missed that on review

I also removed the explicit tenant_id (it was my suggestion, sorry)

