### PR TITLE
Bump sql_exporter to 0.13.1 in compute-node image

### DIFF
--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1298,7 +1298,7 @@ RUN mold -run cargo build --locked --profile release-line-debug-size-lto --bin l
 #########################################################################################
 
 FROM quay.io/prometheuscommunity/postgres-exporter:v0.12.1 AS postgres-exporter
-FROM burningalchemist/sql_exporter:0.13 AS sql-exporter
+FROM burningalchemist/sql_exporter:0.13.1 AS sql-exporter
 
 #########################################################################################
 #


### PR DESCRIPTION
In this release, sql_exporter learned how to handle NULL values by just not collecting them. This fixes an issue when we try to collect metrics, but the LFC is disabled, for instance. In that case, all LFC stats return NULL.
