### PR TITLE
Readme: add more rustup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Building Neon requires 3.15+ version of `protoc` (protobuf-compiler). If your di
 ```
 # recommended approach from https://www.rust-lang.org/tools/install
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# add $HOME/.cargo/bin to PATH
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc
+
+rustup show
 ```
 
 #### Installing dependencies on macOS (12.3.1)
@@ -74,6 +79,11 @@ brew link --force m4
 ```
 # recommended approach from https://www.rust-lang.org/tools/install
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# add $HOME/.cargo/bin to PATH
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc
+
+rustup show
 ```
 
 3. Install PostgreSQL Client


### PR DESCRIPTION
The rustup.sh didn't install rust for me by default, also added a note about PATH 