### PR TITLE
fix(neonctl): set effective_io_concurrency to 0 on macos

### DIFF
--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -319,7 +319,11 @@ impl Endpoint {
         // Postgres defaults to effective_io_concurrency=1, which does not exercise the pageserver's
         // batching logic.  Set this to 2 so that we exercise the code a bit without letting
         // individual tests do a lot of concurrent work on underpowered test machines
-        conf.append("effective_io_concurrency", "2");
+        if cfg!(target_os = "macos") {
+            conf.append("effective_io_concurrency", "0");
+        } else {
+            conf.append("effective_io_concurrency", "2");
+        }
         conf.append("fsync", "off");
         conf.append("max_connections", "100");
         conf.append("wal_level", "logical");


### PR DESCRIPTION
## Problem

Postgres doesn't start with

```
2025-01-13 18:19:06.437 GMT [18213] DETAIL:  effective_io_concurrency must be set to 0 on platforms that lack posix_fadvise().
```

## Summary of changes

Set the config item to 0 on macOS by default.