### PR TITLE
Use GetRedoStartLsn() instead of walproposer epoch start LSN for on-demand WAL download

### DIFF
--- a/pgxn/neon/walsender_hooks.c
+++ b/pgxn/neon/walsender_hooks.c
@@ -191,13 +191,7 @@ NeonOnDemandXLogReaderRoutines(XLogReaderRoutine *xlr)
 
 	if (!wal_reader)
 	{
-		XLogRecPtr	epochStartLsn = pg_atomic_read_u64(&GetWalpropShmemState()->propEpochStartLsn);
-
-		if (epochStartLsn == 0)
-		{
-			elog(ERROR, "Unable to start walsender when propEpochStartLsn is 0!");
-		}
-		wal_reader = NeonWALReaderAllocate(wal_segment_size, epochStartLsn, "[walsender] ");
+		wal_reader = NeonWALReaderAllocate(wal_segment_size, GetRedoStartLsn(), "[walsender] ");
 	}
 	xlr->page_read = NeonWALPageRead;
 	xlr->segment_open = NeonWALReadSegmentOpen;


### PR DESCRIPTION
## Problem

https://neondb.slack.com/archives/C04DGM6SMTM/p1727699529599339

## Summary of changes

Use GetRedoStartLsn() instead of propEpochStartLsn

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
