### PR TITLE
Set libpq path for pg_dump in fast_import

### DIFF
--- a/compute_tools/src/bin/fast_import.rs
+++ b/compute_tools/src/bin/fast_import.rs
@@ -172,6 +172,7 @@ pub(crate) async fn main() -> anyhow::Result<()> {
         .args(["-c", &format!("max_worker_processes={nproc}")])
         .args(["-c", "effective_io_concurrency=100"])
         .env_clear()
+        .env("LD_LIBRARY_PATH", "/usr/local/lib/")
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
@@ -256,6 +257,7 @@ pub(crate) async fn main() -> anyhow::Result<()> {
             .arg(&source_connection_string)
             // how we run it
             .env_clear()
+            .env("LD_LIBRARY_PATH", "/usr/local/lib/")
             .kill_on_drop(true)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -289,6 +291,7 @@ pub(crate) async fn main() -> anyhow::Result<()> {
             .arg(&dumpdir)
             // how we run it
             .env_clear()
+            .env("LD_LIBRARY_PATH", "/usr/local/lib/")
             .kill_on_drop(true)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
Without that psql uses library from apt package libpq5 which is a transitive dependency of libgdal28 which is needed for postgis  extension. And that thing overshadows proper libpq that we install:

```
postgres@a6bde1e8e89e:~$ ldd `which psql` | grep pq
	libpq.so.5 => /usr/lib/aarch64-linux-gnu/libpq.so.5 (0x0000ffffaf135000)
postgres@a6bde1e8e89e:~$ dpkg-query  -S /usr/lib/aarch64-linux-gnu/libpq.so.5
libpq5:arm64: /usr/lib/aarch64-linux-gnu/libpq.so.5
postgres@a6bde1e8e89e:~$ apt-cache rdepends libpq5
libpq5
Reverse Depends:
  libgdal28
postgres@a6bde1e8e89e:~$ apt show libpq5 | grep -i version
Version: 13.18-0+deb11u1
```
In theory we could try to clean up image from that old libpq, but IMO it not worth it. Always setting LD_LIBRARY_PATH should be robust enough, and would work for all versions/archs. 