### PR TITLE
Increase verbosity of invalid compute status logs

### DIFF
--- a/compute_tools/src/http/api.rs
+++ b/compute_tools/src/http/api.rs
@@ -84,8 +84,9 @@ async fn routes(req: Request<Body>, compute: &Arc<ComputeNode>) -> Response<Body
             let status = compute.get_status();
             if status != ComputeStatus::Running {
                 let msg = format!(
-                    "invalid compute status for check_writability request: {:?}",
-                    status
+                    "invalid compute status for check_writability request: {}, need {}",
+                    status,
+                    ComputeStatus::Running
                 );
                 error!(msg);
                 return Response::new(Body::from(msg));
@@ -106,8 +107,9 @@ async fn routes(req: Request<Body>, compute: &Arc<ComputeNode>) -> Response<Body
             let status = compute.get_status();
             if status != ComputeStatus::Running {
                 let msg = format!(
-                    "invalid compute status for extensions request: {:?}",
-                    status
+                    "invalid compute status for extensions request: {}, need {}",
+                    status,
+                    ComputeStatus::Running
                 );
                 error!(msg);
                 return render_json_error(&msg, StatusCode::PRECONDITION_FAILED);
@@ -205,8 +207,9 @@ async fn routes(req: Request<Body>, compute: &Arc<ComputeNode>) -> Response<Body
             let status = compute.get_status();
             if status != ComputeStatus::Running {
                 let msg = format!(
-                    "invalid compute status for set_role_grants request: {:?}",
-                    status
+                    "invalid compute status for set_role_grants request: {}, need {}",
+                    status,
+                    ComputeStatus::Running
                 );
                 error!(msg);
                 return render_json_error(&msg, StatusCode::PRECONDITION_FAILED);
@@ -250,8 +253,9 @@ async fn routes(req: Request<Body>, compute: &Arc<ComputeNode>) -> Response<Body
             let status = compute.get_status();
             if status != ComputeStatus::Running {
                 let msg = format!(
-                    "invalid compute status for extensions request: {:?}",
-                    status
+                    "invalid compute status for extensions request: {}, need {}",
+                    status,
+                    ComputeStatus::Running
                 );
                 error!(msg);
                 return Response::new(Body::from(msg));
@@ -383,10 +387,12 @@ async fn handle_configure_request(
         // ```
         {
             let mut state = compute.state.lock().unwrap();
-            if state.status != ComputeStatus::Empty && state.status != ComputeStatus::Running {
+            if !matches!(state.status, ComputeStatus::Empty | ComputeStatus::Running) {
                 let msg = format!(
-                    "invalid compute status for configuration request: {:?}",
-                    state.status.clone()
+                    "invalid compute status for configuration request: {}, cannot be {} or {}",
+                    state.status,
+                    ComputeStatus::Empty,
+                    ComputeStatus::Running
                 );
                 return Err((msg, StatusCode::PRECONDITION_FAILED));
             }
@@ -462,10 +468,12 @@ async fn handle_terminate_request(compute: &Arc<ComputeNode>) -> Result<(), (Str
         if state.status == ComputeStatus::Terminated {
             return Ok(());
         }
-        if state.status != ComputeStatus::Empty && state.status != ComputeStatus::Running {
+        if !matches!(state.status, ComputeStatus::Empty | ComputeStatus::Running) {
             let msg = format!(
-                "invalid compute status for termination request: {}",
-                state.status
+                "invalid compute status for termination request: {}, cannot be {} or {}",
+                state.status,
+                ComputeStatus::Empty,
+                ComputeStatus::Running,
             );
             return Err((msg, StatusCode::PRECONDITION_FAILED));
         }

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -66,14 +66,15 @@ pub enum ComputeStatus {
 
 impl Display for ComputeStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // snake_case matches the serde implementation
         match self {
             ComputeStatus::Empty => f.write_str("empty"),
-            ComputeStatus::ConfigurationPending => f.write_str("configuration-pending"),
+            ComputeStatus::ConfigurationPending => f.write_str("configuration_pending"),
             ComputeStatus::Init => f.write_str("init"),
             ComputeStatus::Running => f.write_str("running"),
             ComputeStatus::Configuration => f.write_str("configuration"),
             ComputeStatus::Failed => f.write_str("failed"),
-            ComputeStatus::TerminationPending => f.write_str("termination-pending"),
+            ComputeStatus::TerminationPending => f.write_str("termination_pending"),
             ComputeStatus::Terminated => f.write_str("terminated"),
         }
     }


### PR DESCRIPTION
It should reduce a round trip of code inspection when looking at the logs.
