### PR TITLE
refactor(walredo): process launch & kill-on-error machinery

### DIFF
--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -318,11 +318,11 @@ impl PostgresRedoManager {
                 // acquire guard before spawning process, so that we don't spawn new processes
                 // if the gate is already closed.
                 let _launched_processes_guard = match self.launched_processes.enter() {
-                            Ok(guard) => guard,
-                            Err(GateError::GateClosed) => unreachable!(
-                                "shutdown sets the once cell to `ManagerShutDown` state before closing the gate"
-                            ),
-                        };
+                    Ok(guard) => guard,
+                    Err(GateError::GateClosed) => unreachable!(
+                        "shutdown sets the once cell to `ManagerShutDown` state before closing the gate"
+                    ),
+                };
                 let proc = Arc::new(Process {
                     process: process::WalRedoProcess::launch(
                         self.conf,

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -335,7 +335,7 @@ impl PostgresRedoManager {
                 let duration = start.elapsed();
                 WAL_REDO_PROCESS_LAUNCH_DURATION_HISTOGRAM.observe(duration.as_secs_f64());
                 info!(
-                    duration_ms = duration.as_millis(),
+                    elapsed_ms = duration.as_millis(),
                     pid = proc.id(),
                     "launched walredo process"
                 );

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -437,25 +437,25 @@ impl PostgresRedoManager {
                 WAL_REDO_BYTES_HISTOGRAM.observe(nbytes as f64);
 
                 debug!(
-                        "postgres applied {} WAL records ({} bytes) in {} us to reconstruct page image at LSN {}",
-                        len,
-                        nbytes,
-                        duration.as_micros(),
-                        lsn
-                    );
+                    "postgres applied {} WAL records ({} bytes) in {} us to reconstruct page image at LSN {}",
+                    len,
+                    nbytes,
+                    duration.as_micros(),
+                    lsn
+                );
 
                 if let Err(e) = result.as_ref() {
                     error!(
-                            "error applying {} WAL records {}..{} ({} bytes) to key {key}, from base image with LSN {} to reconstruct page image at LSN {} n_attempts={}: {:?}",
-                            records.len(),
-                            records.first().map(|p| p.0).unwrap_or(Lsn(0)),
-                            records.last().map(|p| p.0).unwrap_or(Lsn(0)),
-                            nbytes,
-                            base_img_lsn,
-                            lsn,
-                            n_attempts,
-                            e,
-                        );
+                        "error applying {} WAL records {}..{} ({} bytes) to key {key}, from base image with LSN {} to reconstruct page image at LSN {} n_attempts={}: {:?}",
+                        records.len(),
+                        records.first().map(|p| p.0).unwrap_or(Lsn(0)),
+                        records.last().map(|p| p.0).unwrap_or(Lsn(0)),
+                        nbytes,
+                        base_img_lsn,
+                        lsn,
+                        n_attempts,
+                        e,
+                    );
                 }
 
                 result.map_err(Error::Other)

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -468,8 +468,6 @@ impl PostgresRedoManager {
                 })
                 .await;
 
-            // If something went wrong, don't try to reuse the process. Kill it, and
-            // next request will launch a new one.
             if result.is_ok() && n_attempts != 0 {
                 info!(n_attempts, "retried walredo succeeded");
             }

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -345,10 +345,8 @@ impl PostgresRedoManager {
             }
         };
 
-        let result = closure(
-            proc.clone(), /* lack of true aysnc closures prevents passing a &Process here */
-        )
-        .await;
+        // async closures are unstable, would support &Process
+        let result = closure(proc.clone()).await;
 
         if result.is_err() {
             // Avoid concurrent callers hitting the same issue by taking `proc` out of the rotation.

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -414,7 +414,7 @@ impl PostgresRedoManager {
         let mut n_attempts = 0u32;
         loop {
             let base_img = &base_img;
-            let closure = |proc| async move {
+            let closure = |proc: Arc<Process>| async move {
                 let started_at = std::time::Instant::now();
 
                 // Relational WAL records are applied using wal-redo-postgres


### PR DESCRIPTION
Immediate benefit: easier to spot what's going on.

Later benefit: use in PR

- https://github.com/neondatabase/neon/pull/8952

which adds a `ping` command to walredo.

Found this useful during investigation https://github.com/neondatabase/cloud/issues/16886.
