### PR TITLE
fix(tests): actually enable pipelinig by default in the test suite

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1115,13 +1115,11 @@ class NeonEnv:
 
             # Batching (https://github.com/neondatabase/neon/issues/9377):
             # enable batching by default in tests and benchmarks.
-            # Compat tests are exempt because old versions fail to parse the new config.
-            if not config.compatibility_neon_binpath:
-                ps_cfg["page_service_pipelining"] = {
-                    "mode": "pipelined",
-                    "execution": "concurrent-futures",
-                    "max_batch_size": 32,
-                }
+            ps_cfg["page_service_pipelining"] = {
+                "mode": "pipelined",
+                "execution": "concurrent-futures",
+                "max_batch_size": 32,
+            }
 
             if self.pageserver_virtual_file_io_engine is not None:
                 ps_cfg["virtual_file_io_engine"] = self.pageserver_virtual_file_io_engine


### PR DESCRIPTION
## Problem

PR #9993 was supposed to enable `page_service_pipelining` by default for all `NeonEnv`s, but this  was ineffective in our CI environment.

Thus, CI Python-based tests and benchmarks, unless explicitly configuring pipelining, were still using serial protocol handling.

## Analysis

The root cause was that in our CI environment, `config.compatibility_neon_binpath` is always Truthy.
It's not in local environments, which is why this slipped through in local testing.

Lesson: always add a log line ot pageserver startup and spot-check tests to ensure the intended default is picked up.

## Summary of changes

Fix it. Since enough time has passed, the compatiblity snapshot contains a recent enough software version so we don't need to worry about `compatibility_neon_binpath` anymore.

## Future Work

The question how to add a new default except for compatibliity tests, which is what the broken code was supposed to do, is still unsolved.

Slack discussion: https://neondb.slack.com/archives/C059ZC138NR/p1737490501941309
