### PR TITLE
feat(proxy): allow proxy to connect to separate compute compared to mock cplane

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -3274,7 +3274,7 @@ class NeonProxy(PgProtocol):
         metric_collection_interval: str | None = None,
     ):
         host = "127.0.0.1"
-        domain = "proxy.localtest.me"  # resolves to 127.0.0.1
+        domain = "ep-test-endpoint.localtest.me"  # resolves to 127.0.0.1
         super().__init__(dsn=auth_backend.default_conn_url, host=domain, port=proxy_port)
 
         self.domain = domain
@@ -3639,7 +3639,19 @@ def static_proxy(
     vanilla_pg.safe_psql("create user proxy with login superuser password 'password'")
     vanilla_pg.safe_psql("CREATE SCHEMA IF NOT EXISTS neon_control_plane")
     vanilla_pg.safe_psql(
-        "CREATE TABLE neon_control_plane.endpoints (endpoint_id VARCHAR(255) PRIMARY KEY, allowed_ips VARCHAR(255))"
+        f"""
+        CREATE TABLE neon_control_plane.endpoints (
+            endpoint_id text PRIMARY KEY,
+            allowed_ips text,
+            host text not null default '{host}',
+            port integer not null default {port}
+        )
+        """
+    )
+    vanilla_pg.safe_psql(
+        """
+        insert into neon_control_plane.endpoints (endpoint_id) VALUES ('ep-test-endpoint');
+        """
     )
 
     proxy_port = port_distributor.get_port()


### PR DESCRIPTION
@a-masterov was asking for a way to test compute via proxy. This change allows for an easy way to mock the cplane api in a standalone postgres, while testing against a separate neon compute.

The following guide will be added to the proxy/README.md after some workshopping:

---

To setup locally, run a postgres server with the following schema:

```sql
CREATE SCHEMA neon_control_plane;
CREATE TABLE neon_control_plane.endpoints (
    endpoint_id text PRIMARY KEY,
    allowed_ips text,
    host text not null,
    port integer not null
);
```

And insert a host/port for your endpoint accordingly.

Create a certificate pair for proxy

```sh
openssl req -new -x509 -days 365 -nodes -text -out proxy.crt -keyout proxy.key -subj '/CN=*.localtest.me'
```

Run proxy

```sh
cargo run --bin proxy \
    --auth-backend postgres \
    --auth-endpoint "$CPLANE_MOCK" \
    -c proxy.crt -k proxy.key \
    --proxy "127.0.0.1:5432" \
    --mgmt "127.0.0.1:8080"
```

And connect to proxy via

```sh
psql "postgresql://${username}:${password}@${ENDPOINT}.localtest.me/dbname?sslmode=require"
```

Caveat, the username and password must be exactly the same in both postgres databases for this to work - in fact the salts need to be the same too which likely less useful 🙃 but it is still possible to do using `CREATE ROLE role WITH ENCRYPTED PASSWORD '...'`