### PR TITLE
storcon: return an error for drain attempts while paused

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5711,7 +5711,7 @@ impl Service {
         }
 
         match node_policy {
-            NodeSchedulingPolicy::Active | NodeSchedulingPolicy::Pause => {
+            NodeSchedulingPolicy::Active => {
                 self.node_configure(node_id, None, Some(NodeSchedulingPolicy::Draining))
                     .await?;
 


### PR DESCRIPTION
## Problem

We currently allow drain operations to proceed while the node policy is paused.

## Summary of changes

Return a precondition failed error in such cases. The orchestrator is updated in https://github.com/neondatabase/infra/pull/2544 to skip drain and fills if the pageserver is paused.

Closes: https://github.com/neondatabase/neon/issues/9907
