### PR TITLE
Set tracing's release_max_level_debug feature globally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ toml = "0.8"
 toml_edit = "0.22"
 tonic = {version = "0.12.3", features = ["tls", "tls-roots"]}
 tower-service = "0.3.2"
-tracing = "0.1"
+tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-error = "0.2"
 tracing-opentelemetry = "0.27"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "fmt", "tracing-log", "std", "env-filter", "json"] }

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -310,7 +310,11 @@ mod tests {
             tracing::error!("foo");
         });
 
-        assert_eq!(counter_vec.with_label_values(&["trace"]).get(), 1);
+        if tracing::level_filters::LevelFilter::TRACE <= tracing::level_filters::STATIC_MAX_LEVEL {
+            assert_eq!(counter_vec.with_label_values(&["trace"]).get(), 1);
+        } else {
+            assert_eq!(counter_vec.with_label_values(&["trace"]).get(), 0);
+        }
         assert_eq!(counter_vec.with_label_values(&["debug"]).get(), 1);
         assert_eq!(counter_vec.with_label_values(&["info"]).get(), 1);
         assert_eq!(counter_vec.with_label_values(&["warn"]).get(), 1);

--- a/workspace_hack/Cargo.toml
+++ b/workspace_hack/Cargo.toml
@@ -90,7 +90,7 @@ tokio-util = { version = "0.7", features = ["codec", "compat", "io", "rt"] }
 toml_edit = { version = "0.22", features = ["serde"] }
 tonic = { version = "0.12", features = ["tls-roots"] }
 tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "util"] }
-tracing = { version = "0.1", features = ["log"] }
+tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 url = { version = "2", features = ["serde"] }
 zerocopy = { version = "0.7", features = ["derive", "simd"] }


### PR DESCRIPTION
Logs at TRACE level are too noisy and bloat the binaries.
Enabling `release_max_level_debug` feature will prevent logging at TRACE level and the code is removed from release builds.