### PR TITLE
fix(storage-scrubber): log version after initialize the logger

### DIFF
--- a/storage_scrubber/src/main.rs
+++ b/storage_scrubber/src/main.rs
@@ -121,8 +121,6 @@ enum Command {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    tracing::info!("version: {}, build_tag {}", GIT_VERSION, BUILD_TAG);
-
     let bucket_config = BucketConfig::from_env()?;
 
     let command_log_name = match &cli.command {
@@ -141,6 +139,8 @@ async fn main() -> anyhow::Result<()> {
         bucket_config.bucket,
         chrono::Utc::now().format("%Y_%m_%d__%H_%M_%S")
     ));
+
+    tracing::info!("version: {}, build_tag {}", GIT_VERSION, BUILD_TAG);
 
     let controller_client = cli.controller_api.map(|controller_api| {
         ControllerClientConfig {


### PR DESCRIPTION
## Problem

When I checked the log in Grafana I couldn't find the scrubber version. Then I realized that it should be logged after the logger gets initialized.

## Summary of changes

Log after initializing the logger for the scrubber.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
