### PR TITLE
storcon: do timeline creation on all attached location

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -3035,6 +3035,9 @@ impl Service {
                     .await
                     .map_err(|e| passthrough_api_error(&latest, e))?;
 
+                // We propagate timeline creations to all attached locations such that a compute
+                // for the new timeline is able to start regardless of the current state of the
+                // tenant shard reconciliation.
                 for location in locations.other {
                     tracing::info!(
                         "Creating timeline on shard {}/{}, stale attached to node {} in generation {:?}",

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -17,6 +17,7 @@ use crate::{
     service::ReconcileResultRequest,
 };
 use futures::future::{self, Either};
+use itertools::Itertools;
 use pageserver_api::controller_api::{
     AvailabilityZone, NodeSchedulingPolicy, PlacementPolicy, ShardSchedulingPolicy,
 };
@@ -1409,6 +1410,32 @@ impl TenantShard {
 
     pub(crate) fn set_preferred_az(&mut self, preferred_az_id: AvailabilityZone) {
         self.preferred_az_id = Some(preferred_az_id);
+    }
+
+    pub(crate) fn attached_locations(&self) -> Vec<(NodeId, Generation)> {
+        self.observed
+            .locations
+            .iter()
+            .filter_map(|(node_id, observed)| {
+                let conf = observed.conf.as_ref()?;
+                let is_attached = matches!(
+                    conf.mode,
+                    LocationConfigMode::AttachedMulti
+                        | LocationConfigMode::AttachedSingle
+                        | LocationConfigMode::AttachedStale
+                );
+                let has_generation = conf.generation.is_some();
+                if is_attached && has_generation {
+                    Some((*node_id, conf.generation.unwrap()))
+                } else {
+                    None
+                }
+            })
+            .sorted_by(|(_lhs_node_id, lhs_gen), (_rhs_node_id, rhs_gen)| {
+                lhs_gen.cmp(rhs_gen).reverse()
+            })
+            .map(|(node_id, gen)| (node_id, Generation::new(gen)))
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Problem

Creation of a timelines during a reconciliation can lead to unavailability if the user attempts to
start a compute before the storage controller has notified cplane of the cut-over.

## Summary of changes

Create timelines on all currently attached locations. For the latest location, we still look
at the database (this is a previously). With this change we also look into the observed state
to find *other* attached locations.

Related https://github.com/neondatabase/neon/issues/9144

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
