### PR TITLE
pageserver: work around #9185 in layer visibility calculation

### DIFF
--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -392,6 +392,10 @@ impl InMemoryLayer {
         self.end_lsn.get().copied().unwrap_or(Lsn::MAX)
     }
 
+    pub(crate) fn start_lsn(&self) -> Lsn {
+        self.start_lsn
+    }
+
     pub(crate) fn get_lsn_range(&self) -> Range<Lsn> {
         self.start_lsn..self.end_lsn_or_max()
     }


### PR DESCRIPTION
## Problem

The layer visibility logic considers a layer visible if serving a read from the head LSN or a branch point would hit the layer.  It presumes that an image layer is sufficient to prevent reads reaching a delta.

However, getpage logic doesn't quite match this expectation, and will sometimes read deltas even if an image layer is available: https://github.com/neondatabase/neon/issues/9185

Closes: https://github.com/neondatabase/neon/issues/9058

## Summary of changes

- In `update_layer_visibility`, use the start_lsn of the oldest InMemoryLayer as a read point, so that we will continue to regard delta layers as visible until they are covered by an image layer _and_ that image layer doesn't intersect with an InMemoryLayer's LSN range.

Because we only call update_layer_visibility after generating image layers or at tenant load, this means that such deltas will remain "visible" until the next time one of those things happens.  This degrades the effectiveness of the layer visibility contribution to eviction and heatmap generation, but relieves us of the volume of misleading "became visible" log messages (https://github.com/neondatabase/neon/issues/9058)

This code should be removed when #9185 is fixed.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
