### PR TITLE
storcon: add safekeeper list API

### DIFF
--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -339,16 +339,6 @@ pub enum PlacementPolicy {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TenantShardMigrateResponse {}
 
-#[derive(Serialize, Deserialize)]
-pub struct SafekeeperDescribeResponse {
-    pub id: NodeId,
-    pub region_id: String,
-    pub availability_zone_id: String,
-    pub version: u64,
-    pub listen_http_addr: String,
-    pub listen_http_port: u16,
-}
-
 /// Metadata health record posted from scrubber.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetadataHealthRecord {

--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -339,6 +339,16 @@ pub enum PlacementPolicy {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TenantShardMigrateResponse {}
 
+#[derive(Serialize, Deserialize)]
+pub struct SafekeeperDescribeResponse {
+    pub id: NodeId,
+    pub region_id: String,
+    pub availability_zone_id: String,
+    pub version: u64,
+    pub listen_http_addr: String,
+    pub listen_http_port: u16,
+}
+
 /// Metadata health record posted from scrubber.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetadataHealthRecord {

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -1196,7 +1196,7 @@ impl From<ReconcileError> for ApiError {
 ///
 /// Not used by anything except manual testing.
 async fn handle_get_safekeeper(req: Request<Body>) -> Result<Response<Body>, ApiError> {
-    check_permissions(&req, Scope::Admin)?;
+    check_permissions(&req, Scope::Infra)?;
 
     let id = parse_request_param::<i64>(&req, "id")?;
 

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -869,12 +869,7 @@ async fn handle_safekeeper_list(req: Request<Body>) -> Result<Response<Body>, Ap
 
     let state = get_state(&req);
     let safekeepers = state.service.safekeepers_list().await?;
-    let api_sks = safekeepers
-        .into_iter()
-        .map(|n| n.describe())
-        .collect::<Vec<_>>();
-
-    json_response(StatusCode::OK, api_sks)
+    json_response(StatusCode::OK, safekeepers)
 }
 
 async fn handle_metadata_health_update(req: Request<Body>) -> Result<Response<Body>, ApiError> {

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -1219,7 +1219,7 @@ async fn handle_get_safekeeper(req: Request<Body>) -> Result<Response<Body>, Api
     match res {
         Ok(b) => json_response(StatusCode::OK, b),
         Err(crate::persistence::DatabaseError::Query(diesel::result::Error::NotFound)) => {
-            Err(ApiError::NotFound("unknown instance_id".into()))
+            Err(ApiError::NotFound("unknown instance id".into()))
         }
         Err(other) => Err(other.into()),
     }

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -11,7 +11,6 @@ use diesel::Connection;
 use itertools::Itertools;
 use pageserver_api::controller_api::AvailabilityZone;
 use pageserver_api::controller_api::MetadataHealthRecord;
-use pageserver_api::controller_api::SafekeeperDescribeResponse;
 use pageserver_api::controller_api::ShardSchedulingPolicy;
 use pageserver_api::controller_api::{NodeSchedulingPolicy, PlacementPolicy};
 use pageserver_api::models::TenantConfig;
@@ -1240,16 +1239,6 @@ impl SafekeeperPersistence {
             active: self.active,
             http_port: self.http_port,
             availability_zone_id: &self.availability_zone_id,
-        }
-    }
-    pub(crate) fn describe(&self) -> SafekeeperDescribeResponse {
-        SafekeeperDescribeResponse {
-            id: NodeId(self.id as u64),
-            region_id: self.region_id.clone(),
-            availability_zone_id: self.availability_zone_id.clone(),
-            version: self.version as u64,
-            listen_http_addr: self.host.clone(),
-            listen_http_port: self.http_port as u16,
         }
     }
 }

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1222,7 +1222,6 @@ pub(crate) struct SafekeeperPersistence {
     /// Zero or negative is not really expected.
     /// Otherwise the number from `release-$(number_of_commits_on_branch)` tag.
     pub(crate) version: i64,
-    pub(crate) instance_id: String,
     pub(crate) host: String,
     pub(crate) port: i32,
     pub(crate) active: bool,

--- a/storage_controller/src/schema.rs
+++ b/storage_controller/src/schema.rs
@@ -30,6 +30,19 @@ diesel::table! {
 }
 
 diesel::table! {
+    safekeepers (id) {
+        id -> Int8,
+        region_id -> Text,
+        version -> Int8,
+        host -> Text,
+        port -> Int4,
+        active -> Bool,
+        http_port -> Int4,
+        availability_zone_id -> Text,
+    }
+}
+
+diesel::table! {
     tenant_shards (tenant_id, shard_number, shard_count) {
         tenant_id -> Varchar,
         shard_number -> Int4,
@@ -45,18 +58,10 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(controllers, metadata_health, nodes, tenant_shards,);
-
-diesel::table! {
-    safekeepers {
-        id -> Int8,
-        region_id -> Text,
-        version -> Int8,
-        instance_id -> Text,
-        host -> Text,
-        port -> Int4,
-        active -> Bool,
-        http_port -> Int4,
-        availability_zone_id -> Text,
-    }
-}
+diesel::allow_tables_to_appear_in_same_query!(
+    controllers,
+    metadata_health,
+    nodes,
+    safekeepers,
+    tenant_shards,
+);

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7113,6 +7113,12 @@ impl Service {
         global_observed
     }
 
+    pub(crate) async fn safekeepers_list(
+        &self,
+    ) -> Result<Vec<crate::persistence::SafekeeperPersistence>, DatabaseError> {
+        self.persistence.list_safekeepers().await
+    }
+
     pub(crate) async fn get_safekeeper(
         &self,
         id: i64,

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2314,15 +2314,25 @@ class NeonStorageController(MetricsGetter, LogUtils):
             json=body,
         )
 
-    def get_safekeeper(self, id: int) -> dict[str, Any] | None:
+    def get_safekeeper(self, id: int) -> dict[str, Any]:
+        response = self.request(
+            "GET",
+            f"{self.api}/control/v1/safekeeper/{id}",
+            headers=self.headers(TokenScope.ADMIN),
+        )
+        json = response.json()
+        assert isinstance(json, dict)
+        return json
+
+    def get_safekeepers(self) -> list[dict[str, Any]] | None:
         try:
             response = self.request(
                 "GET",
-                f"{self.api}/control/v1/safekeeper/{id}",
+                f"{self.api}/control/v1/safekeeper",
                 headers=self.headers(TokenScope.ADMIN),
             )
             json = response.json()
-            assert isinstance(json, dict)
+            assert isinstance(json, list)
             return json
         except StorageControllerApiException as e:
             if e.status_code == 404:

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2314,30 +2314,30 @@ class NeonStorageController(MetricsGetter, LogUtils):
             json=body,
         )
 
-    def get_safekeeper(self, id: int) -> dict[str, Any]:
-        response = self.request(
-            "GET",
-            f"{self.api}/control/v1/safekeeper/{id}",
-            headers=self.headers(TokenScope.ADMIN),
-        )
-        json = response.json()
-        assert isinstance(json, dict)
-        return json
-
-    def get_safekeepers(self) -> list[dict[str, Any]] | None:
+    def get_safekeeper(self, id: int) -> dict[str, Any] | None:
         try:
             response = self.request(
                 "GET",
-                f"{self.api}/control/v1/safekeeper",
+                f"{self.api}/control/v1/safekeeper/{id}",
                 headers=self.headers(TokenScope.ADMIN),
             )
             json = response.json()
-            assert isinstance(json, list)
+            assert isinstance(json, dict)
             return json
         except StorageControllerApiException as e:
             if e.status_code == 404:
                 return None
             raise e
+
+    def get_safekeepers(self) -> list[dict[str, Any]]:
+        response = self.request(
+            "GET",
+            f"{self.api}/control/v1/safekeeper",
+            headers=self.headers(TokenScope.ADMIN),
+        )
+        json = response.json()
+        assert isinstance(json, list)
+        return json
 
     def set_preferred_azs(self, preferred_azs: dict[TenantShardId, str]) -> list[TenantShardId]:
         response = self.request(

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2953,6 +2953,8 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
 
     assert target.get_safekeeper(fake_id) is None
 
+    assert len(target.get_safekeepers()) == 0
+
     body = {
         "active": True,
         "id": fake_id,

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2972,6 +2972,7 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
 
     inserted = target.get_safekeeper(fake_id)
     assert inserted is not None
+    assert target.get_safekeepers() == [inserted]
     assert eq_safekeeper_records(body, inserted)
 
     # error out if pk is changed (unexpected)
@@ -2983,6 +2984,7 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
     assert exc.value.status_code == 400
 
     inserted_again = target.get_safekeeper(fake_id)
+    assert target.get_safekeepers() == [inserted_again]
     assert inserted_again is not None
     assert eq_safekeeper_records(inserted, inserted_again)
 
@@ -2991,6 +2993,7 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
     body["version"] += 1
     target.on_safekeeper_deploy(fake_id, body)
     inserted_now = target.get_safekeeper(fake_id)
+    assert target.get_safekeepers() == [inserted_now]
     assert inserted_now is not None
 
     assert eq_safekeeper_records(body, inserted_now)


### PR DESCRIPTION
This adds an API to the storage controller to list safekeepers registered to it.

This PR does a `diesel print-schema > storage_controller/src/schema.rs` because of an inconsistency between up.sql and schema.rs, introduced by [this](https://github.com/neondatabase/neon/pull/8879/commits/2c142f14f7ba9bd9a178ae96723d196330eb34ba) commit, so there is some updates of `schema.rs` due to that. As a followup to this, we should maybe think about running `diesel print-schema` in CI.

Part of #9981