### PR TITLE
utils: leaky bucket should only report throttled if the notify queue is blocked on sleep

### DIFF
--- a/libs/utils/src/leaky_bucket.rs
+++ b/libs/utils/src/leaky_bucket.rs
@@ -204,7 +204,7 @@ impl RateLimiter {
                     }
 
                     // increment the counter after we finish sleeping (or cancel this task).
-                    // this ensures that tasks that have already started the acquire will observer
+                    // this ensures that tasks that have already started the acquire will observe
                     // the new sleep count when they are allowed to resume on the notify.
                     let _inc = Increment(&self.sleep_counter);
                     end_count += 1;


### PR DESCRIPTION
## Problem

Seems that PS might be too eager in reporting throttled tasks

## Summary of changes

Introduce a sleep counter. If the sleep counter increases, then the acquire tasks was throttled.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
