### PR TITLE
safekeeper: fan out from single wal reader to multiple shards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5655,7 +5655,7 @@ dependencies = [
  "crc32c",
  "criterion",
  "desim",
- "env_logger",
+ "env_logger 0.10.2",
  "fail",
  "futures",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5684,6 +5684,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "smallvec",
  "storage_broker",
  "strum",
  "strum_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5709,6 +5709,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "const_format",
+ "pageserver_api",
  "postgres_ffi",
  "pq_proto",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5655,6 +5655,7 @@ dependencies = [
  "crc32c",
  "criterion",
  "desim",
+ "env_logger",
  "fail",
  "futures",
  "hex",

--- a/libs/safekeeper_api/Cargo.toml
+++ b/libs/safekeeper_api/Cargo.toml
@@ -13,3 +13,4 @@ postgres_ffi.workspace = true
 pq_proto.workspace = true
 tokio.workspace = true
 utils.workspace = true
+pageserver_api.workspace = true

--- a/libs/safekeeper_api/src/models.rs
+++ b/libs/safekeeper_api/src/models.rs
@@ -1,5 +1,6 @@
 //! Types used in safekeeper http API. Many of them are also reused internally.
 
+use pageserver_api::shard::ShardIdentity;
 use postgres_ffi::TimestampTz;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -146,8 +147,25 @@ pub type ConnectionId = u32;
 
 /// Serialize is used only for json'ing in API response. Also used internally.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WalSenderState {
+pub enum WalSenderState {
+    Vanilla(VanillaWalSenderState),
+    Interpreted(InterpretedWalSenderState),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VanillaWalSenderState {
     pub ttid: TenantTimelineId,
+    pub addr: SocketAddr,
+    pub conn_id: ConnectionId,
+    // postgres application_name
+    pub appname: Option<String>,
+    pub feedback: ReplicationFeedback,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterpretedWalSenderState {
+    pub ttid: TenantTimelineId,
+    pub shard: ShardIdentity,
     pub addr: SocketAddr,
     pub conn_id: ConnectionId,
     // postgres application_name

--- a/libs/wal_decoder/src/models.rs
+++ b/libs/wal_decoder/src/models.rs
@@ -64,7 +64,7 @@ pub struct InterpretedWalRecords {
 }
 
 /// An interpreted Postgres WAL record, ready to be handled by the pageserver
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct InterpretedWalRecord {
     /// Optional metadata record - may cause writes to metadata keys
     /// in the storage engine

--- a/libs/wal_decoder/src/serialized_batch.rs
+++ b/libs/wal_decoder/src/serialized_batch.rs
@@ -32,7 +32,7 @@ static ZERO_PAGE: Bytes = Bytes::from_static(&[0u8; BLCKSZ as usize]);
 /// relation sizes. In the case of "observed" values, we only need to know
 /// the key and LSN, so two types of metadata are supported to save on network
 /// bandwidth.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub enum ValueMeta {
     Serialized(SerializedValueMeta),
     Observed(ObservedValueMeta),
@@ -79,7 +79,7 @@ impl PartialEq for OrderedValueMeta {
 impl Eq for OrderedValueMeta {}
 
 /// Metadata for a [`Value`] serialized into the batch.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct SerializedValueMeta {
     pub key: CompactKey,
     pub lsn: Lsn,
@@ -91,14 +91,14 @@ pub struct SerializedValueMeta {
 }
 
 /// Metadata for a [`Value`] observed by the batch
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct ObservedValueMeta {
     pub key: CompactKey,
     pub lsn: Lsn,
 }
 
 /// Batch of serialized [`Value`]s.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct SerializedValueBatch {
     /// [`Value`]s serialized in EphemeralFile's native format,
     /// ready for disk write by the pageserver

--- a/safekeeper/Cargo.toml
+++ b/safekeeper/Cargo.toml
@@ -63,6 +63,7 @@ storage_broker.workspace = true
 tokio-stream.workspace = true
 utils.workspace = true
 wal_decoder.workspace = true
+env_logger.workspace = true
 
 workspace_hack.workspace = true
 

--- a/safekeeper/Cargo.toml
+++ b/safekeeper/Cargo.toml
@@ -26,6 +26,7 @@ hex.workspace = true
 humantime.workspace = true
 http.workspace = true
 hyper0.workspace = true
+itertools.workspace = true
 futures.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true

--- a/safekeeper/Cargo.toml
+++ b/safekeeper/Cargo.toml
@@ -39,6 +39,7 @@ scopeguard.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 serde.workspace = true
 serde_json.workspace = true
+smallvec.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true

--- a/safekeeper/src/bin/safekeeper.rs
+++ b/safekeeper/src/bin/safekeeper.rs
@@ -28,8 +28,8 @@ use utils::pid_file;
 use metrics::set_build_info_metric;
 use safekeeper::defaults::{
     DEFAULT_CONTROL_FILE_SAVE_INTERVAL, DEFAULT_EVICTION_MIN_RESIDENT, DEFAULT_HEARTBEAT_TIMEOUT,
-    DEFAULT_HTTP_LISTEN_ADDR, DEFAULT_MAX_DELTA_FOR_FANOUT_BYTES, DEFAULT_MAX_OFFLOADER_LAG_BYTES,
-    DEFAULT_PARTIAL_BACKUP_CONCURRENCY, DEFAULT_PARTIAL_BACKUP_TIMEOUT, DEFAULT_PG_LISTEN_ADDR,
+    DEFAULT_HTTP_LISTEN_ADDR, DEFAULT_MAX_OFFLOADER_LAG_BYTES, DEFAULT_PARTIAL_BACKUP_CONCURRENCY,
+    DEFAULT_PARTIAL_BACKUP_TIMEOUT, DEFAULT_PG_LISTEN_ADDR,
 };
 use safekeeper::http;
 use safekeeper::wal_service;
@@ -212,8 +212,8 @@ struct Args {
     wal_reader_fanout: bool,
     /// Only fan out the WAL reader if the absoulte delta between the new requested position
     /// and the current position of the reader is smaller than this value.
-    #[arg(long, default_value_t = DEFAULT_MAX_DELTA_FOR_FANOUT_BYTES)]
-    max_delta_for_fanout: u64,
+    #[arg(long)]
+    max_delta_for_fanout: Option<u64>,
 }
 
 // Like PathBufValueParser, but allows empty string.

--- a/safekeeper/src/http/routes.rs
+++ b/safekeeper/src/http/routes.rs
@@ -193,7 +193,7 @@ async fn timeline_status_handler(request: Request<Body>) -> Result<Response<Body
         peer_horizon_lsn: inmem.peer_horizon_lsn,
         remote_consistent_lsn: inmem.remote_consistent_lsn,
         peers: tli.get_peers(conf).await,
-        walsenders: tli.get_walsenders().get_all(),
+        walsenders: tli.get_walsenders().get_all_public(),
         walreceivers: tli.get_walreceivers().get_all(),
     };
     json_response(StatusCode::OK, status)

--- a/safekeeper/src/lib.rs
+++ b/safekeeper/src/lib.rs
@@ -68,8 +68,6 @@ pub mod defaults {
     // before uploading a partial segment, so that in normal operation the eviction can happen
     // as soon as we have done the partial segment upload.
     pub const DEFAULT_EVICTION_MIN_RESIDENT: &str = DEFAULT_PARTIAL_BACKUP_TIMEOUT;
-
-    pub const DEFAULT_MAX_DELTA_FOR_FANOUT_BYTES: u64 = 50 * 1024 * 1024;
 }
 
 #[derive(Debug, Clone)]
@@ -111,7 +109,7 @@ pub struct SafeKeeperConf {
     pub partial_backup_concurrency: usize,
     pub eviction_min_resident: Duration,
     pub wal_reader_fanout: bool,
-    pub max_delta_for_fanout: u64,
+    pub max_delta_for_fanout: Option<u64>,
 }
 
 impl SafeKeeperConf {
@@ -155,7 +153,7 @@ impl SafeKeeperConf {
             partial_backup_concurrency: 1,
             eviction_min_resident: Duration::ZERO,
             wal_reader_fanout: false,
-            max_delta_for_fanout: defaults::DEFAULT_MAX_DELTA_FOR_FANOUT_BYTES,
+            max_delta_for_fanout: None,
         }
     }
 }

--- a/safekeeper/src/lib.rs
+++ b/safekeeper/src/lib.rs
@@ -68,6 +68,8 @@ pub mod defaults {
     // before uploading a partial segment, so that in normal operation the eviction can happen
     // as soon as we have done the partial segment upload.
     pub const DEFAULT_EVICTION_MIN_RESIDENT: &str = DEFAULT_PARTIAL_BACKUP_TIMEOUT;
+
+    pub const DEFAULT_MAX_DELTA_FOR_FANOUT_BYTES: u64 = 50 * 1024 * 1024;
 }
 
 #[derive(Debug, Clone)]
@@ -108,6 +110,8 @@ pub struct SafeKeeperConf {
     pub control_file_save_interval: Duration,
     pub partial_backup_concurrency: usize,
     pub eviction_min_resident: Duration,
+    pub wal_reader_fanout: bool,
+    pub max_delta_for_fanout: u64,
 }
 
 impl SafeKeeperConf {
@@ -150,6 +154,8 @@ impl SafeKeeperConf {
             control_file_save_interval: Duration::from_secs(1),
             partial_backup_concurrency: 1,
             eviction_min_resident: Duration::ZERO,
+            wal_reader_fanout: false,
+            max_delta_for_fanout: defaults::DEFAULT_MAX_DELTA_FOR_FANOUT_BYTES,
         }
     }
 }

--- a/safekeeper/src/metrics.rs
+++ b/safekeeper/src/metrics.rs
@@ -12,9 +12,9 @@ use metrics::{
     pow2_buckets,
     proto::MetricFamily,
     register_histogram, register_histogram_vec, register_int_counter, register_int_counter_pair,
-    register_int_counter_pair_vec, register_int_counter_vec, register_int_gauge, Gauge, GaugeVec,
-    Histogram, HistogramVec, IntCounter, IntCounterPair, IntCounterPairVec, IntCounterVec,
-    IntGauge, IntGaugeVec, DISK_FSYNC_SECONDS_BUCKETS,
+    register_int_counter_pair_vec, register_int_counter_vec, register_int_gauge,
+    register_int_gauge_vec, Gauge, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterPair,
+    IntCounterPairVec, IntCounterVec, IntGauge, IntGaugeVec, DISK_FSYNC_SECONDS_BUCKETS,
 };
 use once_cell::sync::Lazy;
 use postgres_ffi::XLogSegNo;
@@ -208,6 +208,14 @@ pub static WAL_RECEIVERS: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "safekeeper_wal_receivers",
         "Number of currently connected WAL receivers (i.e. connected computes)"
+    )
+    .expect("Failed to register safekeeper_wal_receivers")
+});
+pub static WAL_READERS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "safekeeper_wal_readers",
+        "Number of active WAL readers (may serve pageservers or other safekeepers",
+        &["kind", "target"]
     )
     .expect("Failed to register safekeeper_wal_receivers")
 });

--- a/safekeeper/src/metrics.rs
+++ b/safekeeper/src/metrics.rs
@@ -214,7 +214,7 @@ pub static WAL_RECEIVERS: Lazy<IntGauge> = Lazy::new(|| {
 pub static WAL_READERS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "safekeeper_wal_readers",
-        "Number of active WAL readers (may serve pageservers or other safekeepers",
+        "Number of active WAL readers (may serve pageservers or other safekeepers)",
         &["kind", "target"]
     )
     .expect("Failed to register safekeeper_wal_receivers")

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -157,8 +157,8 @@ impl InterpretedWalReader {
         tx: tokio::sync::mpsc::Sender<Batch>,
         shard: ShardIdentity,
         pg_version: u32,
+        cancel: CancellationToken,
     ) -> InterpretedWalReader {
-        let cancel = CancellationToken::new();
         let state = Arc::new(std::sync::RwLock::new(InterpretedWalReaderState::Running {
             current_position: start_pos,
         }));
@@ -175,7 +175,7 @@ impl InterpretedWalReader {
             shard_notification_rx: None,
             state: state.clone(),
             pg_version,
-            cancel: cancel.clone(),
+            cancel,
         }
     }
 

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -383,17 +383,7 @@ impl InterpretedWalReader {
                     // for the steady state).
                     for to_remove in shard_senders_to_remove {
                         let shard_senders = self.shard_senders.get_mut(&to_remove.shard()).expect("saw it above");
-
-                        let mut remove_at = None;
-                        for (idx, shard_sender) in shard_senders.iter().enumerate() {
-                            let crnt_shard_sender_id = ShardSenderId::new(to_remove.shard(), shard_sender.sender_id);
-                            if crnt_shard_sender_id == to_remove {
-                                remove_at = Some(idx);
-                                break;
-                            }
-                        }
-
-                        if let Some(idx) = remove_at {
+                        if let Some(idx) = shard_senders.iter().position(|s| s.sender_id == to_remove.sender_id) {
                             shard_senders.remove(idx);
                             tracing::info!("Removed shard sender {}", to_remove);
                         }

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -280,7 +280,8 @@ impl InterpretedWalReader {
                         Some(some) => some.map_err(InterpretedWalReaderError::ReadOrInterpret)?,
                         None => {
                             // [`StreamingWalReader::next`] is an endless stream of WAL.
-                            // It shouldn't ever finish unless it panicked.
+                            // It shouldn't ever finish unless it panicked or became internally
+                            // inconsistent.
                             return Result::Err(InterpretedWalReaderError::WalStreamClosed);
                         }
                     };

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -387,6 +387,10 @@ impl InterpretedWalReader {
                             shard_senders.remove(idx);
                             tracing::info!("Removed shard sender {}", to_remove);
                         }
+
+                        if shard_senders.is_empty() {
+                            self.shard_senders.remove(&to_remove.shard());
+                        }
                     }
                 },
                 // Listen for new shards that want to attach to this reader.

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
+use futures::future::Either;
 use futures::StreamExt;
 use pageserver_api::shard::ShardIdentity;
 use postgres_backend::{CopyStreamHandlerEnd, PostgresBackend};
@@ -8,24 +11,340 @@ use postgres_ffi::waldecoder::WalDecodeError;
 use postgres_ffi::{get_current_timestamp, waldecoder::WalStreamDecoder};
 use pq_proto::{BeMessage, InterpretedWalRecordsBody, WalSndKeepAlive};
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc::error::SendError;
+use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+use tracing::{info_span, Instrument};
 use utils::lsn::Lsn;
 use utils::postgres_client::Compression;
 use utils::postgres_client::InterpretedFormat;
 use wal_decoder::models::{InterpretedWalRecord, InterpretedWalRecords};
 use wal_decoder::wire_format::ToWireFormat;
 
-use crate::send_wal::EndWatchView;
-use crate::wal_reader_stream::{WalBytes, StreamingWalReader};
+use crate::send_wal::{EndWatchView, WalSenderGuard};
+use crate::timeline::WalResidentTimeline;
+use crate::wal_reader_stream::{StreamingWalReader, WalBytes};
 
-/// Shard-aware interpreted record reader.
-/// This is used for sending WAL to the pageserver. Said WAL
-/// is pre-interpreted and filtered for the shard.
+/// Shard-aware fan-out interpreted record reader.
+/// Reads WAL from disk, decodes it, intepretets it, and sends
+/// it to any [`InterpretedWalSender`] connected to it.
+/// Each [`InterpretedWalSender`] corresponds to one shard
+/// and gets interpreted records concerning that shard only.
 pub(crate) struct InterpretedWalReader {
-    pub(crate) wal_stream: StreamingWalReader,
-    pub(crate) tx: tokio::sync::mpsc::Sender<Batch>,
-    pub(crate) shard: ShardIdentity,
-    pub(crate) pg_version: u32,
+    wal_stream: StreamingWalReader,
+    shards: HashMap<ShardIdentity, ShardState>,
+    shard_notification_rx: Option<tokio::sync::mpsc::UnboundedReceiver<AttachShardNotification>>,
+    state: Arc<std::sync::RwLock<InterpretedWalReaderState>>,
+    pg_version: u32,
+    cancel: CancellationToken,
+}
+
+/// A handle for [`InterpretedWalReader`] which allows for interacting with it
+/// when it runs as a separate tokio task.
+#[derive(Debug)]
+pub(crate) struct InterpretedWalReaderHandle {
+    join_handle: JoinHandle<Result<(), InterpretedWalReaderError>>,
+    state: Arc<std::sync::RwLock<InterpretedWalReaderState>>,
+    shard_notification_tx: tokio::sync::mpsc::UnboundedSender<AttachShardNotification>,
+    // TODO: remove or keep
+    #[allow(unused)]
+    cancel: CancellationToken,
+}
+
+struct ShardState {
+    tx: tokio::sync::mpsc::Sender<Batch>,
+    next_record_lsn: Lsn,
+}
+
+/// State of [`InterpretedWalReader`] visible outside of the task running it.
+#[derive(Debug)]
+pub(crate) enum InterpretedWalReaderState {
+    Running { current_position: Lsn },
+    Done,
+}
+
+pub(crate) struct Batch {
+    wal_end_lsn: Lsn,
+    available_wal_end_lsn: Lsn,
+    records: InterpretedWalRecords,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum InterpretedWalReaderError {
+    /// Handler initiates the end of streaming.
+    #[error("decode error: {0}")]
+    Decode(#[from] WalDecodeError),
+    #[error("read or interpret error: {0}")]
+    ReadOrInterpret(#[from] anyhow::Error),
+    #[error("wal stream closed")]
+    WalStreamClosed,
+}
+
+impl InterpretedWalReaderState {
+    fn current_position(&self) -> Option<Lsn> {
+        match self {
+            InterpretedWalReaderState::Running {
+                current_position, ..
+            } => Some(*current_position),
+            InterpretedWalReaderState::Done => None,
+        }
+    }
+}
+
+pub(crate) struct AttachShardNotification {
+    shard_id: ShardIdentity,
+    sender: tokio::sync::mpsc::Sender<Batch>,
+    start_pos: Lsn,
+}
+
+impl InterpretedWalReader {
+    /// Spawn the reader in a separate tokio task and return a handle
+    pub(crate) fn spawn(
+        wal_stream: StreamingWalReader,
+        start_pos: Lsn,
+        tx: tokio::sync::mpsc::Sender<Batch>,
+        shard: ShardIdentity,
+        pg_version: u32,
+    ) -> InterpretedWalReaderHandle {
+        let cancel = CancellationToken::new();
+
+        let state = Arc::new(std::sync::RwLock::new(InterpretedWalReaderState::Running {
+            current_position: start_pos,
+        }));
+
+        let (shard_notification_tx, shard_notification_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let reader = InterpretedWalReader {
+            wal_stream,
+            shards: HashMap::from([(
+                shard,
+                ShardState {
+                    tx,
+                    next_record_lsn: start_pos,
+                },
+            )]),
+            shard_notification_rx: Some(shard_notification_rx),
+            state: state.clone(),
+            pg_version,
+            cancel: cancel.clone(),
+        };
+
+        let join_handle = tokio::task::spawn(
+            async move {
+                let res = reader.run(start_pos).await;
+                if let Err(ref err) = res {
+                    tracing::error!("Task finished with error: {err}");
+                }
+                res
+            }
+            .instrument(info_span!("interpreted wal reader")),
+        );
+
+        InterpretedWalReaderHandle {
+            join_handle,
+            state,
+            shard_notification_tx,
+            cancel,
+        }
+    }
+
+    /// Construct the reader without spawning anything
+    /// Callers should drive the future returned by [`Self::run`].
+    pub(crate) fn new(
+        wal_stream: StreamingWalReader,
+        start_pos: Lsn,
+        tx: tokio::sync::mpsc::Sender<Batch>,
+        shard: ShardIdentity,
+        pg_version: u32,
+    ) -> InterpretedWalReader {
+        let cancel = CancellationToken::new();
+        let state = Arc::new(std::sync::RwLock::new(InterpretedWalReaderState::Running {
+            current_position: start_pos,
+        }));
+
+        InterpretedWalReader {
+            wal_stream,
+            shards: HashMap::from([(
+                shard,
+                ShardState {
+                    tx,
+                    next_record_lsn: start_pos,
+                },
+            )]),
+            shard_notification_rx: None,
+            state: state.clone(),
+            pg_version,
+            cancel: cancel.clone(),
+        }
+    }
+
+    /// Send interpreted WAL to one or more [`InterpretedWalSender`]s
+    /// Stops when an error is encountered or when [`InterpretedWalReaderHandle::cancel`]
+    /// is called.
+    pub(crate) async fn run(mut self, start_pos: Lsn) -> Result<(), InterpretedWalReaderError> {
+        let defer_state = self.state.clone();
+        scopeguard::defer! {
+            *defer_state.write().unwrap() = InterpretedWalReaderState::Done;
+        }
+
+        let mut wal_decoder = WalStreamDecoder::new(start_pos, self.pg_version);
+
+        loop {
+            tokio::select! {
+                // Main branch for reading WAL and forwarding it
+                wal = self.wal_stream.next() => {
+                    let WalBytes {
+                        wal,
+                        wal_start_lsn: _,
+                        wal_end_lsn,
+                        available_wal_end_lsn,
+                    } = match wal {
+                        Some(some) => some.map_err(InterpretedWalReaderError::ReadOrInterpret)?,
+                        None => {
+                            // [`StreamingWalReader::next`] is an endless stream of WAL.
+                            // It shouldn't ever finish unless it panicked.
+                            return Result::Err(InterpretedWalReaderError::WalStreamClosed);
+                        }
+                    };
+
+                    wal_decoder.feed_bytes(&wal);
+
+                    // Deserialize and interpret WAL records from this batch of WAL.
+                    // Interpreted records for each shard are collected separately.
+                    let shard_ids = self.shards.keys().cloned().collect::<Vec<_>>();
+                    let mut records_by_shard: HashMap<ShardIdentity, Vec<InterpretedWalRecord>> = HashMap::new();
+                    let mut max_next_record_lsn = None;
+                    while let Some((next_record_lsn, recdata)) = wal_decoder.poll_decode()?
+                    {
+                        assert!(next_record_lsn.is_aligned());
+                        max_next_record_lsn = Some(next_record_lsn);
+
+                        let interpreted = InterpretedWalRecord::from_bytes_filtered(
+                            recdata,
+                            &shard_ids,
+                            next_record_lsn,
+                            self.pg_version,
+                        )
+                        .with_context(|| "Failed to interpret WAL")?;
+
+                        for (shard, record) in interpreted {
+                            if !record.is_empty()
+                                && record.next_record_lsn > self.shards.get(&shard).unwrap().next_record_lsn {
+                                records_by_shard.entry(shard).or_default().push(record);
+                            }
+                        }
+                    }
+
+                    let max_next_record_lsn = match max_next_record_lsn {
+                        Some(lsn) => lsn,
+                        None => { continue; }
+                    };
+
+                    // Update the current position such that new receivers can decide
+                    // whether to attach to us or spawn a new WAL reader.
+                    match &mut *self.state.write().unwrap() {
+                        InterpretedWalReaderState::Running { current_position, .. } => {
+                            *current_position = max_next_record_lsn;
+                        },
+                        InterpretedWalReaderState::Done => {
+                            unreachable!()
+                        }
+                    }
+
+                    // Send interpreted records downstream. Anything that has already been seen
+                    // by a shard is filtered out.
+                    let mut shards_to_remove = Vec::new();
+                    for (shard, state) in &mut self.shards {
+                        let records = records_by_shard.remove(shard).unwrap_or_default();
+
+                        if max_next_record_lsn <= state.next_record_lsn {
+                            continue;
+                        }
+
+                        let batch = InterpretedWalRecords {
+                            records,
+                            next_record_lsn: Some(max_next_record_lsn),
+                        };
+
+                        let res = state.tx.send(Batch {
+                            wal_end_lsn,
+                            available_wal_end_lsn,
+                            records: batch,
+                        }).await;
+
+                        if res.is_err() {
+                            shards_to_remove.push(*shard);
+                        } else {
+                            state.next_record_lsn = max_next_record_lsn;
+                        }
+                    }
+
+                    // Clean up any shards that have dropped out.
+                    for shard in shards_to_remove {
+                        let removed = self.shards.remove(&shard);
+                        assert!(removed.is_some());
+                    }
+                },
+                // Listen for new shards that want to attach to this reader.
+                // If the reader is not running as a task, then this is not supported
+                // (see the pending branch below).
+                notification = match self.shard_notification_rx.as_mut() {
+                        Some(rx) => Either::Left(rx.recv()),
+                        None => Either::Right(std::future::pending())
+                    } => {
+                    if let Some(n) = notification {
+                        let AttachShardNotification { shard_id, sender, start_pos } = n;
+
+                        // Update internal and external state, then reset the WAL stream
+                        // if required.
+                        self.shards.insert(shard_id, ShardState { tx: sender, next_record_lsn: start_pos});
+                        let current_pos = self.state.read().unwrap().current_position().unwrap();
+                        if start_pos < current_pos {
+                            self.wal_stream.reset(start_pos);
+                            wal_decoder = WalStreamDecoder::new(start_pos, self.pg_version);
+                        }
+                    }
+                }
+                _ = self.cancel.cancelled() => {
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl InterpretedWalReaderHandle {
+    /// Fan-out the reader by attaching a new shard to it
+    pub(crate) fn fanout(
+        &self,
+        shard_id: ShardIdentity,
+        sender: tokio::sync::mpsc::Sender<Batch>,
+        start_pos: Lsn,
+    ) -> Result<(), SendError<AttachShardNotification>> {
+        self.shard_notification_tx.send(AttachShardNotification {
+            shard_id,
+            sender,
+            start_pos,
+        })
+    }
+
+    /// Get the current WAL position of the reader
+    pub(crate) fn current_position(&self) -> Option<Lsn> {
+        self.state.read().unwrap().current_position()
+    }
+
+    pub(crate) fn abort(&self) {
+        self.join_handle.abort()
+    }
+}
+
+impl Drop for InterpretedWalReaderHandle {
+    fn drop(&mut self) {
+        self.abort()
+    }
 }
 
 pub(crate) struct InterpretedWalSender<'a, IO> {
@@ -33,14 +352,18 @@ pub(crate) struct InterpretedWalSender<'a, IO> {
     pub(crate) compression: Option<Compression>,
     pub(crate) appname: Option<String>,
 
+    pub(crate) tli: WalResidentTimeline,
     pub(crate) start_lsn: Lsn,
 
     pub(crate) pgb: &'a mut PostgresBackend<IO>,
     pub(crate) end_watch_view: EndWatchView,
+    pub(crate) wal_sender_guard: Arc<WalSenderGuard>,
     pub(crate) rx: tokio::sync::mpsc::Receiver<Batch>,
 }
 
 impl<IO: AsyncRead + AsyncWrite + Unpin> InterpretedWalSender<'_, IO> {
+    /// Send interpreted WAL records over the network.
+    /// Also manages keep-alives if nothing was sent for a while.
     pub(crate) async fn run(mut self) -> Result<(), CopyStreamHandlerEnd> {
         let mut keepalive_ticker = tokio::time::interval(Duration::from_secs(1));
         keepalive_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -53,7 +376,11 @@ impl<IO: AsyncRead + AsyncWrite + Unpin> InterpretedWalSender<'_, IO> {
                 batch = self.rx.recv() => {
                     let batch = match batch {
                         Some(b) => b,
-                        None => { break; }
+                        None => {
+                            return Result::Err(
+                                CopyStreamHandlerEnd::Other(anyhow!("Interpreted WAL reader exited early"))
+                            );
+                        }
                     };
 
                     wal_position = batch.wal_end_lsn;
@@ -77,7 +404,21 @@ impl<IO: AsyncRead + AsyncWrite + Unpin> InterpretedWalSender<'_, IO> {
                         })).await?;
                 }
                 // Send a periodic keep alive when the connection has been idle for a while.
+                // Since we've been idle, also check if we can stop streaming.
                 _ = keepalive_ticker.tick() => {
+                    if let Some(remote_consistent_lsn) = self.wal_sender_guard
+                        .walsenders()
+                        .get_ws_remote_consistent_lsn(self.wal_sender_guard.id())
+                    {
+                        if self.tli.should_walsender_stop(remote_consistent_lsn).await {
+                            // Stop streaming if the receivers are caught up and
+                            // there's no active compute. This causes the loop in
+                            // [`crate::send_interpreted_wal::InterpretedWalSender::run`]
+                            // to exit and terminate the WAL stream.
+                            break;
+                        }
+                    }
+
                     self.pgb
                         .write_message(&BeMessage::KeepAlive(WalSndKeepAlive {
                             wal_end: self.end_watch_view.get().0,
@@ -85,127 +426,171 @@ impl<IO: AsyncRead + AsyncWrite + Unpin> InterpretedWalSender<'_, IO> {
                             request_reply: true,
                         }))
                         .await?;
-                }
+                },
             }
         }
 
-        // The loop above ends when the receiver is caught up and there's no more WAL to send
-        // OR when [`InterpretedWalReader`] encountered a failure.
-        if wal_position.0 < self.end_watch_view.get().0 {
-            Err(CopyStreamHandlerEnd::ServerInitiated(format!(
-                "ending streaming to {:?} at {} due to interpreted WAL reader error",
-                self.appname, wal_position,
-            )))
-        } else {
-            Err(CopyStreamHandlerEnd::ServerInitiated(format!(
-                "ending streaming to {:?} at {}, receiver is caughtup and there is no computes",
-                self.appname, wal_position,
-            )))
-        }
+        Err(CopyStreamHandlerEnd::ServerInitiated(format!(
+            "ending streaming to {:?} at {}, receiver is caughtup and there is no computes",
+            self.appname, wal_position,
+        )))
     }
 }
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, str::FromStr, time::Duration};
 
-pub(crate) struct Batch {
-    wal_end_lsn: Lsn,
-    available_wal_end_lsn: Lsn,
-    records: InterpretedWalRecords,
-}
+    use pageserver_api::shard::{ShardIdentity, ShardStripeSize};
+    use postgres_ffi::MAX_SEND_SIZE;
+    use tokio::sync::mpsc::error::TryRecvError;
+    use utils::{
+        id::{NodeId, TenantTimelineId},
+        lsn::Lsn,
+        shard::{ShardCount, ShardNumber},
+    };
 
-#[derive(thiserror::Error, Debug)]
-pub enum InterpretedWalReaderError {
-    /// Handler initiates the end of streaming.
-    #[error("decode error: {0}")]
-    Decode(#[from] WalDecodeError),
-    #[error("read or interpret error: {0}")]
-    ReadOrInterpret(#[from] anyhow::Error),
-    #[error("no receivers available")]
-    NoReceivers,
-}
+    use crate::{
+        send_interpreted_wal::{Batch, InterpretedWalReader},
+        test_utils::Env,
+        wal_reader_stream::StreamingWalReader,
+    };
 
-impl InterpretedWalReader {
-    /// Send interpreted WAL to a receiver.
-    /// Stops when an error occurs or the receiver is caught up and there's no active compute.
-    ///
-    /// Err(CopyStreamHandlerEnd) is always returned; Result is used only for ?
-    /// convenience.
-    pub(crate) async fn run(mut self, start_pos: Lsn) -> Result<(), InterpretedWalReaderError> {
-        let mut wal_decoder = WalStreamDecoder::new(start_pos, self.pg_version);
+    #[tokio::test]
+    async fn test_interpreted_wal_reader_fanout() {
+        let _ = env_logger::builder().is_test(true).try_init();
 
-        let mut keepalive_ticker = tokio::time::interval(Duration::from_secs(1));
-        keepalive_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        keepalive_ticker.reset();
+        const SIZE: usize = 8 * 1024;
+        const MSG_COUNT: usize = 200;
+        const PG_VERSION: u32 = 17;
+        const SHARD_COUNT: u8 = 2;
 
-        let shard = vec![self.shard];
+        let start_lsn = Lsn::from_str("0/149FD18").unwrap();
+        let env = Env::new(true).unwrap();
+        let tli = env
+            .make_timeline(NodeId(1), TenantTimelineId::generate(), start_lsn)
+            .await
+            .unwrap();
 
-        loop {
-            let WalBytes {
-                wal,
-                wal_start_lsn: _,
-                wal_end_lsn,
-                available_wal_end_lsn,
-            } = match self.wal_stream.next().await {
-                Some(some) => some.map_err(InterpretedWalReaderError::ReadOrInterpret)?,
-                None => {
-                    break;
-                }
-            };
+        let resident_tli = tli.wal_residence_guard().await.unwrap();
+        let end_watch = Env::write_wal(tli, start_lsn, SIZE, MSG_COUNT)
+            .await
+            .unwrap();
+        let end_pos = end_watch.get();
 
-            wal_decoder.feed_bytes(&wal);
+        tracing::info!("Doing first round of reads ...");
 
-            let mut records = Vec::new();
-            let mut max_next_record_lsn = None;
-            while let Some((next_record_lsn, recdata)) = wal_decoder
-                .poll_decode()
-                .with_context(|| "Failed to decode WAL")?
-            {
-                assert!(next_record_lsn.is_aligned());
-                max_next_record_lsn = Some(next_record_lsn);
+        let streaming_wal_reader = StreamingWalReader::new(
+            resident_tli,
+            None,
+            start_lsn,
+            end_pos,
+            end_watch,
+            MAX_SEND_SIZE,
+        );
 
-                // Deserialize and interpret WAL record
-                let interpreted = InterpretedWalRecord::from_bytes_filtered(
-                    recdata,
-                    &shard,
-                    next_record_lsn,
-                    self.pg_version,
-                )
-                .with_context(|| "Failed to interpret WAL")?
-                .remove(&self.shard)
-                .unwrap();
+        let shard_0 = ShardIdentity::new(
+            ShardNumber(0),
+            ShardCount(SHARD_COUNT),
+            ShardStripeSize::default(),
+        )
+        .unwrap();
 
-                if !interpreted.is_empty() {
-                    records.push(interpreted);
-                }
-            }
+        let shard_1 = ShardIdentity::new(
+            ShardNumber(1),
+            ShardCount(SHARD_COUNT),
+            ShardStripeSize::default(),
+        )
+        .unwrap();
 
-            let max_next_record_lsn = match max_next_record_lsn {
-                Some(lsn) => lsn,
-                None => {
-                    continue;
-                }
-            };
+        let mut shards = HashMap::new();
 
-            let batch = InterpretedWalRecords {
-                records,
-                next_record_lsn: Some(max_next_record_lsn),
-            };
-
-            self.tx
-                .send(Batch {
-                    wal_end_lsn,
-                    available_wal_end_lsn,
-                    records: batch,
-                })
-                .await
-                .map_err(|_err| InterpretedWalReaderError::NoReceivers)?;
+        for shard_number in 0..SHARD_COUNT {
+            let shard_id = ShardIdentity::new(
+                ShardNumber(shard_number),
+                ShardCount(SHARD_COUNT),
+                ShardStripeSize::default(),
+            )
+            .unwrap();
+            let (tx, rx) = tokio::sync::mpsc::channel::<Batch>(MSG_COUNT * 2);
+            shards.insert(shard_id, (Some(tx), Some(rx)));
         }
 
-        Ok(())
+        let shard_0_tx = shards.get_mut(&shard_0).unwrap().0.take().unwrap();
+        let mut shard_0_rx = shards.get_mut(&shard_0).unwrap().1.take().unwrap();
 
-        // TODO: move to network sender
-        // The loop above ends when the receiver is caught up and there's no more WAL to send.
-        // Err(CopyStreamHandlerEnd::ServerInitiated(format!(
-        //     "ending streaming to {:?} at {}, receiver is caughtup and there is no computes",
-        //     self.appname, wal_position,
-        // )))
+        let handle = InterpretedWalReader::spawn(
+            streaming_wal_reader,
+            start_lsn,
+            shard_0_tx,
+            shard_0,
+            PG_VERSION,
+        );
+
+        tracing::info!("Reading all WAL with only shard 0 attached ...");
+
+        let mut shard_0_interpreted_records = Vec::new();
+        while let Some(batch) = shard_0_rx.recv().await {
+            shard_0_interpreted_records.push(batch.records);
+            if batch.wal_end_lsn == batch.available_wal_end_lsn {
+                break;
+            }
+        }
+
+        let shard_1_tx = shards.get_mut(&shard_1).unwrap().0.take().unwrap();
+        let mut shard_1_rx = shards.get_mut(&shard_1).unwrap().1.take().unwrap();
+
+        tracing::info!("Attaching shard 1 to the reader at start of WAL");
+        handle.fanout(shard_1, shard_1_tx, start_lsn).unwrap();
+
+        tracing::info!("Reading all WAL with shard 0 and shard 1 attached ...");
+
+        let mut shard_1_interpreted_records = Vec::new();
+        while let Some(batch) = shard_1_rx.recv().await {
+            shard_1_interpreted_records.push(batch.records);
+            if batch.wal_end_lsn == batch.available_wal_end_lsn {
+                break;
+            }
+        }
+
+        // This test uses logical messages. Those only go to shard 0. Check that the
+        // filtering worked and shard 1 did not get any.
+        assert!(shard_1_interpreted_records
+            .iter()
+            .all(|recs| recs.records.is_empty()));
+
+        // Shard 0 should not receive anything more since the reader is
+        // going through wal that it has already processed.
+        let res = shard_0_rx.try_recv();
+        if let Ok(ref ok) = res {
+            tracing::error!(
+                "Shard 0 received batch: wal_end_lsn={} available_wal_end_lsn={}",
+                ok.wal_end_lsn,
+                ok.available_wal_end_lsn
+            );
+        }
+        assert!(matches!(res, Err(TryRecvError::Empty)));
+
+        // Check that the next records lsns received by the two shards match up.
+        let shard_0_next_lsns = shard_0_interpreted_records
+            .iter()
+            .map(|recs| recs.next_record_lsn)
+            .collect::<Vec<_>>();
+        let shard_1_next_lsns = shard_1_interpreted_records
+            .iter()
+            .map(|recs| recs.next_record_lsn)
+            .collect::<Vec<_>>();
+        assert_eq!(shard_0_next_lsns, shard_1_next_lsns);
+
+        handle.abort();
+        let mut done = false;
+        for _ in 0..5 {
+            if handle.current_position().is_none() {
+                done = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        assert!(done);
     }
 }

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -252,8 +252,8 @@ impl InterpretedWalReader {
     }
 
     /// Send interpreted WAL to one or more [`InterpretedWalSender`]s
-    /// Stops when an error is encountered or when [`InterpretedWalReaderHandle::cancel`]
-    /// is called.
+    /// Stops when an error is encountered or when the [`InterpretedWalReaderHandle`]
+    /// goes out of scope.
     async fn run_impl(mut self, start_pos: Lsn) -> Result<(), InterpretedWalReaderError> {
         let defer_state = self.state.clone();
         scopeguard::defer! {

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -90,7 +90,8 @@ pub(crate) struct InterpretedWalReaderHandle {
     join_handle: JoinHandle<Result<(), InterpretedWalReaderError>>,
     state: Arc<std::sync::RwLock<InterpretedWalReaderState>>,
     shard_notification_tx: tokio::sync::mpsc::UnboundedSender<AttachShardNotification>,
-    // TODO: remove or keep
+    // Currently, the task is aborted on [`Self`] drop. Cancellation token is here
+    // in case we want to refine the approach later.
     #[allow(unused)]
     cancel: CancellationToken,
 }

--- a/safekeeper/src/send_wal.rs
+++ b/safekeeper/src/send_wal.rs
@@ -528,7 +528,7 @@ impl SafekeeperPostgresHandler {
                 let (tx, rx) = tokio::sync::mpsc::channel::<Batch>(2);
                 let shard = self.shard.unwrap();
 
-                if self.conf.wal_reader_fanout {
+                if self.conf.wal_reader_fanout && !shard.is_unsharded() {
                     let ws_id = ws_guard.id();
                     ws_guard.walsenders().create_or_update_interpreted_reader(
                         ws_id,

--- a/safekeeper/src/send_wal.rs
+++ b/safekeeper/src/send_wal.rs
@@ -26,7 +26,6 @@ use safekeeper_api::models::{
 };
 use safekeeper_api::Term;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_util::sync::CancellationToken;
 use utils::failpoint_support;
 use utils::pageserver_feedback::PageserverFeedback;
 use utils::postgres_client::PostgresClientProtocol;
@@ -602,15 +601,8 @@ impl SafekeeperPostgresHandler {
                         MAX_SEND_SIZE,
                     );
 
-                    let reader_cancel = CancellationToken::new();
-                    let reader = InterpretedWalReader::new(
-                        wal_reader,
-                        start_pos,
-                        tx,
-                        shard,
-                        pg_version,
-                        reader_cancel.clone(),
-                    );
+                    let reader =
+                        InterpretedWalReader::new(wal_reader, start_pos, tx, shard, pg_version);
 
                     let sender = InterpretedWalSender {
                         format,
@@ -625,19 +617,15 @@ impl SafekeeperPostgresHandler {
                     };
 
                     FutureExt::boxed(async move {
-                        let send_and_cancel = async move {
-                            let res = sender.run().await;
-                            reader_cancel.cancel();
-                            res
-                        };
-
-                        let (reader_res, sender_res) =
-                            tokio::join!(reader.run(start_pos, &appname), send_and_cancel);
-                        if let Err(err) = reader_res {
-                            tracing::error!("Interpreted wal reader encountered error: {err}");
+                        // Sender returns an Err on all code paths.
+                        // If the sender finishes first, we will drop the reader future.
+                        // If the reader finishes first, the sender will finish too since
+                        // the wal sender has dropped.
+                        let res = tokio::try_join!(sender.run(), reader.run(start_pos, &appname));
+                        match res.map(|_| ()) {
+                            Ok(_) => unreachable!("sender finishes with Err by convention"),
+                            err_res => err_res,
                         }
-
-                        sender_res
                     })
                 }
             }
@@ -651,7 +639,6 @@ impl SafekeeperPostgresHandler {
             tli,
         };
 
-        // TODO: cancel things nicely
         let res = tokio::select! {
             // todo: add read|write .context to these errors
             r = send_fut => r,

--- a/safekeeper/src/test_utils.rs
+++ b/safekeeper/src/test_utils.rs
@@ -114,6 +114,9 @@ impl Env {
         Ok(timeline)
     }
 
+    // This will be dead code when building a non-benchmark target with the
+    // benchmarking feature enabled.
+    #[allow(dead_code)]
     pub(crate) async fn write_wal(
         tli: Arc<Timeline>,
         start_lsn: Lsn,

--- a/safekeeper/src/test_utils.rs
+++ b/safekeeper/src/test_utils.rs
@@ -1,13 +1,19 @@
 use std::sync::Arc;
 
 use crate::rate_limit::RateLimiter;
-use crate::safekeeper::{ProposerAcceptorMessage, ProposerElected, SafeKeeper, TermHistory};
+use crate::receive_wal::WalAcceptor;
+use crate::safekeeper::{
+    AcceptorProposerMessage, AppendRequest, AppendRequestHeader, ProposerAcceptorMessage,
+    ProposerElected, SafeKeeper, TermHistory,
+};
+use crate::send_wal::EndWatch;
 use crate::state::{TimelinePersistentState, TimelineState};
 use crate::timeline::{get_timeline_dir, SharedState, StateSK, Timeline};
 use crate::timelines_set::TimelinesSet;
 use crate::wal_backup::remote_timeline_path;
-use crate::{control_file, wal_storage, SafeKeeperConf};
+use crate::{control_file, receive_wal, wal_storage, SafeKeeperConf};
 use camino_tempfile::Utf8TempDir;
+use postgres_ffi::v17::wal_generator::{LogicalMessageGenerator, WalGenerator};
 use tokio::fs::create_dir_all;
 use utils::id::{NodeId, TenantTimelineId};
 use utils::lsn::Lsn;
@@ -106,5 +112,57 @@ impl Env {
             RateLimiter::new(0, 0),
         );
         Ok(timeline)
+    }
+
+    pub(crate) async fn write_wal(
+        tli: Arc<Timeline>,
+        start_lsn: Lsn,
+        msg_size: usize,
+        msg_count: usize,
+    ) -> anyhow::Result<EndWatch> {
+        let (msg_tx, msg_rx) = tokio::sync::mpsc::channel(receive_wal::MSG_QUEUE_SIZE);
+        let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel(receive_wal::REPLY_QUEUE_SIZE);
+
+        let end_watch = EndWatch::Commit(tli.get_commit_lsn_watch_rx());
+
+        WalAcceptor::spawn(tli.wal_residence_guard().await?, msg_rx, reply_tx, Some(0));
+
+        let prefix = c"p";
+        let prefixlen = prefix.to_bytes_with_nul().len();
+        assert!(msg_size >= prefixlen);
+        let message = vec![0; msg_size - prefixlen];
+
+        let walgen =
+            &mut WalGenerator::new(LogicalMessageGenerator::new(prefix, &message), start_lsn);
+        for _ in 0..msg_count {
+            let (lsn, record) = walgen.next().unwrap();
+
+            let req = AppendRequest {
+                h: AppendRequestHeader {
+                    term: 1,
+                    term_start_lsn: start_lsn,
+                    begin_lsn: lsn,
+                    end_lsn: lsn + record.len() as u64,
+                    commit_lsn: lsn,
+                    truncate_lsn: Lsn(0),
+                    proposer_uuid: [0; 16],
+                },
+                wal_data: record,
+            };
+
+            let end_lsn = req.h.end_lsn;
+
+            let msg = ProposerAcceptorMessage::AppendRequest(req);
+            msg_tx.send(msg).await?;
+            while let Some(reply) = reply_rx.recv().await {
+                if let AcceptorProposerMessage::AppendResponse(resp) = reply {
+                    if resp.flush_lsn >= end_lsn {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(end_watch)
     }
 }

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -730,7 +730,7 @@ impl Timeline {
         debug_dump::Memory {
             is_cancelled: self.is_cancelled(),
             peers_info_len: state.peers_info.0.len(),
-            walsenders: self.walsenders.get_all(),
+            walsenders: self.walsenders.get_all_public(),
             wal_backup_active: self.wal_backup_active.load(Ordering::Relaxed),
             active: self.broker_active.load(Ordering::Relaxed),
             num_computes: self.walreceivers.get_num() as u32,

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -32,7 +32,7 @@ use crate::control_file;
 use crate::rate_limit::RateLimiter;
 use crate::receive_wal::WalReceivers;
 use crate::safekeeper::{AcceptorProposerMessage, ProposerAcceptorMessage, SafeKeeper, TermLsn};
-use crate::send_wal::WalSenders;
+use crate::send_wal::{WalSenders, WalSendersTimelineMetricValues};
 use crate::state::{EvictionState, TimelineMemState, TimelinePersistentState, TimelineState};
 use crate::timeline_guard::ResidenceGuard;
 use crate::timeline_manager::{AtomicStatus, ManagerCtl};
@@ -702,16 +702,22 @@ impl Timeline {
             return None;
         }
 
-        let (ps_feedback_count, last_ps_feedback) = self.walsenders.get_ps_feedback_stats();
+        let WalSendersTimelineMetricValues {
+            ps_feedback_counter,
+            last_ps_feedback,
+            interpreted_wal_reader_tasks,
+        } = self.walsenders.info_for_metrics();
+
         let state = self.read_shared_state().await;
         Some(FullTimelineInfo {
             ttid: self.ttid,
-            ps_feedback_count,
+            ps_feedback_count: ps_feedback_counter,
             last_ps_feedback,
             wal_backup_active: self.wal_backup_active.load(Ordering::Relaxed),
             timeline_is_active: self.broker_active.load(Ordering::Relaxed),
             num_computes: self.walreceivers.get_num() as u32,
             last_removed_segno: self.last_removed_segno.load(Ordering::Relaxed),
+            interpreted_wal_reader_tasks,
             epoch_start_lsn: state.sk.term_start_lsn(),
             mem_state: state.sk.state().inmem.clone(),
             persisted_state: TimelinePersistentState::clone(state.sk.state()),

--- a/safekeeper/src/wal_reader_stream.rs
+++ b/safekeeper/src/wal_reader_stream.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use async_stream::try_stream;
 use bytes::Bytes;
 use futures::Stream;
-use postgres_backend::CopyStreamHandlerEnd;
 use safekeeper_api::Term;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -51,7 +50,7 @@ impl WalReaderStreamBuilder {
     pub(crate) async fn build(
         self,
         buffer_size: usize,
-    ) -> anyhow::Result<impl Stream<Item = Result<WalBytes, CopyStreamHandlerEnd>>> {
+    ) -> anyhow::Result<impl Stream<Item = anyhow::Result<WalBytes>>> {
         // TODO(vlad): The code below duplicates functionality from [`crate::send_wal`].
         // We can make the raw WAL sender use this stream too and remove the duplication.
         let Self {

--- a/safekeeper/src/wal_reader_stream.rs
+++ b/safekeeper/src/wal_reader_stream.rs
@@ -1,33 +1,16 @@
-use std::sync::Arc;
-
-use async_stream::try_stream;
-use bytes::Bytes;
-use futures::Stream;
-use safekeeper_api::Term;
-use std::time::Duration;
-use tokio::time::timeout;
-use utils::lsn::Lsn;
-
-use crate::{
-    send_wal::{EndWatch, WalSenderGuard},
-    timeline::WalResidentTimeline,
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
 };
 
-pub(crate) struct WalReaderStreamBuilder {
-    pub(crate) tli: WalResidentTimeline,
-    pub(crate) start_pos: Lsn,
-    pub(crate) end_pos: Lsn,
-    pub(crate) term: Option<Term>,
-    pub(crate) end_watch: EndWatch,
-    pub(crate) wal_sender_guard: Arc<WalSenderGuard>,
-}
+use bytes::Bytes;
+use futures::{stream::BoxStream, Stream, StreamExt};
+use utils::lsn::Lsn;
 
-impl WalReaderStreamBuilder {
-    pub(crate) fn start_pos(&self) -> Lsn {
-        self.start_pos
-    }
-}
+use crate::{send_wal::EndWatch, timeline::WalResidentTimeline, wal_storage::WalReader};
+use safekeeper_api::Term;
 
+#[derive(PartialEq, Eq, Debug)]
 pub(crate) struct WalBytes {
     /// Raw PG WAL
     pub(crate) wal: Bytes,
@@ -43,106 +26,260 @@ pub(crate) struct WalBytes {
     pub(crate) available_wal_end_lsn: Lsn,
 }
 
-impl WalReaderStreamBuilder {
-    /// Builds a stream of Postgres WAL starting from [`Self::start_pos`].
-    /// The stream terminates when the receiver (pageserver) is fully caught up
-    /// and there's no active computes.
-    pub(crate) async fn build(
-        self,
+struct PositionedWalReader {
+    start: Lsn,
+    end: Lsn,
+    reader: Option<WalReader>,
+}
+
+/// A streaming WAL reader wrapper which can be reset while running
+pub(crate) struct StreamingWalReader {
+    stream: BoxStream<'static, anyhow::Result<WalBytes>>,
+    start_changed_tx: tokio::sync::watch::Sender<Lsn>,
+}
+
+enum WalOrReset {
+    Wal(anyhow::Result<WalBytes>),
+    Reset(Lsn),
+}
+
+impl WalOrReset {
+    fn get_wal(self) -> Option<anyhow::Result<WalBytes>> {
+        match self {
+            WalOrReset::Wal(wal) => Some(wal),
+            WalOrReset::Reset(_) => None,
+        }
+    }
+}
+
+impl StreamingWalReader {
+    pub(crate) fn new(
+        tli: WalResidentTimeline,
+        term: Option<Term>,
+        start: Lsn,
+        end: Lsn,
+        end_watch: EndWatch,
         buffer_size: usize,
-    ) -> anyhow::Result<impl Stream<Item = anyhow::Result<WalBytes>>> {
-        // TODO(vlad): The code below duplicates functionality from [`crate::send_wal`].
-        // We can make the raw WAL sender use this stream too and remove the duplication.
-        let Self {
+    ) -> Self {
+        let (start_changed_tx, start_changed_rx) = tokio::sync::watch::channel(start);
+
+        let state = WalReaderStreamState {
             tli,
-            mut start_pos,
-            mut end_pos,
+            wal_reader: PositionedWalReader {
+                start,
+                end,
+                reader: None,
+            },
             term,
-            mut end_watch,
-            wal_sender_guard,
-        } = self;
-        let mut wal_reader = tli.get_walreader(start_pos).await?;
-        let mut buffer = vec![0; buffer_size];
+            end_watch,
+            buffer: vec![0; buffer_size],
+            buffer_size,
+            start_changed_rx: Some(start_changed_rx),
+        };
 
-        const POLL_STATE_TIMEOUT: Duration = Duration::from_secs(1);
+        // When a change notification is received while polling the internal
+        // reader, stop polling the read future and service the change.
+        // To make this work with `unfold`, a no-op [`WalOrReset::Reset`]
+        // record is produced and filtered out.
+        let stream = futures::stream::unfold(state, |mut state| async move {
+            let mut change_rx = state.start_changed_rx.take().unwrap();
 
-        Ok(try_stream! {
-            loop {
-                let have_something_to_send = end_pos > start_pos;
-
-                if !have_something_to_send {
-                    // wait for lsn
-                    let res = timeout(POLL_STATE_TIMEOUT, end_watch.wait_for_lsn(start_pos, term)).await;
-                    match res {
-                        Ok(ok) => {
-                            end_pos = ok?;
-                        },
-                        Err(_) => {
-                            if let EndWatch::Commit(_) = end_watch {
-                                if let Some(remote_consistent_lsn) = wal_sender_guard
-                                    .walsenders()
-                                    .get_ws_remote_consistent_lsn(wal_sender_guard.id())
-                                {
-                                    if tli.should_walsender_stop(remote_consistent_lsn).await {
-                                        // Stop streaming if the receivers are caught up and
-                                        // there's no active compute. This causes the loop in
-                                        // [`crate::send_interpreted_wal::InterpretedWalSender::run`]
-                                        // to exit and terminate the WAL stream.
-                                        return;
-                                    }
-                                }
-                            }
-
-                            continue;
-                        }
-                    }
+            let wal_or_reset = tokio::select! {
+                read_res = state.read() => { WalOrReset::Wal(read_res) },
+                changed_res = change_rx.changed() => {
+                    assert!(changed_res.is_ok());
+                    let new_start_pos = change_rx.borrow_and_update();
+                    tracing::info!("Wal stream received reset at {}", *new_start_pos);
+                    WalOrReset::Reset(*new_start_pos)
                 }
+            };
 
+            state.start_changed_rx = Some(change_rx);
 
-                assert!(
-                    end_pos > start_pos,
-                    "nothing to send after waiting for WAL"
-                );
-
-                // try to send as much as available, capped by the buffer size
-                let mut chunk_end_pos = start_pos + buffer_size as u64;
-                // if we went behind available WAL, back off
-                if chunk_end_pos >= end_pos {
-                    chunk_end_pos = end_pos;
-                } else {
-                    // If sending not up to end pos, round down to page boundary to
-                    // avoid breaking WAL record not at page boundary, as protocol
-                    // demands. See walsender.c (XLogSendPhysical).
-                    chunk_end_pos = chunk_end_pos
-                        .checked_sub(chunk_end_pos.block_offset())
-                        .unwrap();
-                }
-                let send_size = (chunk_end_pos.0 - start_pos.0) as usize;
-                let buffer = &mut buffer[..send_size];
-                let send_size: usize;
-                {
-                    // If uncommitted part is being pulled, check that the term is
-                    // still the expected one.
-                    let _term_guard = if let Some(t) = term {
-                        Some(tli.acquire_term(t).await?)
-                    } else {
-                        None
-                    };
-                    // Read WAL into buffer. send_size can be additionally capped to
-                    // segment boundary here.
-                    send_size = wal_reader.read(buffer).await?
-                };
-                let wal = Bytes::copy_from_slice(&buffer[..send_size]);
-
-                yield WalBytes {
-                    wal,
-                    wal_start_lsn: start_pos,
-                    wal_end_lsn: start_pos + send_size as u64,
-                    available_wal_end_lsn: end_pos
-                };
-
-                start_pos += send_size as u64;
+            if let WalOrReset::Reset(lsn) = wal_or_reset {
+                state.wal_reader.start = lsn;
+                state.wal_reader.reader = None;
             }
+
+            Some((wal_or_reset, state))
         })
+        .filter_map(|wal_or_reset| async move { wal_or_reset.get_wal() })
+        .boxed();
+
+        Self {
+            stream,
+            start_changed_tx,
+        }
+    }
+
+    /// Reset the stream to a given position.
+    pub(crate) fn reset(&mut self, start: Lsn) {
+        self.start_changed_tx.send(start).unwrap();
+    }
+}
+
+impl Stream for StreamingWalReader {
+    type Item = anyhow::Result<WalBytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.stream).poll_next(cx)
+    }
+}
+
+struct WalReaderStreamState {
+    tli: WalResidentTimeline,
+    wal_reader: PositionedWalReader,
+    term: Option<Term>,
+    end_watch: EndWatch,
+    buffer: Vec<u8>,
+    buffer_size: usize,
+    start_changed_rx: Option<tokio::sync::watch::Receiver<Lsn>>,
+}
+
+impl WalReaderStreamState {
+    async fn read(&mut self) -> anyhow::Result<WalBytes> {
+        // Create reader if needed
+        if self.wal_reader.reader.is_none() {
+            self.wal_reader.reader = Some(self.tli.get_walreader(self.wal_reader.start).await?);
+        }
+
+        let have_something_to_send = self.wal_reader.end > self.wal_reader.start;
+        if !have_something_to_send {
+            tracing::debug!(
+                "Waiting for wal: start={}, end={}",
+                self.wal_reader.end,
+                self.wal_reader.start
+            );
+            self.wal_reader.end = self
+                .end_watch
+                .wait_for_lsn(self.wal_reader.start, self.term)
+                .await?;
+            tracing::debug!(
+                "Done waiting for wal: start={}, end={}",
+                self.wal_reader.end,
+                self.wal_reader.start
+            );
+        }
+
+        assert!(
+            self.wal_reader.end > self.wal_reader.start,
+            "nothing to send after waiting for WAL"
+        );
+
+        // Calculate chunk size
+        let mut chunk_end_pos = self.wal_reader.start + self.buffer_size as u64;
+        if chunk_end_pos >= self.wal_reader.end {
+            chunk_end_pos = self.wal_reader.end;
+        } else {
+            chunk_end_pos = chunk_end_pos
+                .checked_sub(chunk_end_pos.block_offset())
+                .unwrap();
+        }
+
+        let send_size = (chunk_end_pos.0 - self.wal_reader.start.0) as usize;
+        let buffer = &mut self.buffer[..send_size];
+
+        // Read WAL
+        let send_size = {
+            let _term_guard = if let Some(t) = self.term {
+                Some(self.tli.acquire_term(t).await?)
+            } else {
+                None
+            };
+            self.wal_reader
+                .reader
+                .as_mut()
+                .unwrap()
+                .read(buffer)
+                .await?
+        };
+
+        let wal = Bytes::copy_from_slice(&buffer[..send_size]);
+        let result = WalBytes {
+            wal,
+            wal_start_lsn: self.wal_reader.start,
+            wal_end_lsn: self.wal_reader.start + send_size as u64,
+            available_wal_end_lsn: self.wal_reader.end,
+        };
+
+        self.wal_reader.start += send_size as u64;
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use futures::StreamExt;
+    use postgres_ffi::MAX_SEND_SIZE;
+    use utils::{
+        id::{NodeId, TenantTimelineId},
+        lsn::Lsn,
+    };
+
+    use crate::{test_utils::Env, wal_reader_stream::StreamingWalReader};
+
+    #[tokio::test]
+    async fn test_streaming_wal_reader_reset() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        const SIZE: usize = 8 * 1024;
+        const MSG_COUNT: usize = 200;
+
+        let start_lsn = Lsn::from_str("0/149FD18").unwrap();
+        let env = Env::new(true).unwrap();
+        let tli = env
+            .make_timeline(NodeId(1), TenantTimelineId::generate(), start_lsn)
+            .await
+            .unwrap();
+
+        let resident_tli = tli.wal_residence_guard().await.unwrap();
+        let end_watch = Env::write_wal(tli, start_lsn, SIZE, MSG_COUNT)
+            .await
+            .unwrap();
+        let end_pos = end_watch.get();
+
+        tracing::info!("Doing first round of reads ...");
+
+        let mut streaming_wal_reader = StreamingWalReader::new(
+            resident_tli,
+            None,
+            start_lsn,
+            end_pos,
+            end_watch,
+            MAX_SEND_SIZE,
+        );
+
+        let mut before_reset = Vec::new();
+        while let Some(wal) = streaming_wal_reader.next().await {
+            let wal = wal.unwrap();
+            let stop = wal.available_wal_end_lsn == wal.wal_end_lsn;
+            before_reset.push(wal);
+
+            if stop {
+                break;
+            }
+        }
+
+        tracing::info!("Resetting the WAL stream ...");
+
+        streaming_wal_reader.reset(start_lsn);
+
+        tracing::info!("Doing second round of reads ...");
+
+        let mut after_reset = Vec::new();
+        while let Some(wal) = streaming_wal_reader.next().await {
+            let wal = wal.unwrap();
+            let stop = wal.available_wal_end_lsn == wal.wal_end_lsn;
+            after_reset.push(wal);
+
+            if stop {
+                break;
+            }
+        }
+
+        assert_eq!(before_reset, after_reset);
     }
 }

--- a/safekeeper/src/wal_reader_stream.rs
+++ b/safekeeper/src/wal_reader_stream.rs
@@ -89,7 +89,6 @@ impl StreamingWalReader {
                 changed_res = change_rx.changed() => {
                     assert!(changed_res.is_ok());
                     let new_start_pos = change_rx.borrow_and_update();
-                    tracing::info!("Wal stream received reset at {}", *new_start_pos);
                     WalOrReset::Reset(*new_start_pos)
                 }
             };

--- a/safekeeper/src/wal_reader_stream.rs
+++ b/safekeeper/src/wal_reader_stream.rs
@@ -84,7 +84,10 @@ impl StreamingWalReader {
                 let wal_or_reset = tokio::select! {
                     read_res = state.read() => { WalOrReset::Wal(read_res) },
                     changed_res = rx.changed() => {
-                        assert!(changed_res.is_ok());
+                        if changed_res.is_err() {
+                            return None;
+                        }
+
                         let new_start_pos = rx.borrow_and_update();
                         WalOrReset::Reset(*new_start_pos)
                     }

--- a/safekeeper/tests/walproposer_sim/safekeeper.rs
+++ b/safekeeper/tests/walproposer_sim/safekeeper.rs
@@ -179,7 +179,7 @@ pub fn run_server(os: NodeOs, disk: Arc<SafekeeperDisk>) -> Result<()> {
         partial_backup_concurrency: 1,
         eviction_min_resident: Duration::ZERO,
         wal_reader_fanout: false,
-        max_delta_for_fanout: 1,
+        max_delta_for_fanout: None,
     };
 
     let mut global = GlobalMap::new(disk, conf.clone())?;

--- a/safekeeper/tests/walproposer_sim/safekeeper.rs
+++ b/safekeeper/tests/walproposer_sim/safekeeper.rs
@@ -178,6 +178,8 @@ pub fn run_server(os: NodeOs, disk: Arc<SafekeeperDisk>) -> Result<()> {
         control_file_save_interval: Duration::from_secs(1),
         partial_backup_concurrency: 1,
         eviction_min_resident: Duration::ZERO,
+        wal_reader_fanout: false,
+        max_delta_for_fanout: 1,
     };
 
     let mut global = GlobalMap::new(disk, conf.clone())?;


### PR DESCRIPTION
## Problem

Safekeepers currently decode and interpret WAL for each shard separately.
This is wasteful in terms of CPU memory usage - we've seen this in profiles.

## Summary of changes

Fan-out interpreted WAL to multiple shards. 
The basic  is that wal decoding and interpretation happens in a separate tokio task and senders
attach to it. Senders only receive batches concerning their shard and only past the Lsn they've last seen.

Fan-out is gated behind the `wal_reader_fanout` safekeeper flag (disabled by default for now).

When fan-out is enabled, it might be desirable to control the absolute delta between the
current position and a new shard's desired position (i.e. how far behind or ahead a shard may be).
`max_delta_for_fanout` is a new optional safekeeper flag which dictates whether to create a new
WAL reader or attach to the existing one. By default, this behaviour is disabled. Let's consider enabling
it if we spot the need for it in the field.

## Testing

Tests passed [here](https://github.com/neondatabase/neon/pull/10301) with wal reader fanout enabled
as of https://github.com/neondatabase/neon/pull/10190/commits/34f6a717182c431847bbd5b7828fd0f89027b2be.

Related: https://github.com/neondatabase/neon/issues/9337
Epic: https://github.com/neondatabase/neon/issues/9329
