### PR TITLE
proxy: promote two logs to error, fix multiline log

### DIFF
--- a/proxy/src/context/parquet.rs
+++ b/proxy/src/context/parquet.rs
@@ -398,7 +398,7 @@ async fn upload_parquet(
     .err();
 
     if let Some(err) = maybe_err {
-        tracing::warn!(%id, %err, "failed to upload request data");
+        tracing::error!(%id, error = ?err, "failed to upload request data");
     }
 
     Ok(buffer.writer())


### PR DESCRIPTION
* Promote two logs from mpsc send errors to error level. The channels are unbounded and there shouldn't be errors.
* Fix one multiline log from anyhow::Error. Use Debug instead of Display.
