### PR TITLE
Bump vm-builder v0.29.3 -> v0.35.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -773,7 +773,7 @@ jobs:
       matrix:
         version: [ v14, v15, v16, v17 ]
     env:
-      VM_BUILDER_VERSION: v0.29.3
+      VM_BUILDER_VERSION: v0.35.0
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Update vm-builder to the latest version ([v0.35.0](https://github.com/neondatabase/autoscaling/releases/tag/v0.35.0)). 
From the changelog:
- vm-builder: Change sshd config to use internal-sftp subsystem (neondatabase/autoscaling#1051)
  - Note: This allows scp to work normally
- vm-builder: Remove qemu-img from built vm images (neondatabase/autoscaling#1077)
- vm-builder: Use docker auth (neondatabase/autoscaling#977)
- disk-quota related changes (neondatabase/autoscaling#1062)

## Summary of changes
- Bump vm-builder v0.29.3 -> v0.35.0

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
