### PR TITLE
build: sync between benchies

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -286,6 +286,7 @@ jobs:
           PERF_TEST_RESULT_CONNSTR: "${{ secrets.PERF_TEST_RESULT_CONNSTR }}"
           TEST_RESULT_CONNSTR: "${{ secrets.REGRESS_TEST_RESULT_CONNSTR_NEW }}"
           PAGESERVER_VIRTUAL_FILE_IO_ENGINE: tokio-epoll-uring
+          SYNC_AFTER_EACH_TEST: true
       # XXX: no coverage data handling here, since benchmarks are run on release builds,
       # while coverage is currently collected for the debug ones
 

--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -355,7 +355,7 @@ def sync_after_each_test():
         return
 
     start = time.time()
-    # we only run benches on linuxes, the method might not exist on windows
+    # we only run benches on unices, the method might not exist on windows
     os.sync()
     elapsed = time.time() - start
     log.info(f"called sync after test {elapsed=}")

--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -357,8 +357,8 @@ def sync_after_each_test():
         # regress test, or running locally
         return
 
-    # we only run benches on linuxes, the method might not exist on windows
     start = time.time()
+    # we only run benches on linuxes, the method might not exist on windows
     os.sync()
     elapsed = time.time() - start
     log.info(f"called sync after test {elapsed=}")

--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -340,14 +340,11 @@ def neon_with_baseline(request: FixtureRequest) -> PgCompare:
 
 @pytest.fixture(scope="function", autouse=True)
 def sync_after_each_test():
-    # some of the benchmarks are quite write-happy, and create issues to start
-    # the processes up in 10s.
-    # SYNC_AFTER_EACH_TEST is only "true" for build_and_test workflow
-    # benchmarks, which run test_runner/performance cases sequentially.
-    # however, this fixture is included for all regress tests as well.
-    #
-    # use the environment variable SYNC_AFTER_EACH_TEST to control whether any
-    # syncing happens.
+    # The fixture calls `sync(2)` after each test if `SYNC_AFTER_EACH_TEST` env var is `true`
+    # 
+    # In CI, `SYNC_AFTER_EACH_TEST` is set to `true` only for benchmarks (`test_runner/performance`) 
+    # that are run on self-hosted runners because some of these tests are pretty write-heavy 
+    # and create issues to start the processes within 10s
     key = "SYNC_AFTER_EACH_TEST"
     enabled = os.environ.get(key) == "true"
 

--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -343,7 +343,11 @@ def sync_after_each_test():
     # some of the benchmarks are quite write-happy, and create issues to start
     # the processes up in 10s.
     # SYNC_AFTER_EACH_TEST is only "true" for build_and_test workflow
-    # benchmarks, which run test_runner/performance cases sequentially
+    # benchmarks, which run test_runner/performance cases sequentially.
+    # however, this fixture is included for all regress tests as well.
+    #
+    # use the environment variable SYNC_AFTER_EACH_TEST to control whether any
+    # syncing happens.
     key = "SYNC_AFTER_EACH_TEST"
     enabled = os.environ.get(key) == "true"
 

--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -341,9 +341,9 @@ def neon_with_baseline(request: FixtureRequest) -> PgCompare:
 @pytest.fixture(scope="function", autouse=True)
 def sync_after_each_test():
     # The fixture calls `sync(2)` after each test if `SYNC_AFTER_EACH_TEST` env var is `true`
-    # 
-    # In CI, `SYNC_AFTER_EACH_TEST` is set to `true` only for benchmarks (`test_runner/performance`) 
-    # that are run on self-hosted runners because some of these tests are pretty write-heavy 
+    #
+    # In CI, `SYNC_AFTER_EACH_TEST` is set to `true` only for benchmarks (`test_runner/performance`)
+    # that are run on self-hosted runners because some of these tests are pretty write-heavy
     # and create issues to start the processes within 10s
     key = "SYNC_AFTER_EACH_TEST"
     enabled = os.environ.get(key) == "true"


### PR DESCRIPTION
Sometimes, the benchmarks fail to start up pageserver in 10s without any obvious reason. Benchmarks run sequentially on otherwise idle runners. Try running `sync(2)` after each bench to force a cleaner slate.

Implement this via:
- SYNC_AFTER_EACH_TEST environment variable enabled autouse fixture
- autouse fixture seems to be outermost fixture, so it works as expected
- set SYNC_AFTER_EACH_TEST=true for benchmarks in build_and_test workflow

Evidence: https://neon-github-public-dev.s3.amazonaws.com/reports/main/10678984691/index.html#suites/5008d72a1ba3c0d618a030a938fc035c/1210266507534c0f/