### PR TITLE
Add start_timeout to the `neon_fixtures.py::NeonEnvBuilder::start()`

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -479,6 +479,8 @@ class NeonEnvBuilder:
         Configuring pageserver with remote storage is now the default. There will be a warning if pageserver is created without one.
         """
         env = self.init_configs(default_remote_storage_if_missing=default_remote_storage_if_missing)
+        if (timeout_in_seconds is None) and (os.getenv("BUILD_TYPE") == "debug"):
+            timeout_in_seconds = 30
         env.start(timeout_in_seconds=timeout_in_seconds)
 
         # Prepare the default branch to start the postgres on later.

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -469,6 +469,7 @@ class NeonEnvBuilder:
         default_remote_storage_if_missing: bool = True,
         initial_tenant_shard_count: int | None = None,
         initial_tenant_shard_stripe_size: int | None = None,
+        timeout_in_seconds: int | None = None,
     ) -> NeonEnv:
         """
         Default way to create and start NeonEnv. Also creates the initial_tenant with root initial_timeline.
@@ -478,7 +479,7 @@ class NeonEnvBuilder:
         Configuring pageserver with remote storage is now the default. There will be a warning if pageserver is created without one.
         """
         env = self.init_configs(default_remote_storage_if_missing=default_remote_storage_if_missing)
-        env.start()
+        env.start(timeout_in_seconds=timeout_in_seconds)
 
         # Prepare the default branch to start the postgres on later.
         # Pageserver itself does not create tenants and timelines, until started first and asked via HTTP API.

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -479,8 +479,12 @@ class NeonEnvBuilder:
         Configuring pageserver with remote storage is now the default. There will be a warning if pageserver is created without one.
         """
         env = self.init_configs(default_remote_storage_if_missing=default_remote_storage_if_missing)
-        if (timeout_in_seconds is None) and (os.getenv("BUILD_TYPE") == "debug"):
-            timeout_in_seconds = 30
+        if timeout_in_seconds is None:
+            if os.getenv("BUILD_TYPE") == "release":
+                timeout_in_seconds = 15
+            elif os.getenv("BUILD_TYPE") == "debug":
+                timeout_in_seconds = 30
+
         env.start(timeout_in_seconds=timeout_in_seconds)
 
         # Prepare the default branch to start the postgres on later.

--- a/test_runner/regress/test_sharding.py
+++ b/test_runner/regress/test_sharding.py
@@ -52,9 +52,7 @@ def test_sharding_smoke(
     neon_env_builder.enable_pageserver_remote_storage(s3_storage())
 
     env = neon_env_builder.init_start(
-        initial_tenant_shard_count=shard_count,
-        initial_tenant_shard_stripe_size=stripe_size,
-        timeout_in_seconds=30,  # Just 10s is not always enough
+        initial_tenant_shard_count=shard_count, initial_tenant_shard_stripe_size=stripe_size
     )
     tenant_id = env.initial_tenant
 

--- a/test_runner/regress/test_sharding.py
+++ b/test_runner/regress/test_sharding.py
@@ -52,7 +52,9 @@ def test_sharding_smoke(
     neon_env_builder.enable_pageserver_remote_storage(s3_storage())
 
     env = neon_env_builder.init_start(
-        initial_tenant_shard_count=shard_count, initial_tenant_shard_stripe_size=stripe_size
+        initial_tenant_shard_count=shard_count,
+        initial_tenant_shard_stripe_size=stripe_size,
+        timeout_in_seconds=30,  # Just 10s is not always enough
     )
     tenant_id = env.initial_tenant
 


### PR DESCRIPTION
And set it to 30s

## Problem
Tests ocasionnaily fails in that place with the:
```
FAILED test_runner/regress/test_sharding.py::test_sharding_split_failures[debug-pg17-failure10] - RuntimeError: Run ['/tmp/neon/bin/neon_local', 'pageserver', 'start', '--id=1'] failed:
  stdout:
    Starting pageserver node 1 at 'localhost:24121' in "/tmp/test_output/test_sharding_split_failures[debug-pg17-failure10]/repo/pageserver_1", retrying for 10s.....
    pageserver has not started yet, continuing to wait.....
    SIGKILL & wait the started process
  stderr:
    pageserver start failed: pageserver did not start+pass status checks within 10s seconds
```
for example: 
https://github.com/neondatabase/neon/actions/runs/12053527058/job/33611491689#step:4:2051

## Summary of changes
Taking into account that tests run for about 40 minutes, increase timeout to start from 10s -> 30s shouldb't be big change
if it cant start in 30s, it's an issue to invesitage
while if takes 11-15s could be due to some extra load on Runner, we could wait a bit more