### PR TITLE
fast import: importer: use aws s3 cli

### DIFF
--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1556,31 +1556,29 @@ RUN apt update && \
         locales \
         procps \
         ca-certificates \
-        python3 python3-dev python3-pip \
+        curl \
+        unzip \
         $VERSION_INSTALLS && \
     apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-RUN pip install awscli==2.17.5
-
-# s5cmd 2.2.2 from https://github.com/peak/s5cmd/releases/tag/v2.2.2
-# used by fast_import
+# aws cli is used by fast_import (curl and unzip above are at this time only used for this installation step)
 ARG TARGETARCH
-ADD https://github.com/peak/s5cmd/releases/download/v2.2.2/s5cmd_2.2.2_linux_$TARGETARCH.deb /tmp/s5cmd.deb
 RUN set -ex; \
-    \
-    # Determine the expected checksum based on TARGETARCH
     if [ "${TARGETARCH}" = "amd64" ]; then \
-        CHECKSUM="392c385320cd5ffa435759a95af77c215553d967e4b1c0fffe52e4f14c29cf85"; \
+        TARGETARCH_ALT="x86_64"; \
+        CHECKSUM="c9a9df3770a3ff9259cb469b6179e02829687a464e0824d5c32d378820b53a00"; \
     elif [ "${TARGETARCH}" = "arm64" ]; then \
-        CHECKSUM="939bee3cf4b5604ddb00e67f8c157b91d7c7a5b553d1fbb6890fad32894b7b46"; \
+        TARGETARCH_ALT="aarch64"; \
+        CHECKSUM="8181730be7891582b38b028112e81b4899ca817e8c616aad807c9e9d1289223a"; \
     else \
         echo "Unsupported architecture: ${TARGETARCH}"; exit 1; \
     fi; \
-    \
-    # Compute and validate the checksum
-    echo "${CHECKSUM}  /tmp/s5cmd.deb" | sha256sum -c -
-RUN dpkg -i /tmp/s5cmd.deb && rm /tmp/s5cmd.deb
+    curl -L "https://awscli.amazonaws.com/awscli-exe-linux-${TARGETARCH_ALT}-2.17.5.zip" -o /tmp/awscliv2.zip; \
+    echo "${CHECKSUM}  /tmp/awscliv2.zip" | sha256sum -c -; \
+    unzip /tmp/awscliv2.zip -d /tmp/awscliv2; \
+    /tmp/awscliv2/aws/install; \
+    true
 
 ENV LANG=en_US.utf8
 USER postgres

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1214,42 +1214,42 @@ FROM build-deps AS neon-pg-ext-build
 ARG PG_VERSION
 
 # Public extensions
-COPY --from=postgis-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=postgis-build /sfcgal/* /
-COPY --from=plv8-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=h3-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=h3-pg-build /h3/usr /
-COPY --from=unit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=vector-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pgjwt-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pgrag-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-jsonschema-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-graphql-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-tiktoken-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=hypopg-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-hashids-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=rum-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pgtap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=ip4r-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=prefix-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=hll-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=plpgsql-check-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=timescaledb-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-hint-plan-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-cron-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-pgx-ulid-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-session-jwt-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=rdkit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-uuidv7-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-roaringbitmap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-semver-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-embedding-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=wal2json-pg-build /usr/local/pgsql /usr/local/pgsql
-COPY --from=pg-anon-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-ivm-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-partman-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-mooncake-build /usr/local/pgsql/ /usr/local/pgsql/
-COPY --from=pg-repack-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=postgis-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=postgis-build /sfcgal/* /
+# COPY --from=plv8-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=h3-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=h3-pg-build /h3/usr /
+# COPY --from=unit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=vector-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pgjwt-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pgrag-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-jsonschema-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-graphql-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-tiktoken-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=hypopg-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-hashids-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=rum-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pgtap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=ip4r-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=prefix-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=hll-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=plpgsql-check-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=timescaledb-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-hint-plan-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-cron-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-pgx-ulid-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-session-jwt-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=rdkit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-uuidv7-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-roaringbitmap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-semver-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-embedding-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=wal2json-pg-build /usr/local/pgsql /usr/local/pgsql
+# COPY --from=pg-anon-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-ivm-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-partman-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-mooncake-build /usr/local/pgsql/ /usr/local/pgsql/
+# COPY --from=pg-repack-build /usr/local/pgsql/ /usr/local/pgsql/
 COPY pgxn/ pgxn/
 
 RUN make -j $(getconf _NPROCESSORS_ONLN) \
@@ -1556,6 +1556,7 @@ RUN apt update && \
         locales \
         procps \
         ca-certificates \
+        awscli \
         $VERSION_INSTALLS && \
     apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1556,10 +1556,12 @@ RUN apt update && \
         locales \
         procps \
         ca-certificates \
-        awscli \
+        python python-dev python-pip \
         $VERSION_INSTALLS && \
     apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+RUN pip install awscli==2.17.5
 
 # s5cmd 2.2.2 from https://github.com/peak/s5cmd/releases/tag/v2.2.2
 # used by fast_import

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1556,7 +1556,7 @@ RUN apt update && \
         locales \
         procps \
         ca-certificates \
-        python python-dev python-pip \
+        python3 python3-dev python3-pip \
         $VERSION_INSTALLS && \
     apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1578,6 +1578,7 @@ RUN set -ex; \
     echo "${CHECKSUM}  /tmp/awscliv2.zip" | sha256sum -c -; \
     unzip /tmp/awscliv2.zip -d /tmp/awscliv2; \
     /tmp/awscliv2/aws/install; \
+    rm -rf /tmp/awscliv2.zip /tmp/awscliv2; \
     true
 
 ENV LANG=en_US.utf8

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1214,42 +1214,42 @@ FROM build-deps AS neon-pg-ext-build
 ARG PG_VERSION
 
 # Public extensions
-# COPY --from=postgis-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=postgis-build /sfcgal/* /
-# COPY --from=plv8-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=h3-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=h3-pg-build /h3/usr /
-# COPY --from=unit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=vector-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pgjwt-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pgrag-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-jsonschema-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-graphql-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-tiktoken-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=hypopg-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-hashids-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=rum-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pgtap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=ip4r-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=prefix-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=hll-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=plpgsql-check-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=timescaledb-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-hint-plan-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-cron-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-pgx-ulid-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-session-jwt-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=rdkit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=postgis-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=postgis-build /sfcgal/* /
+COPY --from=plv8-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=h3-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=h3-pg-build /h3/usr /
+COPY --from=unit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=vector-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pgjwt-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pgrag-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-jsonschema-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-graphql-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-tiktoken-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=hypopg-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-hashids-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=rum-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pgtap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=ip4r-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=prefix-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=hll-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=plpgsql-check-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=timescaledb-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-hint-plan-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-cron-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-pgx-ulid-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-session-jwt-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=rdkit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
 COPY --from=pg-uuidv7-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-roaringbitmap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-semver-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-embedding-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=wal2json-pg-build /usr/local/pgsql /usr/local/pgsql
-# COPY --from=pg-anon-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-ivm-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-partman-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-mooncake-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-repack-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-roaringbitmap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-semver-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-embedding-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=wal2json-pg-build /usr/local/pgsql /usr/local/pgsql
+COPY --from=pg-anon-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-ivm-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-partman-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-mooncake-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-repack-build /usr/local/pgsql/ /usr/local/pgsql/
 COPY pgxn/ pgxn/
 
 RUN make -j $(getconf _NPROCESSORS_ONLN) \

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1240,7 +1240,7 @@ ARG PG_VERSION
 # COPY --from=pg-pgx-ulid-build /usr/local/pgsql/ /usr/local/pgsql/
 # COPY --from=pg-session-jwt-build /usr/local/pgsql/ /usr/local/pgsql/
 # COPY --from=rdkit-pg-build /usr/local/pgsql/ /usr/local/pgsql/
-# COPY --from=pg-uuidv7-pg-build /usr/local/pgsql/ /usr/local/pgsql/
+COPY --from=pg-uuidv7-pg-build /usr/local/pgsql/ /usr/local/pgsql/
 # COPY --from=pg-roaringbitmap-pg-build /usr/local/pgsql/ /usr/local/pgsql/
 # COPY --from=pg-semver-pg-build /usr/local/pgsql/ /usr/local/pgsql/
 # COPY --from=pg-embedding-pg-build /usr/local/pgsql/ /usr/local/pgsql/

--- a/compute_tools/src/bin/fast_import.rs
+++ b/compute_tools/src/bin/fast_import.rs
@@ -34,12 +34,12 @@ use nix::unistd::Pid;
 use tracing::{info, info_span, warn, Instrument};
 use utils::fs_ext::is_directory_empty;
 
+#[path = "fast_import/aws_s3_sync.rs"]
+mod aws_s3_sync;
 #[path = "fast_import/child_stdio_to_log.rs"]
 mod child_stdio_to_log;
 #[path = "fast_import/s3_uri.rs"]
 mod s3_uri;
-#[path = "fast_import/s5cmd.rs"]
-mod s5cmd;
 
 #[derive(clap::Parser)]
 struct Args {
@@ -326,7 +326,7 @@ pub(crate) async fn main() -> anyhow::Result<()> {
     }
 
     info!("upload pgdata");
-    s5cmd::sync(Utf8Path::new(&pgdata_dir), &s3_prefix.append("/"))
+    aws_s3_sync::sync(Utf8Path::new(&pgdata_dir), &s3_prefix.append("/pgdata/"))
         .await
         .context("sync dump directory to destination")?;
 
@@ -337,7 +337,7 @@ pub(crate) async fn main() -> anyhow::Result<()> {
         let status_file = status_dir.join("status");
         std::fs::write(&status_file, serde_json::json!({"done": true}).to_string())
             .context("write status file")?;
-        s5cmd::sync(&status_file, &s3_prefix.append("/status/pgdata"))
+        aws_s3_sync::sync(&status_dir, &s3_prefix.append("/status/"))
             .await
             .context("sync status directory to destination")?;
     }

--- a/compute_tools/src/bin/fast_import.rs
+++ b/compute_tools/src/bin/fast_import.rs
@@ -334,7 +334,7 @@ pub(crate) async fn main() -> anyhow::Result<()> {
     {
         let status_dir = working_directory.join("status");
         std::fs::create_dir(&status_dir).context("create status directory")?;
-        let status_file = status_dir.join("status");
+        let status_file = status_dir.join("pgdata");
         std::fs::write(&status_file, serde_json::json!({"done": true}).to_string())
             .context("write status file")?;
         aws_s3_sync::sync(&status_dir, &s3_prefix.append("/status/"))

--- a/compute_tools/src/bin/fast_import/aws_s3_sync.rs
+++ b/compute_tools/src/bin/fast_import/aws_s3_sync.rs
@@ -5,7 +5,7 @@ use super::s3_uri::S3Uri;
 
 pub(crate) async fn sync(local: &Utf8Path, remote: &S3Uri) -> anyhow::Result<()> {
     let mut builder = tokio::process::Command::new("aws");
-    // s5cmd uses aws-sdk-go v1, hence doesn't support AWS_ENDPOINT_URL
+    // s5cmd uses an old version of aws-sdk-go v1, hence doesn't support AWS_ENDPOINT_URL
     if let Some(val) = std::env::var_os("AWS_ENDPOINT_URL") {
         builder.arg("--endpoint-url").arg(val);
     }

--- a/compute_tools/src/bin/fast_import/aws_s3_sync.rs
+++ b/compute_tools/src/bin/fast_import/aws_s3_sync.rs
@@ -5,10 +5,6 @@ use super::s3_uri::S3Uri;
 
 pub(crate) async fn sync(local: &Utf8Path, remote: &S3Uri) -> anyhow::Result<()> {
     let mut builder = tokio::process::Command::new("aws");
-    // s5cmd uses an old version of aws-sdk-go v1, hence doesn't support AWS_ENDPOINT_URL
-    if let Some(val) = std::env::var_os("AWS_ENDPOINT_URL") {
-        builder.arg("--endpoint-url").arg(val);
-    }
     builder
         .arg("s3")
         .arg("sync")

--- a/compute_tools/src/bin/fast_import/s5cmd.rs
+++ b/compute_tools/src/bin/fast_import/s5cmd.rs
@@ -4,24 +4,25 @@ use camino::Utf8Path;
 use super::s3_uri::S3Uri;
 
 pub(crate) async fn sync(local: &Utf8Path, remote: &S3Uri) -> anyhow::Result<()> {
-    let mut builder = tokio::process::Command::new("s5cmd");
+    let mut builder = tokio::process::Command::new("aws");
     // s5cmd uses aws-sdk-go v1, hence doesn't support AWS_ENDPOINT_URL
     if let Some(val) = std::env::var_os("AWS_ENDPOINT_URL") {
         builder.arg("--endpoint-url").arg(val);
     }
     builder
+        .arg("s3")
         .arg("sync")
         .arg(local.as_str())
         .arg(remote.to_string());
     let st = builder
         .spawn()
-        .context("spawn s5cmd")?
+        .context("spawn aws s3 sync")?
         .wait()
         .await
-        .context("wait for s5cmd")?;
+        .context("wait for aws s3 sync")?;
     if st.success() {
         Ok(())
     } else {
-        Err(anyhow::anyhow!("s5cmd failed"))
+        Err(anyhow::anyhow!("aws s3 sync failed"))
     }
 }


### PR DESCRIPTION
## Problem

s5cmd doesn't pick up the pod service account

```
2024/12/16 16:26:01 Ignoring, HTTP credential provider invalid endpoint host, "169.254.170.23", only loopback hosts are allowed. <nil>
ERROR "ls s3://neon-dev-bulk-import-us-east-2/import-pgdata/fast-import/v1/br-wandering-hall-w2xobawv": NoCredentialProviders: no valid providers in chain. Deprecated. For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```

## Summary of changes

Switch to offical CLI.


## Testing

Tested the pre-merge image in staging, using `job_image` override in project settings.

https://neondb.slack.com/archives/C033RQ5SPDH/p1734554944391949?thread_ts=1734368383.258759&cid=C033RQ5SPDH

## Future Work

Switch back to s5cmd once https://github.com/peak/s5cmd/pull/769 gets merged.

## Refs

- fixes https://github.com/neondatabase/cloud/issues/21876