### PR TITLE
Remove get_self_dir()

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -91,7 +91,6 @@ from fixtures.utils import (
     allure_attach_from_dir,
     assert_no_errors,
     get_dir_size,
-    get_self_dir,
     print_gc_result,
     subprocess_capture,
     wait_until,
@@ -130,7 +129,7 @@ BASE_PORT: int = 15000
 @pytest.fixture(scope="session")
 def base_dir() -> Iterator[Path]:
     # find the base directory (currently this is the git root)
-    base_dir = get_self_dir().parent.parent
+    base_dir = Path(__file__).parents[2]
     log.info(f"base_dir is {base_dir}")
 
     yield base_dir

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -42,11 +42,6 @@ from fixtures.common_types import TimelineId
 Fn = TypeVar("Fn", bound=Callable[..., Any])
 
 
-def get_self_dir() -> Path:
-    """Get the path to the directory where this script lives."""
-    return Path(__file__).resolve().parent
-
-
 def subprocess_capture(
     capture_dir: Path,
     cmd: List[str],

--- a/test_runner/performance/test_perf_olap.py
+++ b/test_runner/performance/test_perf_olap.py
@@ -1,12 +1,12 @@
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List, Tuple
 
 import pytest
 from _pytest.mark import ParameterSet
 from fixtures.compare_fixtures import RemoteCompare
 from fixtures.log_helper import log
-from fixtures.utils import get_self_dir
 
 
 @dataclass
@@ -191,7 +191,7 @@ def tpch_queuies() -> Tuple[ParameterSet, ...]:
     - querues in returning tuple are ordered by the query number
     - pytest parameters id is adjusted to match the query id (the numbering starts from 1)
     """
-    queries_dir = get_self_dir().parent / "performance" / "tpc-h" / "queries"
+    queries_dir = Path(__file__).parent / "performance" / "tpc-h" / "queries"
     assert queries_dir.exists(), f"TPC-H queries dir not found: {queries_dir}"
 
     return tuple(


### PR DESCRIPTION
It didn't serve much value, and was only used twice. `Path(__file__).parent` is a pretty easy invocation to use.
