### PR TITLE
Coalesce NULL LFC stats values to 0

### DIFF
--- a/compute/etc/sql_exporter/lfc_approximate_working_set_size.sql
+++ b/compute/etc/sql_exporter/lfc_approximate_working_set_size.sql
@@ -1,1 +1,1 @@
-SELECT neon.approximate_working_set_size(false) AS approximate_working_set_size;
+SELECT COALESCE(neon.approximate_working_set_size(false), 0) AS approximate_working_set_size;

--- a/compute/etc/sql_exporter/lfc_approximate_working_set_size_windows.autoscaling.sql
+++ b/compute/etc/sql_exporter/lfc_approximate_working_set_size_windows.autoscaling.sql
@@ -4,5 +4,5 @@
 
 SELECT
   x::text as duration_seconds,
-  neon.approximate_working_set_size_seconds(x) AS size
+  COALESCE(neon.approximate_working_set_size_seconds(x), 0) AS size
 FROM (SELECT generate_series * 60 AS x FROM generate_series(1, 60)) AS t (x);

--- a/compute/etc/sql_exporter/lfc_approximate_working_set_size_windows.sql
+++ b/compute/etc/sql_exporter/lfc_approximate_working_set_size_windows.sql
@@ -3,6 +3,6 @@
 
 SELECT
   x AS duration,
-  neon.approximate_working_set_size_seconds(extract('epoch' FROM x::interval)::int) AS size FROM (
+  COALESCE(neon.approximate_working_set_size_seconds(extract('epoch' FROM x::interval)::int), 0) AS size FROM (
     VALUES ('5m'), ('15m'), ('1h')
   ) AS t (x);

--- a/compute/etc/sql_exporter/lfc_hits.sql
+++ b/compute/etc/sql_exporter/lfc_hits.sql
@@ -1,1 +1,1 @@
-SELECT lfc_value AS lfc_hits FROM neon.neon_lfc_stats WHERE lfc_key = 'file_cache_hits';
+SELECT COALESCE(lfc_value, 0) AS lfc_hits FROM neon.neon_lfc_stats WHERE lfc_key = 'file_cache_hits';

--- a/compute/etc/sql_exporter/lfc_misses.sql
+++ b/compute/etc/sql_exporter/lfc_misses.sql
@@ -1,1 +1,1 @@
-SELECT lfc_value AS lfc_misses FROM neon.neon_lfc_stats WHERE lfc_key = 'file_cache_misses';
+SELECT COALESCE(lfc_value, 0) AS lfc_misses FROM neon.neon_lfc_stats WHERE lfc_key = 'file_cache_misses';

--- a/compute/etc/sql_exporter/lfc_used.sql
+++ b/compute/etc/sql_exporter/lfc_used.sql
@@ -1,1 +1,1 @@
-SELECT lfc_value AS lfc_used FROM neon.neon_lfc_stats WHERE lfc_key = 'file_cache_used';
+SELECT COALESCE(lfc_value, 0) AS lfc_used FROM neon.neon_lfc_stats WHERE lfc_key = 'file_cache_used';

--- a/compute/etc/sql_exporter/lfc_writes.sql
+++ b/compute/etc/sql_exporter/lfc_writes.sql
@@ -1,1 +1,1 @@
-SELECT lfc_value AS lfc_writes FROM neon.neon_lfc_stats WHERE lfc_key = 'file_cache_writes';
+SELECT COALESCE(lfc_value, 0) AS lfc_writes FROM neon.neon_lfc_stats WHERE lfc_key = 'file_cache_writes';


### PR DESCRIPTION
The Neon extension can work without the LFC enabled. When we query the LFC stats while it is disabled, they return NULL. This is fine for most use cases, but isn't fine for sql_exporter, a Prometheus exporter. sql_exporter tries to create a double precision floating point value out of a NULL value, which it logs as a failure and will subsequently not return data for that metric.

Let's take a simple approach and coalesce NULL values to 0, which should be easily understandable because since the LFC is disabled, there would obviously be 0 hits, misses, etc.
