### PR TITLE
add pgcopydb tool to build tools image

### DIFF
--- a/build-tools.Dockerfile
+++ b/build-tools.Dockerfile
@@ -55,13 +55,8 @@ RUN mkdir -p /pgcopydb/bin && \
     chmod -R 755 /pgcopydb && \
     chown -R nonroot:nonroot /pgcopydb
         
-# COPY --from=pgcopydb_builder \
-#     /usr/lib/postgresql/16/bin/pgcopydb /pgcopydb/bin/ \
-#     /lib/aarch64-linux-gnu/libpq.so.5 /pgcopydb/lib/ \
-#     /lib/aarch64-linux-gnu/libgc.so.1 /pgcopydb/lib/
 COPY --from=pgcopydb_builder /usr/lib/postgresql/16/bin/pgcopydb /pgcopydb/bin/pgcopydb 
 COPY --from=pgcopydb_builder /lib/aarch64-linux-gnu/libpq.so.5 /pgcopydb/lib/libpq.so.5 
-#COPY --from=pgcopydb_builder /lib/aarch64-linux-gnu/libgc.so.1 /pgcopydb/lib/libgc.so.1 
 
 # System deps
 #

--- a/build-tools.Dockerfile
+++ b/build-tools.Dockerfile
@@ -41,9 +41,9 @@ RUN if [ "${DEBIAN_VERSION}" = "bookworm" ]; then \
         mkdir -p /pgcopydb/lib && \
         cp "$libpq_path" /pgcopydb/lib/; \
     else \
-        # copy command below will faile if we don't have dummy files, so we create them for other debian versions
+        # copy command below will fail if we don't have dummy files, so we create them for other debian versions
         mkdir -p /usr/lib/postgresql/16/bin && touch /usr/lib/postgresql/16/bin/pgcopydb && \
-        mkdir -p mkdir -p /pgcopydb/lib && touch  /mkdir -p /pgcopydb/lib/libpq.so.5; \
+        mkdir -p mkdir -p /pgcopydb/lib && touch /pgcopydb/lib/libpq.so.5; \
     fi
 
 FROM debian:${DEBIAN_VERSION}-slim AS build_tools

--- a/build-tools.Dockerfile
+++ b/build-tools.Dockerfile
@@ -36,11 +36,14 @@ RUN if [ "${DEBIAN_VERSION}" = "bookworm" ]; then \
         tar -xzf /tmp/pgcopydb.tar.gz -C /tmp/pgcopydb --strip-components=1 && \
         cd /tmp/pgcopydb && \
         make -s clean && \
-        make -s -j12 install; \
+        make -s -j12 install && \
+        libpq_path=$(find /lib /usr/lib -name "libpq.so.5" | head -n 1) && \
+        mkdir -p /pgcopydb/lib && \
+        cp "$libpq_path" /pgcopydb/lib/; \
     else \
         # copy command below will faile if we don't have dummy files, so we create them for other debian versions
         mkdir -p /usr/lib/postgresql/16/bin && touch /usr/lib/postgresql/16/bin/pgcopydb && \
-        mkdir -p /lib/aarch64-linux-gnu && touch  /lib/aarch64-linux-gnu/libpq.so.5; \
+        mkdir -p mkdir -p /pgcopydb/lib && touch  /mkdir -p /pgcopydb/lib/libpq.so.5; \
     fi
 
 FROM debian:${DEBIAN_VERSION}-slim AS build_tools
@@ -56,7 +59,7 @@ RUN mkdir -p /pgcopydb/bin && \
     chown -R nonroot:nonroot /pgcopydb
         
 COPY --from=pgcopydb_builder /usr/lib/postgresql/16/bin/pgcopydb /pgcopydb/bin/pgcopydb 
-COPY --from=pgcopydb_builder /lib/aarch64-linux-gnu/libpq.so.5 /pgcopydb/lib/libpq.so.5 
+COPY --from=pgcopydb_builder /pgcopydb/lib/libpq.so.5 /pgcopydb/lib/libpq.so.5 
 
 # System deps
 #

--- a/build-tools.Dockerfile
+++ b/build-tools.Dockerfile
@@ -40,7 +40,7 @@ RUN if [ "${DEBIAN_VERSION}" = "bookworm" ]; then \
     else \
         # copy command below will faile if we don't have dummy files, so we create them for other debian versions
         mkdir -p /usr/lib/postgresql/16/bin && touch /usr/lib/postgresql/16/bin/pgcopydb && \
-        touch  /lib/aarch64-linux-gnu/libpq.so.5; \
+        mkdir -p /lib/aarch64-linux-gnu && touch  /lib/aarch64-linux-gnu/libpq.so.5; \
     fi
 
 FROM debian:${DEBIAN_VERSION}-slim AS build_tools

--- a/build-tools.Dockerfile
+++ b/build-tools.Dockerfile
@@ -38,7 +38,7 @@ RUN set -e \
         libseccomp-dev \
         libsqlite3-dev \
         libssl-dev \
-        $([[ "${DEBIAN_VERSION}" = "bullseye" ]] && libstdc++-10-dev || libstdc++-11-dev) \
+        $([[ "${DEBIAN_VERSION}" = "bullseye" ]] && echo libstdc++-10-dev || echo libstdc++-11-dev) \
         libtool \
         libxml2-dev \
         libxmlsec1-dev \
@@ -56,6 +56,17 @@ RUN set -e \
         zlib1g-dev \
         zstd \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Conditional installation of pgcopydb from unstable repository (need version 0.17-1 or higher) for Bookworm only 
+# pgcopydb can be used for project migration / ingest in benchmarking workflows
+RUN if [ "${DEBIAN_VERSION}" = "bookworm" ]; then \
+        echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list \
+        && apt update \
+        && apt install -y -t unstable pgcopydb \
+        && rm /etc/apt/sources.list.d/unstable.list \
+        && apt update \
+        && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+    fi
 
 # sql_exporter
 

--- a/build-tools.Dockerfile
+++ b/build-tools.Dockerfile
@@ -62,7 +62,7 @@ RUN set -e \
 RUN if [ "${DEBIAN_VERSION}" = "bookworm" ]; then \
         echo "deb http://deb.debian.org/debian unstable main" > /etc/apt/sources.list.d/unstable.list \
         && apt update \
-        && apt install -y -t unstable pgcopydb \
+        && apt install -y -t unstable --no-upgrade pgcopydb \
         && rm /etc/apt/sources.list.d/unstable.list \
         && apt update \
         && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \


### PR DESCRIPTION
## Problem

build-tools image does not provide superuser, so additional packages can not be installed during GitHub benchmarking workflows but need to be added to the image

## Summary of changes

install pgcopydb version 0.17-1 or higher into build-tools bookworm image

```bash
docker run -it neondatabase/build-tools:<tag>-bookworm-arm64 /bin/bash
...
nonroot@c23c6f4901ce:~$ LD_LIBRARY_PATH=/pgcopydb/lib /pgcopydb/bin/pgcopydb --version;
13:58:19.768 8 INFO   Running pgcopydb version 0.17 from "/pgcopydb/bin/pgcopydb"
pgcopydb version 0.17
compiled with PostgreSQL 16.4 (Debian 16.4-1.pgdg120+2) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
compatible with Postgres 11, 12, 13, 14, 15, and 16
```

Example usage of that image in a workflow
https://github.com/neondatabase/neon/actions/runs/11725718371/job/32662681172#step:7:14

