### PR TITLE
Replace BUFFERTAGS_EQUAL compatibility macro with new-style function

### DIFF
--- a/pgxn/neon/neon_pgversioncompat.h
+++ b/pgxn/neon/neon_pgversioncompat.h
@@ -7,6 +7,7 @@
 #define NEON_PGVERSIONCOMPAT_H
 
 #include "fmgr.h"
+#include "storage/buf_internals.h"
 
 #if PG_MAJORVERSION_NUM < 17
 #define NRelFileInfoBackendIsTemp(rinfo) (rinfo.backend != InvalidBackendId)
@@ -20,11 +21,24 @@
 	NInfoGetRelNumber(a) == NInfoGetRelNumber(b) \
 )
 
-/* buftag population & RelFileNode/RelFileLocator rework */
+/* These macros were turned into static inline functions in v16 */
 #if PG_MAJORVERSION_NUM < 16
+static inline bool
+BufferTagsEqual(const BufferTag *tag1, const BufferTag *tag2)
+{
+	return BUFFERTAGS_EQUAL(*tag1, *tag2);
+}
 
-#define InitBufferTag(tag, rfn, fn, bn) INIT_BUFFERTAG(*tag, *rfn, fn, bn)
+static inline void
+InitBufferTag(BufferTag *tag, const RelFileNode *rnode,
+			  ForkNumber forkNum, BlockNumber blockNum)
+{
+	INIT_BUFFERTAG(*tag, *rnode, forkNum, blockNum);
+}
+#endif
 
+/* RelFileNode -> RelFileLocator rework */
+#if PG_MAJORVERSION_NUM < 16
 #define USE_RELFILENODE
 
 #define RELFILEINFO_HDR "storage/relfilenode.h"
@@ -72,8 +86,6 @@
 #else							/* major version >= 16 */
 
 #define USE_RELFILELOCATOR
-
-#define BUFFERTAGS_EQUAL(a, b) BufferTagsEqual(&(a), &(b))
 
 #define RELFILEINFO_HDR "storage/relfilelocator.h"
 

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -215,7 +215,7 @@ typedef struct PrfHashEntry
 	sizeof(BufferTag) \
 )
 
-#define SH_EQUAL(tb, a, b)	(BUFFERTAGS_EQUAL((a)->buftag, (b)->buftag))
+#define SH_EQUAL(tb, a, b)	(BufferTagsEqual(&(a)->buftag, &(b)->buftag))
 #define SH_SCOPE			static inline
 #define SH_DEFINE
 #define SH_DECLARE
@@ -853,7 +853,7 @@ Retry:
 			Assert(slot->status != PRFS_UNUSED);
 			Assert(MyPState->ring_last <= ring_index &&
 				   ring_index < MyPState->ring_unused);
-			Assert(BUFFERTAGS_EQUAL(slot->buftag, hashkey.buftag));
+			Assert(BufferTagsEqual(&slot->buftag, &hashkey.buftag));
 
 			/*
 			 * If the caller specified a request LSN to use, only accept

--- a/pgxn/neon_walredo/walredoproc.c
+++ b/pgxn/neon_walredo/walredoproc.c
@@ -992,7 +992,7 @@ redo_block_filter(XLogReaderState *record, uint8 block_id)
 	 * If this block isn't one we are currently restoring, then return 'true'
 	 * so that this gets ignored
 	 */
-	return !BUFFERTAGS_EQUAL(target_tag, target_redo_tag);
+	return !BufferTagsEqual(&target_tag, &target_redo_tag);
 }
 
 /*


### PR DESCRIPTION
In PostgreSQL v16, BUFFERTAGS_EQUAL was replaced with a static inline macro, BufferTagsEqual. Let's use the new name going forward, and have backwards-compatibility glue to allow using the new name on v14 and v15, rather than the other way round. This also makes BufferTagsEquals consistent with InitBufferTag, for which we were already using the new name.
