### PR TITLE
Fix local errors for the tests with the versions mix

### DIFF
--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -636,8 +636,9 @@ def allpairs_versions():
     """
     ids = []
     argvalues = []
-    compat_not_defined = (os.getenv("COMPATIBILITY_NEON_BIN") is None) or (
+    compat_not_defined = (
         os.getenv("COMPATIBILITY_POSTGRES_DISTRIB_DIR") is None
+        or os.getenv("COMPATIBILITY_NEON_BIN") is None
     )
     for pair in VERSIONS_COMBINATIONS:
         cur_id = []

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -633,9 +633,10 @@ def allpairs_versions():
     combinations were pre-computed to test all the pairs of the components with
     the different versions.
     """
-    if (os.getenv("COMPATIBILITY_NEON_BIN") is None) or (
+    only_new = (os.getenv("COMPATIBILITY_NEON_BIN") is None) or (
         os.getenv("COMPATIBILITY_POSTGRES_DISTRIB_DIR") is None
-    ):
+    )
+    if only_new:
         log.info("Compatibility paths are not set, testing only new versions")
         return {"argnames": "combination", "argvalues": [None]}
     ids = []

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -633,9 +633,7 @@ def allpairs_versions():
     combinations were pre-computed to test all the pairs of the components with
     the different versions.
     """
-    only_new = (os.getenv("COMPATIBILITY_NEON_BIN") is None) or (
-        os.getenv("COMPATIBILITY_POSTGRES_DISTRIB_DIR") is None
-    )
+    only_new = (os.getenv('COMPATIBILITY_NEON_BIN') is None) or (os.getenv('COMPATIBILITY_POSTGRES_DISTRIB_DIR') is None)
     if only_new:
         log.info("Compatibility paths are not set, testing only new versions")
         return {"argnames": "combination", "argvalues": [None]}

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -641,7 +641,7 @@ def allpairs_versions():
     )
     for pair in VERSIONS_COMBINATIONS:
         cur_id = []
-        all_new = True
+        all_new = all(v == "new" for v in pair.values())
         for component in sorted(pair.keys()):
             cur_id.append(pair[component][0])
             all_new = all_new and (pair[component] == "new")

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -633,10 +633,9 @@ def allpairs_versions():
     combinations were pre-computed to test all the pairs of the components with
     the different versions.
     """
-    only_new = (os.getenv("COMPATIBILITY_NEON_BIN") is None) or (
+    if (os.getenv("COMPATIBILITY_NEON_BIN") is None) or (
         os.getenv("COMPATIBILITY_POSTGRES_DISTRIB_DIR") is None
-    )
-    if only_new:
+    ):
         log.info("Compatibility paths are not set, testing only new versions")
         return {"argnames": "combination", "argvalues": [None]}
     ids = []

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -633,10 +633,6 @@ def allpairs_versions():
     combinations were pre-computed to test all the pairs of the components with
     the different versions.
     """
-    only_new = (os.getenv('COMPATIBILITY_NEON_BIN') is None) or (os.getenv('COMPATIBILITY_POSTGRES_DISTRIB_DIR') is None)
-    if only_new:
-        log.info("Compatibility paths are not set, testing only new versions")
-        return {"argnames": "combination", "argvalues": [None]}
     ids = []
     for pair in VERSIONS_COMBINATIONS:
         cur_id = []

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -633,7 +633,9 @@ def allpairs_versions():
     combinations were pre-computed to test all the pairs of the components with
     the different versions.
     """
-    only_new = (os.getenv('COMPATIBILITY_NEON_BIN') is None) or (os.getenv('COMPATIBILITY_POSTGRES_DISTRIB_DIR') is None)
+    only_new = (os.getenv("COMPATIBILITY_NEON_BIN") is None) or (
+        os.getenv("COMPATIBILITY_POSTGRES_DISTRIB_DIR") is None
+    )
     if only_new:
         log.info("Compatibility paths are not set, testing only new versions")
         return {"argnames": "combination", "argvalues": [None]}

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -633,6 +633,10 @@ def allpairs_versions():
     combinations were pre-computed to test all the pairs of the components with
     the different versions.
     """
+    only_new = (os.getenv('COMPATIBILITY_NEON_BIN') is None) or (os.getenv('COMPATIBILITY_POSTGRES_DISTRIB_DIR') is None)
+    if only_new:
+        log.info("Compatibility paths are not set, testing only new versions")
+        return {"argnames": "combination", "argvalues": [None]}
     ids = []
     for pair in VERSIONS_COMBINATIONS:
         cur_id = []

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -645,7 +645,9 @@ def allpairs_versions():
         all_new = all(v == "new" for v in pair.values())
         for component in sorted(pair.keys()):
             cur_id.append(pair[component][0])
-            all_new = all_new and (pair[component] == "new")
+        # Adding None if all versions are new, sof no need to mix at all
+        # If COMPATIBILITY_NEON_BIN or COMPATIBILITY_POSTGRES_DISTRIB_DIR are not defined,
+        # we will skip all the tests which include the versions mix.
         argvalues.append(
             pytest.param(
                 None if all_new else pair,


### PR DESCRIPTION
## Problem
If the environment variables `COMPATIBILITY_NEON_BIN` or `COMPATIBILITY_POSTGRES_DISTRIB_DIR` are not set (this is usual during a local run), the tests with the versions mix cannot run.
## Summary of changes
If these variables are not set turn off the version mix.
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
