### PR TITLE
pageserver: log on potentially stuck connection manager loop

### DIFF
--- a/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
@@ -107,7 +107,7 @@ pub(super) async fn connection_manager_loop_step(
     let mut broker_subscription = subscribe_for_timeline_updates(broker_client, id, cancel).await?;
     debug!("Subscribed for broker timeline updates");
 
-    const WARN_ON_INACTIVE_AFTER: Duration = Duration::from_secs(60);
+    const WARN_ON_INACTIVE_AFTER: Duration = Duration::from_secs(180);
 
     loop {
         let time_until_next_retry = connection_manager_state.time_until_next_retry();


### PR DESCRIPTION
## Problem

Connection manager loop can get stuck if there's no broker input and nothing triggers an lsn wait.

## Summary of changes

Add another select arm that warn logs in such scenarios.

Related: https://github.com/neondatabase/neon/issues/10351