### PR TITLE
pageserver: fix `tenant::storage_layer::layer` tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3945,6 +3945,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_with",
+ "serial_test",
  "smallvec",
  "storage_broker",
  "strum",
@@ -5613,6 +5614,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b13f8ea6177672c49d12ed964cca44836f59621981b04a3e26b87e675181de"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5651,6 +5661,12 @@ name = "sd-notify"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
+
+[[package]]
+name = "sdd"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
 
 [[package]]
 name = "sec1"
@@ -5939,6 +5955,31 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct 0.2.0",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ serde_json = "1"
 serde_path_to_error = "0.1"
 serde_with = { version = "2.0", features = [ "base64" ] }
 serde_assert = "0.5.0"
+serial_test = "3.2.0"
 sha2 = "0.10.2"
 signal-hook = "0.3"
 smallvec = "1.11"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -94,6 +94,7 @@ procfs.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 hex-literal.workspace = true
+serial_test.workspace = true
 tokio = { workspace = true, features = ["process", "sync", "fs", "rt", "io-util", "time", "test-util"] }
 indoc.workspace = true
 


### PR DESCRIPTION
## Problem

`cargo test` fails non-deterministically on these tests, because they share global state via `LAYER_IMPL_METRICS` and then assert on this global state.

Tests really should not share global state, but as a simple hack for now, just reset the global state and serialize the tests.

## Summary of changes

Reset `LAYER_IMPL_METRICS` for each test, and run tests serially.