### PR TITLE
storcon: apply all node status changes before handling transitions

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5338,6 +5338,10 @@ impl Service {
         Ok(())
     }
 
+    /// Configure in-memory and persistent state of a node as requested
+    ///
+    /// Note that this function does not trigger any immediate side effects in response
+    /// to the changes. That part is handled by [`Self::handle_node_availability_transition`].
     async fn node_state_configure(
         &self,
         node_id: NodeId,
@@ -5410,6 +5414,11 @@ impl Service {
         Ok(availability_transition)
     }
 
+    /// Handle availability transition of one node
+    ///
+    /// Note that you should first call [`Self::node_state_configure`] to update
+    /// the in-memory state referencing that node. If you need to handle more than one transition
+    /// consider using [`Self::handle_node_availability_transitions`].
     async fn handle_node_availability_transition(
         &self,
         node_id: NodeId,
@@ -5520,6 +5529,10 @@ impl Service {
         Ok(())
     }
 
+    /// Handle availability transition for multiple nodes
+    ///
+    /// Note that you should first call [`Self::node_state_configure`] for
+    /// all nodes being handled here for the handling to use fresh in-memory state.
     async fn handle_node_availability_transitions(
         &self,
         transitions: Vec<(

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -1014,10 +1014,10 @@ impl Service {
 
                     match res {
                         Ok(transition) => {
-                            // Keep hold of the lock on until the availability transitions
-                            // have been handlded in
+                            // Keep hold of the lock until the availability transitions
+                            // have been handled in
                             // [`Service::handle_node_availability_transitions`] in order avoid
-                            // raicng with [`Service::external_node_configure`].
+                            // racing with [`Service::external_node_configure`].
                             to_handle.push((node_id, node_lock, transition));
                         }
                         Err(ApiError::NotFound(_)) => {

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5343,7 +5343,7 @@ impl Service {
         node_id: NodeId,
         availability: Option<NodeAvailability>,
         scheduling: Option<NodeSchedulingPolicy>,
-        nodes_lock: &TracingExclusiveGuard<NodeOperations>,
+        node_lock: &TracingExclusiveGuard<NodeOperations>,
     ) -> Result<AvailabilityTransition, ApiError> {
         if let Some(scheduling) = scheduling {
             // Scheduling is a persistent part of Node: we must write updates to the database before
@@ -5373,7 +5373,7 @@ impl Service {
             };
 
             if matches!(availability_transition, AvailabilityTransition::ToActive) {
-                self.node_activate_reconcile(activate_node, nodes_lock)
+                self.node_activate_reconcile(activate_node, node_lock)
                     .await?;
             }
             availability_transition
@@ -5414,7 +5414,7 @@ impl Service {
         &self,
         node_id: NodeId,
         transition: AvailabilityTransition,
-        _nodes_lock: &TracingExclusiveGuard<NodeOperations>,
+        _node_lock: &TracingExclusiveGuard<NodeOperations>,
     ) -> Result<(), ApiError> {
         // Modify scheduling state for any Tenants that are affected by a change in the node's availability state.
         match transition {


### PR DESCRIPTION
## Problem

When a node goes offline, we trigger reconciles to migrate shards away from it.
If multiple nodes go offline at the same time, we handled them in sequence. Hence,
we might migrate shards from the first offline node to the second offline node and
increase the unavailability period.

## Summary of changes

Refactor heartbeat delta handling to:
1. Update in memory state for all nodes first
2. Handle availability transitions one by one (we have full picture for each node after (1))

Closes https://github.com/neondatabase/neon/issues/9126

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
