### PR TITLE
Don't unarchive a timeline if its ancestor is archived

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -324,9 +324,8 @@ impl From<crate::tenant::TimelineArchivalError> for ApiError {
         match value {
             NotFound => ApiError::NotFound(anyhow::anyhow!("timeline not found").into()),
             Timeout => ApiError::Timeout("hit pageserver internal timeout".into()),
-            HasArchivedParent(parent) => ApiError::PreconditionFailed(
-                format!("Cannot unarchive timeline which has archived ancestor: {parent:?}")
-                    .into_boxed_str(),
+            e @ HasArchivedParent(_) => ApiError::PreconditionFailed(
+                e.to_string().into_boxed_str(),
             ),
             HasUnarchivedChildren(children) => ApiError::PreconditionFailed(
                 format!(

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -324,6 +324,10 @@ impl From<crate::tenant::TimelineArchivalError> for ApiError {
         match value {
             NotFound => ApiError::NotFound(anyhow::anyhow!("timeline not found").into()),
             Timeout => ApiError::Timeout("hit pageserver internal timeout".into()),
+            HasArchivedParent(parent) => ApiError::PreconditionFailed(
+                format!("Cannot unarchive timeline which has archived ancestor: {parent:?}")
+                    .into_boxed_str(),
+            ),
             HasUnarchivedChildren(children) => ApiError::PreconditionFailed(
                 format!(
                     "Cannot archive timeline which has non-archived child timelines: {children:?}"

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -324,9 +324,9 @@ impl From<crate::tenant::TimelineArchivalError> for ApiError {
         match value {
             NotFound => ApiError::NotFound(anyhow::anyhow!("timeline not found").into()),
             Timeout => ApiError::Timeout("hit pageserver internal timeout".into()),
-            e @ HasArchivedParent(_) => ApiError::PreconditionFailed(
-                e.to_string().into_boxed_str(),
-            ),
+            e @ HasArchivedParent(_) => {
+                ApiError::PreconditionFailed(e.to_string().into_boxed_str())
+            }
             HasUnarchivedChildren(children) => ApiError::PreconditionFailed(
                 format!(
                     "Cannot archive timeline which has non-archived child timelines: {children:?}"

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -509,7 +509,7 @@ pub enum TimelineArchivalError {
     #[error("Timeout")]
     Timeout,
 
-    #[error("HasArchivedParent")]
+    #[error("parent is archived: {}", .0)]
     HasArchivedParent(TimelineId),
 
     #[error("HasUnarchivedChildren")]

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -509,7 +509,7 @@ pub enum TimelineArchivalError {
     #[error("Timeout")]
     Timeout,
 
-    #[error("parent is archived: {}", .0)]
+    #[error("ancestor is archived: {}", .0)]
     HasArchivedParent(TimelineId),
 
     #[error("HasUnarchivedChildren")]

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1372,9 +1372,7 @@ impl Tenant {
             };
 
             if state == TimelineArchivalState::Unarchived {
-                let ancestor_timeline = timeline.get_ancestor_timeline();
-
-                if let Some(ancestor_timeline) = ancestor_timeline {
+                if let Some(ancestor_timeline) = timeline.ancestor_timeline() {
                     if ancestor_timeline.is_archived() == Some(true) {
                         return Err(TimelineArchivalError::HasArchivedParent(
                             ancestor_timeline.timeline_id,

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1372,15 +1372,13 @@ impl Tenant {
             };
 
             if state == TimelineArchivalState::Unarchived {
-                let ancestor_id = timeline.get_ancestor_timeline_id();
+                let ancestor_timeline = timeline.get_ancestor_timeline();
 
-                if let Some(ancestor_id) = ancestor_id {
-                    let Some(ancestor_timeline) = timelines.get(&ancestor_id) else {
-                        error!("Couldn't find ancestor timeline {ancestor_id:?}");
-                        return Err(TimelineArchivalError::NotFound);
-                    };
+                if let Some(ancestor_timeline) = ancestor_timeline {
                     if ancestor_timeline.is_archived() == Some(true) {
-                        return Err(TimelineArchivalError::HasArchivedParent(ancestor_id));
+                        return Err(TimelineArchivalError::HasArchivedParent(
+                            ancestor_timeline.timeline_id,
+                        ));
                     }
                 }
             }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -867,7 +867,7 @@ impl Timeline {
             .map(|ancestor| ancestor.timeline_id)
     }
 
-    /// Get the ancestor's timeline id
+    /// Get the ancestor timeline
     pub(crate) fn get_ancestor_timeline(&self) -> Option<&Arc<Timeline>> {
         self.ancestor_timeline.as_ref()
     }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -867,6 +867,11 @@ impl Timeline {
             .map(|ancestor| ancestor.timeline_id)
     }
 
+    /// Get the ancestor's timeline id
+    pub(crate) fn get_ancestor_timeline(&self) -> Option<&Arc<Timeline>> {
+        self.ancestor_timeline.as_ref()
+    }
+
     /// Get the bytes written since the PITR cutoff on this branch, and
     /// whether this branch's ancestor_lsn is within its parent's PITR.
     pub(crate) fn get_pitr_history_stats(&self) -> (u64, bool) {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -868,7 +868,7 @@ impl Timeline {
     }
 
     /// Get the ancestor timeline
-    pub(crate) fn get_ancestor_timeline(&self) -> Option<&Arc<Timeline>> {
+    pub(crate) fn ancestor_timeline(&self) -> Option<&Arc<Timeline>> {
         self.ancestor_timeline.as_ref()
     }
 

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -94,3 +94,29 @@ def test_timeline_archive(neon_simple_env: NeonEnv):
         timeline_id=parent_timeline_id,
         state=TimelineArchivalState.ARCHIVED,
     )
+
+    # Test that the leaf can't be unarchived
+    with pytest.raises(
+        PageserverApiException,
+        match="Cannot unarchive timeline which has archived ancestor",
+    ) as exc:
+        assert timeline_path.exists()
+
+        ps_http.timeline_archival_config(
+            tenant_id=env.initial_tenant,
+            timeline_id=leaf_timeline_id,
+            state=TimelineArchivalState.UNARCHIVED,
+        )
+
+    # Unarchive works for the leaf if the parent gets unarchived first
+    ps_http.timeline_archival_config(
+        tenant_id=env.initial_tenant,
+        timeline_id=parent_timeline_id,
+        state=TimelineArchivalState.UNARCHIVED,
+    )
+
+    ps_http.timeline_archival_config(
+        tenant_id=env.initial_tenant,
+        timeline_id=leaf_timeline_id,
+        state=TimelineArchivalState.UNARCHIVED,
+    )

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -98,7 +98,7 @@ def test_timeline_archive(neon_simple_env: NeonEnv):
     # Test that the leaf can't be unarchived
     with pytest.raises(
         PageserverApiException,
-        match="Cannot unarchive timeline which has archived ancestor",
+        match="ancestor is archived",
     ) as exc:
         assert timeline_path.exists()
 


### PR DESCRIPTION
If a timeline unarchival request comes in, give an error if the parent timeline is archived. This prevents us from the situation of having an archived timeline with children that are not archived.

Follow up of #8824

Part of #8088