### PR TITLE
Fix unoffload_timeline races with creation

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1833,8 +1833,9 @@ impl Tenant {
         let cancel = self.cancel.clone();
 
         // Protect against concurrent attempts to use this TimelineId
+        let allow_offloaded = true;
         let _create_guard = self
-            .create_timeline_create_guard(timeline_id, true)
+            .create_timeline_create_guard(timeline_id, allow_offloaded)
             .map_err(|err| match err {
                 TimelineExclusionError::AlreadyCreating => TimelineArchivalError::AlreadyInProgress,
                 TimelineExclusionError::AlreadyExists(_) => {

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1833,6 +1833,7 @@ impl Tenant {
         let cancel = self.cancel.clone();
 
         // Protect against concurrent attempts to use this TimelineId
+        // We don't care much about idempotency, as it's ensured a layer above.
         let allow_offloaded = true;
         let _create_guard = self
             .create_timeline_create_guard(

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -4169,7 +4169,7 @@ impl Tenant {
                 ..
             }) => {
                 info!("timeline already exists but is offloaded");
-                return Err(CreateTimelineError::Conflict);
+                Err(CreateTimelineError::Conflict)
             }
             Err(TimelineExclusionError::AlreadyExists {
                 existing: TimelineOrOffloaded::Timeline(existing),


### PR DESCRIPTION
This PR does two things:

1. Obtain a `TimelineCreateGuard` object in `unoffload_timeline`. This prevents two unoffload tasks from racing with each other. While they already obtain locks for `timelines` and `offloaded_timelines`, they aren't sufficient, as we have already constructed an entire timeline at that point. We shouldn't ever have two `Timeline` objects in the same process at the same time.
2. don't allow timeline creations for timelines that have been offloaded. Obviously they already exist, so we should not allow creation. the previous logic only looked at the timelines list.

Part of #8088