### PR TITLE
chore: Silence clippy warning with nightly

### DIFF
--- a/pageserver/src/tenant/checks.rs
+++ b/pageserver/src/tenant/checks.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use super::storage_layer::LayerName;
 
 /// Checks whether a layer map is valid (i.e., is a valid result of the current compaction algorithm if nothing goes wrong).
+///
 /// The function checks if we can split the LSN range of a delta layer only at the LSNs of the delta layers. For example,
 ///
 /// ```plain


### PR DESCRIPTION
The warning:

    warning: first doc comment paragraph is too long
      --> pageserver/src/tenant/checks.rs:7:1
       |
    7  | / /// Checks whether a layer map is valid (i.e., is a valid result of the current compaction algorithm if no...
    8  | | /// The function checks if we can split the LSN range of a delta layer only at the LSNs of the delta layer...
    9  | | ///
    10 | | /// ```plain
       | |_
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
       = note: `#[warn(clippy::too_long_first_doc_paragraph)]` on by default
    help: add an empty line
       |
    7  ~ /// Checks whether a layer map is valid (i.e., is a valid result of the current compaction algorithm if nothing goes wrong).
    8  + ///
       |

Fix by applying the suggestion.
