### PR TITLE
docker: don't set LD_LIBRARY_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,11 +103,6 @@ RUN mkdir -p /data/.neon/ && \
   > /data/.neon/pageserver.toml && \
   chown -R neon:neon /data/.neon
 
-# When running a binary that links with libpq, default to using our most recent postgres version.  Binaries
-# that want a particular postgres version will select it explicitly: this is just a default.
-ENV LD_LIBRARY_PATH=/usr/local/v${DEFAULT_PG_VERSION}/lib
-
-
 VOLUME ["/data"]
 USER neon
 EXPOSE 6400


### PR DESCRIPTION
## Problem

This was causing storage controller to still use neon-built libpq instead of vanilla libpq.

Since https://github.com/neondatabase/neon/pull/10269 we have a vanilla postgres in the system path -- anything that wants a postgres library will use that.

## Summary of changes

- Remove LD_LIBRARY_PATH assignment in Dockerfile
