### PR TITLE
pageserver: add `disk_compacted_lsn`

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -121,6 +121,7 @@ Neon safekeeper LSNs. See [safekeeper protocol section](safekeeper-protocol.md) 
 Neon pageserver LSNs:
 * `last_record_lsn` - the end of last processed WAL record.
 * `disk_consistent_lsn` - data is known to be fully flushed and fsync'd to local disk on pageserver up to this LSN.
+* `disk_compacted_lsn` - data is known to be compacted to L1 on local disk up to this LSN.
 * `remote_consistent_lsn` - The last LSN that is synced to remote storage and is guaranteed to survive pageserver crash.
 TODO: use this name consistently in remote storage code. Now `disk_consistent_lsn` is used and meaning depends on the context.
 * `ancestor_lsn` - LSN of the branch point (the LSN at which this branch was created)

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -983,12 +983,18 @@ pub struct TimelineInfo {
     pub last_record_lsn: Lsn,
     pub prev_record_lsn: Option<Lsn>,
     pub latest_gc_cutoff_lsn: Lsn,
+
+    /// The LSN that has been flushed to local disk.
     pub disk_consistent_lsn: Lsn,
 
-    /// The LSN that we have succesfully uploaded to remote storage
+    /// The LSN that has been compacted down to L1 on local disk.
+    pub disk_compacted_lsn: Lsn,
+
+    /// The LSN that we have succesfully uploaded to remote storage, according to
+    /// our generation.
     pub remote_consistent_lsn: Lsn,
 
-    /// The LSN that we are advertizing to safekeepers
+    /// The LSN that we are advertizing to safekeepers, with verified generation.
     pub remote_consistent_lsn_visible: Lsn,
 
     /// The LSN from the start of the root timeline (never changes)

--- a/libs/utils/src/lsn.rs
+++ b/libs/utils/src/lsn.rs
@@ -2,7 +2,7 @@
 
 use serde::{de::Visitor, Deserialize, Serialize};
 use std::fmt;
-use std::ops::{Add, AddAssign};
+use std::ops::{Add, AddAssign, Sub};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -292,6 +292,15 @@ impl AddAssign<u64> for Lsn {
     fn add_assign(&mut self, other: u64) {
         // panic if the addition overflows.
         self.0 = self.0.checked_add(other).unwrap();
+    }
+}
+
+impl Sub<u64> for Lsn {
+    type Output = Lsn;
+
+    fn sub(self, other: u64) -> Self::Output {
+        // panic if the addition overflows.
+        Lsn(self.0.checked_sub(other).unwrap())
     }
 }
 

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -1050,6 +1050,9 @@ components:
         disk_consistent_lsn:
           type: string
           format: hex
+        disk_compacted_lsn:
+          type: string
+          format: hex
         remote_consistent_lsn:
           type: string
           format: hex

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -480,6 +480,7 @@ async fn build_timeline_info_common(
         timeline_id: timeline.timeline_id,
         ancestor_timeline_id,
         ancestor_lsn,
+        disk_compacted_lsn: timeline.get_disk_compacted_lsn().await.unwrap_or(Lsn(0)),
         disk_consistent_lsn: timeline.get_disk_consistent_lsn(),
         remote_consistent_lsn: remote_consistent_lsn_projected,
         remote_consistent_lsn_visible,

--- a/pageserver/src/tenant/storage_layer/inmemory_layer.rs
+++ b/pageserver/src/tenant/storage_layer/inmemory_layer.rs
@@ -53,7 +53,7 @@ pub struct InMemoryLayer {
 
     /// This layer contains all the changes from 'start_lsn'. The
     /// start is inclusive.
-    start_lsn: Lsn,
+    pub(crate) start_lsn: Lsn,
 
     /// Frozen layers have an exclusive end LSN.
     /// Writes are only allowed when this is `None`.


### PR DESCRIPTION
## Problem

Currently, there is no backpressure based on L0 buildup and compaction debt. During heavy ingestion, this can lead to unbounded read amplification if compaction can't keep up.

Touches #10095.

## Summary of changes

Add a `disk_compacted_lsn` and expose it via `TimelineInfo`. This tracks the last LSN known to be compacted to local disk (i.e. the last LSN below any L0 or frozen layers). It does not include S3 upload of compacted layers, which is tracked by `remote_consistent_lsn` instead.

Integration with Safekeeper and compute backpressure will be done later.