### PR TITLE
storage_scrubber: fixes to garbage commands

### DIFF
--- a/storage_scrubber/src/cloud_admin_api.rs
+++ b/storage_scrubber/src/cloud_admin_api.rs
@@ -138,7 +138,7 @@ pub struct ProjectData {
     pub name: String,
     pub region_id: String,
     pub platform_id: String,
-    pub user_id: String,
+    pub user_id: Option<String>,
     pub pageserver_id: Option<u64>,
     #[serde(deserialize_with = "from_nullable_id")]
     pub tenant: TenantId,

--- a/storage_scrubber/src/garbage.rs
+++ b/storage_scrubber/src/garbage.rs
@@ -410,7 +410,7 @@ pub async fn get_tenant_objects(
     // tenants where any timeline's index_part.json has been touched recently.
 
     let cancel = CancellationToken::new();
-    let list = match backoff::retry(
+    let list = backoff::retry(
         || s3_client.list(Some(&tenant_root), ListingMode::NoDelimiter, None, &cancel),
         |_| false,
         3,
@@ -419,12 +419,7 @@ pub async fn get_tenant_objects(
         &cancel,
     )
     .await
-    {
-        None => {
-            unreachable!("Using a dummy cancellation token");
-        }
-        Some(r) => r?,
-    };
+    .expect("dummy cancellation token")?;
     Ok(list.keys)
 }
 
@@ -436,7 +431,7 @@ pub async fn get_timeline_objects(
     let timeline_root = super::remote_timeline_path_id(&ttid);
 
     let cancel = CancellationToken::new();
-    let list = match backoff::retry(
+    let list = backoff::retry(
         || {
             s3_client.list(
                 Some(&timeline_root),
@@ -452,12 +447,7 @@ pub async fn get_timeline_objects(
         &cancel,
     )
     .await
-    {
-        None => {
-            unreachable!("Using a dummy cancellation token");
-        }
-        Some(r) => r?,
-    };
+    .expect("dummy cancellation token")?;
 
     Ok(list.keys)
 }


### PR DESCRIPTION
## Problem

While running `find-garbage` and `purge-garbage`, I encountered two things that needed updating:
- Console API may omit `user_id` since org accounts were added
- When we cut over to using GenericRemoteStorage, the object listings we do during purge did not get proper retry handling, so could easily fail on usual S3 errors, and make the whole process drop out.

...and one bug:
- We had a `.unwrap` which expects that after finding an object in a tenant path, a listing in that path will always return objects.  This is not true, because a pageserver might be deleting the path at the same time as we scan it.

## Summary of changes

- When listing objects during purge, use backoff::retry
- Make `user_id` an `Option`
- Handle the case where a tenant's objects go away during find-garbage.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
