### PR TITLE
compute/sql_exporter: Bump max WSS window from 1h -> 3h

### DIFF
--- a/compute/etc/sql_exporter/lfc_approximate_working_set_size_windows.autoscaling.sql
+++ b/compute/etc/sql_exporter/lfc_approximate_working_set_size_windows.autoscaling.sql
@@ -1,8 +1,8 @@
 -- NOTE: This is the "internal" / "machine-readable" version. This outputs the
--- working set size looking back 1..60 minutes, labeled with the number of
+-- working set size looking back 1..180 minutes, labeled with the number of
 -- minutes.
 
 SELECT
   x::text as duration_seconds,
   neon.approximate_working_set_size_seconds(x) AS size
-FROM (SELECT generate_series * 60 AS x FROM generate_series(1, 60)) AS t (x);
+FROM (SELECT generate_series * 60 AS x FROM generate_series(1, 180)) AS t (x);

--- a/compute/etc/sql_exporter/lfc_approximate_working_set_size_windows.sql
+++ b/compute/etc/sql_exporter/lfc_approximate_working_set_size_windows.sql
@@ -4,5 +4,5 @@
 SELECT
   x AS duration,
   neon.approximate_working_set_size_seconds(extract('epoch' FROM x::interval)::int) AS size FROM (
-    VALUES ('5m'), ('15m'), ('1h')
+    VALUES ('5m'), ('15m'), ('1h'), ('3h')
   ) AS t (x);


### PR DESCRIPTION
## Problem

ref neondatabase/cloud#22214.

For larger workloads, 1-hour working set size windows may not be enough to hold the working set size (and so, autoscaling may not have enough information to do a good job scaling LFC). I'm not sure what the right value is, but 3 hours seems like a reasonable increase.

## Summary of changes

Concretely, this:

1. Changes the normal (public) exporter to add a new 3-hour working set size label onto the existing 5-minute, 15-minute, and 1-hour values.

2. Extends the range on the autoscaling exporter from 1..60 minutes to 1..180 minutes -- keeping the same density, just 3x longer.

---

I'll try using the compute image produced by this PR on some larger workload before merging, to see if any issues pop up.