### PR TITLE
Set disk quotas on bind in compute_ctl

### DIFF
--- a/compute/vm-image-spec.yaml
+++ b/compute/vm-image-spec.yaml
@@ -11,6 +11,10 @@ commands:
     user: root
     sysvInitAction: sysinit
     shell: 'chmod 711 /neonvm/bin/resize-swap'
+  - name: chmod-set-disk-quota
+    user: root
+    sysvInitAction: sysinit
+    shell: 'chmod 711 /neonvm/bin/set-disk-quota'
   - name: pgbouncer
     user: postgres
     sysvInitAction: respawn
@@ -30,11 +34,12 @@ commands:
 shutdownHook: |
   su -p postgres --session-command '/usr/local/bin/pg_ctl stop -D /var/db/postgres/compute/pgdata -m fast --wait -t 10'
 files:
-  - filename: compute_ctl-resize-swap
+  - filename: compute_ctl-sudoers
     content: |
       # Allow postgres user (which is what compute_ctl runs as) to run /neonvm/bin/resize-swap
-      # as root without requiring entering a password (NOPASSWD), regardless of hostname (ALL)
-      postgres ALL=(root) NOPASSWD: /neonvm/bin/resize-swap
+      # and /neonvm/bin/set-disk-quota as root without requiring entering a password (NOPASSWD),
+      # regardless of hostname (ALL)
+      postgres ALL=(root) NOPASSWD: /neonvm/bin/resize-swap, /neonvm/bin/set-disk-quota
   - filename: cgconfig.conf
     content: |
       # Configuration for cgroups in VM compute nodes
@@ -100,7 +105,7 @@ merge: |
       && apt install --no-install-recommends -y \
              sudo \
       && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-  COPY compute_ctl-resize-swap /etc/sudoers.d/compute_ctl-resize-swap
+  COPY compute_ctl-sudoers /etc/sudoers.d/compute_ctl-sudoers
 
   COPY cgconfig.conf /etc/cgconfig.conf
 

--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -421,6 +421,8 @@ fn start_postgres(
     let mut prestartup_failed = false;
     let mut delay_exit = false;
 
+    info!("starting compute node, {swap_size_bytes:?} swap, {resize_swap_on_bind} swapon, {disk_quota_bytes:?} disk quota, {set_disk_quota_on_bind} quotaon");
+
     // Resize swap to the desired size if the compute spec says so
     if let (Some(size_bytes), true) = (swap_size_bytes, resize_swap_on_bind) {
         // To avoid 'swapoff' hitting postgres startup, we need to run resize-swap to completion
@@ -431,7 +433,7 @@ fn start_postgres(
         // OOM-killed during startup because swap wasn't available yet.
         match resize_swap(size_bytes) {
             Ok(()) => {
-                let size_gib = size_bytes as f32 / (1 << 20) as f32; // just for more coherent display.
+                let size_gib = size_bytes as f32 / (1 << 30) as f32; // just for more coherent display.
                 info!(%size_bytes, %size_gib, "resized swap");
             }
             Err(err) => {
@@ -454,7 +456,7 @@ fn start_postgres(
     if let (Some(disk_quota_bytes), true) = (disk_quota_bytes, set_disk_quota_on_bind) {
         match set_disk_quota(disk_quota_bytes, &compute.pgdata) {
             Ok(()) => {
-                let size_gib = disk_quota_bytes as f32 / (1 << 20) as f32; // just for more coherent display.
+                let size_gib = disk_quota_bytes as f32 / (1 << 30) as f32; // just for more coherent display.
                 info!(%disk_quota_bytes, %size_gib, "set disk quota");
             }
             Err(err) => {

--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -421,8 +421,6 @@ fn start_postgres(
     let mut prestartup_failed = false;
     let mut delay_exit = false;
 
-    info!("starting compute node, {swap_size_bytes:?} swap, {resize_swap_on_bind} swapon, {disk_quota_bytes:?} disk quota, {set_disk_quota_on_bind} quotaon");
-
     // Resize swap to the desired size if the compute spec says so
     if let (Some(size_bytes), true) = (swap_size_bytes, resize_swap_on_bind) {
         // To avoid 'swapoff' hitting postgres startup, we need to run resize-swap to completion
@@ -433,8 +431,8 @@ fn start_postgres(
         // OOM-killed during startup because swap wasn't available yet.
         match resize_swap(size_bytes) {
             Ok(()) => {
-                let size_gib = size_bytes as f32 / (1 << 30) as f32; // just for more coherent display.
-                info!(%size_bytes, %size_gib, "resized swap");
+                let size_mib = size_bytes as f32 / (1 << 20) as f32; // just for more coherent display.
+                info!(%size_bytes, %size_mib, "resized swap");
             }
             Err(err) => {
                 let err = err.context("failed to resize swap");
@@ -456,8 +454,8 @@ fn start_postgres(
     if let (Some(disk_quota_bytes), true) = (disk_quota_bytes, set_disk_quota_on_bind) {
         match set_disk_quota(disk_quota_bytes, &compute.pgdata) {
             Ok(()) => {
-                let size_gib = disk_quota_bytes as f32 / (1 << 30) as f32; // just for more coherent display.
-                info!(%disk_quota_bytes, %size_gib, "set disk quota");
+                let size_mib = disk_quota_bytes as f32 / (1 << 20) as f32; // just for more coherent display.
+                info!(%disk_quota_bytes, %size_mib, "set disk quota");
             }
             Err(err) => {
                 let err = err.context("failed to set disk quota");

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -306,6 +306,13 @@ impl ComputeNode {
         self.state_changed.notify_all();
     }
 
+    pub fn set_failed_status(&self, err: anyhow::Error) {
+        let mut state = self.state.lock().unwrap();
+        state.error = Some(format!("{err:?}"));
+        state.status = ComputeStatus::Failed;
+        self.state_changed.notify_all();
+    }
+
     pub fn get_status(&self) -> ComputeStatus {
         self.state.lock().unwrap().status
     }

--- a/compute_tools/src/disk_quota.rs
+++ b/compute_tools/src/disk_quota.rs
@@ -1,22 +1,16 @@
-use std::path::Path;
-
 use anyhow::Context;
 
 pub const DISK_QUOTA_BIN: &str = "/neonvm/bin/set-disk-quota";
 
-/// If size_bytes is 0, it disables the quota.
-/// Otherwise, it sets the quota to size_bytes.
-pub fn set_disk_quota(size_bytes: u64, dir: &str) -> anyhow::Result<()> {
-    // We need to know which filesystem we need to set the quota on. compute_ctl knows only
-    // the PGDATA directory path, but we need to identify in which filesystem it resides.
-    let mountpoint = find_mountpoint(dir).context("finding mountpoint")?;
-
+/// If size_bytes is 0, it disables the quota. Otherwise, it sets filesystem quota to size_bytes.
+/// `fs_mountpoint` should point to the mountpoint of the filesystem where the quota should be set.
+pub fn set_disk_quota(size_bytes: u64, fs_mountpoint: &str) -> anyhow::Result<()> {
     let size_kb = size_bytes / 1024;
     // run `/neonvm/bin/set-disk-quota {size_kb} {mountpoint}`
     let child_result = std::process::Command::new("/usr/bin/sudo")
         .arg(DISK_QUOTA_BIN)
         .arg(size_kb.to_string())
-        .arg(&mountpoint)
+        .arg(fs_mountpoint)
         .spawn();
 
     child_result
@@ -28,54 +22,4 @@ pub fn set_disk_quota(size_bytes: u64, dir: &str) -> anyhow::Result<()> {
         })
         // wrap any prior error with the overall context that we couldn't run the command
         .with_context(|| format!("could not run `/usr/bin/sudo {DISK_QUOTA_BIN}`"))
-}
-
-fn find_mountpoint(dir: &str) -> anyhow::Result<String> {
-    // We're running `find_mountpoint` function before PGDATA directory is created,
-    // and `stat` command doesn't work on non-existing directories.
-    // We need to find the existing parent directory of the PGDATA directory,
-    // and use that to find the mount point.
-    let dir = find_existing_directory(dir)?;
-
-    // run `stat -c %m <dir>` to get the mount point
-    let child_result = std::process::Command::new("/usr/bin/stat")
-        .arg("-c")
-        .arg("%m")
-        .arg(dir)
-        .output()
-        .context("spawn() failed")?;
-
-    if !child_result.status.success() {
-        return Err(anyhow::anyhow!(
-            "process exited with {}",
-            child_result.status
-        ));
-    }
-
-    let mountpoint = String::from_utf8(child_result.stdout)
-        .context("failed to parse mountpoint")?
-        .trim()
-        .to_string();
-
-    Ok(mountpoint)
-}
-
-/// Iterate through the parent directories of the given path until an existing directory is found.
-fn find_existing_directory(path: &str) -> anyhow::Result<String> {
-    let mut current_path = Path::new(path);
-
-    while !current_path.exists() {
-        // If no parent is found, break out of the loop (we reached the root)
-        match current_path.parent() {
-            Some(parent) => {
-                current_path = parent;
-            }
-            None => anyhow::bail!("no directory is found"), // No valid parent, and no existing path was found
-        }
-    }
-
-    Ok(current_path
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("path is not valid utf-8"))?
-        .to_string())
 }

--- a/compute_tools/src/disk_quota.rs
+++ b/compute_tools/src/disk_quota.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Context;
 
@@ -7,6 +7,8 @@ pub const DISK_QUOTA_BIN: &str = "/neonvm/bin/set-disk-quota";
 /// If size_bytes is 0, it disables the quota.
 /// Otherwise, it sets the quota to size_bytes.
 pub fn set_disk_quota(size_bytes: u64, dir: &str) -> anyhow::Result<()> {
+    // We need to know which filesystem we need to set the quota on. compute_ctl knows only
+    // the PGDATA directory path, but we need to identify in which filesystem it resides.
     let mountpoint = find_mountpoint(dir).context("finding mountpoint")?;
 
     let size_kb = size_bytes / 1024;
@@ -25,12 +27,14 @@ pub fn set_disk_quota(size_bytes: u64, dir: &str) -> anyhow::Result<()> {
             false => Err(anyhow::anyhow!("process exited with {status}")),
         })
         // wrap any prior error with the overall context that we couldn't run the command
-        .with_context(|| {
-            format!("could not run `/usr/bin/sudo {DISK_QUOTA_BIN}`")
-        })
+        .with_context(|| format!("could not run `/usr/bin/sudo {DISK_QUOTA_BIN}`"))
 }
 
 fn find_mountpoint(dir: &str) -> anyhow::Result<String> {
+    // We're running `find_mountpoint` function before PGDATA directory is created,
+    // and `stat` command doesn't work on non-existing directories.
+    // We need to find the existing parent directory of the PGDATA directory,
+    // and use that to find the mount point.
     let dir = find_existing_directory(dir)?;
 
     // run `stat -c %m <dir>` to get the mount point
@@ -40,9 +44,12 @@ fn find_mountpoint(dir: &str) -> anyhow::Result<String> {
         .arg(dir)
         .output()
         .context("spawn() failed")?;
-    
+
     if !child_result.status.success() {
-        return Err(anyhow::anyhow!("process exited with {}", child_result.status));
+        return Err(anyhow::anyhow!(
+            "process exited with {}",
+            child_result.status
+        ));
     }
 
     let mountpoint = String::from_utf8(child_result.stdout)
@@ -53,6 +60,7 @@ fn find_mountpoint(dir: &str) -> anyhow::Result<String> {
     Ok(mountpoint)
 }
 
+/// Iterate through the parent directories of the given path until an existing directory is found.
 fn find_existing_directory(path: &str) -> anyhow::Result<String> {
     let mut current_path = Path::new(path);
 
@@ -61,10 +69,13 @@ fn find_existing_directory(path: &str) -> anyhow::Result<String> {
         match current_path.parent() {
             Some(parent) => {
                 current_path = parent;
-            },
+            }
             None => anyhow::bail!("no directory is found"), // No valid parent, and no existing path was found
         }
     }
 
-    Ok(current_path.to_str().ok_or_else(|| anyhow::anyhow!("path is not valid utf-8"))?.to_string())
+    Ok(current_path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("path is not valid utf-8"))?
+        .to_string())
 }

--- a/compute_tools/src/disk_quota.rs
+++ b/compute_tools/src/disk_quota.rs
@@ -1,0 +1,50 @@
+use anyhow::Context;
+
+pub const DISK_QUOTA_BIN: &str = "/neonvm/bin/set-disk-quota";
+
+/// If size_bytes is 0, it disables the quota.
+/// Otherwise, it sets the quota to size_bytes.
+pub fn set_disk_quota(size_bytes: u64, dir: &str) -> anyhow::Result<()> {
+    let mountpoint = find_mountpoint(dir)?;
+
+    let size_kb = size_bytes / 1024;
+    // run `/neonvm/bin/set-disk-quota {size_kb} {mountpoint}`
+    let child_result = std::process::Command::new("/usr/bin/sudo")
+        .arg(DISK_QUOTA_BIN)
+        .arg(size_kb.to_string())
+        .arg(&mountpoint)
+        .spawn();
+
+    child_result
+        .context("spawn() failed")
+        .and_then(|mut child| child.wait().context("wait() failed"))
+        .and_then(|status| match status.success() {
+            true => Ok(()),
+            false => Err(anyhow::anyhow!("process exited with {status}")),
+        })
+        // wrap any prior error with the overall context that we couldn't run the command
+        .with_context(|| {
+            format!("could not run `/usr/bin/sudo {DISK_QUOTA_BIN}`")
+        })
+}
+
+fn find_mountpoint(dir: &str) -> anyhow::Result<String> {
+    // run `stat -c %m <dir>` to get the mount point
+    let child_result = std::process::Command::new("/usr/bin/stat")
+        .arg("-c")
+        .arg("%m")
+        .arg(dir)
+        .output()
+        .context("spawn() failed")?;
+    
+    if !child_result.status.success() {
+        return Err(anyhow::anyhow!("process exited with {}", child_result.status));
+    }
+
+    let mountpoint = String::from_utf8(child_result.stdout)
+        .context("failed to parse mountpoint")?
+        .trim()
+        .to_string();
+
+    Ok(mountpoint)
+}

--- a/compute_tools/src/lib.rs
+++ b/compute_tools/src/lib.rs
@@ -10,6 +10,7 @@ pub mod http;
 pub mod logger;
 pub mod catalog;
 pub mod compute;
+pub mod disk_quota;
 pub mod extension_server;
 pub mod lsn_lease;
 mod migration;

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -561,6 +561,7 @@ impl Endpoint {
             operation_uuid: None,
             features: self.features.clone(),
             swap_size_bytes: None,
+            pgdata_disk_quota_bytes: None,
             cluster: Cluster {
                 cluster_id: None, // project ID: not used
                 name: None,       // project name: not used

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -561,7 +561,7 @@ impl Endpoint {
             operation_uuid: None,
             features: self.features.clone(),
             swap_size_bytes: None,
-            pgdata_disk_quota_bytes: None,
+            disk_quota_bytes: None,
             cluster: Cluster {
                 cluster_id: None, // project ID: not used
                 name: None,       // project name: not used

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -50,15 +50,15 @@ pub struct ComputeSpec {
     #[serde(default)]
     pub swap_size_bytes: Option<u64>,
 
-    /// If compute_ctl was passed `--set-disk-quota-on-bind`, a value of `Some(_)` instructs
-    /// compute_ctl to run `/neonvm/bin/set-disk-quota` with the given size, when the spec is first
-    /// received.
+    /// If compute_ctl was passed `--set-disk-quota-for-fs`, a value of `Some(_)` instructs
+    /// compute_ctl to run `/neonvm/bin/set-disk-quota` with the given size and fs, when the
+    /// spec is first received.
     ///
-    /// Both this field and `--set-disk-quota-on-bind` are required, so that the control plane's
+    /// Both this field and `--set-disk-quota-for-fs` are required, so that the control plane's
     /// spec generation doesn't need to be aware of the actual compute it's running on, while
     /// guaranteeing gradual rollout of disk quota.
     #[serde(default)]
-    pub pgdata_disk_quota_bytes: Option<u64>,
+    pub disk_quota_bytes: Option<u64>,
 
     /// Expected cluster state at the end of transition process.
     pub cluster: Cluster,

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -50,7 +50,13 @@ pub struct ComputeSpec {
     #[serde(default)]
     pub swap_size_bytes: Option<u64>,
 
-    /// TODO: write comment
+    /// If compute_ctl was passed `--set-disk-quota-on-bind`, a value of `Some(_)` instructs
+    /// compute_ctl to run `/neonvm/bin/set-disk-quota` with the given size, when the spec is first
+    /// received.
+    ///
+    /// Both this field and `--set-disk-quota-on-bind` are required, so that the control plane's
+    /// spec generation doesn't need to be aware of the actual compute it's running on, while
+    /// guaranteeing gradual rollout of disk quota.
     #[serde(default)]
     pub pgdata_disk_quota_bytes: Option<u64>,
 

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -50,6 +50,10 @@ pub struct ComputeSpec {
     #[serde(default)]
     pub swap_size_bytes: Option<u64>,
 
+    /// TODO: write comment
+    #[serde(default)]
+    pub pgdata_disk_quota_bytes: Option<u64>,
+
     /// Expected cluster state at the end of transition process.
     pub cluster: Cluster,
     pub delta_operations: Option<Vec<DeltaOp>>,


### PR DESCRIPTION
Part of https://github.com/neondatabase/cloud/issues/13127. Resolves #9153

What changed in this PR:
1. Adds `ComputeSpec.disk_quota_bytes: Option<u64>`
2. Adds new arg to compute_ctl: `--set-disk-quota-for-fs <mountpoint>`
3. Implements running `/neonvm/bin/set-disk-quota` with the right value if both cmdline arg AND field in the spec are specified
4. Patches `/etc/sudoers.d` to allow `compute_ctl` to set quota with sudo

This PR is very similar to the swap support added earlier, you can take a look at it as prior art: #7434

In theory, it can be implemented outside of compute_ctl when we will have a separate neonvm daemon, but we are not there yet. Current implementation is the simplest possible to unblock computes with larger disks.

All code related to usage of `/neonvm/bin/set-disk-quota` is located in `disk_quota.rs`. We need to call this script with the following arguments: `/neonvm/bin/set-disk-quota {size_kb} {mountpoint}`. Quotas are set on the filesystem level, so we need to provide path to the directory that filesystem was mounted to.

I tested this change locally with https://github.com/neondatabase/cloud/pull/17270. It should be safe to merge, because this feature is gated by both cmdline arg and field in the spec. If control-plane doesn't set values in both places, compute_ctl won't be affected by this change.