### PR TITLE
Run docker-compose based tests in multiple test workers

### DIFF
--- a/docker-compose/run-tests.sh
+++ b/docker-compose/run-tests.sh
@@ -8,7 +8,7 @@ for d in ${LIST}
 do
        [ -d "${d}" ] || continue
     psql -c "select 1" >/dev/null || break
-       USE_PGXS=1 make -C "${d}" installcheck || FAILED="${d} ${FAILED}"
+       USE_PGXS=1 make -C "${d}" -j $( nproc ) installcheck || FAILED="${d} ${FAILED}"
 done
 [ -z "${FAILED}" ] && exit 0
 echo "${FAILED}"


### PR DESCRIPTION
Previously they were run sequentially, which meant a very long runtime. Now, it's reduced by a good factor when the CPU time is available.

## Problem

The runtime for https://github.com/neondatabase/neon/actions/runs/12773839881/job/35613450148?pr=10394 is 17 minutes, which is a really bad developer experience.

## Summary of changes

We parallelize the tests, allowing for much faster completion when and where tests are parallelizable.