### PR TITLE
increase lifetime of AWS session token to 12 hours

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -683,7 +683,7 @@ jobs:
       with:
         aws-region: eu-central-1
         role-to-assume: ${{ vars.DEV_AWS_OIDC_ROLE_ARN }}
-        role-duration-seconds: 18000 # 5 hours
+        role-duration-seconds: 43200 # 12 hours
 
     - name: Download Neon artifact
       uses: ./.github/actions/download


### PR DESCRIPTION
## Problem

clickbench regression causes clickbench to run >9 hours and the AWS session token is expired before the run completes

## Summary of changes

extend lifetime of session token for this job to 12 hours

