### PR TITLE
postgres_backend: don't print error stack traces

### DIFF
--- a/libs/postgres_backend/src/lib.rs
+++ b/libs/postgres_backend/src/lib.rs
@@ -1013,7 +1013,7 @@ fn log_query_error(query: &str, e: &QueryError) {
             }
         }
         QueryError::Disconnected(other_connection_error) => {
-            error!("query handler for '{query}' failed with connection error: {other_connection_error:?}")
+            error!("query handler for '{query}' failed with connection error: {other_connection_error}")
         }
         QueryError::SimulatedConnectionError => {
             error!("query handler for query '{query}' failed due to a simulated connection error")
@@ -1031,7 +1031,7 @@ fn log_query_error(query: &str, e: &QueryError) {
             warn!("query handler for '{query}' failed with authentication error: {e}");
         }
         QueryError::Other(e) => {
-            error!("query handler for '{query}' failed: {e:?}");
+            error!("query handler for '{query}' failed: {e}");
         }
     }
 }


### PR DESCRIPTION
## Problem

The use of `:?` when printing errors will dump stack traces, which can be overly dramatic and noisy for benign errors. For example:

```
2025-01-08T09:00:12.184800Z ERROR {cid=1168202 ttid=foo/bar application_name=Some("walreceiver")}: query handler for 'IDENTIFY_SYSTEM' failed: Timeline foo/bar was not found in global map
Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
             at /home/nonroot/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.94/src/backtrace.rs:27:14
   1: <T as core::convert::Into<U>>::into
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/convert/mod.rs:759:9
   2: safekeeper::handler::SafekeeperPostgresHandler::handle_identify_system::{{closure}}::{{closure}}
             at /home/nonroot/safekeeper/src/handler.rs:403:46
   3: core::result::Result<T,E>::map_err
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/result.rs:856:27
   4: safekeeper::handler::SafekeeperPostgresHandler::handle_identify_system::{{closure}}
             at /home/nonroot/safekeeper/src/handler.rs:400:19
   5: <safekeeper::handler::SafekeeperPostgresHandler as postgres_backend::Handler<IO>>::process_query::{{closure}}
             at /home/nonroot/safekeeper/src/handler.rs:306:95
   6: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/future/future.rs:123:9
[50 more lines of stack]
```

## Summary of changes

Don't print stack traces for errors.