### PR TITLE
chore(libs/proxy): refactor tokio-postgres connection control flow

### DIFF
--- a/libs/proxy/tokio-postgres2/src/connection.rs
+++ b/libs/proxy/tokio-postgres2/src/connection.rs
@@ -216,19 +216,14 @@ where
                     self.state = State::Terminating;
                     let mut request = BytesMut::new();
                     frontend::terminate(&mut request);
-                    let request = RequestMessages::Single(FrontendMessage::Raw(request.freeze()));
+                    let request = FrontendMessage::Raw(request.freeze());
 
-                    match request {
-                        RequestMessages::Single(request) => {
-                            Pin::new(&mut self.stream)
-                                .start_send(request)
-                                .map_err(Error::io)?;
-                            if self.state == State::Terminating {
-                                trace!("poll_write: sent eof, closing");
-                                self.state = State::Closing;
-                            }
-                        }
-                    }
+                    Pin::new(&mut self.stream)
+                        .start_send(request)
+                        .map_err(Error::io)?;
+
+                    trace!("poll_write: sent eof, closing");
+                    self.state = State::Closing;
 
                     continue;
                 }

--- a/libs/proxy/tokio-postgres2/src/connection.rs
+++ b/libs/proxy/tokio-postgres2/src/connection.rs
@@ -91,6 +91,8 @@ where
             .map(|o| o.map(|r| r.map_err(Error::io)))
     }
 
+    /// Read and process messages from the connection to postgres.
+    /// client <- postgres
     fn poll_read(&mut self, cx: &mut Context<'_>) -> Result<Option<AsyncMessage>, Error> {
         if self.state != State::Active {
             trace!("poll_read: done");
@@ -168,6 +170,7 @@ where
         }
     }
 
+    /// Fetch the next client request and enqueue the response sender.
     fn poll_request(&mut self, cx: &mut Context<'_>) -> Poll<Option<RequestMessages>> {
         if self.receiver.is_closed() {
             return Poll::Ready(None);
@@ -186,6 +189,8 @@ where
         }
     }
 
+    /// Process client requests and write them to the postgres connection, flushing if necessary.
+    /// client -> postgres
     fn poll_write(&mut self, cx: &mut Context<'_>) -> Result<(), Error> {
         loop {
             if self.state == State::Closing {

--- a/libs/proxy/tokio-postgres2/src/connection.rs
+++ b/libs/proxy/tokio-postgres2/src/connection.rs
@@ -214,7 +214,7 @@ where
                         .start_send(request)
                         .map_err(Error::io)?;
                 }
-                Poll::Ready(None) if self.responses.is_empty() && self.state == State::Active => {
+                Poll::Ready(None) if self.responses.is_empty() => {
                     trace!("poll_write: at eof, terminating");
                     let mut request = BytesMut::new();
                     frontend::terminate(&mut request);


### PR DESCRIPTION
In #10207 it was clear there was some confusion with the current connection logic. To analyse the flow to make sure there was no poll stalling, I ended up with the following refactor.

Notable changes:
1. Now all functions called `poll_xyz` and that have a `cx: &mut Context` argument must return a `Poll<_>` type, and can only return `Pending` iff an internal poll call also returned `Pending`
2. State management is handled entirely by `poll_messages`. There are now only 2 states which makes it much easier to keep track of.

Each commit should be self-reviewable and should be simple to verify that it keeps the same behaviour