### PR TITLE
wal_decoder: add rate limited log for unexpected rm ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6962,6 +6962,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "once_cell",
  "pageserver_api",
  "postgres_ffi",
  "serde",

--- a/libs/postgres_ffi/src/pg_constants.rs
+++ b/libs/postgres_ffi/src/pg_constants.rs
@@ -170,6 +170,7 @@ pub const RM_RELMAP_ID: u8 = 7;
 pub const RM_STANDBY_ID: u8 = 8;
 pub const RM_HEAP2_ID: u8 = 9;
 pub const RM_HEAP_ID: u8 = 10;
+pub const RM_BTREE_ID: u8 = 11;
 pub const RM_REPLORIGIN_ID: u8 = 19;
 pub const RM_LOGICALMSG_ID: u8 = 21;
 

--- a/libs/wal_decoder/Cargo.toml
+++ b/libs/wal_decoder/Cargo.toml
@@ -10,6 +10,7 @@ testing = []
 [dependencies]
 anyhow.workspace = true
 bytes.workspace = true
+once_cell.workspace = true
 pageserver_api.workspace = true
 postgres_ffi.workspace = true
 serde.workspace = true

--- a/libs/wal_decoder/src/decoder.rs
+++ b/libs/wal_decoder/src/decoder.rs
@@ -169,6 +169,7 @@ impl MetadataRecord {
             }
             pg_constants::RM_STANDBY_ID => Self::decode_standby_record(&mut buf, decoded),
             pg_constants::RM_REPLORIGIN_ID => Self::decode_replorigin_record(&mut buf, decoded),
+            pg_constants::RM_BTREE_ID => Ok(None),
             unexpected => {
                 // TODO: consider failing here instead of blindly doing something without
                 // understanding the protocol

--- a/libs/wal_decoder/src/decoder.rs
+++ b/libs/wal_decoder/src/decoder.rs
@@ -169,7 +169,11 @@ impl MetadataRecord {
             }
             pg_constants::RM_STANDBY_ID => Self::decode_standby_record(&mut buf, decoded),
             pg_constants::RM_REPLORIGIN_ID => Self::decode_replorigin_record(&mut buf, decoded),
-            pg_constants::RM_BTREE_ID => Ok(None),
+            pg_constants::RM_BTREE_ID => {
+                // No special handling required for these record types.
+                // We just ingest the blocks that come with it.
+                Ok(None)
+            }
             unexpected => {
                 // TODO: consider failing here instead of blindly doing something without
                 // understanding the protocol


### PR DESCRIPTION
## Problem

We would like to handle the tightening of unexpected WAL record types, but don't know if this happens in the field.

## Summary of Changes

Add a rate-limited WAL log on such events. The rate limiting is to play it safe and guard against spewing in prod.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
