### PR TITLE
Change expected error message for test_physical_replication_config_mismatch_max_locks_per_transaction

### DIFF
--- a/test_runner/regress/test_physical_replication.py
+++ b/test_runner/regress/test_physical_replication.py
@@ -260,4 +260,4 @@ def test_physical_replication_config_mismatch_max_locks_per_transaction(neon_sim
         secondary.stop()
 
     log.info(f"Replica crashed with {e}")
-    assert secondary.log_contains("You might need to increase")
+    assert secondary.log_contains("out of shared memory")


### PR DESCRIPTION
## Problem

Test  test_physical_replication_config_mismatch_max_locks_per_transaction its flaky.
Expected message (hint) `You might need to increase "max_locks_per_transaction".` is not always found in compute log:

```
PG:2025-01-13 18:14:57.300 GMT [177976] ERROR:  out of shared memory
PG:2025-01-13 18:14:57.300 GMT [177976] CONTEXT:  writing block 13 of relation base/5/2659
PG:2025-01-13 18:14:57.300 GMT [177981] ERROR:  out of shared memory
2025-01-13T18:14:57.300792Z  WARN failed to get list of active logical replication subscriptions: Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E53200), message: "out of shared memory", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("dynahash.c"), line: Some(1105), routine: Some("hash_search_with_hash_value") }) }
PG:2025-01-13 18:14:57.300 GMT [177981] STATEMENT:  select count(*) from pg_stat_subscription where pid is not null;
PG:2025-01-13 18:14:57.417 GMT [177977] FATAL:  out of shared memory
PG:2025-01-13 18:14:57.417 GMT [177977] CONTEXT:  writing block 13 of relation base/5/2659​	WAL redo at 0/17A0EC8 for neon/MULTI_INSERT+INIT: ntuples: 4, flags: 0x02; blkref #0: rel 1663/5/1249, blk 118
PG:2025-01-13 18:14:57.417 GMT [177977] WARNING:  could not write block 13 of base/5/2659
PG:2025-01-13 18:14:57.417 GMT [177977] DETAIL:  Multiple failures --- write error might be permanent.
PG:2025-01-13 18:14:57.420 GMT [177939] LOG:  startup process (PID 177977) exited with exit code 1
```
https://neon-github-public-dev.s3.amazonaws.com/reports/pr-10371/12750135109/index.html#/testresult/6e9a3492f423a2e1

## Summary of changes

Look for "out of shared memory" message instead.
