### PR TITLE
Collect compute backpressure throttling time

### DIFF
--- a/compute/etc/neon_collector.jsonnet
+++ b/compute/etc/neon_collector.jsonnet
@@ -3,6 +3,7 @@
   metrics: [
     import 'sql_exporter/checkpoints_req.libsonnet',
     import 'sql_exporter/checkpoints_timed.libsonnet',
+    import 'sql_exporter/compute_backpressure_throttling_ms.libsonnet',
     import 'sql_exporter/compute_current_lsn.libsonnet',
     import 'sql_exporter/compute_logical_snapshot_files.libsonnet',
     import 'sql_exporter/compute_receive_lsn.libsonnet',

--- a/compute/etc/sql_exporter/compute_backpressure_throttling_ms.libsonnet
+++ b/compute/etc/sql_exporter/compute_backpressure_throttling_ms.libsonnet
@@ -1,0 +1,10 @@
+{
+  metric_name: 'compute_backpressure_throttling_ms',
+  type: 'gauge',
+  help: 'Time compute has spent throttled',
+  key_labels: null,
+  values: [
+    'throttled',
+  ],
+  query: importstr 'sql_exporter/compute_backpressure_throttling_ms.sql',
+}

--- a/compute/etc/sql_exporter/compute_backpressure_throttling_ms.sql
+++ b/compute/etc/sql_exporter/compute_backpressure_throttling_ms.sql
@@ -1,0 +1,1 @@
+SELECT neon.backpressure_throttling_time() AS throttled;


### PR DESCRIPTION
This will tell us how much time the compute has spent throttled if
pageserver/safekeeper cannot keep up with WAL generation.