### PR TITLE
Suppress wal lag timeout warnings right after tenant attachment

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -319,6 +319,9 @@ pub struct Tenant {
     /// background warmup.
     pub(crate) activate_now_sem: tokio::sync::Semaphore,
 
+    /// Time it took for the tenant to activate. Zero if not active yet.
+    attach_wal_lag_cooldown: Arc<std::sync::OnceLock<std::time::Instant>>,
+
     // Cancellation token fires when we have entered shutdown().  This is a parent of
     // Timelines' cancellation token.
     pub(crate) cancel: CancellationToken,
@@ -1000,11 +1003,16 @@ impl Tenant {
                 // Remote preload is complete.
                 drop(remote_load_completion);
 
+
                 // We will time the duration of the attach phase unless this is a creation (attach will do no work)
+                let attach_start = std::time::Instant::now();
                 let attached = {
                     let _attach_timer = Some(TENANT.attach.start_timer());
                     tenant_clone.attach(preload, &ctx).await
                 };
+                let attach_duration = attach_start.elapsed();
+                let wal_lag_cooldown = attach_start + 2 * attach_duration + Duration::from_secs(60);
+                _ = tenant_clone.attach_wal_lag_cooldown.set(wal_lag_cooldown);
 
                 match attached {
                     Ok(()) => {
@@ -2754,6 +2762,7 @@ impl Tenant {
             pg_version,
             state,
             last_aux_file_policy,
+            self.attach_wal_lag_cooldown.clone(),
             self.cancel.child_token(),
         );
 
@@ -2860,6 +2869,7 @@ impl Tenant {
                 Some(Duration::from_secs(3600 * 24)),
             )),
             activate_now_sem: tokio::sync::Semaphore::new(0),
+            attach_wal_lag_cooldown: Arc::new(std::sync::OnceLock::new()),
             cancel: CancellationToken::default(),
             gate: Gate::default(),
             timeline_get_throttle: Arc::new(throttle::Throttle::new(

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -64,14 +64,12 @@ use std::{
 use std::{pin::pin, sync::OnceLock};
 
 use crate::{
-    aux_file::AuxFileSizeEstimator,
-    tenant::{
+    aux_file::AuxFileSizeEstimator, tenant::{
         config::AttachmentMode,
         layer_map::{LayerMap, SearchResult},
         metadata::TimelineMetadata,
         storage_layer::{inmemory_layer::IndexEntry, PersistentLayerDesc},
-    },
-    walredo,
+    }, walingest::WalLagCooldown, walredo
 };
 use crate::{
     context::{DownloadBehavior, RequestContext},

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -64,12 +64,15 @@ use std::{
 use std::{pin::pin, sync::OnceLock};
 
 use crate::{
-    aux_file::AuxFileSizeEstimator, tenant::{
+    aux_file::AuxFileSizeEstimator,
+    tenant::{
         config::AttachmentMode,
         layer_map::{LayerMap, SearchResult},
         metadata::TimelineMetadata,
         storage_layer::{inmemory_layer::IndexEntry, PersistentLayerDesc},
-    }, walingest::WalLagCooldown, walredo
+    },
+    walingest::WalLagCooldown,
+    walredo,
 };
 use crate::{
     context::{DownloadBehavior, RequestContext},

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -430,7 +430,7 @@ pub struct Timeline {
 
     pub(crate) handles: handle::PerTimelineState<crate::page_service::TenantManagerTypes>,
 
-    pub(crate) attach_wal_lag_cooldown: Arc<OnceLock<std::time::Instant>>,
+    pub(crate) attach_wal_lag_cooldown: Arc<OnceLock<WalLagCooldown>>,
 }
 
 pub struct WalReceiverInfo {
@@ -2132,7 +2132,7 @@ impl Timeline {
         pg_version: u32,
         state: TimelineState,
         aux_file_policy: Option<AuxFilePolicy>,
-        attach_wal_lag_cooldown: Arc<OnceLock<std::time::Instant>>,
+        attach_wal_lag_cooldown: Arc<OnceLock<WalLagCooldown>>,
         cancel: CancellationToken,
     ) -> Arc<Self> {
         let disk_consistent_lsn = metadata.disk_consistent_lsn();

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -48,7 +48,6 @@ use utils::{
     sync::gate::{Gate, GateGuard},
 };
 
-use std::{pin::pin, sync::OnceLock};
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant, SystemTime};
@@ -62,6 +61,7 @@ use std::{
     collections::btree_map::Entry,
     ops::{Deref, Range},
 };
+use std::{pin::pin, sync::OnceLock};
 
 use crate::{
     aux_file::AuxFileSizeEstimator,

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -72,8 +72,15 @@ impl CheckPoint {
     }
 }
 
+/// Temporary limitation of WAL lag warnings after attach
+///
+/// After tenant attach, we want to limit WAL lag warnings because
+/// we don't look at the WAL until the attach is complete, which
+/// might take a while.
 pub struct WalLagCooldown {
+    /// Until when should this limitation apply at all
     active_until: std::time::Instant,
+    /// The maximum lag to suppress. Lags above this limit get reported anyways.
     max_lag: Duration,
 }
 


### PR DESCRIPTION
As seen in https://github.com/neondatabase/cloud/issues/17335, during releases we can have ingest lags that are above the limits for warnings. However, such lags are part of normal pageserver startup.

Therefore, calculate a certain cooldown timestamp until which we accept lags. The heuristic is chosen to grow the later we get to fully load the tenant, and we also add 60 seconds as a grace period after that term.