### PR TITLE
libs/proxy: Add missing waker wake in poll_shutdown

### DIFF
--- a/libs/proxy/tokio-postgres2/src/connection.rs
+++ b/libs/proxy/tokio-postgres2/src/connection.rs
@@ -258,6 +258,7 @@ where
 
     fn poll_shutdown(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
         if self.state != State::Closing {
+            cx.waker().wake_by_ref();
             return Poll::Pending;
         }
 


### PR DESCRIPTION
## Problem

`poll_shutdown()` returns `Poll::Pending` but does not trigger a wake and callers seems to rely on this.

## Summary of changes

Add a `wake_by_ref()`.