### PR TITLE
ci: gh-workflow-stats-action v0.1.4: remove debug output and proper pagination

### DIFF
--- a/.github/workflows/report-workflow-stats.yml
+++ b/.github/workflows/report-workflow-stats.yml
@@ -33,7 +33,7 @@ jobs:
       actions: read
     steps:
     - name: Export GH Workflow Stats
-      uses: fedordikarev/gh-workflow-stats-action@v0.1.4
+      uses: neondatabase/gh-workflow-stats-action@v0.1.4
       with:
         DB_URI: ${{ secrets.GH_REPORT_STATS_DB_RW_CONNSTR }}
         DB_TABLE: "gh_workflow_stats_neon"

--- a/.github/workflows/report-workflow-stats.yml
+++ b/.github/workflows/report-workflow-stats.yml
@@ -33,7 +33,7 @@ jobs:
       actions: read
     steps:
     - name: Export GH Workflow Stats
-      uses: fedordikarev/gh-workflow-stats-action@v0.1.2
+      uses: fedordikarev/gh-workflow-stats-action@v0.1.4
       with:
         DB_URI: ${{ secrets.GH_REPORT_STATS_DB_RW_CONNSTR }}
         DB_TABLE: "gh_workflow_stats_neon"


### PR DESCRIPTION
## Problem
In previous version pagination didn't work so we collect information only for first 30 jobs in WorkflowRun