### PR TITLE
fix(pageserver): consider partial compaction layer map in layer check

### DIFF
--- a/pageserver/src/tenant/checks.rs
+++ b/pageserver/src/tenant/checks.rs
@@ -30,7 +30,7 @@ use super::storage_layer::LayerName;
 /// If layer 2 and 4 contain the same single key, this is also a valid layer map.
 ///
 /// However, if a partial compaction is still going on, it is possible that we get a layer map not satisfying the above condition.
-/// Therefore, we fallback to simply check if any of the two delta layers overlap. (See "a slow path...")
+/// Therefore, we fallback to simply check if any of the two delta layers overlap. (See "A slow path...")
 pub fn check_valid_layermap(metadata: &[LayerName]) -> Option<String> {
     let mut lsn_split_point = BTreeSet::new(); // TODO: use a better data structure (range tree / range set?)
     let mut all_delta_layers = Vec::new();

--- a/pageserver/src/tenant/checks.rs
+++ b/pageserver/src/tenant/checks.rs
@@ -47,25 +47,26 @@ pub fn check_valid_layermap(metadata: &[LayerName]) -> Option<String> {
         }
     }
     for (idx, layer) in all_delta_layers.iter().enumerate() {
-        if layer.key_range.start.next() != layer.key_range.end {
-            let lsn_range = layer.lsn_range.clone();
-            let intersects = lsn_split_point.range(lsn_range).collect_vec();
-            if intersects.len() > 1 {
-                // A slow path to check if the layer intersects with any other delta layer.
-                for (other_idx, other_layer) in all_delta_layers.iter().enumerate() {
-                    if other_idx == idx {
-                        // do not check self intersects with self
-                        continue;
-                    }
-                    if overlaps_with(&layer.lsn_range, &other_layer.lsn_range)
-                        && overlaps_with(&layer.key_range, &other_layer.key_range)
-                    {
-                        let err = format!(
+        if layer.key_range.start.next() == layer.key_range.end {
+            continue;
+        }
+        let lsn_range = layer.lsn_range.clone();
+        let intersects = lsn_split_point.range(lsn_range).collect_vec();
+        if intersects.len() > 1 {
+            // A slow path to check if the layer intersects with any other delta layer.
+            for (other_idx, other_layer) in all_delta_layers.iter().enumerate() {
+                if other_idx == idx {
+                    // do not check self intersects with self
+                    continue;
+                }
+                if overlaps_with(&layer.lsn_range, &other_layer.lsn_range)
+                    && overlaps_with(&layer.key_range, &other_layer.key_range)
+                {
+                    let err = format!(
                             "layer violates the layer map LSN split assumption: layer {} intersects with layer {}",
                             layer, other_layer
                         );
-                        return Some(err);
-                    }
+                    return Some(err);
                 }
             }
         }

--- a/pageserver/src/tenant/checks.rs
+++ b/pageserver/src/tenant/checks.rs
@@ -30,53 +30,43 @@ use super::storage_layer::LayerName;
 /// If layer 2 and 4 contain the same single key, this is also a valid layer map.
 ///
 /// However, if a partial compaction is still going on, it is possible that we get a layer map not satisfying the above condition.
-/// Therefore, we fallback to simply check if any of the two delta layers overlap.
+/// Therefore, we fallback to simply check if any of the two delta layers overlap. (See "a slow path...")
 pub fn check_valid_layermap(metadata: &[LayerName]) -> Option<String> {
     let mut lsn_split_point = BTreeSet::new(); // TODO: use a better data structure (range tree / range set?)
-    let mut all_delta_layers = Vec::new();
-    for name in metadata {
-        if let LayerName::Delta(layer) = name {
-            if layer.key_range.start.next() != layer.key_range.end {
-                all_delta_layers.push(layer.clone());
-            }
-        }
-    }
-    for layer in &all_delta_layers {
-        let lsn_range = &layer.lsn_range;
-        lsn_split_point.insert(lsn_range.start);
-        lsn_split_point.insert(lsn_range.end);
-    }
-    for layer in &all_delta_layers {
-        let lsn_range = layer.lsn_range.clone();
-        let intersects = lsn_split_point.range(lsn_range).collect_vec();
-        if intersects.len() > 1 {
-            return check_valid_layermap_slowpath(metadata);
-        }
-    }
-    None
-}
-
-/// A slow path check for the layer map. Do a one-by-one check for all delta layers and see if any of them overlaps.
-/// Overlapping delta layer would cause wrong results in both compaction and the normal read path.
-fn check_valid_layermap_slowpath(metadata: &[LayerName]) -> Option<String> {
     let mut all_delta_layers = Vec::new();
     for name in metadata {
         if let LayerName::Delta(layer) = name {
             all_delta_layers.push(layer.clone());
         }
     }
-    for a in 0..all_delta_layers.len() {
-        for b in 0..a {
-            let layer_a = &all_delta_layers[a];
-            let layer_b = &all_delta_layers[b];
-            if overlaps_with(&layer_a.lsn_range, &layer_b.lsn_range)
-                && overlaps_with(&layer_a.key_range, &layer_b.key_range)
-            {
-                let err = format!(
-                    "layer violates the layer map LSN split assumption: layer {} intersects with layer {}",
-                    layer_a, layer_b
-                );
-                return Some(err);
+    for layer in &all_delta_layers {
+        if layer.key_range.start.next() != layer.key_range.end {
+            let lsn_range = &layer.lsn_range;
+            lsn_split_point.insert(lsn_range.start);
+            lsn_split_point.insert(lsn_range.end);
+        }
+    }
+    for (idx, layer) in all_delta_layers.iter().enumerate() {
+        if layer.key_range.start.next() != layer.key_range.end {
+            let lsn_range = layer.lsn_range.clone();
+            let intersects = lsn_split_point.range(lsn_range).collect_vec();
+            if intersects.len() > 1 {
+                // A slow path to check if the layer intersects with any other delta layer.
+                for (other_idx, other_layer) in all_delta_layers.iter().enumerate() {
+                    if other_idx == idx {
+                        // do not check self intersects with self
+                        continue;
+                    }
+                    if overlaps_with(&layer.lsn_range, &other_layer.lsn_range)
+                        && overlaps_with(&layer.key_range, &other_layer.key_range)
+                    {
+                        let err = format!(
+                            "layer violates the layer map LSN split assumption: layer {} intersects with layer {}",
+                            layer, other_layer
+                        );
+                        return Some(err);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

In https://github.com/neondatabase/neon/pull/9897 we temporarily disabled the layer valid check because the current one only considers the end result of all compaction algorithms, but partial gc-compaction would temporarily produce an "invalid" layer map.

part of https://github.com/neondatabase/neon/issues/9114

## Summary of changes

Allow LSN splits to overlap in the slow path check. Currently, the valid check is only used in storage scrubber (background job) and during gc-compaction (without taking layer lock). Therefore, it's fine for such checks to be a little bit inefficient but more accurate.