### PR TITLE
Add installation instructions for m4 on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ brew install protobuf openssl flex bison icu4c pkg-config
 echo 'export PATH="$(brew --prefix openssl)/bin:$PATH"' >> ~/.zshrc
 ```
 
-If you get errors about missing `m4` you many have install manually it.
+If you get errors about missing `m4` you may have to install it manually:
 ```
 brew install m4
 brew link --force m4

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you get errors about missing `m4` you may have to install it manually:
 ```
 brew install m4
 brew link --force m4
-````
+```
 
 2. [Install Rust](https://www.rust-lang.org/tools/install)
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ brew install protobuf openssl flex bison icu4c pkg-config
 echo 'export PATH="$(brew --prefix openssl)/bin:$PATH"' >> ~/.zshrc
 ```
 
+If you get errors about missing `m4` you many have install manually it.
+```
+brew install m4
+brew link --force m4
+````
+
 2. [Install Rust](https://www.rust-lang.org/tools/install)
 ```
 # recommended approach from https://www.rust-lang.org/tools/install


### PR DESCRIPTION
## Problem
Building on MacOS failed due to missing m4. Although a window was popping up claiming to install m4, this was not helping.

## Summary of changes
Add instructions to install m4 using brew and link it (thanks to Folke for helping).