### PR TITLE
Remove `--verbore` argument from `storage_scrubber` command

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -4634,8 +4634,6 @@ class StorageScrubber:
         if timeline_lsns is not None:
             args.append("--timeline-lsns")
             args.append(json.dumps(timeline_lsns))
-        if node_kind == NodeKind.PAGESERVER:
-            args.append("--verbose")
         stdout = self.scrubber_cli(args, timeout=30, extra_env=extra_env)
 
         try:


### PR DESCRIPTION
## Problem
`storage_scrubber` currently does not support the argument `--verbose`
However, it may be added to the command line in our test scripts
## Summary of changes
This argument is removed