### PR TITLE
increase the default timeout for the storage controller

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2301,7 +2301,7 @@ class NeonProxiedStorageController(NeonStorageController):
 
     def start(
         self,
-        timeout_in_seconds: int = 60,
+        timeout_in_seconds: Optional[int] = 60,
         instance_id: Optional[int] = None,
         base_port: Optional[int] = None,
     ):

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2301,7 +2301,7 @@ class NeonProxiedStorageController(NeonStorageController):
 
     def start(
         self,
-        timeout_in_seconds: Optional[int] = None,
+        timeout_in_seconds: int = 60,
         instance_id: Optional[int] = None,
         base_port: Optional[int] = None,
     ):


### PR DESCRIPTION
## Problem
Sometimes tests fail with the following error:
```
 pageserver start failed: pageserver did not start+pass status checks within 10s seconds
```
due to heavy disk load

## Summary of changes

increase the default timeout

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
