### PR TITLE
bench: sync before benchies

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -271,6 +271,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: sync(1)
+        shell: bash -euxo pipefail {0}
+        run: sync
+
       - name: Pytest benchmarks
         uses: ./.github/actions/run-python-test-set
         with:


### PR DESCRIPTION
the first benchmark repeatedly fails:
<https://neon-github-public-dev.s3.amazonaws.com/reports/main/10743838300/index.html#behaviors/b1a8273437954620fa374b796ffaacdd/6e88523163820fdd/>