### PR TITLE
build: link storage controller with system libpq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ RUN set -e \
         libreadline-dev \
         libseccomp-dev \
         ca-certificates \
+	# System postgres for use with client libraries (e.g. in storage controller)
+        postgresql-15 \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && useradd -d /data neon \
     && chown -R neon:neon /data

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,6 @@ CARGO_BUILD_FLAGS += $(filter -j1,$(MAKEFLAGS))
 CARGO_CMD_PREFIX += $(if $(filter n,$(MAKEFLAGS)),,+)
 # Force cargo not to print progress bar
 CARGO_CMD_PREFIX += CARGO_TERM_PROGRESS_WHEN=never CI=1
-# Set PQ_LIB_DIR to make sure `storage_controller` get linked with bundled libpq (through diesel)
-CARGO_CMD_PREFIX += PQ_LIB_DIR=$(POSTGRES_INSTALL_DIR)/v16/lib
 
 CACHEDIR_TAG_CONTENTS := "Signature: 8a477f597d28d172789f06886806bc55"
 


### PR DESCRIPTION
## Problem

We see occasional storage controller segfaults (https://github.com/neondatabase/cloud/issues/21010), which are correlated with database connection errors, and it is known that using statically linked openssl from multi-threaded programs is risky (https://github.com/neondatabase/cloud/issues/16155)

## Summary of changes

- Include the system postgres 15 package in container image
- Don't set `CARGO_CMD_PREFIX` to link with our custom postgres build when building.

**Important**: helm charts set LD_LIBRARY_PATH to point to a v16 path -- because we'll be building binaries against v15 (because that's what's available on debian bookworm), that might not work seamlessly, we might need to coordinate a helm chart change deploy with this change.

Why is it okay to only use statically-linked openssl for our other binaries and not for the storage controller?  Because the purpose of that static linking is to make our postgres builds agnostic wrt the specific openssl version on the distro where we run.  The controller doesn't need that, because it can use a totally vanilla upstream postgres for its client library, and that vanilla system postgres package will already use whichever openssl is available on the distro where we're running.
