### PR TITLE
Stop changing the value of neon.extension_server_port at runtime

### DIFF
--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -37,7 +37,7 @@ pub fn line_in_file(path: &Path, line: &str) -> Result<bool> {
 pub fn write_postgres_conf(
     path: &Path,
     spec: &ComputeSpec,
-    extension_server_port: Option<u16>,
+    extension_server_port: u16,
 ) -> Result<()> {
     // File::create() destroys the file content if it exists.
     let mut file = File::create(path)?;
@@ -127,9 +127,7 @@ pub fn write_postgres_conf(
         writeln!(file, "# Managed by compute_ctl: end")?;
     }
 
-    if let Some(port) = extension_server_port {
-        writeln!(file, "neon.extension_server_port={}", port)?;
-    }
+    writeln!(file, "neon.extension_server_port={}", extension_server_port)?;
 
     // This is essential to keep this line at the end of the file,
     // because it is intended to override any settings above.


### PR DESCRIPTION
On reconfigure, we no longer passed a port for the extension server which caused us to not write out the neon.extension_server_port line. Thus, Postgres thought we were setting the port to the default value of 0. PGC_POSTMASTER GUCs cannot be set at runtime, which causes the following log messages:

> LOG:  parameter "neon.extension_server_port" cannot be changed without restarting the server
> LOG:  configuration file "/var/db/postgres/compute/pgdata/postgresql.conf" contains errors; unaffected changes were applied

Fixes: https://github.com/neondatabase/neon/issues/9945
