### PR TITLE
Remove unnecessary dev package from compute image

### DIFF
--- a/compute/Dockerfile.compute-node
+++ b/compute/Dockerfile.compute-node
@@ -1258,7 +1258,7 @@ RUN apt update && \
         libxml2 \
         libxslt1.1 \
         libzstd1 \
-        libcurl4-openssl-dev \
+        libcurl4 \
         locales \
         procps \
         ca-certificates \


### PR DESCRIPTION
libcurl4-openssl-dev is needed to build pgxn/, but libcurl4 is enough at runtime.
