### PR TITLE
refactor(pageserver): make image layer creation atomic

### DIFF
--- a/pageserver/src/tenant/storage_layer/batch_split_writer.rs
+++ b/pageserver/src/tenant/storage_layer/batch_split_writer.rs
@@ -120,6 +120,8 @@ impl BatchLayerWriter {
                         writer.finish(layer_key.key_range.end, ctx).await
                     }
                     LayerWriterWrapper::Image(writer) => {
+                        assert_eq!(writer.key_range().start, layer_key.key_range.start);
+                        assert_eq!(writer.lsn(), layer_key.lsn_range.start);
                         writer
                             .finish_with_end_key(layer_key.key_range.end, ctx)
                             .await

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -885,6 +885,7 @@ impl ImageLayerWriterInner {
         }
 
         let final_key_range = if let Some(end_key) = end_key {
+            assert!(end_key <= self.key_range.end);
             self.key_range.start..end_key
         } else {
             self.key_range.clone()
@@ -1032,6 +1033,14 @@ impl ImageLayerWriter {
         ctx: &RequestContext,
     ) -> anyhow::Result<(PersistentLayerDesc, Utf8PathBuf)> {
         self.inner.take().unwrap().finish(ctx, Some(end_key)).await
+    }
+
+    pub(crate) fn key_range(&self) -> Range<Key> {
+        self.inner.as_ref().unwrap().key_range.clone()
+    }
+
+    pub(crate) fn lsn(&self) -> Lsn {
+        self.inner.as_ref().unwrap().lsn
     }
 }
 

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -2461,7 +2461,10 @@ impl TimelineAdaptor {
             )
             .await?;
 
-        if let Some(image_layer) = image {
+        if let Some(image_layer_writer) = image {
+            let (desc, path) = image_layer_writer.finish(ctx).await?;
+            let image_layer =
+                Layer::finish_creating(self.timeline.conf, &self.timeline, desc, &path)?;
             self.new_images.push(image_layer);
         }
 


### PR DESCRIPTION
## Problem

If image layer creation failed in the middle, it will leave some temporary files on the disk. Part of https://github.com/neondatabase/neon/issues/8362, also need to fix L0 compaction path in the future.

## Summary of changes

Use the newly-added batch layer writer to ensure either all of them are created successfully or none of them are created successfully.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
