### PR TITLE
Increase neon_local http client to compute timeout in reconfigure.

### DIFF
--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -810,7 +810,7 @@ impl Endpoint {
         }
 
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(120))
             .build()
             .unwrap();
         let response = client


### PR DESCRIPTION
Seems like 30s sometimes not enough when CI runners are overloaded, causing pull_timeline flakiness.

ref https://github.com/neondatabase/neon/issues/9731#issuecomment-2535946443
