### PR TITLE
test: Make test_lfc_resize more robust

### DIFF
--- a/test_runner/regress/test_lfc_resize.py
+++ b/test_runner/regress/test_lfc_resize.py
@@ -63,7 +63,9 @@ def test_lfc_resize(neon_simple_env: NeonEnv, pg_bin: PgBin):
     while True:
         lfc_file_path = f"{endpoint.pg_data_dir_path()}/file.cache"
         lfc_file_size = os.path.getsize(lfc_file_path)
-        res = subprocess.run(["ls", "-sk", lfc_file_path], check=True, text=True, capture_output=True)
+        res = subprocess.run(
+            ["ls", "-sk", lfc_file_path], check=True, text=True, capture_output=True
+        )
         lfc_file_blocks = re.findall("([0-9A-F]+)", res.stdout)[0]
         log.info(f"Size of LFC file {lfc_file_size}, blocks {lfc_file_blocks}")
         assert lfc_file_size <= 512 * 1024 * 1024


### PR DESCRIPTION
1. Increase statement_timeout. It defaults to 120 s, which is not quite enough on slow or busy systems with debug build. On my laptop, the index creation takes about 100 s. On buildfarm, we've seen failures, e.g: https://neon-github-public-dev.s3.amazonaws.com/reports/pr-9084/10997888708/index.html#suites/821f97908a487f1d7d3a2a4dd1571e99/db1834bddfe8c5b9/

2. Keep twiddling the LFC size through the whole test. Before, we would do it for the first 10 seconds, but that only covers a small part of the pgbench initialization phase. Change the loop so that the pgbench run time determines how long the test runs, and we keep changing the LFC for the whole time.

In the passing, also fix bogus test description, copy-pasted from a completely unrelated test.
