### PR TITLE
fix(proxy): remove postgres notice logs

### DIFF
--- a/libs/proxy/tokio-postgres2/src/connect.rs
+++ b/libs/proxy/tokio-postgres2/src/connect.rs
@@ -1,11 +1,9 @@
 use crate::client::SocketConfig;
-use crate::codec::BackendMessage;
 use crate::config::Host;
 use crate::connect_raw::connect_raw;
 use crate::connect_socket::connect_socket;
 use crate::tls::{MakeTlsConnect, TlsConnect};
 use crate::{Client, Config, Connection, Error, RawConnection};
-use postgres_protocol2::message::backend::Message;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 
@@ -43,7 +41,7 @@ where
     let RawConnection {
         stream,
         parameters,
-        delayed_notice,
+        delayed_notice: _,
         process_id,
         secret_key,
     } = connect_raw(socket, tls, config).await?;
@@ -63,13 +61,7 @@ where
         secret_key,
     );
 
-    // delayed notices are always sent as "Async" messages.
-    let delayed = delayed_notice
-        .into_iter()
-        .map(|m| BackendMessage::Async(Message::NoticeResponse(m)))
-        .collect();
-
-    let connection = Connection::new(stream, delayed, parameters, receiver);
+    let connection = Connection::new(stream, parameters, receiver);
 
     Ok((client, connection))
 }

--- a/libs/proxy/tokio-postgres2/src/connection.rs
+++ b/libs/proxy/tokio-postgres2/src/connection.rs
@@ -66,7 +66,6 @@ where
 {
     pub(crate) fn new(
         stream: Framed<MaybeTlsStream<S, T>, PostgresCodec>,
-        pending_responses: VecDeque<BackendMessage>,
         parameters: HashMap<String, String>,
         receiver: mpsc::UnboundedReceiver<Request>,
     ) -> Connection<S, T> {
@@ -74,7 +73,7 @@ where
             stream,
             parameters,
             receiver,
-            pending_responses,
+            pending_responses: VecDeque::new(),
             responses: VecDeque::new(),
             state: State::Active,
         }

--- a/libs/proxy/tokio-postgres2/src/lib.rs
+++ b/libs/proxy/tokio-postgres2/src/lib.rs
@@ -6,7 +6,6 @@ pub use crate::client::{Client, SocketConfig};
 pub use crate::config::Config;
 pub use crate::connect_raw::RawConnection;
 pub use crate::connection::Connection;
-use crate::error::DbError;
 pub use crate::error::Error;
 pub use crate::generic_client::GenericClient;
 pub use crate::query::RowStream;
@@ -100,10 +99,6 @@ impl Notification {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum AsyncMessage {
-    /// A notice.
-    ///
-    /// Notices use the same format as errors, but aren't "errors" per-se.
-    Notice(DbError),
     /// A notification.
     ///
     /// Connections can subscribe to notifications with the `LISTEN` command.

--- a/proxy/src/serverless/conn_pool.rs
+++ b/proxy/src/serverless/conn_pool.rs
@@ -124,9 +124,7 @@ pub(crate) fn poll_client<C: ClientInnerExt>(
                 let message = ready!(connection.poll_message(cx));
 
                 match message {
-                    Some(Ok(AsyncMessage::Notice(notice))) => {
-                        info!(%session_id, "notice: {}", notice);
-                    }
+                    Some(Ok(AsyncMessage::Notice(_))) => {}
                     Some(Ok(AsyncMessage::Notification(notif))) => {
                         warn!(%session_id, pid = notif.process_id(), channel = notif.channel(), "notification received");
                     }

--- a/proxy/src/serverless/conn_pool.rs
+++ b/proxy/src/serverless/conn_pool.rs
@@ -124,7 +124,6 @@ pub(crate) fn poll_client<C: ClientInnerExt>(
                 let message = ready!(connection.poll_message(cx));
 
                 match message {
-                    Some(Ok(AsyncMessage::Notice(_))) => {}
                     Some(Ok(AsyncMessage::Notification(notif))) => {
                         warn!(%session_id, pid = notif.process_id(), channel = notif.channel(), "notification received");
                     }

--- a/proxy/src/serverless/local_conn_pool.rs
+++ b/proxy/src/serverless/local_conn_pool.rs
@@ -227,9 +227,7 @@ pub(crate) fn poll_client<C: ClientInnerExt>(
                 let message = ready!(connection.poll_message(cx));
 
                 match message {
-                    Some(Ok(AsyncMessage::Notice(notice))) => {
-                        info!(%session_id, "notice: {}", notice);
-                    }
+                    Some(Ok(AsyncMessage::Notice(_))) => {}
                     Some(Ok(AsyncMessage::Notification(notif))) => {
                         warn!(%session_id, pid = notif.process_id(), channel = notif.channel(), "notification received");
                     }

--- a/proxy/src/serverless/local_conn_pool.rs
+++ b/proxy/src/serverless/local_conn_pool.rs
@@ -227,7 +227,6 @@ pub(crate) fn poll_client<C: ClientInnerExt>(
                 let message = ready!(connection.poll_message(cx));
 
                 match message {
-                    Some(Ok(AsyncMessage::Notice(_))) => {}
                     Some(Ok(AsyncMessage::Notification(notif))) => {
                         warn!(%session_id, pid = notif.process_id(), channel = notif.channel(), "notification received");
                     }


### PR DESCRIPTION
The notice logs don't serve much utility for us for managed connections, so we can remove them.

As a side effect, the notice infrastructure within connection.rs is no longer necessary which allows us to simplify some things.