### PR TITLE
Forbid creation of child timelines of archived timeline

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -589,6 +589,10 @@ async fn timeline_create_handler(
                 StatusCode::SERVICE_UNAVAILABLE,
                 HttpErrorBody::from_msg(e.to_string()),
             ),
+            Err(e @ tenant::CreateTimelineError::AncestorArchived) => json_response(
+                StatusCode::NOT_ACCEPTABLE,
+                HttpErrorBody::from_msg(e.to_string()),
+            ),
             Err(tenant::CreateTimelineError::ShuttingDown) => json_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 HttpErrorBody::from_msg("tenant shutting down".to_string()),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -563,6 +563,8 @@ pub enum CreateTimelineError {
     AncestorLsn(anyhow::Error),
     #[error("ancestor timeline is not active")]
     AncestorNotActive,
+    #[error("ancestor timeline is archived")]
+    AncestorArchived,
     #[error("tenant shutting down")]
     ShuttingDown,
     #[error(transparent)]
@@ -1696,6 +1698,11 @@ impl Tenant {
                 // ready for other purposes either.
                 if !ancestor_timeline.is_active() {
                     return Err(CreateTimelineError::AncestorNotActive);
+                }
+
+                if !ancestor_timeline.is_archived() {
+                    info!("tried to branch archived timeline");
+                    return Err(CreateTimelineError::AncestorArchived);
                 }
 
                 if let Some(lsn) = ancestor_start_lsn.as_mut() {

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1700,7 +1700,7 @@ impl Tenant {
                     return Err(CreateTimelineError::AncestorNotActive);
                 }
 
-                if !ancestor_timeline.is_archived() {
+                if ancestor_timeline.is_archived() == Some(true) {
                     info!("tried to branch archived timeline");
                     return Err(CreateTimelineError::AncestorArchived);
                 }


### PR DESCRIPTION
We don't want to allow any new child timelines of archived timelines. If you want any new child timelines, you should first un-archive the timeline.
 
Part of #8088