### PR TITLE
page_service: don't count time spent flushing towards smgr latency metrics

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -1271,9 +1271,7 @@ impl SmgrOpTimer {
 
     /// Returns `None`` if this method has already been called, `Some` otherwise.
     fn smgr_op_end(&mut self) -> Option<(Instant, SmgrOpTimerInner)> {
-        let Some(inner) = self.0.take() else {
-            return None;
-        };
+        let inner = self.0.take()?;
 
         let now = Instant::now();
         let elapsed = now - inner.start;

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -1229,9 +1229,20 @@ pub(crate) struct SmgrOpTimer {
     // Optional because not all op types are tracked per-timeline
     per_timeline_latency_histo: Option<Histogram>,
 
+    /// Always Some() except when we transition into [`SmgrOpFlushInProgress`]
+    global_flush_in_progress_micros: Option<IntCounter>,
+    /// See [`Self::global_flush_in_progress_micros`].
+    per_timeline_flush_in_progress_micros: Option<IntCounter>,
+
     start: Instant,
     throttled: Duration,
     op: SmgrQueryType,
+}
+
+pub(crate) struct SmgrOpFlushInProgress {
+    base: Instant,
+    global_micros: IntCounter,
+    per_timeline_micros: IntCounter,
 }
 
 impl SmgrOpTimer {
@@ -1241,11 +1252,20 @@ impl SmgrOpTimer {
         };
         self.throttled += *throttle;
     }
-}
 
-impl Drop for SmgrOpTimer {
-    fn drop(&mut self) {
-        let elapsed = self.start.elapsed();
+    pub(crate) fn observe_smgr_op_completion_and_start_flushing(mut self) -> SmgrOpFlushInProgress {
+        let flush_start = self.smgr_op_end();
+        SmgrOpFlushInProgress {
+            base: flush_start,
+            global_micros: self.global_flush_in_progress_micros.take().unwrap(),
+            per_timeline_micros: self.per_timeline_flush_in_progress_micros.take().unwrap(),
+        }
+    }
+
+    /// Must only call once!
+    fn smgr_op_end(&self) -> Instant {
+        let now = Instant::now();
+        let elapsed = now - self.start;
 
         let elapsed = match elapsed.checked_sub(self.throttled) {
             Some(elapsed) => elapsed,
@@ -1271,6 +1291,46 @@ impl Drop for SmgrOpTimer {
         self.global_latency_histo.observe(elapsed);
         if let Some(per_timeline_getpage_histo) = &self.per_timeline_latency_histo {
             per_timeline_getpage_histo.observe(elapsed);
+        }
+
+        now
+    }
+}
+
+impl Drop for SmgrOpTimer {
+    fn drop(&mut self) {
+        self.smgr_op_end();
+    }
+}
+
+impl SmgrOpFlushInProgress {
+    pub(crate) async fn measure<Fut, O>(mut self, mut fut: Fut) -> O
+    where
+        Fut: std::future::Future<Output = O>,
+    {
+        let mut fut = std::pin::pin!(fut);
+        let mut observe_guard = scopeguard::guard(
+            || {
+                let now = Instant::now();
+                let elapsed = now - self.base;
+                self.global_micros
+                    .inc_by(u64::try_from(elapsed.as_micros()).unwrap());
+                self.per_timeline_micros
+                    .inc_by(u64::try_from(elapsed.as_micros()).unwrap());
+                self.base = now;
+            },
+            |mut observe| {
+                observe();
+            },
+        );
+
+        loop {
+            match tokio::time::timeout(Duration::from_secs(10), &mut fut).await {
+                Ok(v) => return v,
+                Err(_timeout) => {
+                    (&mut *observe_guard)();
+                }
+            }
         }
     }
 }
@@ -1302,6 +1362,8 @@ pub(crate) struct SmgrQueryTimePerTimeline {
     per_timeline_getpage_latency: Histogram,
     global_batch_size: Histogram,
     per_timeline_batch_size: Histogram,
+    global_flush_in_progress_micros: IntCounter,
+    per_timeline_flush_in_progress_micros: IntCounter,
 }
 
 static SMGR_QUERY_STARTED_GLOBAL: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -1464,6 +1526,26 @@ fn set_page_service_config_max_batch_size(conf: &PageServicePipeliningConfig) {
         .set(value.try_into().unwrap());
 }
 
+static PAGE_SERVICE_SMGR_FLUSH_INPROGRESS_MICROS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "pageserver_page_service_pagestream_flush_in_progress_micros",
+        "Counter that sums up the microseconds that a pagestream response was being flushed into the TCP connection. \
+         If the flush is particularly slow, this counter will be updated periodically to make slow flushes \
+         easily discoverable in monitoring. \
+         Hence, this is NOT a completion latency historgram.",
+        &["tenant_id", "shard_id", "timeline_id"],
+    )
+    .expect("failed to define a metric")
+});
+
+static PAGE_SERVICE_SMGR_FLUSH_INPROGRESS_MICROS_GLOBAL: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "pageserver_page_service_pagestream_flush_in_progress_micros_global",
+        "Like pageserver_page_service_pagestream_flush_in_progress_seconds, but instance-wide.",
+    )
+    .expect("failed to define a metric")
+});
+
 impl SmgrQueryTimePerTimeline {
     pub(crate) fn new(tenant_shard_id: &TenantShardId, timeline_id: &TimelineId) -> Self {
         let tenant_id = tenant_shard_id.tenant_id.to_string();
@@ -1504,6 +1586,12 @@ impl SmgrQueryTimePerTimeline {
             .get_metric_with_label_values(&[&tenant_id, &shard_slug, &timeline_id])
             .unwrap();
 
+        let global_flush_in_progress_micros =
+            PAGE_SERVICE_SMGR_FLUSH_INPROGRESS_MICROS_GLOBAL.clone();
+        let per_timeline_flush_in_progress_micros = PAGE_SERVICE_SMGR_FLUSH_INPROGRESS_MICROS
+            .get_metric_with_label_values(&[&tenant_id, &shard_slug, &timeline_id])
+            .unwrap();
+
         Self {
             global_started,
             global_latency,
@@ -1511,6 +1599,8 @@ impl SmgrQueryTimePerTimeline {
             per_timeline_getpage_started,
             global_batch_size,
             per_timeline_batch_size,
+            global_flush_in_progress_micros,
+            per_timeline_flush_in_progress_micros,
         }
     }
     pub(crate) fn start_smgr_op(&self, op: SmgrQueryType, started_at: Instant) -> SmgrOpTimer {
@@ -1529,6 +1619,10 @@ impl SmgrQueryTimePerTimeline {
             start: started_at,
             op,
             throttled: Duration::ZERO,
+            global_flush_in_progress_micros: Some(self.global_flush_in_progress_micros.clone()),
+            per_timeline_flush_in_progress_micros: Some(self
+                .per_timeline_flush_in_progress_micros
+                .clone()),
         }
     }
 
@@ -2773,6 +2867,11 @@ impl TimelineMetrics {
             timeline_id,
         ]);
         let _ = PAGESERVER_TIMELINE_WAL_RECORDS_RECEIVED.remove_label_values(&[
+            tenant_id,
+            shard_id,
+            timeline_id,
+        ]);
+        let _ = PAGE_SERVICE_SMGR_FLUSH_INPROGRESS_MICROS.remove_label_values(&[
             tenant_id,
             shard_id,
             timeline_id,

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -65,7 +65,7 @@ use crate::tenant::timeline::{self, WaitLsnError};
 use crate::tenant::GetTimelineError;
 use crate::tenant::PageReconstructError;
 use crate::tenant::Timeline;
-use crate::{basebackup, timed, timed_after_cancellation};
+use crate::{basebackup, timed_after_cancellation};
 use pageserver_api::key::rel_block_to_key;
 use pageserver_api::reltag::{BlockNumber, RelTag, SlruKind};
 use postgres_ffi::pg_constants::DEFAULTTABLESPACE_OID;

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1076,12 +1076,6 @@ impl PageServerHandler {
 
             // what we want to do
             let flush_fut = pgb_writer.flush();
-            // make log noise if flushing is really slow
-            let flush_fut = timed(
-                flush_fut,
-                "flush pagestream response",
-                Duration::from_secs(60),
-            );
             // metric for how long flushing takes
             let flush_fut = match flushing_timer {
                 Some(flushing_timer) => {

--- a/test_runner/fixtures/metrics.py
+++ b/test_runner/fixtures/metrics.py
@@ -176,6 +176,7 @@ PAGESERVER_PER_TENANT_METRICS: tuple[str, ...] = (
     counter("pageserver_tenant_throttling_wait_usecs_sum"),
     counter("pageserver_tenant_throttling_count"),
     counter("pageserver_timeline_wal_records_received"),
+    counter("pageserver_page_service_pagestream_flush_in_progress_micros"),
     *histogram("pageserver_page_service_batch_size"),
     *PAGESERVER_PER_TENANT_REMOTE_TIMELINE_CLIENT_METRICS,
     # "pageserver_directory_entries_count", -- only used if above a certain threshold


### PR DESCRIPTION
## Problem

In #9962 I changed the smgr metrics to include time spent on flush.

It isn't under our (=storage team's) control how long that flush takes because the client can stop reading requests.

## Summary of changes

Stop the timer as soon as we've buffered up the response in the `pgb_writer`.

Track flush time in a separate metric.