### PR TITLE
test_prefetch: reduce timeout to default 5m from 10m

### DIFF
--- a/test_runner/regress/test_prefetch_buffer_resize.py
+++ b/test_runner/regress/test_prefetch_buffer_resize.py
@@ -7,7 +7,6 @@ from fixtures.neon_fixtures import NeonEnvBuilder
 
 
 @pytest.mark.parametrize("shard_count", [None, 4])
-@pytest.mark.timeout(600)
 def test_prefetch(neon_env_builder: NeonEnvBuilder, shard_count: int | None):
     if shard_count is not None:
         neon_env_builder.num_pageservers = shard_count


### PR DESCRIPTION
## Problem

`test_prefetch` is flaky (https://github.com/neondatabase/neon/issues/9961), but if it passes, the run time is less than 30 seconds — we don't need an extended timeout for it.

## Summary of changes
- Remove extended test timeout for `test_prefetch`
