### PR TITLE
chore(proxy): remove allow_self_signed from regular proxy

### DIFF
--- a/proxy/src/proxy/mod.rs
+++ b/proxy/src/proxy/mod.rs
@@ -191,13 +191,6 @@ impl ClientMode {
         }
     }
 
-    pub(crate) fn allow_self_signed_compute(&self, config: &ProxyConfig) -> bool {
-        match self {
-            ClientMode::Tcp => config.allow_self_signed_compute,
-            ClientMode::Websockets { .. } => false,
-        }
-    }
-
     fn hostname<'a, S>(&'a self, s: &'a Stream<S>) -> Option<&'a str> {
         match self {
             ClientMode::Tcp => s.sni_hostname(),
@@ -355,7 +348,8 @@ pub(crate) async fn handle_client<S: AsyncRead + AsyncWrite + Unpin>(
             params_compat,
             params: &params,
             locks: &config.connect_compute_locks,
-            allow_self_signed_compute: mode.allow_self_signed_compute(config),
+            // only used for console redirect testing.
+            allow_self_signed_compute: false,
         },
         &user_info,
         config.wake_compute_retry_config,


### PR DESCRIPTION
I noticed that the only place we use this flag is for testing console redirect proxy. Makes sense to me to make this assumption more explicit.