### PR TITLE
DNM: add tokio taskdump support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,7 +11,7 @@ rustdocflags = ["-Arustdoc::private_intra_doc_links"]
 # * <https://github.com/rust-lang/rust/pull/122646>
 #
 # NB: the RUSTFLAGS envvar will replace this. Make sure to update e.g. Dockerfile as well.
-rustflags = ["-Cforce-frame-pointers=yes"]
+rustflags = ["-Cforce-frame-pointers=yes", "--cfg", "tokio_unstable", "--cfg", "tokio_taskdump"]
 
 [alias]
 build_testing = ["build", "--features", "testing"]

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -2923,6 +2923,33 @@ async fn get_utilization(
         .map_err(ApiError::InternalServerError)
 }
 
+async fn get_taskdump(
+    request: Request<Body>,
+    _cancel: CancellationToken,
+) -> Result<Response<Body>, ApiError> {
+    check_permission(&request, None)?;
+
+    use std::io::Write;
+    use tokio::runtime::Handle;
+
+    let out = async {
+        let mut out = Vec::new();
+        // Inside an async block or function.
+        let handle = Handle::current();
+        let dump = handle.dump().await;
+        for (i, task) in dump.tasks().iter().enumerate() {
+            let trace = task.trace();
+            writeln!(out, "TASK {i}:")?;
+            writeln!(out, "{trace}\n")?;
+        }
+        Ok(String::from_utf8(out).unwrap())
+    }
+    .await
+    .map_err(|e: anyhow::Error| ApiError::InternalServerError(e))?;
+
+    json_response(StatusCode::OK, out)
+}
+
 async fn list_aux_files(
     mut request: Request<Body>,
     _cancel: CancellationToken,
@@ -3607,6 +3634,10 @@ pub fn make_router(
         .put(
             "/v1/tenant/:tenant_id/timeline/:timeline_id/import_wal",
             |r| api_handler(r, put_tenant_timeline_import_wal),
+        )
+        .get(
+            "/debug/taskdump",
+            |r| api_handler(r,  get_taskdump),
         )
         .any(handler_404))
 }


### PR DESCRIPTION
Usage

```
christian@neon-hetzner-dev-christian:[~/src/neon-work-1]: curl localhost:15008/debug/taskdump | jq --raw-output | less -S
```