### PR TITLE
storcon: update compute hook state on detach

### DIFF
--- a/storage_controller/src/compute_hook.rs
+++ b/storage_controller/src/compute_hook.rs
@@ -77,7 +77,7 @@ impl ComputeHookTenant {
 
     /// Clear compute hook state for the specified shard.
     /// Only valid for [`ComputeHookTenant::Sharded`] instances.
-    fn handle_detach(&mut self, tenant_shard_id: TenantShardId, stripe_size: ShardStripeSize) {
+    fn remove_shard(&mut self, tenant_shard_id: TenantShardId, stripe_size: ShardStripeSize) {
         match self {
             ComputeHookTenant::Sharded(sharded) => {
                 if sharded.stripe_size != stripe_size
@@ -668,7 +668,7 @@ impl ComputeHook {
                 if !sharded {
                     e.remove();
                 } else {
-                    e.get_mut().handle_detach(tenant_shard_id, stripe_size);
+                    e.get_mut().remove_shard(tenant_shard_id, stripe_size);
                 }
 
                 tracing::debug!("Compute hook handled shard detach");

--- a/storage_controller/src/reconciler.rs
+++ b/storage_controller/src/reconciler.rs
@@ -811,6 +811,11 @@ impl Reconciler {
                     tenant_conf: self.config.clone(),
                 },
             ));
+
+            // TODO: Consider notifying control plane about detaches. This would avoid situations
+            // where the compute tries to start-up with a stale set of pageservers.
+            self.compute_hook
+                .handle_detach(self.tenant_shard_id, self.shard.stripe_size);
         }
 
         for (node, conf) in changes {

--- a/storage_controller/src/reconciler.rs
+++ b/storage_controller/src/reconciler.rs
@@ -811,11 +811,6 @@ impl Reconciler {
                     tenant_conf: self.config.clone(),
                 },
             ));
-
-            // TODO: Consider notifying control plane about detaches. This would avoid situations
-            // where the compute tries to start-up with a stale set of pageservers.
-            self.compute_hook
-                .handle_detach(self.tenant_shard_id, self.shard.stripe_size);
         }
 
         for (node, conf) in changes {
@@ -823,6 +818,19 @@ impl Reconciler {
                 return Err(ReconcileError::Cancel);
             }
             self.location_config(&node, conf, None, false).await?;
+        }
+
+
+        // A None attached intent indicates that we are detaching from the primary location.
+        // Pass this information to the [`ComputeHook`] such that it can update its tenant-wide
+        // state.
+        if self.intent.attached.is_none() {
+            assert!(!self.detach.is_empty());
+
+            // TODO: Consider notifying control plane about detaches. This would avoid situations
+            // where the compute tries to start-up with a stale set of pageservers.
+            self.compute_hook
+                .handle_detach(self.tenant_shard_id, self.shard.stripe_size);
         }
 
         failpoint_support::sleep_millis_async!("sleep-on-reconcile-epilogue");

--- a/storage_controller/src/reconciler.rs
+++ b/storage_controller/src/reconciler.rs
@@ -820,13 +820,10 @@ impl Reconciler {
             self.location_config(&node, conf, None, false).await?;
         }
 
-
-        // A None attached intent indicates that we are detaching from the primary location.
-        // Pass this information to the [`ComputeHook`] such that it can update its tenant-wide
-        // state.
-        if self.intent.attached.is_none() {
-            assert!(!self.detach.is_empty());
-
+        // The condition below identifies a detach. We must have no attached intent and
+        // must have been attached to something previously. Pass this information to
+        // the [`ComputeHook`] such that it can update its tenant-wide state.
+        if self.intent.attached.is_none() && !self.detach.is_empty() {
             // TODO: Consider notifying control plane about detaches. This would avoid situations
             // where the compute tries to start-up with a stale set of pageservers.
             self.compute_hook


### PR DESCRIPTION
## Problem

Previously, the storage controller may send compute notifications containing stale pageservers (i.e. pageserver serving the shard was detached). This happened because detaches did not update the compute hook state.

## Summary of Changes

Update compute hook state on shard detach.

Fixes #8928
