### PR TITLE
fix(compute_ctl): Resolve issues with dropping roles having dangling permissions

### DIFF
--- a/compute_tools/src/spec_apply.rs
+++ b/compute_tools/src/spec_apply.rs
@@ -510,7 +510,7 @@ async fn get_operations<'a>(
                                     // TODO: this is obviously not 100% true because of the above case,
                                     // there could be still some privileges that are not revoked. Maybe this
                                     // only drops privileges that were granted *by this* role, not *to this* role,
-                                    // but this is has to be checked.
+                                    // but this has to be checked.
                                     Operation {
                                         query: format!("DROP OWNED BY {}", quoted),
                                         comment: None,

--- a/compute_tools/src/sql/pre_drop_role_revoke_privileges.sql
+++ b/compute_tools/src/sql/pre_drop_role_revoke_privileges.sql
@@ -1,0 +1,28 @@
+SET SESSION ROLE neon_superuser;
+
+DO $$
+DECLARE
+    schema TEXT;
+    revoke_query TEXT;
+BEGIN
+    FOR schema IN
+        SELECT schema_name
+        FROM information_schema.schemata
+        -- So far, we only had issues with 'public' schema. Probably, because we do some additional grants,
+        -- e.g., make DB owner the owner of 'public' schema automatically (when created via API).
+        -- See https://github.com/neondatabase/cloud/issues/13582 for the context.
+        -- Still, keep the loop because i) it efficiently handles the case when there is no 'public' schema,
+        -- ii) it's easy to add more schemas to the list if needed.
+        WHERE schema_name IN ('public')
+    LOOP
+        revoke_query := format(
+            'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I FROM {role_name} GRANTED BY neon_superuser;',
+            schema
+        );
+
+        EXECUTE revoke_query;
+    END LOOP;
+END;
+$$;
+
+RESET ROLE;

--- a/test_runner/regress/test_compute_catalog.py
+++ b/test_runner/regress/test_compute_catalog.py
@@ -256,7 +256,7 @@ def test_compute_drop_role(neon_simple_env: NeonEnv):
     """
     Test that compute_ctl can drop a role even if it has some depending objects
     like permissions in one of the databases.
-    Repro test for https://github.com/neondatabase/cloud/issues/13582
+    Reproduction test for https://github.com/neondatabase/cloud/issues/13582
     """
     env = neon_simple_env
     TEST_DB_NAME = "db_with_permissions"
@@ -273,7 +273,7 @@ def test_compute_drop_role(neon_simple_env: NeonEnv):
                         # additional grants equivalent to our real environment, so we can repro some
                         # issues.
                         "name": "neon",
-                        # XXX: this is a hash suggested by LLM, no specific meaning.
+                        # Some autocomplete-suggested hash, no specific meaning.
                         "encrypted_password": "SCRAM-SHA-256$4096:hBT22QjqpydQWqEulorfXA==$miBogcoj68JWYdsNB5PW1X6PjSLBEcNuctuhtGkb4PY=:hxk2gxkwxGo6P7GCtfpMlhA9zwHvPMsCz+NQf2HfvWk=",
                         "options": [],
                     },
@@ -297,7 +297,7 @@ def test_compute_drop_role(neon_simple_env: NeonEnv):
     with endpoint.cursor(dbname=TEST_DB_NAME, user="neon") as cursor:
         cursor.execute("create role readonly")
         # We (`compute_ctl`) make 'neon' the owner of schema 'public' in the owned database.
-        # Postgres has all sorts of permissions and grant that we may not handle well,
+        # Postgres has all sorts of permissions and grants that we may not handle well,
         # but this is the shortest repro grant for the issue
         # https://github.com/neondatabase/cloud/issues/13582
         cursor.execute("grant select on all tables in schema public to readonly")


### PR DESCRIPTION
## Problem

In Postgres, one cannot drop a role if it has any dependent objects in the DB. In `compute_ctl`, we automatically reassign all dependent objects in every DB to the corresponding DB owner. Yet, it seems that it doesn't help with some implicit permissions. The issue is reproduced by installing a `postgis` extension because it creates some views and tables in the public schema.

## Summary of changes

Added a repro test without using a `postgis`: i) create a role via `compute_ctl` (with `neon_superuser` grant); ii) create a test role, a table in schema public, and grant permissions via the role in `neon_superuser`.

To fix the issue, I added a new `compute_ctl` code that removes such dangling permissions before dropping the role. It's done in the least invasive way, i.e., only touches the schema public, because i) that's the problem we had with PostGIS; ii) it creates a smaller chance of messing anything up and getting a stuck operation again, just for a different reason.

Properly, any API-based catalog operations should fail gracefully and provide an actionable error and status code to the control plane, allowing the latter to unwind the operation and propagate an error message and hint to the user. In this sense, it's aligned with another feature request https://github.com/neondatabase/cloud/issues/21611

Resolve neondatabase/cloud#13582