### PR TITLE
Track application_name in connection_counts metric

### DIFF
--- a/compute/etc/sql_exporter/connection_counts.libsonnet
+++ b/compute/etc/sql_exporter/connection_counts.libsonnet
@@ -4,6 +4,7 @@
   help: 'Connection counts',
   key_labels: [
     'datname',
+    'application_name',
     'state',
   ],
   values: [

--- a/compute/etc/sql_exporter/connection_counts.sql
+++ b/compute/etc/sql_exporter/connection_counts.sql
@@ -1,1 +1,1 @@
-SELECT datname, state, count(*) AS count FROM pg_stat_activity WHERE state <> '' GROUP BY datname, state;
+SELECT datname, application_name, state, count(*) AS count FROM pg_stat_activity WHERE state <> '' GROUP BY datname, state;


### PR DESCRIPTION
It will help us understand what applications are exhausting the number of direct database connections.
