### PR TITLE
Write a newline after adding dynamic_shared_memory_type to PG conf

### DIFF
--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -116,7 +116,7 @@ pub fn write_postgres_conf(
                 vartype: "enum".to_owned(),
             };
 
-            write!(file, "{}", opt.to_pg_setting())?;
+            writeln!(file, "{}", opt.to_pg_setting())?;
         }
     }
 


### PR DESCRIPTION
Without adding a newline, we can end up with a conf line that looks like the following:

dynamic_shared_memory_type = mmap# Managed by compute_ctl: begin

This leads to Postgres logging:

LOG:  configuration file "/var/db/postgres/compute/pgdata/postgresql.conf" contains errors; unaffected changes were applied
