### PR TITLE
[local_proxy]: install pg_session_jwt extension on demand

### DIFF
--- a/compute/Dockerfile.compute-node
+++ b/compute/Dockerfile.compute-node
@@ -978,8 +978,8 @@ ARG PG_VERSION
 RUN case "${PG_VERSION}" in "v17") \
     echo "pg_session_jwt does not yet have a release that supports pg17" && exit 0;; \
     esac && \
-    wget https://github.com/neondatabase/pg_session_jwt/archive/5aee2625af38213650e1a07ae038fdc427250ee4.tar.gz -O pg_session_jwt.tar.gz && \
-    echo "5d91b10bc1347d36cffc456cb87bec25047935d6503dc652ca046f04760828e7 pg_session_jwt.tar.gz" | sha256sum --check && \
+    wget https://github.com/neondatabase/pg_session_jwt/archive/e642528f429dd3f5403845a50191b78d434b84a6.tar.gz -O pg_session_jwt.tar.gz && \
+    echo "1a69210703cc91224785e59a0a67562dd9eed9a0914ac84b11447582ca0d5b93 pg_session_jwt.tar.gz" | sha256sum --check && \
     mkdir pg_session_jwt-src && cd pg_session_jwt-src && tar xzf ../pg_session_jwt.tar.gz --strip-components=1 -C . && \
     sed -i 's/pgrx = "=0.11.3"/pgrx = { version = "=0.11.3", features = [ "unsafe-postgres" ] }/g' Cargo.toml && \
     cargo pgrx install --release

--- a/proxy/src/compute_ctl/mod.rs
+++ b/proxy/src/compute_ctl/mod.rs
@@ -1,0 +1,51 @@
+use anyhow::Context;
+use hyper::Method;
+use typed_json::json;
+
+use crate::http;
+
+pub struct ComputeCtlApi {
+    pub(crate) api: http::Endpoint,
+}
+
+// The following article is a stub.
+// You can help Wikipedia by filling it out
+
+impl ComputeCtlApi {
+    pub async fn install_extension(&self, db: &str, ext: &str) -> anyhow::Result<()> {
+        self.api
+            .request_with_url(Method::POST, |url| {
+                url.path_segments_mut().push("extension");
+            })
+            .json(&json! {{
+                "extension": ext,
+                "database": db,
+            }})
+            .send()
+            .await
+            .context("connection error")?
+            .error_for_status()
+            .context("api error")?;
+
+        Ok(())
+    }
+
+    pub async fn grant_role(&self, db: &str, role: &str, schema: &str) -> anyhow::Result<()> {
+        self.api
+            .request_with_url(Method::POST, |url| {
+                url.path_segments_mut().push("grant");
+            })
+            .json(&json! {{
+                "schema": schema,
+                "role": role,
+                "database": db,
+            }})
+            .send()
+            .await
+            .context("connection error")?
+            .error_for_status()
+            .context("api error")?;
+
+        Ok(())
+    }
+}

--- a/proxy/src/compute_ctl/mod.rs
+++ b/proxy/src/compute_ctl/mod.rs
@@ -48,7 +48,7 @@ pub enum ComputeCtlError {
         body: Option<GenericAPIError>,
     },
     #[error("response parsing error: {0}")]
-    ResonseError(#[source] reqwest::Error),
+    ResponseError(#[source] reqwest::Error),
 }
 
 impl ComputeCtlApi {
@@ -96,6 +96,6 @@ impl ComputeCtlApi {
             return Err(ComputeCtlError::RequestError { status, body });
         }
 
-        resp.json().await.map_err(ComputeCtlError::ResonseError)
+        resp.json().await.map_err(ComputeCtlError::ResponseError)
     }
 }

--- a/proxy/src/compute_ctl/mod.rs
+++ b/proxy/src/compute_ctl/mod.rs
@@ -1,51 +1,101 @@
-use anyhow::Context;
-use hyper::Method;
-use typed_json::json;
+use compute_api::responses::GenericAPIError;
+use hyper::{Method, StatusCode};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-use crate::http;
+use crate::url::ApiUrl;
+use crate::{http, DbName, RoleName};
 
 pub struct ComputeCtlApi {
     pub(crate) api: http::Endpoint,
 }
 
-// The following article is a stub.
-// You can help Wikipedia by filling it out
+#[derive(Serialize, Debug)]
+pub struct ExtensionInstallRequest {
+    pub extension: &'static str,
+    pub database: DbName,
+    pub version: &'static str,
+}
+
+#[derive(Serialize, Debug)]
+pub struct SetRoleGrantsRequest {
+    pub database: DbName,
+    pub schema: &'static str,
+    pub privileges: Vec<Privilege>,
+    pub role: RoleName,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExtensionInstallResponse {}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SetRoleGrantsResponse {}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Privilege {
+    Usage,
+}
+
+#[derive(Error, Debug)]
+pub enum ComputeCtlError {
+    #[error("connection error: {0}")]
+    ConnectionError(#[source] reqwest_middleware::Error),
+    #[error("request error [{status}]: {body:?}")]
+    RequestError {
+        status: StatusCode,
+        body: Option<GenericAPIError>,
+    },
+    #[error("response parsing error: {0}")]
+    ResonseError(#[source] reqwest::Error),
+}
 
 impl ComputeCtlApi {
-    pub async fn install_extension(&self, db: &str, ext: &str) -> anyhow::Result<()> {
-        self.api
-            .request_with_url(Method::POST, |url| {
-                url.path_segments_mut().push("extension");
-            })
-            .json(&json! {{
-                "extension": ext,
-                "database": db,
-            }})
-            .send()
-            .await
-            .context("connection error")?
-            .error_for_status()
-            .context("api error")?;
-
-        Ok(())
+    pub async fn install_extension(
+        &self,
+        req: &ExtensionInstallRequest,
+    ) -> Result<ExtensionInstallResponse, ComputeCtlError> {
+        self.generic_request(req, Method::POST, |url| {
+            url.path_segments_mut().push("extensions");
+        })
+        .await
     }
 
-    pub async fn grant_role(&self, db: &str, role: &str, schema: &str) -> anyhow::Result<()> {
-        self.api
-            .request_with_url(Method::POST, |url| {
-                url.path_segments_mut().push("grant");
-            })
-            .json(&json! {{
-                "schema": schema,
-                "role": role,
-                "database": db,
-            }})
+    pub async fn grant_role(
+        &self,
+        req: &SetRoleGrantsRequest,
+    ) -> Result<SetRoleGrantsResponse, ComputeCtlError> {
+        self.generic_request(req, Method::POST, |url| {
+            url.path_segments_mut().push("grants");
+        })
+        .await
+    }
+
+    async fn generic_request<Req, Resp>(
+        &self,
+        req: &Req,
+        method: Method,
+        url: impl for<'a> FnOnce(&'a mut ApiUrl),
+    ) -> Result<Resp, ComputeCtlError>
+    where
+        Req: Serialize,
+        Resp: DeserializeOwned,
+    {
+        let resp = self
+            .api
+            .request_with_url(method, url)
+            .json(req)
             .send()
             .await
-            .context("connection error")?
-            .error_for_status()
-            .context("api error")?;
+            .map_err(ComputeCtlError::ConnectionError)?;
 
-        Ok(())
+        let status = resp.status();
+        if status.is_client_error() || status.is_server_error() {
+            let body = resp.json().await.ok();
+            return Err(ComputeCtlError::RequestError { status, body });
+        }
+
+        resp.json().await.map_err(ComputeCtlError::ResonseError)
     }
 }

--- a/proxy/src/http/mod.rs
+++ b/proxy/src/http/mod.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use anyhow::bail;
 use bytes::Bytes;
+use http::Method;
 use http_body_util::BodyExt;
 use hyper::body::Body;
 pub(crate) use reqwest::{Request, Response};
@@ -93,9 +94,19 @@ impl Endpoint {
     /// Return a [builder](RequestBuilder) for a `GET` request,
     /// accepting a closure to modify the url path segments for more complex paths queries.
     pub(crate) fn get_with_url(&self, f: impl for<'a> FnOnce(&'a mut ApiUrl)) -> RequestBuilder {
+        self.request_with_url(Method::GET, f)
+    }
+
+    /// Return a [builder](RequestBuilder) for a request,
+    /// accepting a closure to modify the url path segments for more complex paths queries.
+    pub(crate) fn request_with_url(
+        &self,
+        method: Method,
+        f: impl for<'a> FnOnce(&'a mut ApiUrl),
+    ) -> RequestBuilder {
         let mut url = self.endpoint.clone();
         f(&mut url);
-        self.client.get(url.into_inner())
+        self.client.request(method, url.into_inner())
     }
 
     /// Execute a [request](reqwest::Request).

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -94,6 +94,7 @@ pub mod auth;
 pub mod cache;
 pub mod cancellation;
 pub mod compute;
+pub mod compute_ctl;
 pub mod config;
 pub mod console_redirect_proxy;
 pub mod context;

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -261,7 +261,6 @@ impl PoolingBackend {
             auth::Backend::Local(local) => local,
         };
 
-        #[allow(unreachable_code, clippy::todo)]
         if !self.local_pool.initialized(&conn_info) {
             // only install and grant usage one at a time.
             let _permit = local_backend.initialize.acquire().await.unwrap();

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -273,7 +273,6 @@ impl PoolingBackend {
                     .install_extension(&ExtensionInstallRequest {
                         extension: EXT_NAME,
                         database: conn_info.dbname.clone(),
-                        // todo: move to const or config
                         version: EXT_VERSION,
                     })
                     .await?;
@@ -281,7 +280,6 @@ impl PoolingBackend {
                 local_backend
                     .compute_ctl
                     .grant_role(&SetRoleGrantsRequest {
-                        // fixed for pg_session_jwt
                         schema: EXT_SCHEMA,
                         privileges: vec![Privilege::Usage],
                         database: conn_info.dbname.clone(),

--- a/proxy/src/serverless/local_conn_pool.rs
+++ b/proxy/src/serverless/local_conn_pool.rs
@@ -38,6 +38,10 @@ use crate::metrics::Metrics;
 use crate::usage_metrics::{Ids, MetricCounter, USAGE_METRICS};
 use crate::{DbName, RoleName};
 
+pub(crate) const EXT_NAME: &str = "pg_session_jwt";
+pub(crate) const EXT_VERSION: &str = "0.1.1";
+pub(crate) const EXT_SCHEMA: &str = "auth";
+
 struct ConnPoolEntry<C: ClientInnerExt> {
     conn: ClientInner<C>,
     _last_access: std::time::Instant,

--- a/proxy/src/serverless/local_conn_pool.rs
+++ b/proxy/src/serverless/local_conn_pool.rs
@@ -1,3 +1,14 @@
+//! Manages the pool of connections between local_proxy and postgres.
+//!
+//! The pool is keyed by database and role_name, and can contain multiple connections
+//! shared between users.
+//!
+//! The pool manages the pg_session_jwt extension used for authorizing
+//! requests in the db.
+//!
+//! The first time a db/role pair is seen, local_proxy attempts to install the extension
+//! and grant usage to the role on the given schema.
+
 use std::collections::HashMap;
 use std::pin::pin;
 use std::sync::{Arc, Weak};
@@ -31,9 +42,6 @@ struct ConnPoolEntry<C: ClientInnerExt> {
     conn: ClientInner<C>,
     _last_access: std::time::Instant,
 }
-
-// /// key id for the pg_session_jwt state
-// static PG_SESSION_JWT_KID: AtomicU64 = AtomicU64::new(1);
 
 // Per-endpoint connection pool, (dbname, username) -> DbUserConnPool
 // Number of open connections is limited by the `max_conns_per_endpoint`.
@@ -140,11 +148,18 @@ impl<C: ClientInnerExt> Drop for EndpointConnPool<C> {
 
 pub(crate) struct DbUserConnPool<C: ClientInnerExt> {
     conns: Vec<ConnPoolEntry<C>>,
+
+    // true if we have definitely installed the extension and
+    // granted the role access to the auth schema.
+    initialized: bool,
 }
 
 impl<C: ClientInnerExt> Default for DbUserConnPool<C> {
     fn default() -> Self {
-        Self { conns: Vec::new() }
+        Self {
+            conns: Vec::new(),
+            initialized: false,
+        }
     }
 }
 
@@ -199,25 +214,16 @@ impl<C: ClientInnerExt> LocalConnPool<C> {
         self.config.pool_options.idle_timeout
     }
 
-    // pub(crate) fn shutdown(&self) {
-    //     let mut pool = self.global_pool.write();
-    //     pool.pools.clear();
-    //     pool.total_conns = 0;
-    // }
-
     pub(crate) fn get(
         self: &Arc<Self>,
         ctx: &RequestMonitoring,
         conn_info: &ConnInfo,
     ) -> Result<Option<LocalClient<C>>, HttpConnError> {
-        let mut client: Option<ClientInner<C>> = None;
-        if let Some(entry) = self
+        let client = self
             .global_pool
             .write()
             .get_conn_entry(conn_info.db_and_user())
-        {
-            client = Some(entry.conn);
-        }
+            .map(|entry| entry.conn);
 
         // ok return cached connection if found and establish a new one otherwise
         if let Some(client) = client {
@@ -244,6 +250,23 @@ impl<C: ClientInnerExt> LocalConnPool<C> {
             )));
         }
         Ok(None)
+    }
+
+    pub(crate) fn initialized(self: &Arc<Self>, conn_info: &ConnInfo) -> bool {
+        self.global_pool
+            .read()
+            .pools
+            .get(&conn_info.db_and_user())
+            .map_or(false, |pool| pool.initialized)
+    }
+
+    pub(crate) fn set_initialized(self: &Arc<Self>, conn_info: &ConnInfo) {
+        self.global_pool
+            .write()
+            .pools
+            .entry(conn_info.db_and_user())
+            .or_default()
+            .initialized = true;
     }
 }
 


### PR DESCRIPTION
Follow up on #9344. We want to install the extension automatically. We didn't want to couple the extension into compute_ctl so instead local_proxy is the one to issue requests specific to the extension.

depends on #9344 and #9395