### PR TITLE
fix(pageserver): queue stopped error should be ignored during create timeline

### DIFF
--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -369,11 +369,15 @@ def test_create_churn_during_restart(neon_env_builder: NeonEnvBuilder):
     - Bad response codes during shutdown (e.g. returning 500 instead of 503)
     - Issues where a tenant is still starting up while we receive a request for it
     - Issues with interrupting/resuming tenant/timeline creation in shutdown
+    - Issues with a timeline is not created successfully because of restart.
     """
     env = neon_env_builder.init_configs()
     env.start()
     tenant_id: TenantId = env.initial_tenant
     timeline_id = env.initial_timeline
+
+    # At this point, the initial tenant/timeline might not have been created successfully,
+    # and this is the case we want to test.
 
     # Multiple creation requests which race will generate this error on the pageserver
     # and storage controller respectively

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -389,8 +389,6 @@ def test_create_churn_during_restart(neon_env_builder: NeonEnvBuilder):
     # so we allow it to log at WARN, even if it is occasionally a false positive.
     env.pageserver.allowed_errors.append(".*failed to freeze and flush.*")
 
-    wait_until_tenant_active(env.pageserver.http_client(), tenant_id)
-
     def create_bg(delay_ms):
         time.sleep(delay_ms / 1000.0)
         try:

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -389,6 +389,8 @@ def test_create_churn_during_restart(neon_env_builder: NeonEnvBuilder):
     # so we allow it to log at WARN, even if it is occasionally a false positive.
     env.pageserver.allowed_errors.append(".*failed to freeze and flush.*")
 
+    wait_until_tenant_active(env.pageserver.http_client(), tenant_id)
+
     def create_bg(delay_ms):
         time.sleep(delay_ms / 1000.0)
         try:


### PR DESCRIPTION
## Problem

close https://github.com/neondatabase/neon/issues/9730

The test case tests if anything goes wrong during pageserver restart + *during timeline creation not complete*. Therefore, queue is stopped error is normal in this case, except that it should be categorized as a shutdown error instead of a real error.

## Summary of changes

* More comments for the test case.
* Queue stopped error will now be forwarded as CreateTimelineError::ShuttingDown.