### PR TITLE
Do not assign max(lsn) to maxLastWrittenLsn in SetLastWrittenLSNForblokv

### DIFF
--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,7 +1,11 @@
 {
   "v17": [
     "17.2",
+<<<<<<< HEAD
     "4276717f6e91023e504de355f4f21d4824074de8"
+=======
+    "53213c4948ea0edeb379c2fe5beaba7de53ea96e"
+>>>>>>> 52df539e7 (Do not assign max(lsn) to maxLastWrittenLsn in SetLastWrittenLSNForBlockv)
   ],
   "v16": [
     "16.6",

--- a/vendor/revisions.json
+++ b/vendor/revisions.json
@@ -1,11 +1,7 @@
 {
   "v17": [
     "17.2",
-<<<<<<< HEAD
-    "4276717f6e91023e504de355f4f21d4824074de8"
-=======
-    "53213c4948ea0edeb379c2fe5beaba7de53ea96e"
->>>>>>> 52df539e7 (Do not assign max(lsn) to maxLastWrittenLsn in SetLastWrittenLSNForBlockv)
+    "46f9b96555e084c35dd975da9485996db9e86181"
   ],
   "v16": [
     "16.6",


### PR DESCRIPTION
## Problem

See https://github.com/neondatabase/neon/issues/10281

`SetLastWrittenLSNForBlockv` is assigning max(lsn) to `maxLastWrittenLsn` while its should contain only max LSN not present in LwLSN cache. It case unnecessary waits in PS.

## Summary of changes

Restore status-quo for pg17.

Related Postgres PR: https://github.com/neondatabase/postgres/pull/563