### PR TITLE
proxy: Add separate flag to disable allowed IP address check

### DIFF
--- a/proxy/src/auth/backend.rs
+++ b/proxy/src/auth/backend.rs
@@ -306,8 +306,7 @@ async fn auth_quirks(
     let (allowed_ips, maybe_secret) = api.get_allowed_ips_and_secret(ctx, &info).await?;
 
     // check allowed list
-    if config.ip_allowlist_check_enabled
-        && !check_peer_addr_is_in_list(&ctx.peer_addr(), &allowed_ips)
+    if !config.skip_allowed_ips_check && !check_peer_addr_is_in_list(&ctx.peer_addr(), &allowed_ips)
     {
         return Err(auth::AuthError::ip_address_not_allowed(ctx.peer_addr()));
     }
@@ -600,7 +599,7 @@ mod tests {
         rate_limiter_enabled: true,
         rate_limiter: AuthRateLimiter::new(&RateBucketInfo::DEFAULT_AUTH_SET),
         rate_limit_ip_subnet: 64,
-        ip_allowlist_check_enabled: true,
+        skip_allowed_ips_check: false,
     });
 
     async fn read_message(r: &mut (impl AsyncRead + Unpin), b: &mut BytesMut) -> PgMessage {

--- a/proxy/src/auth/backend/web.rs
+++ b/proxy/src/auth/backend/web.rs
@@ -91,7 +91,7 @@ pub(super) async fn authenticate(
     info!(parent: &span, "waiting for console's reply...");
     let db_info = waiter.await.map_err(WebAuthError::from)?;
 
-    if auth_config.ip_allowlist_check_enabled {
+    if !auth_config.skip_allowed_ips_check {
         if let Some(allowed_ips) = &db_info.allowed_ips {
             if !auth::check_peer_addr_is_in_list(&ctx.peer_addr(), allowed_ips) {
                 return Err(auth::AuthError::ip_address_not_allowed(ctx.peer_addr()));

--- a/proxy/src/bin/local_proxy.rs
+++ b/proxy/src/bin/local_proxy.rs
@@ -232,7 +232,7 @@ fn build_config(args: &LocalProxyCliArgs) -> anyhow::Result<&'static ProxyConfig
             rate_limiter_enabled: false,
             rate_limiter: BucketRateLimiter::new(vec![]),
             rate_limit_ip_subnet: 64,
-            ip_allowlist_check_enabled: true,
+            skip_allowed_ips_check: false,
         },
         require_client_ip: false,
         handshake_timeout: Duration::from_secs(10),

--- a/proxy/src/bin/proxy.rs
+++ b/proxy/src/bin/proxy.rs
@@ -225,8 +225,11 @@ struct ProxyCliArgs {
     /// Whether to retry the wake_compute request
     #[clap(long, default_value = config::RetryConfig::WAKE_COMPUTE_DEFAULT_VALUES)]
     wake_compute_retry: String,
+    /// Disables the check for allowed IP addresses.
+    #[clap(long, default_value_t = false, value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
+    skip_allowed_ips_check: bool,
 
-    /// Configure if this is a private access proxy for the POC: In that case the proxy will ignore the IP allowlist
+    /// Configure if this is a private access proxy for the POC. This overrides other settings.
     #[clap(long, default_value_t = false, value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
     is_private_access_proxy: bool,
 }
@@ -697,7 +700,7 @@ fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
         rate_limiter_enabled: args.auth_rate_limit_enabled,
         rate_limiter: AuthRateLimiter::new(args.auth_rate_limit.clone()),
         rate_limit_ip_subnet: args.auth_rate_limit_ip_subnet,
-        ip_allowlist_check_enabled: !args.is_private_access_proxy,
+        skip_allowed_ips_check: args.skip_allowed_ips_check || args.is_private_access_proxy,
     };
 
     let config = Box::leak(Box::new(ProxyConfig {

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -66,7 +66,7 @@ pub struct AuthenticationConfig {
     pub rate_limiter_enabled: bool,
     pub rate_limiter: AuthRateLimiter,
     pub rate_limit_ip_subnet: u8,
-    pub ip_allowlist_check_enabled: bool,
+    pub skip_allowed_ips_check: bool,
 }
 
 impl TlsConfig {

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -50,7 +50,7 @@ impl PoolingBackend {
             .as_ref()
             .map(|()| user_info.clone());
         let (allowed_ips, maybe_secret) = backend.get_allowed_ips_and_secret(ctx).await?;
-        if config.ip_allowlist_check_enabled
+        if !config.skip_allowed_ips_check
             && !check_peer_addr_is_in_list(&ctx.peer_addr(), &allowed_ips)
         {
             return Err(AuthError::ip_address_not_allowed(ctx.peer_addr()));


### PR DESCRIPTION
* Add an independent and more permanent flag to disable the allowed IP address check.
* Rename from ip_allowlist to allowed_ips to match other identifiers.