### PR TITLE
feat(proxy): add option to forward startup params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,9 +1031,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ bindgen = "0.70"
 bit_field = "0.10.2"
 bstr = "1.0"
 byteorder = "1.4"
-bytes = "1.0"
+bytes = "1.9"
 camino = "1.1.6"
 cfg-if = "1.0.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/libs/pq_proto/src/lib.rs
+++ b/libs/pq_proto/src/lib.rs
@@ -100,7 +100,7 @@ impl StartupMessageParamsBuilder {
 
 #[derive(Debug, Clone, Default)]
 pub struct StartupMessageParams {
-    params: Bytes,
+    pub params: Bytes,
 }
 
 impl StartupMessageParams {

--- a/libs/proxy/postgres-protocol2/src/authentication/sasl.rs
+++ b/libs/proxy/postgres-protocol2/src/authentication/sasl.rs
@@ -117,7 +117,7 @@ enum Credentials<const N: usize> {
     /// A regular password as a vector of bytes.
     Password(Vec<u8>),
     /// A precomputed pair of keys.
-    Keys(Box<ScramKeys<N>>),
+    Keys(ScramKeys<N>),
 }
 
 enum State {
@@ -176,7 +176,7 @@ impl ScramSha256 {
 
     /// Constructs a new instance which will use the provided key pair for authentication.
     pub fn new_with_keys(keys: ScramKeys<32>, channel_binding: ChannelBinding) -> ScramSha256 {
-        let password = Credentials::Keys(keys.into());
+        let password = Credentials::Keys(keys);
         ScramSha256::new_inner(password, channel_binding, nonce())
     }
 

--- a/libs/proxy/postgres-protocol2/src/message/frontend.rs
+++ b/libs/proxy/postgres-protocol2/src/message/frontend.rs
@@ -255,23 +255,6 @@ pub fn ssl_request(buf: &mut BytesMut) {
 }
 
 #[inline]
-pub fn startup_message<'a, I>(parameters: I, buf: &mut BytesMut) -> io::Result<()>
-where
-    I: IntoIterator<Item = (&'a str, &'a str)>,
-{
-    write_body(buf, |buf| {
-        // postgres protocol version 3.0(196608) in bigger-endian
-        buf.put_i32(0x00_03_00_00);
-        for (key, value) in parameters {
-            write_cstr(key.as_bytes(), buf)?;
-            write_cstr(value.as_bytes(), buf)?;
-        }
-        buf.put_u8(0);
-        Ok(())
-    })
-}
-
-#[inline]
 pub fn startup_message_cstr(
     parameters: &StartupMessageParams,
     buf: &mut BytesMut,
@@ -287,7 +270,7 @@ pub fn startup_message_cstr(
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StartupMessageParams {
-    params: BytesMut,
+    pub params: BytesMut,
 }
 
 impl StartupMessageParams {

--- a/libs/proxy/postgres-protocol2/src/message/frontend.rs
+++ b/libs/proxy/postgres-protocol2/src/message/frontend.rs
@@ -273,12 +273,12 @@ pub struct StartupMessageParams {
 impl StartupMessageParams {
     /// Set parameter's value by its name.
     pub fn insert(&mut self, name: &str, value: &str) {
-        if name.contains('\0') | value.contains('\0') {
+        if name.contains('\0') || value.contains('\0') {
             panic!("startup parameter name or value contained a null")
         }
-        self.params.put(name.as_bytes());
+        self.params.put_slice(name.as_bytes());
         self.params.put_u8(0);
-        self.params.put(value.as_bytes());
+        self.params.put_slice(value.as_bytes());
         self.params.put_u8(0);
     }
 }

--- a/libs/proxy/postgres-protocol2/src/message/frontend.rs
+++ b/libs/proxy/postgres-protocol2/src/message/frontend.rs
@@ -272,18 +272,14 @@ pub struct StartupMessageParams {
 
 impl StartupMessageParams {
     /// Set parameter's value by its name.
-    pub fn insert(&mut self, name: &str, value: &str) -> Result<(), io::Error> {
+    pub fn insert(&mut self, name: &str, value: &str) {
         if name.contains('\0') | value.contains('\0') {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "string contains embedded null",
-            ));
+            panic!("startup parameter name or value contained a null")
         }
         self.params.put(name.as_bytes());
         self.params.put_u8(0);
         self.params.put(value.as_bytes());
         self.params.put_u8(0);
-        Ok(())
     }
 }
 

--- a/libs/proxy/postgres-protocol2/src/message/frontend.rs
+++ b/libs/proxy/postgres-protocol2/src/message/frontend.rs
@@ -272,6 +272,62 @@ where
 }
 
 #[inline]
+pub fn startup_message_cstr(
+    parameters: &StartupMessageParams,
+    buf: &mut BytesMut,
+) -> io::Result<()> {
+    write_body(buf, |buf| {
+        // postgres protocol version 3.0(196608) in bigger-endian
+        buf.put_i32(0x00_03_00_00);
+        buf.put_slice(&parameters.params);
+        buf.put_u8(0);
+        Ok(())
+    })
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StartupMessageParams {
+    params: BytesMut,
+}
+
+impl StartupMessageParams {
+    /// Set parameter's value by its name.
+    pub fn insert(&mut self, name: &str, value: &str) -> Result<(), io::Error> {
+        if name.contains('\0') | value.contains('\0') {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "string contains embedded null",
+            ));
+        }
+        self.params.put(name.as_bytes());
+        self.params.put(&b"\0"[..]);
+        self.params.put(value.as_bytes());
+        self.params.put(&b"\0"[..]);
+        Ok(())
+    }
+    pub fn str_iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        let params =
+            std::str::from_utf8(&self.params).expect("should be validated as utf8 already");
+        StrParamsIter(params)
+    }
+    /// Get parameter's value by its name.
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.str_iter().find_map(|(k, v)| (k == name).then_some(v))
+    }
+}
+
+struct StrParamsIter<'a>(&'a str);
+impl<'a> Iterator for StrParamsIter<'a> {
+    type Item = (&'a str, &'a str);
+    fn next(&mut self) -> Option<Self::Item> {
+        let (key, r) = self.0.split_once('\0')?;
+        let (value, r) = r.split_once('\0')?;
+        self.0 = r;
+        Some((key, value))
+    }
+}
+
+#[inline]
 pub fn sync(buf: &mut BytesMut) {
     buf.put_u8(b'S');
     write_body(buf, |_| Ok::<(), io::Error>(())).unwrap();

--- a/libs/proxy/tokio-postgres2/src/codec.rs
+++ b/libs/proxy/tokio-postgres2/src/codec.rs
@@ -35,9 +35,7 @@ impl FallibleIterator for BackendMessages {
     }
 }
 
-pub struct PostgresCodec {
-    pub max_message_size: Option<usize>,
-}
+pub struct PostgresCodec;
 
 impl Encoder<FrontendMessage> for PostgresCodec {
     type Error = io::Error;
@@ -64,15 +62,6 @@ impl Decoder for PostgresCodec {
             let len = header.len() as usize + 1;
             if src[idx..].len() < len {
                 break;
-            }
-
-            if let Some(max) = self.max_message_size {
-                if len > max {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "message too large",
-                    ));
-                }
             }
 
             match header.tag() {

--- a/libs/proxy/tokio-postgres2/src/config.rs
+++ b/libs/proxy/tokio-postgres2/src/config.rs
@@ -71,7 +71,6 @@ pub struct Config {
 
     pub(crate) password: Option<Vec<u8>>,
     pub(crate) auth_keys: Option<Box<AuthKeys>>,
-    pub(crate) options: Option<String>,
     pub(crate) ssl_mode: SslMode,
     pub(crate) connect_timeout: Option<Duration>,
     pub(crate) channel_binding: ChannelBinding,
@@ -86,13 +85,9 @@ impl Config {
             port,
             password: None,
             auth_keys: None,
-            // dbname: None,
-            options: None,
-            // application_name: None,
             ssl_mode: SslMode::Prefer,
             connect_timeout: None,
             channel_binding: ChannelBinding::Prefer,
-            // replication_mode: None,
             server_params: StartupMessageParams::default(),
         }
     }
@@ -107,8 +102,8 @@ impl Config {
 
     /// Gets the user to authenticate with, if one has been configured with
     /// the `user` method.
-    pub fn get_user(&self) -> Option<&str> {
-        self.server_params.get("user")
+    pub fn user_is_set(&self) -> bool {
+        self.server_params.get("user").is_some()
     }
 
     /// Sets the password to authenticate with.
@@ -152,20 +147,8 @@ impl Config {
 
     /// Gets the name of the database to connect to, if one has been configured
     /// with the `dbname` method.
-    pub fn get_dbname(&self) -> Option<&str> {
-        self.server_params.get("database")
-    }
-
-    /// Sets command line options used to configure the server.
-    pub fn options(&mut self, options: &str) -> &mut Config {
-        self.options = Some(options.to_string());
-        self
-    }
-
-    /// Gets the command line options used to configure the server, if the
-    /// options have been set with the `options` method.
-    pub fn get_options(&self) -> Option<&str> {
-        self.options.as_deref()
+    pub fn db_is_set(&self) -> bool {
+        self.server_params.get("database").is_some()
     }
 
     pub fn set_param(&mut self, name: &str, value: &str) -> &mut Config {
@@ -264,7 +247,6 @@ impl fmt::Debug for Config {
 
         f.debug_struct("Config")
             .field("password", &self.password.as_ref().map(|_| Redaction {}))
-            .field("options", &self.options)
             .field("ssl_mode", &self.ssl_mode)
             .field("host", &self.host)
             .field("port", &self.port)

--- a/libs/proxy/tokio-postgres2/src/config.rs
+++ b/libs/proxy/tokio-postgres2/src/config.rs
@@ -160,9 +160,7 @@ impl Config {
             self.username = true;
         }
 
-        self.server_params
-            .insert(name, value)
-            .expect("name or value must not have null bytes");
+        self.server_params.insert(name, value);
         self
     }
 

--- a/libs/proxy/tokio-postgres2/src/config.rs
+++ b/libs/proxy/tokio-postgres2/src/config.rs
@@ -69,7 +69,6 @@ pub struct Config {
     pub(crate) host: Host,
     pub(crate) port: u16,
 
-    pub(crate) user: Option<String>,
     pub(crate) password: Option<Vec<u8>>,
     pub(crate) auth_keys: Option<Box<AuthKeys>>,
     pub(crate) options: Option<String>,
@@ -85,7 +84,6 @@ impl Config {
         Config {
             host: Host::Tcp(host),
             port,
-            user: None,
             password: None,
             auth_keys: None,
             // dbname: None,
@@ -103,7 +101,6 @@ impl Config {
     ///
     /// Required.
     pub fn user(&mut self, user: &str) -> &mut Config {
-        self.user = Some(user.to_string());
         self.server_settings.insert("user", user).unwrap();
         self
     }
@@ -111,7 +108,7 @@ impl Config {
     /// Gets the user to authenticate with, if one has been configured with
     /// the `user` method.
     pub fn get_user(&self) -> Option<&str> {
-        self.user.as_deref()
+        self.server_settings.get("user")
     }
 
     /// Sets the password to authenticate with.
@@ -294,7 +291,7 @@ impl fmt::Debug for Config {
         }
 
         f.debug_struct("Config")
-            .field("user", &self.user)
+            .field("user", &self.get_user())
             .field("password", &self.password.as_ref().map(|_| Redaction {}))
             .field("dbname", &self.get_dbname())
             .field("options", &self.options)

--- a/libs/proxy/tokio-postgres2/src/config.rs
+++ b/libs/proxy/tokio-postgres2/src/config.rs
@@ -75,6 +75,9 @@ pub struct Config {
     pub(crate) connect_timeout: Option<Duration>,
     pub(crate) channel_binding: ChannelBinding,
     pub(crate) server_params: StartupMessageParams,
+
+    database: bool,
+    username: bool,
 }
 
 impl Config {
@@ -89,6 +92,9 @@ impl Config {
             connect_timeout: None,
             channel_binding: ChannelBinding::Prefer,
             server_params: StartupMessageParams::default(),
+
+            database: false,
+            username: false,
         }
     }
 
@@ -96,14 +102,13 @@ impl Config {
     ///
     /// Required.
     pub fn user(&mut self, user: &str) -> &mut Config {
-        self.server_params.insert("user", user).unwrap();
-        self
+        self.set_param("user", user)
     }
 
     /// Gets the user to authenticate with, if one has been configured with
     /// the `user` method.
     pub fn user_is_set(&self) -> bool {
-        self.server_params.get("user").is_some()
+        self.username
     }
 
     /// Sets the password to authenticate with.
@@ -139,19 +144,22 @@ impl Config {
     ///
     /// Defaults to the user.
     pub fn dbname(&mut self, dbname: &str) -> &mut Config {
-        self.server_params
-            .insert("database", dbname)
-            .expect("dbname must not have nulls");
-        self
+        self.set_param("database", dbname)
     }
 
     /// Gets the name of the database to connect to, if one has been configured
     /// with the `dbname` method.
     pub fn db_is_set(&self) -> bool {
-        self.server_params.get("database").is_some()
+        self.database
     }
 
     pub fn set_param(&mut self, name: &str, value: &str) -> &mut Config {
+        if name == "database" {
+            self.database = true;
+        } else if name == "user" {
+            self.username = true;
+        }
+
         self.server_params
             .insert(name, value)
             .expect("name or value must not have null bytes");

--- a/libs/proxy/tokio-postgres2/src/connect_raw.rs
+++ b/libs/proxy/tokio-postgres2/src/connect_raw.rs
@@ -125,7 +125,7 @@ where
         .expect("value does not contain null");
 
     let mut buf = BytesMut::new();
-    frontend::startup_message_cstr(&params, &mut buf).map_err(Error::encode)?;
+    frontend::startup_message(&params, &mut buf).map_err(Error::encode)?;
 
     stream
         .send(FrontendMessage::Raw(buf.freeze()))

--- a/libs/proxy/tokio-postgres2/src/connect_raw.rs
+++ b/libs/proxy/tokio-postgres2/src/connect_raw.rs
@@ -119,7 +119,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
     T: AsyncRead + AsyncWrite + Unpin,
 {
-    let mut params = config.server_settings.clone();
+    let mut params = config.server_params.clone();
     params
         .insert("client_encoding", "UTF8")
         .expect("value does not contain null");

--- a/libs/proxy/tokio-postgres2/src/connect_raw.rs
+++ b/libs/proxy/tokio-postgres2/src/connect_raw.rs
@@ -120,9 +120,7 @@ where
     T: AsyncRead + AsyncWrite + Unpin,
 {
     let mut params = config.server_params.clone();
-    params
-        .insert("client_encoding", "UTF8")
-        .expect("value does not contain null");
+    params.insert("client_encoding", "UTF8");
 
     let mut buf = BytesMut::new();
     frontend::startup_message(&params, &mut buf).map_err(Error::encode)?;

--- a/libs/proxy/tokio-postgres2/src/connect_raw.rs
+++ b/libs/proxy/tokio-postgres2/src/connect_raw.rs
@@ -96,12 +96,7 @@ where
     let stream = connect_tls(stream, config.ssl_mode, tls).await?;
 
     let mut stream = StartupStream {
-        inner: Framed::new(
-            stream,
-            PostgresCodec {
-                max_message_size: config.max_backend_message_size,
-            },
-        ),
+        inner: Framed::new(stream, PostgresCodec),
         buf: BackendMessages::empty(),
         delayed_notice: Vec::new(),
     };

--- a/libs/proxy/tokio-postgres2/src/connect_raw.rs
+++ b/libs/proxy/tokio-postgres2/src/connect_raw.rs
@@ -119,11 +119,8 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
     T: AsyncRead + AsyncWrite + Unpin,
 {
-    let mut params = config.server_params.clone();
-    params.insert("client_encoding", "UTF8");
-
     let mut buf = BytesMut::new();
-    frontend::startup_message(&params, &mut buf).map_err(Error::encode)?;
+    frontend::startup_message(&config.server_params, &mut buf).map_err(Error::encode)?;
 
     stream
         .send(FrontendMessage::Raw(buf.freeze()))

--- a/libs/proxy/tokio-postgres2/src/connect_raw.rs
+++ b/libs/proxy/tokio-postgres2/src/connect_raw.rs
@@ -123,16 +123,16 @@ where
     if let Some(user) = &config.user {
         params.push(("user", &**user));
     }
-    if let Some(dbname) = &config.dbname {
+    if let Some(dbname) = &config.get_dbname() {
         params.push(("database", &**dbname));
     }
     if let Some(options) = &config.options {
         params.push(("options", &**options));
     }
-    if let Some(application_name) = &config.application_name {
+    if let Some(application_name) = &config.get_application_name() {
         params.push(("application_name", &**application_name));
     }
-    if let Some(replication_mode) = &config.replication_mode {
+    if let Some(replication_mode) = &config.get_replication_mode() {
         match replication_mode {
             ReplicationMode::Physical => params.push(("replication", "true")),
             ReplicationMode::Logical => params.push(("replication", "database")),

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -70,11 +70,12 @@ impl ReportableError for CancelError {
 impl<P: CancellationPublisher> CancellationHandler<P> {
     /// Run async action within an ephemeral session identified by [`CancelKeyData`].
     pub(crate) fn get_session(self: Arc<Self>) -> Session<P> {
-        // HACK: We'd rather get the real backend_pid but postgres_client doesn't
-        // expose it and we don't want to do another roundtrip to query
-        // for it. The client will be able to notice that this is not the
-        // actual backend_pid, but backend_pid is not used for anything
-        // so it doesn't matter.
+        // we intentionally generate a random "backend pid" and "secret key" here.
+        // we use the corresponding u64 as an identifier for the
+        // actual endpoint+pid+secret for postgres/pgbouncer.
+        //
+        // if we forwarded the backend_pid from postgres to the client, there would be a lot
+        // of overlap between our computes as most pids are small (~100).
         let key = loop {
             let key = rand::random();
 

--- a/proxy/src/compute.rs
+++ b/proxy/src/compute.rs
@@ -138,11 +138,11 @@ impl ConnCfg {
             match k {
                 // Only set `user` if it's not present in the config.
                 // Console redirect auth flow takes username from the console's response.
-                "user" if self.get_user().is_some() => continue,
-                "database" if self.get_dbname().is_some() => continue,
+                "user" if self.user_is_set() => continue,
+                "database" if self.db_is_set() => continue,
                 "options" => {
                     if let Some(options) = filtered_options(v) {
-                        self.options(&options);
+                        self.set_param(k, &options);
                     }
                 }
                 "user" | "database" | "application_name" | "replication" => {

--- a/proxy/src/compute.rs
+++ b/proxy/src/compute.rs
@@ -136,6 +136,9 @@ impl ConnCfg {
         params: &StartupMessageParams,
         arbitrary_params: bool,
     ) {
+        if !arbitrary_params {
+            self.set_param("client_encoding", "UTF8");
+        }
         for (k, v) in params.iter() {
             match k {
                 // Only set `user` if it's not present in the config.

--- a/proxy/src/compute.rs
+++ b/proxy/src/compute.rs
@@ -131,9 +131,11 @@ impl ConnCfg {
     }
 
     /// Apply startup message params to the connection config.
-    pub(crate) fn set_startup_params(&mut self, params: &StartupMessageParams) {
-        let arbitrary_params = false;
-
+    pub(crate) fn set_startup_params(
+        &mut self,
+        params: &StartupMessageParams,
+        arbitrary_params: bool,
+    ) {
         for (k, v) in params.iter() {
             match k {
                 // Only set `user` if it's not present in the config.
@@ -426,7 +428,7 @@ mod tests {
         let params = "project = foo";
         assert_eq!(filtered_options(params).as_deref(), Some("project = foo"));
 
-        let params = "project = foo neon_endpoint_type:read_write   neon_lsn:0/2";
+        let params = "project = foo neon_endpoint_type:read_write   neon_lsn:0/2 neon_proxy_params_compat:true";
         assert_eq!(filtered_options(params).as_deref(), Some("project = foo"));
     }
 }

--- a/proxy/src/compute.rs
+++ b/proxy/src/compute.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use futures::{FutureExt, TryFutureExt};
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
+use postgres_client::config::ReplicationMode;
 use postgres_client::tls::MakeTlsConnect;
 use postgres_client::{CancelToken, RawConnection};
 use postgres_protocol::message::backend::NoticeResponseBody;
@@ -132,48 +133,54 @@ impl ConnCfg {
 
     /// Apply startup message params to the connection config.
     pub(crate) fn set_startup_params(&mut self, params: &StartupMessageParams) {
-        // Only set `user` if it's not present in the config.
-        // Console redirect auth flow takes username from the console's response.
-        if let (None, Some(user)) = (self.get_user(), params.get("user")) {
-            self.user(user);
-        }
-
-        // Only set `dbname` if it's not present in the config.
-        // Console redirect auth flow takes dbname from the console's response.
-        if let (None, Some(dbname)) = (self.get_dbname(), params.get("database")) {
-            self.dbname(dbname);
-        }
-
-        // Don't add `options` if they were only used for specifying a project.
-        // Connection pools don't support `options`, because they affect backend startup.
-        if let Some(options) = filtered_options(params) {
-            self.options(&options);
-        }
-
-        if let Some(app_name) = params.get("application_name") {
-            self.application_name(app_name);
-        }
-
-        // TODO: This is especially ugly...
-        if let Some(replication) = params.get("replication") {
-            use postgres_client::config::ReplicationMode;
-            match replication {
-                "true" | "on" | "yes" | "1" => {
-                    self.replication_mode(ReplicationMode::Physical);
+        let arbitrary_params = false;
+        for (k, v) in params.iter() {
+            match k {
+                // Only set `user` if it's not present in the config.
+                // Console redirect auth flow takes username from the console's response.
+                "user" => {
+                    if self.get_user().is_none() {
+                        self.user(v);
+                    }
                 }
+                // Only set `dbname` if it's not present in the config.
+                // Console redirect auth flow takes dbname from the console's response.
                 "database" => {
-                    self.replication_mode(ReplicationMode::Logical);
+                    if self.get_dbname().is_none() {
+                        self.user(v);
+                    }
                 }
-                _other => {}
+                "options" => {
+                    if let Some(options) = filtered_options(v) {
+                        self.options(&options);
+                    }
+                }
+                "application_name" => {
+                    self.application_name(v);
+                }
+                "replication" => match v {
+                    // TODO: This is especially ugly...
+                    "true" | "on" | "yes" | "1" => {
+                        self.replication_mode(ReplicationMode::Physical);
+                    }
+                    "database" => {
+                        self.replication_mode(ReplicationMode::Logical);
+                    }
+                    _other => {}
+                },
+
+                // TODO: extend the list of the forwarded startup parameters.
+                // Currently, tokio-postgres doesn't allow us to pass
+                // arbitrary parameters, but the ones above are a good start.
+                //
+                // This and the reverse params problem can be better addressed
+                // in a bespoke connection machinery (a new library for that sake).
+                _k if arbitrary_params => {
+                    // self.set_param(k, v)
+                }
+                _ => {}
             }
         }
-
-        // TODO: extend the list of the forwarded startup parameters.
-        // Currently, tokio-postgres doesn't allow us to pass
-        // arbitrary parameters, but the ones above are a good start.
-        //
-        // This and the reverse params problem can be better addressed
-        // in a bespoke connection machinery (a new library for that sake).
     }
 }
 
@@ -347,10 +354,9 @@ impl ConnCfg {
 }
 
 /// Retrieve `options` from a startup message, dropping all proxy-secific flags.
-fn filtered_options(params: &StartupMessageParams) -> Option<String> {
+fn filtered_options(options: &str) -> Option<String> {
     #[allow(unstable_name_collisions)]
-    let options: String = params
-        .options_raw()?
+    let options: String = StartupMessageParams::parse_options_raw(options)
         .filter(|opt| parse_endpoint_param(opt).is_none() && neon_option(opt).is_none())
         .intersperse(" ") // TODO: use impl from std once it's stabilized
         .collect();
@@ -427,27 +433,24 @@ mod tests {
     #[test]
     fn test_filtered_options() {
         // Empty options is unlikely to be useful anyway.
-        let params = StartupMessageParams::new([("options", "")]);
-        assert_eq!(filtered_options(&params), None);
+        let params = "";
+        assert_eq!(filtered_options(params), None);
 
         // It's likely that clients will only use options to specify endpoint/project.
-        let params = StartupMessageParams::new([("options", "project=foo")]);
-        assert_eq!(filtered_options(&params), None);
+        let params = "project=foo";
+        assert_eq!(filtered_options(params), None);
 
         // Same, because unescaped whitespaces are no-op.
-        let params = StartupMessageParams::new([("options", " project=foo ")]);
-        assert_eq!(filtered_options(&params).as_deref(), None);
+        let params = " project=foo ";
+        assert_eq!(filtered_options(params).as_deref(), None);
 
-        let params = StartupMessageParams::new([("options", r"\  project=foo \ ")]);
-        assert_eq!(filtered_options(&params).as_deref(), Some(r"\  \ "));
+        let params = r"\  project=foo \ ";
+        assert_eq!(filtered_options(params).as_deref(), Some(r"\  \ "));
 
-        let params = StartupMessageParams::new([("options", "project = foo")]);
-        assert_eq!(filtered_options(&params).as_deref(), Some("project = foo"));
+        let params = "project = foo";
+        assert_eq!(filtered_options(params).as_deref(), Some("project = foo"));
 
-        let params = StartupMessageParams::new([(
-            "options",
-            "project = foo neon_endpoint_type:read_write   neon_lsn:0/2",
-        )]);
-        assert_eq!(filtered_options(&params).as_deref(), Some("project = foo"));
+        let params = "project = foo neon_endpoint_type:read_write   neon_lsn:0/2";
+        assert_eq!(filtered_options(params).as_deref(), Some("project = foo"));
     }
 }

--- a/proxy/src/console_redirect_proxy.rs
+++ b/proxy/src/console_redirect_proxy.rs
@@ -206,6 +206,7 @@ pub(crate) async fn handle_client<S: AsyncRead + AsyncWrite + Unpin>(
     let mut node = connect_to_compute(
         ctx,
         &TcpMechanism {
+            params_compat: true,
             params: &params,
             locks: &config.connect_compute_locks,
         },

--- a/proxy/src/proxy/connect_compute.rs
+++ b/proxy/src/proxy/connect_compute.rs
@@ -66,6 +66,8 @@ pub(crate) trait ComputeConnectBackend {
 }
 
 pub(crate) struct TcpMechanism<'a> {
+    pub(crate) params_compat: bool,
+
     /// KV-dictionary with PostgreSQL connection params.
     pub(crate) params: &'a StartupMessageParams,
 
@@ -92,7 +94,7 @@ impl ConnectMechanism for TcpMechanism<'_> {
     }
 
     fn update_connect_config(&self, config: &mut compute::ConnCfg) {
-        config.set_startup_params(self.params);
+        config.set_startup_params(self.params, self.params_compat);
     }
 }
 

--- a/proxy/src/proxy/mod.rs
+++ b/proxy/src/proxy/mod.rs
@@ -436,11 +436,15 @@ impl NeonOptions {
     }
 
     pub(crate) fn is_ephemeral(&self) -> bool {
+        fn parameter_is_not_ephemeral(p: &str) -> bool {
+            p == "proxy_params_compat"
+        }
+
         self.0
             .iter()
-            .filter(|(k, _)| k != "proxy_params_compat")
+            .filter(|(k, _)| !parameter_is_not_ephemeral(k))
             .count()
-            == 0
+            > 0
     }
 
     fn parse_from_iter<'a>(options: impl Iterator<Item = &'a str>) -> Self {

--- a/proxy/src/proxy/tests/mitm.rs
+++ b/proxy/src/proxy/tests/mitm.rs
@@ -55,7 +55,7 @@ async fn proxy_mitm(
 
         // give the end_server the startup parameters
         let mut buf = BytesMut::new();
-        frontend::startup_message_cstr(
+        frontend::startup_message(
             &postgres_protocol::message::frontend::StartupMessageParams {
                 params: startup.params.into(),
             },

--- a/proxy/src/proxy/tests/mitm.rs
+++ b/proxy/src/proxy/tests/mitm.rs
@@ -55,7 +55,13 @@ async fn proxy_mitm(
 
         // give the end_server the startup parameters
         let mut buf = BytesMut::new();
-        frontend::startup_message(startup.iter(), &mut buf).unwrap();
+        frontend::startup_message_cstr(
+            &postgres_protocol::message::frontend::StartupMessageParams {
+                params: startup.params.into(),
+            },
+            &mut buf,
+        )
+        .unwrap();
         end_server.send(buf.freeze()).await.unwrap();
 
         // proxy messages between end_client and end_server

--- a/proxy/src/proxy/tests/mod.rs
+++ b/proxy/src/proxy/tests/mod.rs
@@ -252,7 +252,7 @@ async fn handshake_raw() -> anyhow::Result<()> {
     let _conn = postgres_client::Config::new("test".to_owned(), 5432)
         .user("john_doe")
         .dbname("earth")
-        .options("project=generic-project-name")
+        .set_param("options", "project=generic-project-name")
         .ssl_mode(SslMode::Prefer)
         .connect_raw(server, NoTls)
         .await?;

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -309,10 +309,13 @@ impl PoolingBackend {
             .config
             .user(&conn_info.user_info.user)
             .dbname(&conn_info.dbname)
-            .options(&format!(
-                "-c pg_session_jwt.jwk={}",
-                serde_json::to_string(&jwk).expect("serializing jwk to json should not fail")
-            ));
+            .set_param(
+                "options",
+                &format!(
+                    "-c pg_session_jwt.jwk={}",
+                    serde_json::to_string(&jwk).expect("serializing jwk to json should not fail")
+                ),
+            );
 
         let pause = ctx.latency_timer_pause(crate::metrics::Waiting::Compute);
         let (client, connection) = config.connect(postgres_client::NoTls).await?;

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -269,7 +269,7 @@ class PgProtocol:
             for match in re.finditer(r"-c(\w*)=(\w*)", options):
                 key = match.group(1)
                 val = match.group(2)
-                if "server_options" in conn_options:
+                if "server_settings" in conn_options:
                     conn_options["server_settings"].update({key: val})
                 else:
                     conn_options["server_settings"] = {key: val}

--- a/test_runner/regress/test_proxy.py
+++ b/test_runner/regress/test_proxy.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import closing
 import json
 import subprocess
 import time
 import urllib.parse
+from contextlib import closing
 from typing import TYPE_CHECKING
 
 import psycopg2

--- a/test_runner/regress/test_proxy.py
+++ b/test_runner/regress/test_proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import closing
 import json
 import subprocess
 import time
@@ -129,6 +130,24 @@ def test_proxy_options(static_proxy: NeonProxy, option_name: str):
     options = "-c proxytest.foo=\\ str"
     out = static_proxy.safe_psql("show proxytest.foo", options=options)
     assert out[0][0] == " str"
+
+
+@pytest.mark.asyncio
+async def test_proxy_arbitrary_params(static_proxy: NeonProxy):
+    with closing(
+        await static_proxy.connect_async(server_settings={"IntervalStyle": "iso_8601"})
+    ) as conn:
+        out = await conn.fetchval("select to_json('0 seconds'::interval)")
+        assert out == '"00:00:00"'
+
+    options = "neon_proxy_params_compat:true"
+    with closing(
+        await static_proxy.connect_async(
+            server_settings={"IntervalStyle": "iso_8601", "options": options}
+        )
+    ) as conn:
+        out = await conn.fetchval("select to_json('0 seconds'::interval)")
+        assert out == '"PT0S"'
 
 
 def test_auth_errors(static_proxy: NeonProxy):


### PR DESCRIPTION
(stacked on #9990 and #9995)

Partially fixes #1287 with a custom option field to enable the fixed behaviour. This allows us to gradually roll out the fix without silently changing the observed behaviour for our customers.

related to https://github.com/neondatabase/cloud/issues/15284