### PR TITLE
Add scheduling_policy column to safekeepers table

### DIFF
--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -1043,8 +1043,8 @@ async fn main() -> anyhow::Result<()> {
                     sk.host,
                     format!("{}", sk.port),
                     format!("{}", sk.http_port),
-                    sk.availability_zone_id.to_string(),
-                    format!("{}", sk.scheduling_policy),
+                    sk.availability_zone_id.clone(),
+                    sk.scheduling_policy.clone(),
                 ]);
             }
             println!("{table}");

--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -1044,7 +1044,7 @@ async fn main() -> anyhow::Result<()> {
                     format!("{}", sk.port),
                     format!("{}", sk.http_port),
                     sk.availability_zone_id.clone(),
-                    sk.scheduling_policy.clone(),
+                    String::from(sk.scheduling_policy),
                 ]);
             }
             println!("{table}");

--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -1044,7 +1044,7 @@ async fn main() -> anyhow::Result<()> {
                     format!("{}", sk.port),
                     format!("{}", sk.http_port),
                     sk.availability_zone_id.to_string(),
-                    format!("{}", sk.scheduling_policy.unwrap_or_default()),
+                    format!("{}", sk.scheduling_policy),
                 ]);
             }
             println!("{table}");

--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -1035,7 +1035,15 @@ async fn main() -> anyhow::Result<()> {
             resp.sort_by(|a, b| a.id.cmp(&b.id));
 
             let mut table = comfy_table::Table::new();
-            table.set_header(["Id", "Version", "Host", "Port", "Http Port", "AZ Id"]);
+            table.set_header([
+                "Id",
+                "Version",
+                "Host",
+                "Port",
+                "Http Port",
+                "AZ Id",
+                "Scheduling",
+            ]);
             for sk in resp {
                 table.add_row([
                     format!("{}", sk.id),

--- a/control_plane/storcon_cli/src/main.rs
+++ b/control_plane/storcon_cli/src/main.rs
@@ -1044,6 +1044,7 @@ async fn main() -> anyhow::Result<()> {
                     format!("{}", sk.port),
                     format!("{}", sk.http_port),
                     sk.availability_zone_id.to_string(),
+                    format!("{}", sk.scheduling_policy.unwrap_or_default()),
                 ]);
             }
             println!("{table}");

--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -419,7 +419,7 @@ pub struct SafekeeperDescribeResponse {
     pub port: i32,
     pub http_port: i32,
     pub availability_zone_id: String,
-    pub scheduling_policy: Option<String>,
+    pub scheduling_policy: String,
 }
 
 #[cfg(test)]

--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -387,6 +387,7 @@ pub struct SafekeeperDescribeResponse {
     pub port: i32,
     pub http_port: i32,
     pub availability_zone_id: String,
+    pub scheduling_policy: Option<String>,
 }
 
 #[cfg(test)]

--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -419,7 +419,7 @@ pub struct SafekeeperDescribeResponse {
     pub port: i32,
     pub http_port: i32,
     pub availability_zone_id: String,
-    pub scheduling_policy: String,
+    pub scheduling_policy: SkSchedulingPolicy,
 }
 
 #[cfg(test)]

--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -320,6 +320,38 @@ impl From<NodeSchedulingPolicy> for String {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Copy, Eq, PartialEq, Debug)]
+pub enum SkSchedulingPolicy {
+    Active,
+    Disabled,
+    Decomissioned,
+}
+
+impl FromStr for SkSchedulingPolicy {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "active" => Self::Active,
+            "disabled" => Self::Disabled,
+            "decomissioned" => Self::Decomissioned,
+            _ => return Err(anyhow::anyhow!("Unknown scheduling state '{s}'")),
+        })
+    }
+}
+
+impl From<SkSchedulingPolicy> for String {
+    fn from(value: SkSchedulingPolicy) -> String {
+        use SkSchedulingPolicy::*;
+        match value {
+            Active => "active",
+            Disabled => "disabled",
+            Decomissioned => "decomissioned",
+        }
+        .to_string()
+    }
+}
+
 /// Controls how tenant shards are mapped to locations on pageservers, e.g. whether
 /// to create secondary locations.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/storage_controller/migrations/2024-12-12-212515_safekeepers_scheduling_policy/down.sql
+++ b/storage_controller/migrations/2024-12-12-212515_safekeepers_scheduling_policy/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE safekeepers DROP scheduling_policy;

--- a/storage_controller/migrations/2024-12-12-212515_safekeepers_scheduling_policy/up.sql
+++ b/storage_controller/migrations/2024-12-12-212515_safekeepers_scheduling_policy/up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE safekeepers ADD scheduling_policy VARCHAR NOT NULL DEFAULT "disabled";
+ALTER TABLE safekeepers ADD scheduling_policy VARCHAR NOT NULL DEFAULT 'disabled';

--- a/storage_controller/migrations/2024-12-12-212515_safekeepers_scheduling_policy/up.sql
+++ b/storage_controller/migrations/2024-12-12-212515_safekeepers_scheduling_policy/up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE safekeepers ADD scheduling_policy VARCHAR;
+ALTER TABLE safekeepers ADD scheduling_policy VARCHAR NOT NULL DEFAULT "disabled";

--- a/storage_controller/migrations/2024-12-12-212515_safekeepers_scheduling_policy/up.sql
+++ b/storage_controller/migrations/2024-12-12-212515_safekeepers_scheduling_policy/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE safekeepers ADD scheduling_policy VARCHAR;

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -3,7 +3,7 @@ use crate::metrics::{
     HttpRequestLatencyLabelGroup, HttpRequestStatusLabelGroup, PageserverRequestLabelGroup,
     METRICS_REGISTRY,
 };
-use crate::persistence::SafekeeperPersistence;
+use crate::persistence::SafekeeperUpsert;
 use crate::reconciler::ReconcileError;
 use crate::service::{LeadershipStatus, Service, RECONCILE_TIMEOUT, STARTUP_RECONCILE_TIMEOUT};
 use anyhow::Context;
@@ -1249,7 +1249,7 @@ async fn handle_get_safekeeper(req: Request<Body>) -> Result<Response<Body>, Api
 async fn handle_upsert_safekeeper(mut req: Request<Body>) -> Result<Response<Body>, ApiError> {
     check_permissions(&req, Scope::Infra)?;
 
-    let body = json_request::<SafekeeperPersistence>(&mut req).await?;
+    let body = json_request::<SafekeeperUpsert>(&mut req).await?;
     let id = parse_request_param::<i64>(&req, "id")?;
 
     if id != body.id {

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1227,6 +1227,7 @@ pub(crate) struct SafekeeperPersistence {
     pub(crate) active: bool,
     pub(crate) http_port: i32,
     pub(crate) availability_zone_id: String,
+    pub(crate) scheduling_policy: Option<String>,
 }
 
 impl SafekeeperPersistence {
@@ -1252,6 +1253,7 @@ impl SafekeeperPersistence {
             port: self.port,
             http_port: self.http_port,
             availability_zone_id: self.availability_zone_id.clone(),
+            scheduling_policy: self.scheduling_policy.clone(),
         }
     }
 }

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1241,6 +1241,7 @@ impl SafekeeperPersistence {
             active: self.active,
             http_port: self.http_port,
             availability_zone_id: &self.availability_zone_id,
+            scheduling_policy: None,
         }
     }
     pub(crate) fn as_describe_response(&self) -> SafekeeperDescribeResponse {
@@ -1260,6 +1261,7 @@ impl SafekeeperPersistence {
 
 #[derive(Insertable, AsChangeset)]
 #[diesel(table_name = crate::schema::safekeepers)]
+#[diesel(treat_none_as_null = true)]
 struct InsertUpdateSafekeeper<'a> {
     id: i64,
     region_id: &'a str,
@@ -1269,4 +1271,5 @@ struct InsertUpdateSafekeeper<'a> {
     active: bool,
     http_port: i32,
     availability_zone_id: &'a str,
+    scheduling_policy: Option<&'a str>,
 }

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1227,7 +1227,7 @@ pub(crate) struct SafekeeperPersistence {
     pub(crate) active: bool,
     pub(crate) http_port: i32,
     pub(crate) availability_zone_id: String,
-    pub(crate) scheduling_policy: Option<String>,
+    pub(crate) scheduling_policy: String,
 }
 
 impl SafekeeperPersistence {
@@ -1241,7 +1241,7 @@ impl SafekeeperPersistence {
             active: self.active,
             http_port: self.http_port,
             availability_zone_id: &self.availability_zone_id,
-            scheduling_policy: None,
+            scheduling_policy: &self.scheduling_policy,
         }
     }
     pub(crate) fn as_describe_response(&self) -> SafekeeperDescribeResponse {
@@ -1271,5 +1271,5 @@ struct InsertUpdateSafekeeper<'a> {
     active: bool,
     http_port: i32,
     availability_zone_id: &'a str,
-    scheduling_policy: Option<&'a str>,
+    scheduling_policy: &'a str,
 }

--- a/storage_controller/src/schema.rs
+++ b/storage_controller/src/schema.rs
@@ -39,7 +39,7 @@ diesel::table! {
         active -> Bool,
         http_port -> Int4,
         availability_zone_id -> Text,
-        scheduling_policy -> Nullable<Varchar>,
+        scheduling_policy -> Varchar,
     }
 }
 

--- a/storage_controller/src/schema.rs
+++ b/storage_controller/src/schema.rs
@@ -39,6 +39,7 @@ diesel::table! {
         active -> Bool,
         http_port -> Int4,
         availability_zone_id -> Text,
+        scheduling_policy -> Nullable<Varchar>,
     }
 }
 

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7171,13 +7171,13 @@ impl Service {
     pub(crate) async fn safekeepers_list(
         &self,
     ) -> Result<Vec<SafekeeperDescribeResponse>, DatabaseError> {
-        Ok(self
+        self
             .persistence
             .list_safekeepers()
             .await?
             .into_iter()
             .map(|v| v.as_describe_response())
-            .collect::<Vec<_>>())
+            .collect::<Result<Vec<_>, _>>()
     }
 
     pub(crate) async fn get_safekeeper(
@@ -7187,7 +7187,7 @@ impl Service {
         self.persistence
             .safekeeper_get(id)
             .await
-            .map(|v| v.as_describe_response())
+            .and_then(|v| v.as_describe_response())
     }
 
     pub(crate) async fn upsert_safekeeper(

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7192,7 +7192,7 @@ impl Service {
 
     pub(crate) async fn upsert_safekeeper(
         &self,
-        record: crate::persistence::SafekeeperPersistence,
+        record: crate::persistence::SafekeeperUpsert,
     ) -> Result<(), DatabaseError> {
         self.persistence.safekeeper_upsert(record).await
     }

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7171,8 +7171,7 @@ impl Service {
     pub(crate) async fn safekeepers_list(
         &self,
     ) -> Result<Vec<SafekeeperDescribeResponse>, DatabaseError> {
-        self
-            .persistence
+        self.persistence
             .list_safekeepers()
             .await?
             .into_iter()

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -3009,7 +3009,7 @@ def test_safekeeper_deployment_time_update(neon_env_builder: NeonEnvBuilder):
 def eq_safekeeper_records(a: dict[str, Any], b: dict[str, Any]) -> bool:
     compared = [dict(a), dict(b)]
 
-    masked_keys = ["created_at", "updated_at", "active"]
+    masked_keys = ["created_at", "updated_at", "active", "scheduling_policy"]
 
     for d in compared:
         # keep deleting these in case we are comparing the body as it will be uploaded by real scripts


### PR DESCRIPTION
Add a `scheduling_policy` column to the safekeepers table of the storage controller.

Part of #9981