### PR TITLE
azure_blob: connect/read timeouts to the reqwest client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5062,6 +5062,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "rand 0.8.5",
+ "reqwest",
  "scopeguard",
  "serde",
  "serde_json",

--- a/libs/remote_storage/Cargo.toml
+++ b/libs/remote_storage/Cargo.toml
@@ -18,6 +18,7 @@ camino = { workspace = true, features = ["serde1"] }
 humantime-serde.workspace = true
 hyper = { workspace = true, features = ["client"] }
 futures.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["sync", "fs", "io-util"] }


### PR DESCRIPTION
## Problem

We already have timeouts at the higher levels of the stack, via select and friends, but the timeouts might not actually reach the reqwest client. Therefore, set it up in a way that the timeouts are preconfigured.

https://github.com/neondatabase/cloud/issues/20971

## Summary of changes

Pass down timeouts from the SDK to the reqwest client. Hopefully this will address the port exhaustion issue. We always use `read_timeout` because that one is shorter: there is only one global timeout we can configure.

Related earlier work: #9938