### PR TITLE
Move load_timeline_metadata into separate function

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1307,11 +1307,11 @@ impl Tenant {
         let mut part_downloads = JoinSet::new();
         for timeline_id in timeline_ids {
             let cancel_clone = cancel.clone();
-            part_downloads.spawn(self.clone().load_timeline_metadata(
-                timeline_id,
-                remote_storage.clone(),
-                cancel_clone,
-            ));
+            part_downloads.spawn(
+                self.clone()
+                    .load_timeline_metadata(timeline_id, remote_storage.clone(), cancel_clone)
+                    .instrument(info_span!("download_index_part", %timeline_id)),
+            );
         }
 
         let mut timeline_preloads: HashMap<TimelineId, TimelinePreload> = HashMap::new();
@@ -1365,7 +1365,6 @@ impl Tenant {
                 index_part,
             }
         }
-        .instrument(info_span!("download_index_part", %timeline_id))
         .await
     }
 

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1344,6 +1344,7 @@ impl Tenant {
         remote_storage: GenericRemoteStorage,
         cancel: CancellationToken,
     ) -> impl Future<Output = TimelinePreload> {
+        debug_assert_current_span_has_tenant_and_timeline_id();
         let client = RemoteTimelineClient::new(
             remote_storage.clone(),
             self.deletion_queue_client.clone(),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1030,8 +1030,7 @@ impl Tenant {
         }
 
         Ok(TenantPreload {
-            timelines: Self::load_timelines_metadata(
-                self,
+            timelines: self.load_timelines_metadata(
                 remote_timeline_ids,
                 remote_storage,
                 cancel,

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1344,7 +1344,6 @@ impl Tenant {
         remote_storage: GenericRemoteStorage,
         cancel: CancellationToken,
     ) -> impl Future<Output = TimelinePreload> {
-        debug_assert_current_span_has_tenant_and_timeline_id();
         let client = RemoteTimelineClient::new(
             remote_storage.clone(),
             self.deletion_queue_client.clone(),
@@ -1354,6 +1353,7 @@ impl Tenant {
             self.generation,
         );
         async move {
+            debug_assert_current_span_has_tenant_and_timeline_id();
             debug!("starting index part download");
 
             let index_part = client.download_index_file(&cancel).await;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1030,12 +1030,9 @@ impl Tenant {
         }
 
         Ok(TenantPreload {
-            timelines: self.load_timelines_metadata(
-                remote_timeline_ids,
-                remote_storage,
-                cancel,
-            )
-            .await?,
+            timelines: self
+                .load_timelines_metadata(remote_timeline_ids, remote_storage, cancel)
+                .await?,
         })
     }
 


### PR DESCRIPTION
Moves the per-timeline code to load timeline metadata into a new dedicated function called `load_timeline_metadata`. The old `load_timeline_metadata` becomes `load_timelines_metadata`.

Split out of #8907

Part of #8088