### PR TITLE
storcon: add peer token for peer to peer communication

### DIFF
--- a/libs/utils/src/auth.rs
+++ b/libs/utils/src/auth.rs
@@ -43,7 +43,8 @@ pub enum Scope {
 
     /// This scope is used for communication with other storage controller instances.
     /// At the time of writing, this is only used for the step down request.
-    Peer,
+    #[serde(rename = "controller_peer")]
+    ControllerPeer,
 }
 
 /// JWT payload. See docs/authentication.md for the format

--- a/libs/utils/src/auth.rs
+++ b/libs/utils/src/auth.rs
@@ -40,6 +40,10 @@ pub enum Scope {
     /// Allows access to storage controller APIs used by the scrubber, to interrogate the state
     /// of a tenant & post scrub results.
     Scrubber,
+
+    /// This scope is used for communication with other storage controller instances.
+    /// At the time of writing, this is only used for the step down request.
+    Peer,
 }
 
 /// JWT payload. See docs/authentication.md for the format

--- a/pageserver/src/auth.rs
+++ b/pageserver/src/auth.rs
@@ -19,7 +19,8 @@ pub fn check_permission(claims: &Claims, tenant_id: Option<TenantId>) -> Result<
             | Scope::SafekeeperData
             | Scope::GenerationsApi
             | Scope::Infra
-            | Scope::Scrubber,
+            | Scope::Scrubber
+            | Scope::ControllerPeer,
             _,
         ) => Err(AuthError(
             format!(

--- a/safekeeper/src/auth.rs
+++ b/safekeeper/src/auth.rs
@@ -20,7 +20,8 @@ pub fn check_permission(claims: &Claims, tenant_id: Option<TenantId>) -> Result<
             | Scope::PageServerApi
             | Scope::GenerationsApi
             | Scope::Infra
-            | Scope::Scrubber,
+            | Scope::Scrubber
+            | Scope::ControllerPeer,
             _,
         ) => Err(AuthError(
             format!(

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -1033,7 +1033,7 @@ async fn handle_update_preferred_azs(req: Request<Body>) -> Result<Response<Body
 }
 
 async fn handle_step_down(req: Request<Body>) -> Result<Response<Body>, ApiError> {
-    check_permissions(&req, Scope::Admin)?;
+    check_permissions(&req, Scope::Peer)?;
 
     let req = match maybe_forward(req).await {
         ForwardOutcome::Forwarded(res) => {

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -1033,7 +1033,7 @@ async fn handle_update_preferred_azs(req: Request<Body>) -> Result<Response<Body
 }
 
 async fn handle_step_down(req: Request<Body>) -> Result<Response<Body>, ApiError> {
-    check_permissions(&req, Scope::Peer)?;
+    check_permissions(&req, Scope::ControllerPeer)?;
 
     let req = match maybe_forward(req).await {
         ForwardOutcome::Forwarded(res) => {


### PR DESCRIPTION
## Problem

We wish to stop using admin tokens in the infra repo, but step down requests use the admin token.

## Summary of Changes

Introduce a new "Peer" scope and use it for step-down requests.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics? if so did you add the relevant metrics to the dashboard?
- [ ] If this PR requires public announcement, mark it with /release-notes label and add several sentences in this section.

## Checklist before merging

- [ ] Do not forget to reformat commit message to not include the above checklist
