### PR TITLE
Fix allure report creation on periodic `pg_regress` testing

### DIFF
--- a/.github/workflows/cloud-regress.yml
+++ b/.github/workflows/cloud-regress.yml
@@ -113,6 +113,8 @@ jobs:
         uses: ./.github/actions/allure-report-generate
         with:
           aws-oicd-role-arn: ${{ vars.DEV_AWS_OIDC_ROLE_ARN }}
+        env:
+          REGRESS_TEST_RESULT_CONNSTR_NEW: ${{ secrets.REGRESS_TEST_RESULT_CONNSTR_NEW }}
 
       - name: Post to a Slack channel
         if: ${{ github.event.schedule && failure() }}

--- a/.github/workflows/cloud-regress.yml
+++ b/.github/workflows/cloud-regress.yml
@@ -115,8 +115,6 @@ jobs:
         uses: ./.github/actions/allure-report-generate
         with:
           aws-oicd-role-arn: ${{ vars.DEV_AWS_OIDC_ROLE_ARN }}
-        env:
-          REGRESS_TEST_RESULT_CONNSTR_NEW: ${{ secrets.REGRESS_TEST_RESULT_CONNSTR_NEW }}
 
       - name: Post to a Slack channel
         if: ${{ github.event.schedule && failure() }}

--- a/.github/workflows/cloud-regress.yml
+++ b/.github/workflows/cloud-regress.yml
@@ -24,6 +24,11 @@ permissions:
 
 jobs:
   regress:
+    permissions:
+      id-token: write # aws-actions/configure-aws-credentials
+      statuses: write
+      contents: write
+      pull-requests: write
     env:
       POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install
       TEST_OUTPUT: /tmp/test_output

--- a/.github/workflows/cloud-regress.yml
+++ b/.github/workflows/cloud-regress.yml
@@ -21,14 +21,11 @@ concurrency:
 
 permissions:
   id-token: write # aws-actions/configure-aws-credentials
+  statuses: write
+  contents: write
 
 jobs:
   regress:
-    permissions:
-      id-token: write # aws-actions/configure-aws-credentials
-      statuses: write
-      contents: write
-      pull-requests: write
     env:
       POSTGRES_DISTRIB_DIR: /tmp/neon/pg_install
       TEST_OUTPUT: /tmp/test_output


### PR DESCRIPTION
## Problem
The allure report finishes with the error `HttpError: Resource not accessible by integration` while running the `pg_regress` test against a cloud staging project due to a lack of permissions.
## Summary of changes
The permissions are added.