### PR TITLE
fix(pageserver): barrier should wait for deletions

### DIFF
--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1905,7 +1905,7 @@ impl RemoteTimelineClient {
                 UploadOp::Barrier(sender) => {
                     // Barrier operation needs to wait until all deletions are uploaded.
                     //
-                    // There is an optimization in the deletion queue client that if generation is enabled for a tenant,
+                    // There is an optimization in the deletion queue client that if generations are enabled for a tenant,
                     // we do not wait for the deletions to be flushed to the remote storage before we tell the user that
                     // the deletion is complete. This would cause problems for barrier semantics, as we expect all
                     // deletion to be persistent when the barrier is processed. For example, when we reload a timeline

--- a/pageserver/src/tenant/remote_timeline_client.rs
+++ b/pageserver/src/tenant/remote_timeline_client.rs
@@ -1914,7 +1914,7 @@ impl RemoteTimelineClient {
                     //
                     // Let's think about the following operation sequence:
                     //
-                    // schedule deletion of layer A at generation 5
+                    // schedule deletion of layer A at generation 5, this can be for example a future layer
                     // schedule a barrier
                     // schedule a compaction that creates layer A at generation 5
                     // the actual deletion happens here


### PR DESCRIPTION
## Problem

INC-317 https://neondb.slack.com/archives/C033RQ5SPDH/p1730815677932209

## Summary of changes

Barrier waits for deletions.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
