### PR TITLE
compaction_level0_phase1: change default streaming-kmerge without validation

### DIFF
--- a/libs/pageserver_api/src/config.rs
+++ b/libs/pageserver_api/src/config.rs
@@ -239,10 +239,7 @@ pub enum CompactL0BypassPageCacheValidation {
 
 impl Default for CompactL0Phase1ValueAccess {
     fn default() -> Self {
-        CompactL0Phase1ValueAccess::StreamingKmerge {
-            // TODO(https://github.com/neondatabase/neon/issues/8184): change to None once confident
-            validate: Some(CompactL0BypassPageCacheValidation::KeyLsnValue),
-        }
+        CompactL0Phase1ValueAccess::StreamingKmerge { validate: None }
     }
 }
 


### PR DESCRIPTION
After this PR is merged, deployed, and guaranteed to not be rolled back,
we can remove the field from `pageserver.toml`s.

refs https://github.com/neondatabase/neon/issues/8184
