### PR TITLE
Fix clippy warning on macOS

### DIFF
--- a/compute_tools/src/bin/compute_ctl.rs
+++ b/compute_tools/src/bin/compute_ctl.rs
@@ -428,6 +428,7 @@ fn start_postgres(
     let &ComputeSpec {
         swap_size_bytes,
         disk_quota_bytes,
+        #[cfg(target_os = "linux")]
         disable_lfc_resizing,
         ..
     } = &state.pspec.as_ref().unwrap().spec;


### PR DESCRIPTION
## Problem

On macOS:

```
error: unused variable: `disable_lfc_resizing`
   --> compute_tools/src/bin/compute_ctl.rs:431:9
    |
431 |         disable_lfc_resizing,
    |         ^^^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `disable_lfc_resizing: _`
    |
    = note: `-D unused-variables` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_variables)]`
```

## Summary of changes
- Initialise `disable_lfc_resizing` only on Linux (because it's used on Linux only in further bloc)
