### PR TITLE
.github: reduce test execution concurrency (8)

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -135,7 +135,7 @@ runs:
         fi
         if [[ "${{ inputs.run_in_parallel }}" == "true" ]]; then
           # -n sets the number of parallel processes that pytest-xdist will run
-          EXTRA_PARAMS="-n12 $EXTRA_PARAMS"
+          EXTRA_PARAMS="-n8 $EXTRA_PARAMS"
 
           # --dist=loadgroup points tests marked with @pytest.mark.xdist_group
           # to the same worker to make @pytest.mark.order work with xdist


### PR DESCRIPTION
## Problem

Test nodes are overloaded.  We have seen various tests become unstable, and in some cases this has led to proposals to use really huge timeouts (https://github.com/neondatabase/neon/pull/9924) when something as simple as starting a pageserver has been seen to take longer than 10s.

## Summary of changes

- Reduce test concurrency from 12 to 8.
