### PR TITLE
pageserver_api: add skip_serializing_none to TenantConfig

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -327,6 +327,7 @@ impl Default for ShardParameters {
 
 /// An alternative representation of `pageserver::tenant::TenantConf` with
 /// simpler types.
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
 pub struct TenantConfig {
     pub checkpoint_distance: Option<u64>,


### PR DESCRIPTION
## Problem

Storcon currently uses the serde_json-serialized representation of `pageserver_api::models::TenantConf` to represent desired tenant config in storcon db.
 
The same type is also used in API responses.
 
Most often, all fields except `pitr_interval` are `null`, meaning fallback to the `pagesever.toml`'s default tenant config value.


## Summary of changes

Adds the `skip_serializing_none` macro from `serde_with` to `TenantConfig`, which makes serialization code not emit `null` for fields that are `None`.

Fixes #9983