### PR TITLE
pageserver: don't drop multixact slrus on non zero shards

### DIFF
--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1049,16 +1049,18 @@ impl WalIngest {
 
         // Delete all the segments except the last one. The last segment can still
         // contain, possibly partially, valid data.
-        while segment != endsegment {
-            modification
-                .drop_slru_segment(SlruKind::MultiXactMembers, segment as u32, ctx)
-                .await?;
+        if modification.tline.get_shard_identity().is_shard_zero() {
+            while segment != endsegment {
+                modification
+                    .drop_slru_segment(SlruKind::MultiXactMembers, segment as u32, ctx)
+                    .await?;
 
-            /* move to next segment, handling wraparound correctly */
-            if segment == maxsegment {
-                segment = 0;
-            } else {
-                segment += 1;
+                /* move to next segment, handling wraparound correctly */
+                if segment == maxsegment {
+                    segment = 0;
+                } else {
+                    segment += 1;
+                }
             }
         }
 


### PR DESCRIPTION
## Problem

We get slru truncation commands on non-zero shards.
Compaction will drop the slru dir keys and ingest will fail when receiving such records.
https://github.com/neondatabase/neon/pull/10080 fixed it for clog, but not for multixact.

## Summary of changes

Only truncate multixact slrus on shard zero. I audited the rest of the ingest code and it looks
fine from this pov.