### PR TITLE
libpagestore: timeout = max(0, difference), not min(0, difference)

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -680,7 +680,7 @@ call_PQgetCopyData(shardno_t shard_no, char **buffer)
 	 * but in the cases that take exceptionally long, it's useful to log the
 	 * exact timestamps.
 	 */
-#define LOG_INTERVAL_MS		UINT64CONST(10 * 1000)
+#define LOG_INTERVAL_MS		INT64CONST(10 * 1000)
 
 	INSTR_TIME_SET_CURRENT(now);
 	start_ts = last_log_ts = now;


### PR DESCRIPTION
Using `min(0, ...)`  causes us to fail to wait in most situations, so a lack of data would be a hot wait loop, which is bad.

## Problem

We noticed high CPU usage in some situations