### PR TITLE
fix(pageserver): run psql in thread to avoid blocking

### DIFF
--- a/test_runner/regress/test_pageserver_layer_rolling.py
+++ b/test_runner/regress/test_pageserver_layer_rolling.py
@@ -42,7 +42,7 @@ async def run_worker_for_tenant(
 
         loop = asyncio.get_running_loop()
         sql = await loop.run_in_executor(
-            None, lambda ep=ep: ep.safe_psql("SELECT pg_current_wal_flush_lsn()")
+            None, lambda ep: ep.safe_psql("SELECT pg_current_wal_flush_lsn()"), ep
         )
         last_flush_lsn = Lsn(sql[0][0])
         return last_flush_lsn
@@ -52,7 +52,7 @@ async def run_worker(env: NeonEnv, tenant_conf, entries: int) -> tuple[TenantId,
     loop = asyncio.get_running_loop()
     # capture tenant_conf by specifying `tenant_conf=tenant_conf`, otherwise it will be evaluated to some random value
     tenant, timeline = await loop.run_in_executor(
-        None, lambda tenant_conf=tenant_conf, env=env: env.create_tenant(conf=tenant_conf)
+        None, lambda tenant_conf, env: env.create_tenant(conf=tenant_conf), tenant_conf, env
     )
     last_flush_lsn = await run_worker_for_tenant(env, entries, tenant)
     return tenant, timeline, last_flush_lsn

--- a/test_runner/regress/test_pageserver_layer_rolling.py
+++ b/test_runner/regress/test_pageserver_layer_rolling.py
@@ -22,7 +22,10 @@ CHECKPOINT_TIMEOUT_SECONDS = 60
 
 
 async def run_worker_for_tenant(
-    env: NeonEnv, entries: int, tenant: TenantId, offset: int | None = None
+    env: NeonEnv,
+    entries: int,
+    tenant: TenantId,
+    offset: int | None = None,
 ) -> Lsn:
     if offset is None:
         offset = 0
@@ -37,12 +40,17 @@ async def run_worker_for_tenant(
         finally:
             await conn.close(timeout=10)
 
-        last_flush_lsn = Lsn(ep.safe_psql("SELECT pg_current_wal_flush_lsn()")[0][0])
+        loop = asyncio.get_running_loop()
+        sql = await loop.run_in_executor(
+            None, lambda: ep.safe_psql("SELECT pg_current_wal_flush_lsn()")
+        )
+        last_flush_lsn = Lsn(sql[0][0])
         return last_flush_lsn
 
 
 async def run_worker(env: NeonEnv, tenant_conf, entries: int) -> tuple[TenantId, TimelineId, Lsn]:
-    tenant, timeline = env.create_tenant(conf=tenant_conf)
+    loop = asyncio.get_running_loop()
+    tenant, timeline = await loop.run_in_executor(None, lambda: env.create_tenant(conf=tenant_conf))
     last_flush_lsn = await run_worker_for_tenant(env, entries, tenant)
     return tenant, timeline, last_flush_lsn
 

--- a/test_runner/regress/test_pageserver_layer_rolling.py
+++ b/test_runner/regress/test_pageserver_layer_rolling.py
@@ -42,7 +42,7 @@ async def run_worker_for_tenant(
 
         loop = asyncio.get_running_loop()
         sql = await loop.run_in_executor(
-            None, lambda: ep.safe_psql("SELECT pg_current_wal_flush_lsn()")
+            None, lambda ep=ep: ep.safe_psql("SELECT pg_current_wal_flush_lsn()")
         )
         last_flush_lsn = Lsn(sql[0][0])
         return last_flush_lsn
@@ -50,7 +50,10 @@ async def run_worker_for_tenant(
 
 async def run_worker(env: NeonEnv, tenant_conf, entries: int) -> tuple[TenantId, TimelineId, Lsn]:
     loop = asyncio.get_running_loop()
-    tenant, timeline = await loop.run_in_executor(None, lambda: env.create_tenant(conf=tenant_conf))
+    # capture tenant_conf by specifying `tenant_conf=tenant_conf`, otherwise it will be evaluated to some random value
+    tenant, timeline = await loop.run_in_executor(
+        None, lambda tenant_conf=tenant_conf, env=env: env.create_tenant(conf=tenant_conf)
+    )
     last_flush_lsn = await run_worker_for_tenant(env, entries, tenant)
     return tenant, timeline, last_flush_lsn
 


### PR DESCRIPTION
## Problem

ref https://github.com/neondatabase/neon/issues/10170
ref https://github.com/neondatabase/neon/issues/9994

The psql command will block the main thread, causing other async tasks to timeout (i.e., HTTP connect). Therefore, we need to move it to an I/O executor thread.

## Summary of changes

* run psql connection in a thread