### PR TITLE
Fix metric name of the 'getpage_wait_seconds_bucket' metric

### DIFF
--- a/compute/etc/neon_collector.yml
+++ b/compute/etc/neon_collector.yml
@@ -148,7 +148,7 @@ metrics:
   values: [pageserver_send_flushes_total]
   query_ref: neon_perf_counters
 
-- metric_name: getpage_wait_seconds_buckets
+- metric_name: getpage_wait_seconds_bucket
   type: counter
   help: 'Histogram buckets of getpage request latency'
   key_labels:


### PR DESCRIPTION
Per convention, histogram buckets have the '_bucket' suffix. I got that wrong in commit 0d500bbd5b.

Fixes https://github.com/neondatabase/neon/issues/9241
