### PR TITLE
Add new compute metrics to sql exporter

### DIFF
--- a/compute/etc/neon_collector.yml
+++ b/compute/etc/neon_collector.yml
@@ -120,7 +120,7 @@ metrics:
 
 - metric_name: getpage_prefetch_misses_total
   type: counter
-  help: 'Number of prefetch misses (XXX what does this mean?)'
+  help: 'Total number of readahead misses; consisting of either prefetches that don't satisfy the LSN bounds once the prefetch got read by the backend, or cases where somehow no readahead was issued for the read'
   values: [getpage_prefetch_misses_total]
   query_ref: neon_perf_counters
 

--- a/compute/etc/neon_collector.yml
+++ b/compute/etc/neon_collector.yml
@@ -321,7 +321,7 @@ queries:
         (SELECT value FROM c WHERE metric = 'getpage_prefetch_misses_total')  AS getpage_prefetch_misses_total,
         (SELECT value FROM c WHERE metric = 'getpage_prefetch_discards_total')  AS getpage_prefetch_discards_total,
         (SELECT value FROM c WHERE metric = 'pageserver_requests_sent_total')  AS pageserver_requests_sent_total,
-        (SELECT value FROM c WHERE metric = 'pageserver_requests_disconnects_total')  AS pageserver_requests_disconnects_total,
+        (SELECT value FROM c WHERE metric = 'pageserver_disconnects_total')  AS pageserver_disconnects_total,
         (SELECT value FROM c WHERE metric = 'pageserver_send_flushes_total')  AS pageserver_send_flushes_total;
 
   - query_name: getpage_wait_seconds_buckets

--- a/compute/etc/neon_collector.yml
+++ b/compute/etc/neon_collector.yml
@@ -94,6 +94,67 @@ metrics:
   query: |
     select sum(pg_database_size(datname)) as total from pg_database;
 
+- metric_name: getpage_wait_seconds_count
+  type: counter
+  help: 'Number of getpage requests'
+  values: [getpage_wait_seconds_count]
+  query_ref: neon_perf_counters
+
+- metric_name: getpage_wait_seconds_sum
+  type: counter
+  help: 'Time spent in getpage requests'
+  values: [getpage_wait_seconds_sum]
+  query_ref: neon_perf_counters
+
+- metric_name: getpage_prefetch_requests_total
+  type: counter
+  help: 'Number of getpage issued for prefetching'
+  values: [getpage_prefetch_requests_total]
+  query_ref: neon_perf_counters
+
+- metric_name: getpage_sync_requests_total
+  type: counter
+  help: 'Number of synchronous getpage issued'
+  values: [getpage_sync_requests_total]
+  query_ref: neon_perf_counters
+
+- metric_name: getpage_prefetch_misses_total
+  type: counter
+  values: [getpage_prefetch_misses_total]
+  query_ref: neon_perf_counters
+
+- metric_name: getpage_prefetch_discards_total
+  type: counter
+  help: 'Number of prefetch responses issued but not used'
+  values: [getpage_prefetch_discards_total]
+  query_ref: neon_perf_counters
+
+- metric_name: pageserver_requests_sent_total
+  type: counter
+  help: 'Number of all requests sent to the pageserver (not just GetPage requests)'
+  values: [pageserver_requests_sent_total]
+  query_ref: neon_perf_counters
+
+- metric_name: pageserver_disconnects_total
+  type: counter
+  help: 'Number of times that the connection to the pageserver was lost'
+  values: [pageserver_disconnects_total]
+  query_ref: neon_perf_counters
+
+- metric_name: pageserver_send_flushes_total
+  type: counter
+  help: 'Number of flushes to the pageserver connection'
+  values: [pageserver_send_flushes_total]
+  query_ref: neon_perf_counters
+
+- metric_name: getpage_wait_seconds_buckets
+  type: counter
+  help: 'Histogram buckets of getpage request latency'
+  key_labels:
+      - bucket_le
+  values: [value]
+  query_ref: getpage_wait_seconds_buckets
+
 # DEPRECATED
 - metric_name: lfc_approximate_working_set_size
   type: gauge
@@ -244,3 +305,24 @@ metrics:
     SELECT slot_name,
            CASE WHEN wal_status = 'lost' THEN 1 ELSE 0 END AS wal_is_lost
     FROM pg_replication_slots;
+
+queries:
+  - query_name: neon_perf_counters
+    query: |
+      WITH c AS (
+        SELECT metric, value FROM neon.neon_perf_counters
+      )
+      SELECT
+        (SELECT value FROM c WHERE metric = 'getpage_wait_seconds_count') AS getpage_wait_seconds_count,
+        (SELECT value FROM c WHERE metric = 'getpage_wait_seconds_sum') AS getpage_wait_seconds_sum,
+        (SELECT value FROM c WHERE metric = 'getpage_prefetch_requests_total')  AS getpage_prefetch_requests_total,
+        (SELECT value FROM c WHERE metric = 'getpage_sync_requests_total')  AS getpage_sync_requests_total,
+        (SELECT value FROM c WHERE metric = 'getpage_prefetch_misses_total')  AS getpage_prefetch_misses_total,
+        (SELECT value FROM c WHERE metric = 'getpage_prefetch_discards_total')  AS getpage_prefetch_discards_total,
+        (SELECT value FROM c WHERE metric = 'pageserver_requests_sent_total')  AS pageserver_requests_sent_total,
+        (SELECT value FROM c WHERE metric = 'pageserver_requests_disconnects_total')  AS pageserver_requests_disconnects_total,
+        (SELECT value FROM c WHERE metric = 'pageserver_send_flushes_total')  AS pageserver_send_flushes_total;
+
+  - query_name: getpage_wait_seconds_buckets
+    query: |
+      SELECT bucket_le, value FROM neon.neon_perf_counters WHERE metric = 'getpage_wait_seconds_bucket';

--- a/compute/etc/neon_collector.yml
+++ b/compute/etc/neon_collector.yml
@@ -314,7 +314,7 @@ queries:
         SELECT jsonb_object_agg(metric, value) jb FROM neon.neon_perf_counters
       )
       SELECT d.*
-      FROM jsonb_to_record(select jb from c) as d(
+      FROM jsonb_to_record((select jb from c)) as d(
           getpage_wait_seconds_count numeric,
           getpage_wait_seconds_sum numeric,
           getpage_prefetch_requests_total numeric,

--- a/compute/etc/neon_collector.yml
+++ b/compute/etc/neon_collector.yml
@@ -120,6 +120,7 @@ metrics:
 
 - metric_name: getpage_prefetch_misses_total
   type: counter
+  help: 'Number of prefetch misses (XXX what does this mean?)'
   values: [getpage_prefetch_misses_total]
   query_ref: neon_perf_counters
 

--- a/compute/etc/neon_collector.yml
+++ b/compute/etc/neon_collector.yml
@@ -311,18 +311,20 @@ queries:
   - query_name: neon_perf_counters
     query: |
       WITH c AS (
-        SELECT metric, value FROM neon.neon_perf_counters
+        SELECT jsonb_object_agg(metric, value) jb FROM neon.neon_perf_counters
       )
-      SELECT
-        (SELECT value FROM c WHERE metric = 'getpage_wait_seconds_count') AS getpage_wait_seconds_count,
-        (SELECT value FROM c WHERE metric = 'getpage_wait_seconds_sum') AS getpage_wait_seconds_sum,
-        (SELECT value FROM c WHERE metric = 'getpage_prefetch_requests_total')  AS getpage_prefetch_requests_total,
-        (SELECT value FROM c WHERE metric = 'getpage_sync_requests_total')  AS getpage_sync_requests_total,
-        (SELECT value FROM c WHERE metric = 'getpage_prefetch_misses_total')  AS getpage_prefetch_misses_total,
-        (SELECT value FROM c WHERE metric = 'getpage_prefetch_discards_total')  AS getpage_prefetch_discards_total,
-        (SELECT value FROM c WHERE metric = 'pageserver_requests_sent_total')  AS pageserver_requests_sent_total,
-        (SELECT value FROM c WHERE metric = 'pageserver_disconnects_total')  AS pageserver_disconnects_total,
-        (SELECT value FROM c WHERE metric = 'pageserver_send_flushes_total')  AS pageserver_send_flushes_total;
+      SELECT d.*
+      FROM jsonb_to_record(select jb from c) as d(
+          getpage_wait_seconds_count numeric,
+          getpage_wait_seconds_sum numeric,
+          getpage_prefetch_requests_total numeric,
+          getpage_sync_requests_total numeric,
+          getpage_prefetch_misses_total numeric,
+          getpage_prefetch_discards_total numeric,
+          pageserver_requests_sent_total numeric,
+          pageserver_disconnects_total numeric,
+          pageserver_send_flushes_total numeric
+      );
 
   - query_name: getpage_wait_seconds_buckets
     query: |

--- a/compute/etc/neon_collector.yml
+++ b/compute/etc/neon_collector.yml
@@ -311,10 +311,10 @@ queries:
   - query_name: neon_perf_counters
     query: |
       WITH c AS (
-        SELECT jsonb_object_agg(metric, value) jb FROM neon.neon_perf_counters
+        SELECT pg_catalog.jsonb_object_agg(metric, value) jb FROM neon.neon_perf_counters
       )
       SELECT d.*
-      FROM jsonb_to_record((select jb from c)) as d(
+      FROM pg_catalog.jsonb_to_record((select jb from c)) as d(
           getpage_wait_seconds_count numeric,
           getpage_wait_seconds_sum numeric,
           getpage_prefetch_requests_total numeric,

--- a/pgxn/neon/neon_perf_counters.c
+++ b/pgxn/neon/neon_perf_counters.c
@@ -137,7 +137,7 @@ neon_perf_counters_to_metrics(neon_per_backend_counters *counters)
 	metrics[i].is_bucket = false;
 	metrics[i].value = (double) counters->pageserver_requests_sent_total;
 	i++;
-	metrics[i].name = "pageserver_requests_disconnects_total";
+	metrics[i].name = "pageserver_disconnects_total";
 	metrics[i].is_bucket = false;
 	metrics[i].value = (double) counters->pageserver_disconnects_total;
 	i++;


### PR DESCRIPTION
These are the perf counters added in commit 263dfba6ee.

Note: This relies on 'neon' extension version 1.5. The default was bumped to 1.5 in commit d696c41807306333dab3568da523937963f7a116.