### PR TITLE
tests: use multiple AZs by default

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -370,7 +370,7 @@ class NeonEnvBuilder:
         pageserver_config_override: str | Callable[[dict[str, Any]], None] | None = None,
         num_safekeepers: int = 1,
         num_pageservers: int = 1,
-        num_azs: int = 1,
+        num_azs: int = 3,
         # Use non-standard SK ids to check for various parsing bugs
         safekeepers_id_start: int = 0,
         # fsync is disabled by default to make the tests go faster

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2138,6 +2138,10 @@ def test_graceful_cluster_restart(neon_env_builder: NeonEnvBuilder):
     fill hooks in order to migrate attachments away from pageservers before
     restarting. In practice, Ansible will drive this process.
     """
+
+    # Run with a single AZ to exercise the general case of balancing shards based on count
+    neon_env_builder.num_azs = 1
+
     neon_env_builder.num_pageservers = 2
     env = neon_env_builder.init_configs()
     env.start()
@@ -2394,7 +2398,6 @@ def test_storage_controller_node_deletion(
     Test that deleting a node works & properly reschedules everything that was on the node.
     """
     neon_env_builder.num_pageservers = 3
-    neon_env_builder.num_azs = 3
     env = neon_env_builder.init_configs()
     env.start()
 
@@ -3229,12 +3232,7 @@ def eq_safekeeper_records(a: dict[str, Any], b: dict[str, Any]) -> bool:
 
 @run_only_on_default_postgres("this is like a 'unit test' against storcon db")
 def test_shard_preferred_azs(neon_env_builder: NeonEnvBuilder):
-    def assign_az(ps_cfg):
-        az = f"az-{ps_cfg['id'] % 2}"
-        log.info("Assigned AZ {az}")
-        ps_cfg["availability_zone"] = az
-
-    neon_env_builder.pageserver_config_override = assign_az
+    neon_env_builder.num_azs = 2
     neon_env_builder.num_pageservers = 4
     env = neon_env_builder.init_configs()
     env.start()

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2394,6 +2394,7 @@ def test_storage_controller_node_deletion(
     Test that deleting a node works & properly reschedules everything that was on the node.
     """
     neon_env_builder.num_pageservers = 3
+    neon_env_builder.num_azs = 3
     env = neon_env_builder.init_configs()
     env.start()
 
@@ -2406,6 +2407,9 @@ def test_storage_controller_node_deletion(
         env.create_tenant(
             tid, placement_policy='{"Attached":1}', shard_count=shard_count_per_tenant
         )
+
+    # Sanity check: initial creations should not leave the system in an unstable scheduling state
+    assert env.storage_controller.reconcile_all() == 0
 
     victim = env.pageservers[-1]
 

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1026,6 +1026,8 @@ def test_sharded_tad_interleaved_after_partial_success(neon_env_builder: NeonEnv
     """
 
     shard_count = 2
+    # Single AZ so that a sharded tenant can spread across all pageservers
+    neon_env_builder.num_azs = 1
     neon_env_builder.num_pageservers = shard_count
     env = neon_env_builder.init_start(initial_tenant_shard_count=shard_count)
 


### PR DESCRIPTION
## Problem

To prevent repeats of https://github.com/neondatabase/neon/pull/10420, a more robust default is to use multiple AZs when using multiple pageservers.  This is also more realistic.

## Summary of changes

- Set `NeonEnvBuilder.num_azs` to 3 by default
- Set `num_azs=1` explicitly in tests that rely on that (i.e. tests that create multiple pageservers and expect a sharded tenant to use all of them).
