### PR TITLE
fix(page_service): Timeline::gate held open while throttling

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -601,6 +601,9 @@ impl BatchedFeMessage {
         };
         let throttled = tokio::select! {
             throttled = shard.pagestream_throttle.throttle(tokens) => { throttled }
+            _ = shard.cancel.cancelled() => {
+                return Err(QueryError::Shutdown);
+            }
             _ = cancel.cancelled() => {
                 return Err(QueryError::Shutdown);
             }


### PR DESCRIPTION
When we moved throttling up from Timeline::get into page_service,
we stopped being sensitive to `Timeline::cancel`, even though we're
holding a Handle and thus a guard on the `Timeline::gate` open.

This PR rectifies the situation.

Refs

- Found while investigating #10309 (hung detach because gate kept open),
  but not expected to be the root cause of that issue because the
  affected tenants are not being throttled according to their metrics.
