### PR TITLE
Do tenant manifest validation with index-part

### DIFF
--- a/storage_scrubber/src/checks.rs
+++ b/storage_scrubber/src/checks.rs
@@ -621,6 +621,8 @@ pub(crate) async fn list_tenant_manifests(
         .map(|(g, obj)| (*g, obj.clone()))
         .unwrap();
 
+    manifests.retain(|(gen, _obj)| gen != &latest_generation);
+
     let manifest_bytes =
         match download_object_with_retries(remote_client, &latest_listing_object.key).await {
             Ok(bytes) => bytes,
@@ -646,7 +648,7 @@ pub(crate) async fn list_tenant_manifests(
                     manifest,
                     listing_object: latest_listing_object,
                 }),
-                manifests: vec![],
+                manifests,
             });
         }
         Err(parse_error) => errors.push((

--- a/storage_scrubber/src/pageserver_physical_gc.rs
+++ b/storage_scrubber/src/pageserver_physical_gc.rs
@@ -684,9 +684,7 @@ fn validate_index_part_with_offloaded(
             ));
         }
     } else {
-        warnings.push(format!(
-            "Timeline offloaded in manifest but not archived in index-part"
-        ));
+        warnings.push("Timeline offloaded in manifest but not archived in index-part".to_string());
     }
     if index_part.metadata.ancestor_timeline() != offloaded.ancestor_timeline_id {
         warnings.push(format!(

--- a/storage_scrubber/src/pageserver_physical_gc.rs
+++ b/storage_scrubber/src/pageserver_physical_gc.rs
@@ -610,7 +610,7 @@ async fn gc_timeline(
             .iter()
             .find(|offloaded_timeline| offloaded_timeline.timeline_id == ttid.timeline_id);
         if let Some(offloaded) = maybe_offloaded {
-            let warnings = validate_index_part_with_offloaded(ttid, index_part, offloaded);
+            let warnings = validate_index_part_with_offloaded(index_part, offloaded);
             let warn = if warnings.is_empty() {
                 false
             } else {
@@ -668,7 +668,6 @@ async fn gc_timeline(
 }
 
 fn validate_index_part_with_offloaded(
-    ttid: TenantShardTimelineId,
     index_part: &IndexPart,
     offloaded: &OffloadedTimelineManifest,
 ) -> Vec<String> {


### PR DESCRIPTION
This adds some validation of invariants that we want to uphold wrt the tenant manifest and `index_part.json`:

* the data the manifest has about a timeline must match with the data in `index_part.json`. It might actually change, e.g. when we do reparenting during detach ancestor, but that requires the timeline to be unoffloaded, i.e. removed from the manifest.
* any timeline mentioned in index part, must, if present, be archived. If we unarchive, we first update the tenant manifest to unoffload, and only then update index part. And one needs to archive before offloading. 
* it is legal for timelines to be mentioned in the manifest but have no `index_part`: this is a temporary state visible during deletion of the timeline. if the pageserver crashed, an attach of the tenant will clean the state up.
* it is also legal for offloaded timelines to have an `ancestor_retain_lsn` of None while having an `ancestor_timeline_id`. This is for the to-be-added flattening functionality: the plan is to set former to None if we have flattened a timeline.

follow-up of #9942
part of #8088