### PR TITLE
Implement replica prewarm

### DIFF
--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -184,6 +184,7 @@ pub const XLOG_NEON_HEAP_UPDATE: u8 = 0x20;
 pub const XLOG_NEON_HEAP_HOT_UPDATE: u8 = 0x30;
 pub const XLOG_NEON_HEAP_LOCK: u8 = 0x40;
 pub const XLOG_NEON_HEAP_MULTI_INSERT: u8 = 0x50;
+pub const XLOG_NEON_LFC_PREWARM: u8 = 0x60;
 
 pub const XLOG_NEON_HEAP_VISIBLE: u8 = 0x40;
 

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1159,6 +1159,7 @@ impl WalIngest {
                             flags = pg_constants::VISIBILITYMAP_ALL_FROZEN;
                         }
                     }
+                    pg_constants::XLOG_NEON_LFC_PREWARM => {}
                     info => bail!("Unknown WAL record type for Neon RMGR: {}", info),
                 }
             }

--- a/pgxn/neon/file_cache.h
+++ b/pgxn/neon/file_cache.h
@@ -1,0 +1,64 @@
+/*-------------------------------------------------------------------------
+ *
+ * file_cache.h
+ *
+ *
+ * Portions Copyright (c) 1996-2021, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef file_cache_h
+#define file_cache_h
+
+#include "neon_pgversioncompat.h"
+
+/* Local file storage allocation chunk.
+ * Should be power of two. Using larger than page chunks can
+ * 1. Reduce hash-map memory footprint: 8TB database contains billion pages
+ *    and size of hash entry is 40 bytes, so we need 40Gb just for hash map.
+ *    1Mb chunks can reduce hash map size to 320Mb.
+ * 2. Improve access locality, subsequent pages will be allocated together improving seqscan speed
+ */
+#define BLOCKS_PER_CHUNK	128 /* 1Mb chunk */
+#define CHUNK_BITMAP_SIZE   ((BLOCKS_PER_CHUNK + 31) / 32)
+
+typedef struct
+{
+	BufferTag	key;
+	uint32		bitmap[CHUNK_BITMAP_SIZE];
+} FileCacheEntryDesc;
+
+PGDLLEXPORT void FileCachePrewarmMain(Datum main_arg);
+
+extern void lfc_writev(NRelFileInfo rinfo, ForkNumber forkNum,
+					   BlockNumber blkno, const void *const *buffers,
+					   BlockNumber nblocks);
+/* returns number of blocks read, with one bit set in *read for each  */
+extern int lfc_readv_select(NRelFileInfo rinfo, ForkNumber forkNum,
+							BlockNumber blkno, void **buffers,
+							BlockNumber nblocks, bits8 *mask);
+
+extern bool lfc_cache_contains(NRelFileInfo rinfo, ForkNumber forkNum,
+							   BlockNumber blkno);
+extern int lfc_cache_containsv(NRelFileInfo rinfo, ForkNumber forkNum,
+							   BlockNumber blkno, int nblocks, bits8 *bitmap);
+extern void lfc_evict(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno);
+extern void lfc_init(void);
+
+static inline bool
+lfc_read(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno,
+		 void *buffer)
+{
+	bits8		rv = 0;
+	return lfc_readv_select(rinfo, forkNum, blkno, &buffer, 1, &rv) == 1;
+}
+
+static inline void
+lfc_write(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno,
+		  const void *buffer)
+{
+	return lfc_writev(rinfo, forkNum, blkno, &buffer, 1);
+}
+
+#endif

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -33,6 +33,7 @@
 #include "neon_perf_counters.h"
 #include "neon_utils.h"
 #include "pagestore_client.h"
+#include "file_cache.h"
 #include "walproposer.h"
 
 #define PageStoreTrace DEBUG5

--- a/pgxn/neon/pagestore_client.h
+++ b/pgxn/neon/pagestore_client.h
@@ -261,35 +261,5 @@ extern void set_cached_relsize(NRelFileInfo rinfo, ForkNumber forknum, BlockNumb
 extern void update_cached_relsize(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber size);
 extern void forget_cached_relsize(NRelFileInfo rinfo, ForkNumber forknum);
 
-/* functions for local file cache */
-extern void lfc_writev(NRelFileInfo rinfo, ForkNumber forkNum,
-					   BlockNumber blkno, const void *const *buffers,
-					   BlockNumber nblocks);
-/* returns number of blocks read, with one bit set in *read for each  */
-extern int lfc_readv_select(NRelFileInfo rinfo, ForkNumber forkNum,
-							BlockNumber blkno, void **buffers,
-							BlockNumber nblocks, bits8 *mask);
-
-extern bool lfc_cache_contains(NRelFileInfo rinfo, ForkNumber forkNum,
-							   BlockNumber blkno);
-extern int lfc_cache_containsv(NRelFileInfo rinfo, ForkNumber forkNum,
-							   BlockNumber blkno, int nblocks, bits8 *bitmap);
-extern void lfc_evict(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno);
-extern void lfc_init(void);
-
-static inline bool
-lfc_read(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno,
-		 void *buffer)
-{
-	bits8		rv = 0;
-	return lfc_readv_select(rinfo, forkNum, blkno, &buffer, 1, &rv) == 1;
-}
-
-static inline void
-lfc_write(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno,
-		  const void *buffer)
-{
-	return lfc_writev(rinfo, forkNum, blkno, &buffer, 1);
-}
 
 #endif

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -68,6 +68,7 @@
 
 #include "neon_perf_counters.h"
 #include "pagestore_client.h"
+#include "file_cache.h"
 #include "bitmap.h"
 
 #if PG_VERSION_NUM >= 150000

--- a/pgxn/neon_rmgr/neon_rmgr.h
+++ b/pgxn/neon_rmgr/neon_rmgr.h
@@ -5,6 +5,8 @@
 #include "replication/decode.h"
 #include "replication/logical.h"
 
+#define XLOG_NEON_LFC_PREWARM	0x60
+
 extern void neon_rm_desc(StringInfo buf, XLogReaderState *record);
 extern void neon_rm_decode(LogicalDecodingContext *ctx, XLogRecordBuffer *buf);
 extern const char *neon_rm_identify(uint8 info);

--- a/pgxn/neon_rmgr/neon_rmgr_decode.c
+++ b/pgxn/neon_rmgr/neon_rmgr_decode.c
@@ -456,6 +456,8 @@ neon_rm_decode(LogicalDecodingContext *ctx, XLogRecordBuffer *buf)
 			if (SnapBuildProcessChange(builder, xid, buf->origptr))
 				DecodeNeonMultiInsert(ctx, buf);
 			break;
+		case XLOG_NEON_LFC_PREWARM:
+			break;
 		default:
 			elog(ERROR, "unexpected RM_HEAP_ID record type: %u", info);
 			break;

--- a/pgxn/neon_rmgr/neon_rmgr_desc.c
+++ b/pgxn/neon_rmgr/neon_rmgr_desc.c
@@ -113,6 +113,10 @@ neon_rm_desc(StringInfo buf, XLogReaderState *record)
 					   xlrec->ntuples, &offset_elem_desc, NULL);
 		}
 	}
+	else if (info == XLOG_NEON_LFC_PREWARM)
+	{
+		appendStringInfo(buf, "%d chunks", XLogRecGetDataLen(record));
+	}
 }
 
 const char *
@@ -151,6 +155,9 @@ neon_rm_identify(uint8 info)
 			break;
 		case XLOG_NEON_HEAP_MULTI_INSERT | XLOG_NEON_INIT_PAGE:
 			id = "MULTI_INSERT+INIT";
+			break;
+		case XLOG_NEON_LFC_PREWARM:
+			id = "LFC_PREWARM";
 			break;
 	}
 

--- a/test_runner/regress/test_replica_prewarm.py
+++ b/test_runner/regress/test_replica_prewarm.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+from fixtures.neon_fixtures import NeonEnv, wait_replica_caughtup
+from fixtures.pg_version import PgVersion
+
+
+def test_replica_prewarm(neon_simple_env: NeonEnv):
+    env = neon_simple_env
+    n_records = 1000000
+    if env.pg_version < PgVersion.V16:
+        pytest.skip("NEON_RM is available only in PG16")
+    primary = env.endpoints.create_start(
+        branch_name="main",
+        endpoint_id="primary",
+        config_lines=[
+            "autovacuum = off",
+            "shared_buffers=1MB",
+            "neon.max_file_cache_size=1GB",
+            "neon.file_cache_size_limit=1GB",
+            "neon.file_cache_prewarm_rate=1s",
+        ],
+    )
+    p_con = primary.connect()
+    p_cur = p_con.cursor()
+
+    p_cur.execute("create extension neon")
+    p_cur.execute("create table t(pk integer primary key, payload text default repeat('?', 128))")
+
+    secondary = env.endpoints.new_replica_start(
+        origin=primary,
+        endpoint_id="secondary",
+        config_lines=[
+            "autovacuum = off",
+            "shared_buffers=1MB",
+            "neon.max_file_cache_size=1GB",
+            "neon.file_cache_size_limit=1GB",
+            "neon.file_cache_prewarm_limit=1000",
+        ],
+    )
+    p_cur.execute(f"insert into t (pk) values (generate_series(1,{n_records}))")
+
+    wait_replica_caughtup(primary, secondary)
+
+    s_con = secondary.connect()
+    s_cur = s_con.cursor()
+
+    s_cur.execute("select lfc_value from neon_lfc_stats where lfc_key='file_cache_used_pages'")
+    lfc_used_pages = s_cur.fetchall()[0][0]
+    assert lfc_used_pages > 10000
+
+    s_cur.execute("select sum(pk) from t")
+    assert s_cur.fetchall()[0][0] == n_records * (n_records + 1) / 2


### PR DESCRIPTION
## Problem

LFC has critical impact on Neon node speed. In case of node restart we need to prewarm LFC to reach acceptable level of performance. The idea is to start replica and prewarm its LFC cache while primary is still active and serving user's requests.
Once LFC is rewarmed, we can stop primary node and promote replica to new primary.

This PR implements prewarming of replica's LFC through normal replication protocol.
Primary periodically creates WAL records with state of LFC cache. By replaying this WAL records, replica can load this pages and so maintain the same state LFC as primary.

## Summary of changes

I have added new WAL record to Neon RMGR: `XLOG_NEON_LFC_PREWARM`. This records contains information of LFC chunks. Size of this records is limited by `LFC_MAX_PREWARM_SIZE=1024` (right now hardcoded by can be changed to GUC if needed). This records are produced with `neon.file_cache_prewarm_rate` period (msec).
It includes most recently accessed LFC chunks which are not yet synced. I have added `synced` flag to LFC chunk entry which is set when information about this chunk is sent to replica is created when new page was added to the chunk.

This `XLOG_NEON_LFC_PREWARM` are create by background worker launched by neon extension extension.
PS is changed to ignore this records. Replay of this record is implemented in neon_rmgr extension: it just load specified pages.

PPrewarming is controlled by `neon.file_cache_prewarm_rate` GUC which can be changed at any moment of time (using `pg_reload_conf`). Setting it to 0 disables prewarm.

Known issues:
1. This approach increase WAL size (but not storage size)
2. Pages are loaded by wal receiver, so it slows down applying WAL by replica.
3. There is no limit for number of prewarmed pages (can add special GUC for it)
4. If pages are frequently changed at primary node, the same page can be requested to prewarm multiple times at replica.
5. It works only for PG16/17, because Neon RMGR is not supported by earlier Postgres versions
6. No parallel prewarming.

In future it can be easily changed to use vector load once they are supported by SMGR protocol.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
