### PR TITLE
We don't have legacy proxies anymore

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1118,7 +1118,6 @@ jobs:
               -f deployPgSniRouter=true \
               -f deployProxyLink=true \
               -f deployPrivatelinkProxy=true \
-              -f deployLegacyProxyScram=true \
               -f deployProxyScram=true \
               -f deployProxyAuthBroker=true \
               -f branch=main \


### PR DESCRIPTION
We don't have legacy scram proxies anymore:
cc: https://github.com/neondatabase/cloud/issues/9745