### PR TITLE
build(deps): bump smallvec to 1.13.2 to get UB fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5663,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol_str"


### PR DESCRIPTION
Smallvec 1.13.2 contains [an UB fix](https://github.com/servo/rust-smallvec/pull/345).

Upstream opened [a request](https://github.com/rustsec/advisory-db/issues/1960)
for this in the advisory-db but it never got acted upon.

Found while working on https://github.com/neondatabase/neon/pull/9321.
