### PR TITLE
scrubber: perform manifest check with etag and refactors

### DIFF
--- a/libs/remote_storage/src/azure_blob.rs
+++ b/libs/remote_storage/src/azure_blob.rs
@@ -385,6 +385,7 @@ impl RemoteStorage for AzureBlobStorage {
                     .map(|k| ListingObject{
                         key: self.name_to_relative_path(&k.name),
                         last_modified: k.properties.last_modified.into(),
+                        etag: k.properties.etag.clone(),
                         size: k.properties.content_length,
                     }
                 );
@@ -450,6 +451,7 @@ impl RemoteStorage for AzureBlobStorage {
         Ok(ListingObject {
             key: key.to_owned(),
             last_modified: SystemTime::from(properties.last_modified),
+            etag: properties.etag,
             size: properties.content_length,
         })
     }

--- a/libs/remote_storage/src/lib.rs
+++ b/libs/remote_storage/src/lib.rs
@@ -166,6 +166,7 @@ pub enum ListingMode {
 pub struct ListingObject {
     pub key: RemotePath,
     pub last_modified: SystemTime,
+    pub etag: Etag,
     pub size: u64,
 }
 

--- a/libs/remote_storage/src/local_fs.rs
+++ b/libs/remote_storage/src/local_fs.rs
@@ -372,6 +372,7 @@ impl RemoteStorage for LocalFs {
                 objects.push(ListingObject {
                     key: key.clone(),
                     last_modified: metadata.modified()?,
+                    etag: mock_etag(&metadata),
                     size: metadata.len(),
                 });
             }
@@ -414,6 +415,7 @@ impl RemoteStorage for LocalFs {
                         result.keys.push(ListingObject {
                             key: RemotePath::from_string(&relative_key).unwrap(),
                             last_modified: object.last_modified,
+                            etag: object.etag,
                             size: object.size,
                         });
                     }
@@ -457,6 +459,7 @@ impl RemoteStorage for LocalFs {
         Ok(ListingObject {
             key: key.clone(),
             last_modified: metadata.modified()?,
+            etag: mock_etag(&metadata),
             size: metadata.len(),
         })
     }

--- a/storage_scrubber/src/checks.rs
+++ b/storage_scrubber/src/checks.rs
@@ -538,6 +538,16 @@ pub(crate) struct RemoteTenantManifestInfo {
     pub(crate) listing_object: ListingObject,
 }
 
+impl RemoteTenantManifestInfo {
+    /// Whether the two objects point to the same remote storage object or not
+    ///
+    /// This compares last modified time and etag, which only match if the content is the same.
+    /// It is cheaper than doing an equality check over the content.
+    pub(crate) fn eq_fast(&self, rhs: &Self) -> bool {
+        self.generation == rhs.generation && self.listing_object == rhs.listing_object
+    }
+}
+
 pub(crate) enum ListTenantManifestResult {
     WithErrors {
         errors: Vec<(String, String)>,

--- a/storage_scrubber/src/pageserver_physical_gc.rs
+++ b/storage_scrubber/src/pageserver_physical_gc.rs
@@ -630,13 +630,7 @@ async fn gc_timeline(
                         manifests: _,
                     } => {
                         if let Some(new_latest_gen) = latest_generation {
-                            let manifest_changed = (
-                                new_latest_gen.generation,
-                                new_latest_gen.listing_object.last_modified,
-                            ) == (
-                                tenant_manifest_info.generation,
-                                tenant_manifest_info.listing_object.last_modified,
-                            );
+                            let manifest_changed = !new_latest_gen.eq_fast(tenant_manifest_info);
                             if manifest_changed {
                                 tracing::debug!(%ttid, "tenant manifest changed since it was loaded, suppressing {} warnings", warnings.len());
                             }

--- a/storage_scrubber/src/pageserver_physical_gc.rs
+++ b/storage_scrubber/src/pageserver_physical_gc.rs
@@ -614,33 +614,17 @@ async fn gc_timeline(
             let warn = if warnings.is_empty() {
                 false
             } else {
-                // Verify that the manifest hasn't changed. If it has, a potential racing change could have been cause for our troubles.
-                match list_tenant_manifests(remote_client, ttid.tenant_shard_id, target).await? {
-                    ListTenantManifestResult::WithErrors {
-                        errors,
-                        unknown_keys: _,
-                    } => {
-                        for (_key, error) in errors {
-                            tracing::warn!(%ttid, "list_tenant_manifests in gc_timeline: {error}");
-                        }
-                        true
-                    }
-                    ListTenantManifestResult::NoErrors {
-                        latest_generation,
-                        manifests: _,
-                    } => {
-                        if let Some(new_latest_gen) = latest_generation {
-                            let manifest_changed = !new_latest_gen.eq_fast(tenant_manifest_info);
-                            if manifest_changed {
-                                tracing::debug!(%ttid, "tenant manifest changed since it was loaded, suppressing {} warnings", warnings.len());
-                            }
-                            manifest_changed
-                        } else {
-                            // The latest generation is gone. This timeline is in the progress of being deleted?
-                            false
-                        }
-                    }
-                }
+                // Verify that the manifest hasn't changed.
+                // If it hasn't, then we have measured at two time points A and C that the manifest
+                // was the same, so we can be sure it was that also at time point B, where A < B < C.
+                manifest_has_changed_on_remote(
+                    remote_client,
+                    target,
+                    ttid,
+                    tenant_manifest_info,
+                    warnings.len(),
+                )
+                .await?
             };
             if warn {
                 for warning in warnings {
@@ -659,6 +643,41 @@ async fn gc_timeline(
     }
 
     Ok(summary)
+}
+
+async fn manifest_has_changed_on_remote(
+    remote_client: &GenericRemoteStorage,
+    target: &RootTarget,
+    ttid: TenantShardTimelineId,
+    tenant_manifest_info: &RemoteTenantManifestInfo,
+    warnings_count: usize,
+) -> anyhow::Result<bool> {
+    match list_tenant_manifests(remote_client, ttid.tenant_shard_id, target).await? {
+        ListTenantManifestResult::WithErrors {
+            errors,
+            unknown_keys: _,
+        } => {
+            for (_key, error) in errors {
+                tracing::warn!(%ttid, "list_tenant_manifests in gc_timeline: {error}");
+            }
+            Ok(true)
+        }
+        ListTenantManifestResult::NoErrors {
+            latest_generation,
+            manifests: _,
+        } => {
+            if let Some(new_latest_gen) = latest_generation {
+                let manifest_changed = !new_latest_gen.eq_fast(tenant_manifest_info);
+                if manifest_changed {
+                    tracing::debug!(%ttid, "tenant manifest changed since it was loaded, suppressing {warnings_count} warnings");
+                }
+                Ok(manifest_changed)
+            } else {
+                // The latest generation is gone. This timeline is in the progress of being deleted?
+                Ok(false)
+            }
+        }
+    }
 }
 
 fn validate_index_part_with_offloaded(


### PR DESCRIPTION
This adds the etag to `remote_storage::ListingObject`, and uses it in the scrubber for performing the manifest freshness check added in #10007. This is in response to review giving feedback about the clock precision not being enough to prevent races.

I think the addition of the etag is useful enough as a general change, even without the motivation of wanting to do cheap checks whether there has been a change or not.

Note that the etag check still isn't 100% perfect, and we could get there also by just comparing the manifest, but I think the addition of the etag is useful enough of its own right. I don't know, please write if you think that it's baggage.

As for why the etag check is not perfect: it is fully determined by the content at least on AWS (md5 on AWS, didn't check Azure). So if you change a file from A to B and back to A, the etag will be the original one. Maybe something based on the version ID would be better, but we can't assume to always have it, as sometimes versioning is disabled on the bucket.

Follow-up of https://github.com/neondatabase/neon/pull/10007