### PR TITLE
storcon: boilerplate to upsert safekeeper records on deploy

### DIFF
--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -1849,7 +1849,7 @@ impl Timeline {
 
         let dry_run = flags.contains(CompactFlags::DryRun);
 
-        info!("running enhanced gc bottom-most compaction, dry_run={dry_run}");
+        info!(dry_run, "running enhanced gc bottom-most compaction");
 
         scopeguard::defer! {
             info!("done enhanced gc bottom-most compaction");

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -1849,7 +1849,7 @@ impl Timeline {
 
         let dry_run = flags.contains(CompactFlags::DryRun);
 
-        info!(dry_run, "running enhanced gc bottom-most compaction");
+        info!("running enhanced gc bottom-most compaction, dry_run={dry_run}");
 
         scopeguard::defer! {
             info!("done enhanced gc bottom-most compaction");

--- a/storage_controller/migrations/2024-08-23-102952_safekeepers/down.sql
+++ b/storage_controller/migrations/2024-08-23-102952_safekeepers/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE safekeepers;

--- a/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
+++ b/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
@@ -1,16 +1,17 @@
--- Your SQL goes here
 -- very much a copy of cplane version, except that the projects_count is not included
 CREATE TABLE safekeepers (
-	id BIGSERIAL PRIMARY KEY,
+	-- the surrogate identifier defined by control plane database sequence
+	id BIGINT PRIMARY KEY,
 	created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 	updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 	region_id TEXT NOT NULL,
 	version BIGINT NOT NULL,
-	instance_id TEXT NOT NULL,
+	-- the natural id on whatever cloud platform
+	instance_id TEXT UNIQUE NOT NULL,
 	host TEXT NOT NULL,
 	port INTEGER NOT NULL,
 	active BOOLEAN NOT NULL DEFAULT false,
 	-- projects_count INTEGER NOT NULL DEFAULT 0,
-	http_port TEXT NOT NULL,
+	http_port INTEGER NOT NULL,
 	availability_zone_id TEXT NOT NULL,
 );

--- a/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
+++ b/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
@@ -13,5 +13,5 @@ CREATE TABLE safekeepers (
 	active BOOLEAN NOT NULL DEFAULT false,
 	-- projects_count INTEGER NOT NULL DEFAULT 0,
 	http_port INTEGER NOT NULL,
-	availability_zone_id TEXT NOT NULL,
+	availability_zone_id TEXT NOT NULL
 );

--- a/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
+++ b/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
@@ -1,4 +1,4 @@
--- very much a copy of cplane version, except that the projects_count is not included
+-- started out as a copy of cplane schema, removed the unnecessary columns.
 CREATE TABLE safekeepers (
 	-- the surrogate identifier defined by control plane database sequence
 	id BIGINT PRIMARY KEY,
@@ -6,8 +6,8 @@ CREATE TABLE safekeepers (
 	updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 	region_id TEXT NOT NULL,
 	version BIGINT NOT NULL,
-	-- the natural id on whatever cloud platform
-	instance_id TEXT UNIQUE NOT NULL,
+	-- the natural id on whatever cloud platform, not needed in storage controller
+	-- instance_id TEXT UNIQUE NOT NULL,
 	host TEXT NOT NULL,
 	port INTEGER NOT NULL,
 	active BOOLEAN NOT NULL DEFAULT false,

--- a/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
+++ b/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
@@ -2,8 +2,6 @@
 CREATE TABLE safekeepers (
 	-- the surrogate identifier defined by control plane database sequence
 	id BIGINT PRIMARY KEY,
-	created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-	updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 	region_id TEXT NOT NULL,
 	version BIGINT NOT NULL,
 	-- the natural id on whatever cloud platform, not needed in storage controller

--- a/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
+++ b/storage_controller/migrations/2024-08-23-102952_safekeepers/up.sql
@@ -1,0 +1,16 @@
+-- Your SQL goes here
+-- very much a copy of cplane version, except that the projects_count is not included
+CREATE TABLE safekeepers (
+	id BIGSERIAL PRIMARY KEY,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+	region_id TEXT NOT NULL,
+	version BIGINT NOT NULL,
+	instance_id TEXT NOT NULL,
+	host TEXT NOT NULL,
+	port INTEGER NOT NULL,
+	active BOOLEAN NOT NULL DEFAULT false,
+	-- projects_count INTEGER NOT NULL DEFAULT 0,
+	http_port TEXT NOT NULL,
+	availability_zone_id TEXT NOT NULL,
+);

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -754,7 +754,8 @@ impl From<ReconcileError> for ApiError {
 ///
 /// Not used by anything except manual testing.
 async fn handle_get_safekeeper(req: Request<Body>) -> Result<Response<Body>, ApiError> {
-    // TODO: jwt, see POST handler in handle_upsert_safekeeper
+    check_permissions(&req, Scope::Admin)?;
+
     let id = parse_request_param::<i64>(&req, "id")?;
 
     let state = get_state(&req);
@@ -775,8 +776,7 @@ async fn handle_get_safekeeper(req: Request<Body>) -> Result<Response<Body>, Api
 /// Assumes information is only relayed to storage controller after first selecting an unique id on
 /// control plane database, which means we have an id field in the request and payload.
 async fn handle_upsert_safekeeper(mut req: Request<Body>) -> Result<Response<Body>, ApiError> {
-    // todo: jwt -- as long we don't use this for anything, it doesn't really need much security
-    // either
+    check_permissions(&req, Scope::Admin)?;
 
     let body = json_request::<SafekeeperPersistence>(&mut req).await?;
     let id = parse_request_param::<i64>(&req, "id")?;

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -1159,6 +1159,13 @@ pub fn make_router(
         .put("/control/v1/step_down", |r| {
             named_request_span(r, handle_step_down, RequestName("control_v1_step_down"))
         })
+        .get("/control/v1/safekeeper/:id", |r| {
+            named_request_span(r, handle_get_safekeeper, RequestName("v1_safekeeper"))
+        })
+        .post("/control/v1/safekeeper/:id", |r| {
+            // id is in the body
+            named_request_span(r, handle_upsert_safekeeper, RequestName("v1_safekeeper"))
+        })
         // Tenant operations
         // The ^/v1/ endpoints act as a "Virtual Pageserver", enabling shard-naive clients to call into
         // this service to manage tenants that actually consist of many tenant shards, as if they are a single entity.
@@ -1237,12 +1244,5 @@ pub fn make_router(
                 handle_tenant_timeline_passthrough,
                 RequestName("v1_tenant_passthrough"),
             )
-        })
-        .get("/v1/safekeeper/:id", |r| {
-            named_request_span(r, handle_get_safekeeper, RequestName("v1_safekeeper"))
-        })
-        .post("/v1/safekeeper/:id", |r| {
-            // id is in the body
-            named_request_span(r, handle_upsert_safekeeper, RequestName("v1_safekeeper"))
         })
 }

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -952,8 +952,6 @@ impl Persistence {
         record: SafekeeperPersistence,
     ) -> Result<(), DatabaseError> {
         use crate::schema::safekeepers::dsl::*;
-        use diesel::dsl::now;
-        use diesel::query_dsl::methods::FilterDsl;
 
         self.with_conn(move |conn| -> DatabaseResult<()> {
             let bind = record.as_insert_or_update();
@@ -962,9 +960,7 @@ impl Persistence {
                 .values(&bind)
                 .on_conflict(id)
                 .do_update()
-                .set(((&bind), (updated_at.eq(now))))
-                // FIXME: is this needed
-                .filter(id.eq(&record.id))
+                .set(&bind)
                 .execute(conn)?;
 
             if inserted_updated != 1 {
@@ -1118,8 +1114,6 @@ pub(crate) struct ControllerPersistence {
 #[diesel(table_name = crate::schema::safekeepers)]
 pub(crate) struct SafekeeperPersistence {
     pub(crate) id: i64,
-    pub(crate) created_at: chrono::DateTime<chrono::Utc>,
-    pub(crate) updated_at: chrono::DateTime<chrono::Utc>,
     pub(crate) region_id: String,
     /// 1 is special, it means just created (not currently posted to storcon).
     /// Zero or negative is not really expected.

--- a/storage_controller/src/schema.rs
+++ b/storage_controller/src/schema.rs
@@ -45,3 +45,19 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(controllers, metadata_health, nodes, tenant_shards,);
+
+diesel::table! {
+    safekeepers {
+        id -> Int8,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+        region_id -> Text,
+        version -> Int8,
+        instance_id -> Text,
+        host -> Text,
+        port -> Int4,
+        active -> Bool,
+        http_port -> Int4,
+        availability_zone_id -> Text,
+    }
+}

--- a/storage_controller/src/schema.rs
+++ b/storage_controller/src/schema.rs
@@ -49,8 +49,6 @@ diesel::allow_tables_to_appear_in_same_query!(controllers, metadata_health, node
 diesel::table! {
     safekeepers {
         id -> Int8,
-        created_at -> Timestamptz,
-        updated_at -> Timestamptz,
         region_id -> Text,
         version -> Int8,
         instance_id -> Text,

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -6438,4 +6438,18 @@ impl Service {
 
         global_observed
     }
+
+    pub(crate) async fn get_safekeeper(
+        &self,
+        instance_id: String,
+    ) -> Result<crate::persistence::SafekeeperPersistence, DatabaseError> {
+        self.persistence.safekeeper_get(instance_id).await
+    }
+
+    pub(crate) async fn upsert_safekeeper(
+        &self,
+        record: crate::persistence::SafekeeperPersistence,
+    ) -> Result<(), DatabaseError> {
+        self.persistence.safekeeper_upsert(record).await
+    }
 }

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -6441,9 +6441,9 @@ impl Service {
 
     pub(crate) async fn get_safekeeper(
         &self,
-        instance_id: String,
+        id: i64,
     ) -> Result<crate::persistence::SafekeeperPersistence, DatabaseError> {
-        self.persistence.safekeeper_get(instance_id).await
+        self.persistence.safekeeper_get(id).await
     }
 
     pub(crate) async fn upsert_safekeeper(

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2849,7 +2849,7 @@ class NeonStorageController(MetricsGetter, LogUtils):
     def on_safekeeper_deploy(self, id: int, body: dict[str, Any]):
         self.request(
             "POST",
-            f"{self.api}/v1/safekeeper/{id}",
+            f"{self.api}/control/v1/safekeeper/{id}",
             headers=self.headers(TokenScope.ADMIN),
             json=body,
         )
@@ -2858,7 +2858,7 @@ class NeonStorageController(MetricsGetter, LogUtils):
         try:
             response = self.request(
                 "GET",
-                f"{self.api}/v1/safekeeper/{id}",
+                f"{self.api}/control/v1/safekeeper/{id}",
                 headers=self.headers(TokenScope.ADMIN),
             )
             json = response.json()

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2852,7 +2852,7 @@ class NeonStorageController(MetricsGetter, LogUtils):
             "POST",
             f"{self.api}/v1/safekeeper/{instance_id}",
             headers=self.headers(TokenScope.ADMIN),
-            body=json.dumps(body),
+            json=body,
         )
 
     def get_safekeeper(self, instance_id: str) -> Optional[dict[str, Any]]:

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2846,19 +2846,19 @@ class NeonStorageController(MetricsGetter, LogUtils):
 
         raise AssertionError("unreachable")
 
-    def on_safekeeper_deploy(self, instance_id: str, body: dict[str, Any]):
+    def on_safekeeper_deploy(self, id: int, body: dict[str, Any]):
         self.request(
             "POST",
-            f"{self.api}/v1/safekeeper/{instance_id}",
+            f"{self.api}/v1/safekeeper/{id}",
             headers=self.headers(TokenScope.ADMIN),
             json=body,
         )
 
-    def get_safekeeper(self, instance_id: str) -> Optional[dict[str, Any]]:
+    def get_safekeeper(self, id: int) -> Optional[dict[str, Any]]:
         try:
             response = self.request(
                 "GET",
-                f"{self.api}/v1/safekeeper/{instance_id}",
+                f"{self.api}/v1/safekeeper/{id}",
                 headers=self.headers(TokenScope.ADMIN),
             )
             json = response.json()

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -967,12 +967,11 @@ class NeonEnvBuilder:
         # Stop all the nodes.
         if self.env:
             log.info("Cleaning up all storage and compute nodes")
-            failed_already = exc_type is None
             self.env.stop(
-                immediate=not failed_already,
+                immediate=False,
                 # if the test threw an exception, don't check for errors
                 # as a failing assertion would cause the cleanup below to fail
-                ps_assert_metric_no_errors=failed_already,
+                ps_assert_metric_no_errors=(exc_type is None),
                 # do not fail on endpoint errors to allow the rest of cleanup to proceed
                 fail_on_endpoint_errors=False,
             )

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2861,7 +2861,9 @@ class NeonStorageController(MetricsGetter, LogUtils):
                 f"{self.api}/v1/safekeeper/{instance_id}",
                 headers=self.headers(TokenScope.ADMIN),
             )
-            return response.json()
+            json = response.json()
+            assert isinstance(json, dict)
+            return json
         except StorageControllerApiException as e:
             if e.status_code == 404:
                 return None

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2337,7 +2337,7 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_configs()
     env.start()
 
-    fake_id = "i-fffffffffffffffff"
+    fake_id = 5
 
     target = env.storage_controller
 
@@ -2345,7 +2345,7 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
 
     body = {
         "active": True,
-        "id": 5,
+        "id": fake_id,
         "created_at": "2023-10-25T09:11:25Z",
         "updated_at": "2024-08-28T11:32:43Z",
         "region_id": "aws-us-east-2",
@@ -2353,7 +2353,6 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
         "port": 6401,
         "http_port": 7676,
         "version": 5957,
-        "instance_id": fake_id,
         "availability_zone_id": "us-east-2b",
     }
 
@@ -2369,10 +2368,7 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
         different_pk["id"] = 4
         assert different_pk["id"] != body["id"]
         target.on_safekeeper_deploy(fake_id, different_pk)
-    assert exc.value.status_code == 500
-    target.allowed_errors.append(
-        ".*Error processing HTTP request: InternalServerError\\(unsupported: surrogate id update \\(old=5, new=4\\)"
-    )
+    assert exc.value.status_code == 400
 
     inserted_again = target.get_safekeeper(fake_id)
     assert inserted_again is not None

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2387,8 +2387,12 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
 def eq_safekeeper_records(a: dict[str, Any], b: dict[str, Any]) -> bool:
     compared = [dict(a), dict(b)]
 
+    masked_keys = ["created_at", "updated_at"]
+
     for d in compared:
-        del d["created_at"]
-        del d["updated_at"]
+        # keep deleting these in case we are comparing the body as it will be uploaded by real scripts
+        for key in masked_keys:
+            if key in d:
+                del d[key]
 
     return compared[0] == compared[1]

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2379,6 +2379,7 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
     assert eq_safekeeper_records(inserted, inserted_again)
 
     # the most common case, version goes up:
+    assert isinstance(body["version"], int)
     body["version"] += 1
     target.on_safekeeper_deploy(fake_id, body)
     inserted_now = target.get_safekeeper(fake_id)

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -31,7 +31,7 @@ from fixtures.pageserver.utils import (
     remote_storage_delete_key,
     timeline_delete_wait_completed,
 )
-from fixtures.pg_version import PgVersion
+from fixtures.pg_version import PgVersion, run_only_on_default_postgres
 from fixtures.port_distributor import PortDistributor
 from fixtures.remote_storage import RemoteStorageKind, s3_storage
 from fixtures.storage_controller_proxy import StorageControllerProxy
@@ -2332,6 +2332,7 @@ def test_storage_controller_timeline_crud_race(neon_env_builder: NeonEnvBuilder)
     ).timeline_create(PgVersion.NOT_SET, tenant_id, create_timeline_id)
 
 
+@run_only_on_default_postgres("this is like a 'unit test' against storcon db")
 def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
     env = neon_env_builder.init_configs()
     env.start()


### PR DESCRIPTION
We currently do not record safekeepers in the storage controller database. We want to migrate timelines across safekeepers eventually, so start recording the safekeepers on deploy.

Cc: #8698 