### PR TITLE
storcon: add an API to cancel ongoing reconciler

### DIFF
--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -111,6 +111,11 @@ enum Command {
         #[arg(long)]
         node: NodeId,
     },
+    /// Cancel any ongoing reconciliation for this shard
+    TenantShardCancel {
+        #[arg(long)]
+        tenant_shard_id: TenantShardId,
+    },
     /// Modify the pageserver tenant configuration of a tenant: this is the configuration structure
     /// that is passed through to pageservers, and does not affect storage controller behavior.
     TenantConfig {
@@ -532,6 +537,15 @@ async fn main() -> anyhow::Result<()> {
                     Method::PUT,
                     format!("control/v1/tenant/{tenant_shard_id}/migrate"),
                     Some(req),
+                )
+                .await?;
+        }
+        Command::TenantShardCancel { tenant_shard_id } => {
+            storcon_client
+                .dispatch::<(), ()>(
+                    Method::PUT,
+                    format!("control/v1/tenant/{tenant_shard_id}/cancel"),
+                    None,
                 )
                 .await?;
         }

--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -112,7 +112,7 @@ enum Command {
         node: NodeId,
     },
     /// Cancel any ongoing reconciliation for this shard
-    TenantShardCancel {
+    TenantShardCancelReconcile {
         #[arg(long)]
         tenant_shard_id: TenantShardId,
     },
@@ -540,11 +540,11 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .await?;
         }
-        Command::TenantShardCancel { tenant_shard_id } => {
+        Command::TenantShardCancelReconcile { tenant_shard_id } => {
             storcon_client
                 .dispatch::<(), ()>(
                     Method::PUT,
-                    format!("control/v1/tenant/{tenant_shard_id}/cancel"),
+                    format!("control/v1/tenant/{tenant_shard_id}/cancel_reconcile"),
                     None,
                 )
                 .await?;

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -968,6 +968,26 @@ async fn handle_tenant_shard_migrate(
     )
 }
 
+async fn handle_tenant_shard_cancel(
+    service: Arc<Service>,
+    req: Request<Body>,
+) -> Result<Response<Body>, ApiError> {
+    check_permissions(&req, Scope::Admin)?;
+
+    let req = match maybe_forward(req).await {
+        ForwardOutcome::Forwarded(res) => {
+            return res;
+        }
+        ForwardOutcome::NotForwarded(req) => req,
+    };
+
+    let tenant_shard_id: TenantShardId = parse_request_param(&req, "tenant_shard_id")?;
+    json_response(
+        StatusCode::OK,
+        service.tenant_shard_cancel(tenant_shard_id).await?,
+    )
+}
+
 async fn handle_tenant_update_policy(req: Request<Body>) -> Result<Response<Body>, ApiError> {
     check_permissions(&req, Scope::Admin)?;
 
@@ -1774,6 +1794,13 @@ pub fn make_router(
                 r,
                 handle_tenant_shard_migrate,
                 RequestName("control_v1_tenant_migrate"),
+            )
+        })
+        .put("/control/v1/tenant/:tenant_shard_id/cancel", |r| {
+            tenant_service_handler(
+                r,
+                handle_tenant_shard_cancel,
+                RequestName("control_v1_tenant_cancel"),
             )
         })
         .put("/control/v1/tenant/:tenant_id/shard_split", |r| {

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -968,7 +968,7 @@ async fn handle_tenant_shard_migrate(
     )
 }
 
-async fn handle_tenant_shard_cancel(
+async fn handle_tenant_shard_cancel_reconcile(
     service: Arc<Service>,
     req: Request<Body>,
 ) -> Result<Response<Body>, ApiError> {
@@ -984,7 +984,9 @@ async fn handle_tenant_shard_cancel(
     let tenant_shard_id: TenantShardId = parse_request_param(&req, "tenant_shard_id")?;
     json_response(
         StatusCode::OK,
-        service.tenant_shard_cancel(tenant_shard_id).await?,
+        service
+            .tenant_shard_cancel_reconcile(tenant_shard_id)
+            .await?,
     )
 }
 
@@ -1796,13 +1798,16 @@ pub fn make_router(
                 RequestName("control_v1_tenant_migrate"),
             )
         })
-        .put("/control/v1/tenant/:tenant_shard_id/cancel", |r| {
-            tenant_service_handler(
-                r,
-                handle_tenant_shard_cancel,
-                RequestName("control_v1_tenant_cancel"),
-            )
-        })
+        .put(
+            "/control/v1/tenant/:tenant_shard_id/cancel_reconcile",
+            |r| {
+                tenant_service_handler(
+                    r,
+                    handle_tenant_shard_cancel_reconcile,
+                    RequestName("control_v1_tenant_cancel_reconcile"),
+                )
+            },
+        )
         .put("/control/v1/tenant/:tenant_id/shard_split", |r| {
             tenant_service_handler(
                 r,

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -4832,6 +4832,43 @@ impl Service {
         Ok(TenantShardMigrateResponse {})
     }
 
+    /// 'cancel' in this context means cancel any ongoing reconcile
+    pub(crate) async fn tenant_shard_cancel(
+        &self,
+        tenant_shard_id: TenantShardId,
+    ) -> Result<(), ApiError> {
+        // Take state lock and fire the cancellation token, after which we drop lock and wait for any ongoing reconcile to complete
+        let waiter = {
+            let locked = self.inner.write().unwrap();
+            let Some(shard) = locked.tenants.get(&tenant_shard_id) else {
+                return Err(ApiError::NotFound(
+                    anyhow::anyhow!("Tenant shard not found").into(),
+                ));
+            };
+
+            let waiter = shard.get_waiter();
+            match waiter {
+                None => {
+                    tracing::info!("Shard does not have an ongoing Reconciler");
+                    return Ok(());
+                }
+                Some(waiter) => {
+                    tracing::info!("Cancelling Reconciler");
+                    shard.cancel_reconciler();
+                    waiter
+                }
+            }
+        };
+
+        // Cancellation should be prompt.  If this fails we have still done our job of firing the
+        // cancellatino token, but by returning an ApiError we will indicate to the caller that
+        // the Reconciler is misbehaving and not respecting the cancellation token
+        self.await_waiters(vec![waiter], SHORT_RECONCILE_TIMEOUT)
+            .await?;
+
+        Ok(())
+    }
+
     /// This is for debug/support only: we simply drop all state for a tenant, without
     /// detaching or deleting it on pageservers.
     pub(crate) async fn tenant_drop(&self, tenant_id: TenantId) -> Result<(), ApiError> {

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -4861,7 +4861,7 @@ impl Service {
         };
 
         // Cancellation should be prompt.  If this fails we have still done our job of firing the
-        // cancellatino token, but by returning an ApiError we will indicate to the caller that
+        // cancellation token, but by returning an ApiError we will indicate to the caller that
         // the Reconciler is misbehaving and not respecting the cancellation token
         self.await_waiters(vec![waiter], SHORT_RECONCILE_TIMEOUT)
             .await?;

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -4833,7 +4833,7 @@ impl Service {
     }
 
     /// 'cancel' in this context means cancel any ongoing reconcile
-    pub(crate) async fn tenant_shard_cancel(
+    pub(crate) async fn tenant_shard_cancel_reconcile(
         &self,
         tenant_shard_id: TenantShardId,
     ) -> Result<(), ApiError> {

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -1317,6 +1317,12 @@ impl TenantShard {
         })
     }
 
+    pub(crate) fn cancel_reconciler(&self) {
+        if let Some(handle) = self.reconciler.as_ref() {
+            handle.cancel.cancel()
+        }
+    }
+
     /// Get a waiter for any reconciliation in flight, but do not start reconciliation
     /// if it is not already running
     pub(crate) fn get_waiter(&self) -> Option<ReconcilerWaiter> {

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -875,7 +875,7 @@ def test_storage_controller_debug_apis(neon_env_builder: NeonEnvBuilder):
     # Reconciler cancel API should be a no-op when nothing is in flight
     env.storage_controller.request(
         "PUT",
-        f"{env.storage_controller_api}/control/v1/tenant/{tenant_id}-0102/cancel",
+        f"{env.storage_controller_api}/control/v1/tenant/{tenant_id}-0102/cancel_reconcile",
         headers=env.storage_controller.headers(TokenScope.ADMIN),
     )
 
@@ -1669,7 +1669,9 @@ def test_storcon_cli(neon_env_builder: NeonEnvBuilder):
     assert "Stop" in storcon_cli(["tenants"])[3]
 
     # Cancel ongoing reconcile on a tenant
-    storcon_cli(["tenant-shard-cancel", "--tenant-shard-id", f"{env.initial_tenant}-0104"])
+    storcon_cli(
+        ["tenant-shard-cancel-reconcile", "--tenant-shard-id", f"{env.initial_tenant}-0104"]
+    )
 
     # Change a tenant's placement
     storcon_cli(


### PR DESCRIPTION
## Problem

If something goes wrong with a live migration, we currently only have awkward ways to interrupt that:
- Restart the storage controller
- Ask it to do some other modification/migration on the shard, which we don't really want.

## Summary of changes

- Add a new `/cancel` control API, and storcon_cli wrapper for it, which fires the Reconciler's cancellation token.  This is just for on-call use and we do not expect it to be used by any other services.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
