### PR TITLE
proxy: stub the VPC config cache and invalidation code

### DIFF
--- a/proxy/src/control_plane/messages.rs
+++ b/proxy/src/control_plane/messages.rs
@@ -238,6 +238,8 @@ pub(crate) struct GetEndpointAccessControl {
     pub(crate) allowed_ips: Option<Vec<IpPattern>>,
     pub(crate) project_id: Option<ProjectIdInt>,
     pub(crate) allowed_vpc_endpoint_ids: Option<Vec<EndpointIdInt>>,
+    pub(crate) block_public_connections: Option<bool>,
+    pub(crate) block_vpc_connections: Option<bool>,
 }
 
 // Manually implement debug to omit sensitive info.

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -556,6 +556,8 @@ pub enum RedisEventsCount {
     CancelSession,
     PasswordUpdate,
     AllowedIpsUpdate,
+    AllowedVpcEndpointIdsUpdate,
+    BlockPublicOrVpcAccessUpdate,
 }
 
 pub struct ThreadPoolWorkers(usize);


### PR DESCRIPTION
This commit defines cache entries for projects:

- the two "block public or VPC connections" booleans. This is implemented (for now) as a pair of `bools` because they are always delivered together from the project settings in cplane. The corresponding fields in the `/get_endpoint_access_control` response are `block_public_connections` and `block_vpc_connections`.

  We will use the redis broadcast channel `/block_public_or_vpc_access_updated`` for this. It will be notified when the **project settings** are changed in the control plane.

- the VPC endpoint ID list. The corresponding field in the `/get_endpoint_access_control` response is `allowed_vpc_endpoint_ids`.

  We will use the redis broadcast channel `/allowed_vpc_endpoint_ids_updated` for this. It will be notified when the **VPC config service** detects a configuration change for the project.

Informs https://github.com/neondatabase/cloud/issues/21426.