### PR TITLE
tests: make reconcile_until_idle more aggressive by default

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2105,7 +2105,7 @@ class NeonStorageController(MetricsGetter, LogUtils):
         log.info(f"reconcile_all waited for {n} shards")
         return n
 
-    def reconcile_until_idle(self, timeout_secs=30, max_interval=5):
+    def reconcile_until_idle(self, timeout_secs=30, max_interval=1):
         start_at = time.time()
         n = 1
         delay_sec = 0.1


### PR DESCRIPTION
## Problem

The `reconcile_until_idle` helper backs off when the controller appears to be busy.  However, this leads to long runtimes when there are multiple optimisations pending, for example after a shard split.  The #9916 changes made migrations take extra steps in some cases (creating temporary secondary locations), which highlights runtime impact of reconcile_until_idle.

Example failure of test_timeline_ancestor_detach_idempotent_success where reconcile had backed off to 5s period
https://neon-github-public-dev.s3.amazonaws.com/reports/pr-10411/12794755547/index.html#/testresult/47e461aab29cdf4b

## Summary of changes

- Change the default max backoff to 1s from 5s.  This means that in the default 30s timeout we should have comfortably enough iterations to quiesce an 8 shard split, so that tests doing this don't have to pass any non-default arguments.  Tests that do huge numbers of operations will continue to override max_interval as needed.