### PR TITLE
Extend Request/Response limit in sql-over-http to 32MiB

### DIFF
--- a/proxy/src/serverless/sql_over_http.rs
+++ b/proxy/src/serverless/sql_over_http.rs
@@ -87,8 +87,8 @@ enum Payload {
     Batch(BatchQueryData),
 }
 
-const MAX_RESPONSE_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
-const MAX_REQUEST_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
+const MAX_RESPONSE_SIZE: usize = 32 * 1024 * 1024; // 32 MiB
+const MAX_REQUEST_SIZE: u64 = 32 * 1024 * 1024; // 32 MiB
 
 static CONN_STRING: HeaderName = HeaderName::from_static("neon-connection-string");
 static RAW_TEXT_OUTPUT: HeaderName = HeaderName::from_static("neon-raw-text-output");

--- a/test_runner/regress/test_proxy.py
+++ b/test_runner/regress/test_proxy.py
@@ -558,7 +558,7 @@ def test_sql_over_http_pool_dos(static_proxy: NeonProxy):
         400,
         "select * from generate_series(1, 5000) a cross join generate_series(1, 5000) b cross join (select 'foo'::foo) c;",
     )
-    assert "response is too large (max is 10485760 bytes)" in response["message"]
+    assert "response is too large (max is 33554432 bytes)" in response["message"]
 
 
 def test_sql_over_http_pool_custom_types(static_proxy: NeonProxy):


### PR DESCRIPTION
## Problem
Fixes: #8983

TLDR; We are hitting this limit in more than one app, each with real-world use-cases.

## Summary of changes
This extends the limit from 10MiB to 32MiB (as a sanity check, Planet Scale's limit is currently [64MiB](https://planetscale.com/docs/reference/planetscale-system-limits#query-limits)). I'm open to changing this to whatever you think makes the most sense. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [x] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
