### PR TITLE
Rename 'installed_extensions' metric to 'compute_installed_extensions'

### DIFF
--- a/compute_tools/src/installed_extensions.rs
+++ b/compute_tools/src/installed_extensions.rs
@@ -115,7 +115,7 @@ pub fn get_installed_extensions_sync(connstr: Url) -> Result<()> {
 
 static INSTALLED_EXTENSIONS: Lazy<UIntGaugeVec> = Lazy::new(|| {
     register_uint_gauge_vec!(
-        "installed_extensions",
+        "compute_installed_extensions",
         "Number of databases where the version of extension is installed",
         &["extension_name", "version"]
     )

--- a/test_runner/regress/test_installed_extensions.py
+++ b/test_runner/regress/test_installed_extensions.py
@@ -99,11 +99,11 @@ def test_installed_extensions(neon_simple_env: NeonEnv):
     res = client.metrics()
     info("Metrics: %s", res)
     m = parse_metrics(res)
-    neon_m = m.query_all("installed_extensions", {"extension_name": "neon", "version": "1.2"})
+    neon_m = m.query_all("compute_installed_extensions", {"extension_name": "neon", "version": "1.2"})
     assert len(neon_m) == 1
     for sample in neon_m:
         assert sample.value == 2
-    neon_m = m.query_all("installed_extensions", {"extension_name": "neon", "version": "1.3"})
+    neon_m = m.query_all("compute_installed_extensions", {"extension_name": "neon", "version": "1.3"})
     assert len(neon_m) == 1
     for sample in neon_m:
         assert sample.value == 1
@@ -116,7 +116,7 @@ def test_installed_extensions(neon_simple_env: NeonEnv):
         try:
             res = client.metrics()
             timeout = -1
-            if len(parse_metrics(res).query_all("installed_extensions")) < 4:
+            if len(parse_metrics(res).query_all("compute_installed_extensions")) < 4:
                 # Assume that not all metrics that are collected yet
                 time.sleep(1)
                 timeout -= 1
@@ -128,17 +128,17 @@ def test_installed_extensions(neon_simple_env: NeonEnv):
             continue
 
         assert (
-            len(parse_metrics(res).query_all("installed_extensions")) >= 4
+            len(parse_metrics(res).query_all("compute_installed_extensions")) >= 4
         ), "Not all metrics are collected"
 
         info("After restart metrics: %s", res)
         m = parse_metrics(res)
-        neon_m = m.query_all("installed_extensions", {"extension_name": "neon", "version": "1.2"})
+        neon_m = m.query_all("compute_installed_extensions", {"extension_name": "neon", "version": "1.2"})
         assert len(neon_m) == 1
         for sample in neon_m:
             assert sample.value == 1
 
-        neon_m = m.query_all("installed_extensions", {"extension_name": "neon", "version": "1.3"})
+        neon_m = m.query_all("compute_installed_extensions", {"extension_name": "neon", "version": "1.3"})
         assert len(neon_m) == 1
         for sample in neon_m:
             assert sample.value == 1

--- a/test_runner/regress/test_installed_extensions.py
+++ b/test_runner/regress/test_installed_extensions.py
@@ -99,11 +99,15 @@ def test_installed_extensions(neon_simple_env: NeonEnv):
     res = client.metrics()
     info("Metrics: %s", res)
     m = parse_metrics(res)
-    neon_m = m.query_all("compute_installed_extensions", {"extension_name": "neon", "version": "1.2"})
+    neon_m = m.query_all(
+        "compute_installed_extensions", {"extension_name": "neon", "version": "1.2"}
+    )
     assert len(neon_m) == 1
     for sample in neon_m:
         assert sample.value == 2
-    neon_m = m.query_all("compute_installed_extensions", {"extension_name": "neon", "version": "1.3"})
+    neon_m = m.query_all(
+        "compute_installed_extensions", {"extension_name": "neon", "version": "1.3"}
+    )
     assert len(neon_m) == 1
     for sample in neon_m:
         assert sample.value == 1
@@ -133,12 +137,16 @@ def test_installed_extensions(neon_simple_env: NeonEnv):
 
         info("After restart metrics: %s", res)
         m = parse_metrics(res)
-        neon_m = m.query_all("compute_installed_extensions", {"extension_name": "neon", "version": "1.2"})
+        neon_m = m.query_all(
+            "compute_installed_extensions", {"extension_name": "neon", "version": "1.2"}
+        )
         assert len(neon_m) == 1
         for sample in neon_m:
             assert sample.value == 1
 
-        neon_m = m.query_all("compute_installed_extensions", {"extension_name": "neon", "version": "1.3"})
+        neon_m = m.query_all(
+            "compute_installed_extensions", {"extension_name": "neon", "version": "1.3"}
+        )
         assert len(neon_m) == 1
         for sample in neon_m:
             assert sample.value == 1


### PR DESCRIPTION
to keep it consistent with existing compute metrics.

flux-fleet change is not needed, because it doesn't have any filter by metric name for compute metrics.