### PR TITLE
chore(compute): bumps pg_session_jwt to latest version

### DIFF
--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -975,8 +975,8 @@ ARG PG_VERSION
 RUN case "${PG_VERSION}" in "v17") \
     echo "pg_session_jwt does not yet have a release that supports pg17" && exit 0;; \
     esac && \
-    wget https://github.com/neondatabase/pg_session_jwt/archive/e642528f429dd3f5403845a50191b78d434b84a6.tar.gz -O pg_session_jwt.tar.gz && \
-    echo "1a69210703cc91224785e59a0a67562dd9eed9a0914ac84b11447582ca0d5b93 pg_session_jwt.tar.gz" | sha256sum --check && \
+    wget https://github.com/neondatabase/pg_session_jwt/archive/e1310b08ba51377a19e0559e4d1194883b9b2ba2.tar.gz -O pg_session_jwt.tar.gz && \
+    echo "837932a077888d5545fd54b0abcc79e5f8e37017c2769a930afc2f5c94df6f4e pg_session_jwt.tar.gz" | sha256sum --check && \
     mkdir pg_session_jwt-src && cd pg_session_jwt-src && tar xzf ../pg_session_jwt.tar.gz --strip-components=1 -C . && \
     sed -i 's/pgrx = "=0.11.3"/pgrx = { version = "=0.11.3", features = [ "unsafe-postgres" ] }/g' Cargo.toml && \
     cargo pgrx install --release


### PR DESCRIPTION
## Problem
This brings in https://github.com/neondatabase/pg_session_jwt/commit/e1310b08ba51377a19e0559e4d1194883b9b2ba2 from pg_session_jwt.

I have tested this in a preview environment. I got `permission denied for language c` at first, but then I ran:

```
update projects set settings=jsonb_set(settings, '{compute_image}', '"369495373322.dkr.ecr.eu-central-1.amazonaws.com/vm-compute-node-v16:11445855639"') where id='solitary-frost-64400715';
```

And I was able to install the extension after restarting the compute:
![image](https://github.com/user-attachments/assets/ff4fe7be-a198-407e-a46d-722295473e2f)

## Summary of changes
It bumps the version of `pg_session_jwt` to the latest version.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [x] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [x] Do not forget to reformat commit message to not include the above checklist