### PR TITLE
adapt pgvector bench to minor version upgrades of PostgreSql

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -546,8 +546,8 @@ jobs:
 
         cd /home/nonroot
         wget -q "https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-17/libpq5_17.0-1.pgdg110+1_${arch}.deb"
-        wget -q "https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-client-16_16.4-1.pgdg110+2_${arch}.deb"
-        wget -q "https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-16_16.4-1.pgdg110+2_${arch}.deb"
+        wget -q "https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-client-16_16.5-1.pgdg110+1_${arch}.deb"
+        wget -q "https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-16/postgresql-16_16.5-1.pgdg110+1_${arch}.deb"
         dpkg -x libpq5_17.0-1.pgdg110+1_${arch}.deb pg
         dpkg -x postgresql-16_16.4-1.pgdg110+2_${arch}.deb pg
         dpkg -x postgresql-client-16_16.4-1.pgdg110+2_${arch}.deb pg


### PR DESCRIPTION
## Problem

pgvector benchmark is failing because after PostgreSQL minor version upgrade previous version packages are no longer available in deb repository

## Summary of changes

Update postgres minor version of packages to current version
