### PR TITLE
CI: Leave out unnecessary build files from binary artifact

### DIFF
--- a/.github/workflows/_build-and-test-locally.yml
+++ b/.github/workflows/_build-and-test-locally.yml
@@ -258,9 +258,9 @@ jobs:
 
       - name: Install postgres binaries
         run: |
-          mkdir /tmp/neon/pg_install
+          mkdir /tmp/neon
           # Use tar to copy files matching the pattern, preserving the paths in the destionation
-          tar cv pg_install/v* pg_install/build/*/src/test/regress/*.so | tar  xv -C /tmp/neon/pg_install
+          tar cv pg_install/v* pg_install/build/*/src/test/regress/*.so | tar  xv -C /tmp/neon
 
       - name: Upload Neon artifact
         uses: ./.github/actions/upload

--- a/.github/workflows/_build-and-test-locally.yml
+++ b/.github/workflows/_build-and-test-locally.yml
@@ -259,7 +259,13 @@ jobs:
       - name: Install postgres binaries
         run: |
           # Use tar to copy files matching the pattern, preserving the paths in the destionation
-          tar cv pg_install/v* pg_install/build/*/src/test/regress/*.so | tar  xv -C /tmp/neon
+          tar c \
+            pg_install/v* \
+            pg_install/build/*/src/test/regress/*.so \
+            pg_install/build/*/src/test/regress/pg_regress \
+            pg_install/build/v17/src/test/isolation/isolationtester \
+            pg_install/build/v17/src/test/isolation/pg_isolation_regress \
+            | tar  x -C /tmp/neon
 
       - name: Upload Neon artifact
         uses: ./.github/actions/upload

--- a/.github/workflows/_build-and-test-locally.yml
+++ b/.github/workflows/_build-and-test-locally.yml
@@ -263,8 +263,8 @@ jobs:
             pg_install/v* \
             pg_install/build/*/src/test/regress/*.so \
             pg_install/build/*/src/test/regress/pg_regress \
-            pg_install/build/v17/src/test/isolation/isolationtester \
-            pg_install/build/v17/src/test/isolation/pg_isolation_regress \
+            pg_install/build/*/src/test/isolation/isolationtester \
+            pg_install/build/*/src/test/isolation/pg_isolation_regress \
             | tar  x -C /tmp/neon
 
       - name: Upload Neon artifact

--- a/.github/workflows/_build-and-test-locally.yml
+++ b/.github/workflows/_build-and-test-locally.yml
@@ -258,7 +258,6 @@ jobs:
 
       - name: Install postgres binaries
         run: |
-          mkdir /tmp/neon
           # Use tar to copy files matching the pattern, preserving the paths in the destionation
           tar cv pg_install/v* pg_install/build/*/src/test/regress/*.so | tar  xv -C /tmp/neon
 

--- a/.github/workflows/_build-and-test-locally.yml
+++ b/.github/workflows/_build-and-test-locally.yml
@@ -257,7 +257,10 @@ jobs:
           ${cov_prefix} cargo nextest run $CARGO_FLAGS $CARGO_FEATURES -E 'package(remote_storage)' -E 'test(test_real_azure)'
 
       - name: Install postgres binaries
-        run: cp -a pg_install /tmp/neon/pg_install
+        run: |
+          mkdir /tmp/neon/pg_install
+          # Use tar to copy files matching the pattern, preserving the paths in the destionation
+          tar cv pg_install/v* pg_install/build/*/src/test/regress/*.so | tar  xv -C /tmp/neon/pg_install
 
       - name: Upload Neon artifact
         uses: ./.github/actions/upload


### PR DESCRIPTION
The pg_install/build directory contains .o files and such intermediate results from the build, which are not needed in the final tarball. Except for src/test/regress/regress.so and a few other .so files in that directory; keep those.

This reduces the size of the neon-Linux-X64-release-artifact.tar.zst artifact from about 1.5 GB to 700 MB.

(I attempted this a long time ago already, by moving the build/ directory out of pg_install altogether, see PR #2127. But I never got around to finish that work.)
