### PR TITLE
storage_scrubber: retry on index deletion failures

### DIFF
--- a/storage_scrubber/src/pageserver_physical_gc.rs
+++ b/storage_scrubber/src/pageserver_physical_gc.rs
@@ -333,7 +333,7 @@ async fn maybe_delete_index(
         |_| false,
         3,
         MAX_RETRIES as u32,
-        "head_object",
+        "maybe_delete_index",
         &cancel,
     )
     .await


### PR DESCRIPTION
## Problem

In automated tests running on AWS S3, we frequently see scrubber failures when it can't delete an index.

`location_conf_churn`:
https://neon-github-public-dev.s3.amazonaws.com/reports/main/11076221056/index.html#/testresult/f89b1916b6a693e2

`scrubber_physical_gc`:
https://neon-github-public-dev.s3.amazonaws.com/reports/pr-9178/11074269153/index.html#/testresult/9885ed5aa0fe38b6

## Summary of changes

Wrap index deletion in a backoff::retry

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
