### PR TITLE
proxy: Demote errors from cplane request routines to debug

### DIFF
--- a/proxy/src/control_plane/client/mock.rs
+++ b/proxy/src/control_plane/client/mock.rs
@@ -114,7 +114,7 @@ impl MockControlPlane {
 
             Ok((secret, allowed_ips))
         }
-        .map_err(crate::error::log_error::<GetAuthInfoError>)
+        .inspect_err(|e: &GetAuthInfoError| tracing::error!("{e}"))
         .instrument(info_span!("postgres", url = self.endpoint.as_str()))
         .await?;
         Ok(AuthInfo {

--- a/proxy/src/control_plane/client/neon.rs
+++ b/proxy/src/control_plane/client/neon.rs
@@ -134,8 +134,8 @@ impl NeonControlPlaneClient {
                 project_id: body.project_id,
             })
         }
-        .map_err(crate::error::log_error)
-        .instrument(info_span!("http", id = request_id))
+        .inspect_err(|e| tracing::debug!(error = ?e))
+        .instrument(info_span!("do_get_auth_info", request_id))
         .await
     }
 
@@ -193,8 +193,8 @@ impl NeonControlPlaneClient {
 
             Ok(rules)
         }
-        .map_err(crate::error::log_error)
-        .instrument(info_span!("http", id = request_id))
+        .inspect_err(|e| tracing::debug!(error = ?e))
+        .instrument(info_span!("do_get_endpoint_jwks", request_id))
         .await
     }
 
@@ -252,9 +252,9 @@ impl NeonControlPlaneClient {
 
             Ok(node)
         }
-        .map_err(crate::error::log_error)
+        .inspect_err(|e| tracing::debug!(error = ?e))
         // TODO: redo this span stuff
-        .instrument(info_span!("http", id = request_id))
+        .instrument(info_span!("do_wake_compute", request_id))
         .await
     }
 }

--- a/proxy/src/control_plane/client/neon.rs
+++ b/proxy/src/control_plane/client/neon.rs
@@ -135,7 +135,7 @@ impl NeonControlPlaneClient {
             })
         }
         .inspect_err(|e| tracing::debug!(error = ?e))
-        .instrument(info_span!("do_get_auth_info", request_id))
+        .instrument(info_span!("do_get_auth_info"))
         .await
     }
 
@@ -194,7 +194,7 @@ impl NeonControlPlaneClient {
             Ok(rules)
         }
         .inspect_err(|e| tracing::debug!(error = ?e))
-        .instrument(info_span!("do_get_endpoint_jwks", request_id))
+        .instrument(info_span!("do_get_endpoint_jwks"))
         .await
     }
 
@@ -253,8 +253,7 @@ impl NeonControlPlaneClient {
             Ok(node)
         }
         .inspect_err(|e| tracing::debug!(error = ?e))
-        // TODO: redo this span stuff
-        .instrument(info_span!("do_wake_compute", request_id))
+        .instrument(info_span!("do_wake_compute"))
         .await
     }
 }

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -10,12 +10,6 @@ pub(crate) fn io_error(e: impl Into<Box<dyn StdError + Send + Sync>>) -> io::Err
     io::Error::new(io::ErrorKind::Other, e)
 }
 
-/// A small combinator for pluggable error logging.
-pub(crate) fn log_error<E: fmt::Display>(e: E) -> E {
-    tracing::error!("{e}");
-    e
-}
-
 /// Marks errors that may be safely shown to a client.
 /// This trait can be seen as a specialized version of [`ToString`].
 ///


### PR DESCRIPTION
## Problem

Any errors from these async blocks are unconditionally logged at error level
even though we already handle such errors based on context.

## Summary of changes

* Log raw errors from creating and executing cplane requests at debug level.
* Inline macro calls to retain the correct callsite.