### PR TITLE
Use '-f' for make clean in  Makefile compute

### DIFF
--- a/compute/Makefile
+++ b/compute/Makefile
@@ -34,7 +34,7 @@ sql_exporter_autoscaling.yml: $(jsonnet_files)
 
 .PHONY: clean
 clean:
-	rm --force \
+	rm -f \
 		etc/neon_collector.yml \
 		etc/neon_collector_autoscaling.yml \
 		etc/sql_exporter.yml \


### PR DESCRIPTION
Use '-f' instead of '--force' because it is impossible to clean the targets on MacOS
