### PR TITLE
Bump default Postgres version for tests to v17

### DIFF
--- a/test_runner/fixtures/pg_version.py
+++ b/test_runner/fixtures/pg_version.py
@@ -22,8 +22,8 @@ class PgVersion(str, enum.Enum):
     V16 = "16"
     V17 = "17"
 
-    # Default Postgres Version for tests that don't really depend on Postgres itself
-    DEFAULT = V16
+    # Postgres Version for tests that uses `fixtures.utils.run_only_on_default_postgres`
+    DEFAULT = V17
 
     # Instead of making version an optional parameter in methods, we can use this fake entry
     # to explicitly rely on the default server version (could be different from pg_version fixture value)

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -23,7 +23,7 @@ from fixtures.pageserver.utils import (
 )
 from fixtures.pg_version import PgVersion
 from fixtures.remote_storage import S3Storage, s3_storage
-from fixtures.utils import run_only_on_default_postgres, wait_until
+from fixtures.utils import run_only_on_default_postgres, skip_in_debug_build, wait_until
 from mypy_boto3_s3.type_defs import (
     ObjectTypeDef,
 )
@@ -390,6 +390,7 @@ def test_timeline_offload_persist(neon_env_builder: NeonEnvBuilder, delete_timel
 
 
 @run_only_on_default_postgres("this test isn't sensitive to the contents of timelines")
+@skip_in_debug_build("times out in debug builds")
 def test_timeline_archival_chaos(neon_env_builder: NeonEnvBuilder):
     """
     A general consistency check on archival/offload timeline state, and its intersection

--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -416,7 +416,7 @@ def test_timeline_archival_chaos(neon_env_builder: NeonEnvBuilder):
         [
             ".*error sending request.*",
             # FIXME: the pageserver should not return 500s on cancellation (https://github.com/neondatabase/neon/issues/97680)
-            ".*InternalServerError(Error deleting timeline .* on .* on .*: pageserver API: error: Cancelled",
+            ".*InternalServerError\\(Error deleting timeline .* on .* on .*: pageserver API: error: Cancelled",
         ]
     )
 


### PR DESCRIPTION
## Problem
Tests that are marked with `run_only_on_default_postgres` do not run on debug builds on CI because we run debug builds only for the latest Postgres version (which is 17)

## Summary of changes
- Bump `PgVersion.DEFAULT` to `v17`
- Skip `test_timeline_archival_chaos` in debug builds
