### PR TITLE
neon_local: add --pg-version for init subcommand

### DIFF
--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -974,7 +974,7 @@ fn handle_init(args: &InitCmdArgs) -> anyhow::Result<LocalEnv> {
                     }
                 })
                 .collect(),
-            pg_version: args.pg_version,
+            pg_version: Some(args.pg_version),
             pg_distrib_dir: None,
             neon_distrib_dir: None,
             default_tenant_id: TenantId::from_array(std::array::from_fn(|_| 0)),

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -46,6 +46,8 @@ pub struct LocalEnv {
     // must be an absolute path. If the env var is not set, $PWD/.neon is used.
     pub base_data_dir: PathBuf,
 
+    pub pg_version: u32,
+
     // Path to postgres distribution. It's expected that "bin", "include",
     // "lib", "share" from postgres distribution are there. If at some point
     // in time we will be able to run against vanilla postgres we may split that
@@ -93,6 +95,7 @@ pub struct LocalEnv {
 #[derive(PartialEq, Eq, Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct OnDiskConfig {
+    pub pg_version: u32,
     pub pg_distrib_dir: PathBuf,
     pub neon_distrib_dir: PathBuf,
     pub default_tenant_id: Option<TenantId>,
@@ -124,6 +127,7 @@ where
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NeonLocalInitConf {
+    pub pg_version: u32,
     // TODO: do we need this? Seems unused
     pub pg_distrib_dir: Option<PathBuf>,
     // TODO: do we need this? Seems unused
@@ -512,6 +516,7 @@ impl LocalEnv {
         let on_disk_config: OnDiskConfig = toml::from_str(config_file_contents.as_str())?;
         let mut env = {
             let OnDiskConfig {
+                pg_version,
                 pg_distrib_dir,
                 neon_distrib_dir,
                 default_tenant_id,
@@ -526,6 +531,7 @@ impl LocalEnv {
             } = on_disk_config;
             LocalEnv {
                 base_data_dir: repopath.to_owned(),
+                pg_version,
                 pg_distrib_dir,
                 neon_distrib_dir,
                 default_tenant_id,
@@ -629,6 +635,7 @@ impl LocalEnv {
         Self::persist_config_impl(
             &self.base_data_dir,
             &OnDiskConfig {
+                pg_version: self.pg_version,
                 pg_distrib_dir: self.pg_distrib_dir.clone(),
                 neon_distrib_dir: self.neon_distrib_dir.clone(),
                 default_tenant_id: self.default_tenant_id,
@@ -713,6 +720,7 @@ impl LocalEnv {
         }
 
         let NeonLocalInitConf {
+            pg_version,
             pg_distrib_dir,
             neon_distrib_dir,
             default_tenant_id,
@@ -759,6 +767,7 @@ impl LocalEnv {
         // TODO: refactor to avoid this, LocalEnv should only be constructed from on-disk state
         let env = LocalEnv {
             base_data_dir: base_path.clone(),
+            pg_version,
             pg_distrib_dir,
             neon_distrib_dir,
             default_tenant_id: Some(default_tenant_id),

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -127,7 +127,7 @@ where
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NeonLocalInitConf {
-    pub pg_version: u32,
+    pub pg_version: Option<u32>,
     // TODO: do we need this? Seems unused
     pub pg_distrib_dir: Option<PathBuf>,
     // TODO: do we need this? Seems unused
@@ -731,6 +731,8 @@ impl LocalEnv {
             control_plane_api,
             control_plane_compute_hook_api,
         } = conf;
+
+        let pg_version = pg_version.unwrap_or(DEFAULT_PG_VERSION);
 
         // Find postgres binaries.
         // Follow POSTGRES_DISTRIB_DIR if set, otherwise look in "pg_install".

--- a/control_plane/src/storage_controller.rs
+++ b/control_plane/src/storage_controller.rs
@@ -183,7 +183,13 @@ impl StorageController {
     /// to other versions if that one isn't found.  Some automated tests create circumstances
     /// where only one version is available in pg_distrib_dir, such as `test_remote_extensions`.
     async fn get_pg_dir(&self, dir_name: &str) -> anyhow::Result<Utf8PathBuf> {
-        let prefer_versions = [STORAGE_CONTROLLER_POSTGRES_VERSION, 16, 15, 14];
+        let prefer_versions = [
+            self.env.pg_version,
+            STORAGE_CONTROLLER_POSTGRES_VERSION,
+            16,
+            15,
+            14,
+        ];
 
         for v in prefer_versions {
             let path = Utf8PathBuf::from_path_buf(self.env.pg_dir(v, dir_name)?).unwrap();


### PR DESCRIPTION
## Problem

Solve the issue https://github.com/neondatabase/neon/issues/10441.

`cargo neon init` has not the '--pg-version' argument yet. That's ok for now as the `init` subcommand does not initialize any postgres instance and the `tenant create` and `endpoint create` subcommand have the '--pg-version' for postgres initialization.
However, adding the '--pg-version' argument for the `init` subcommand will make life better.

Extra notes: in my test, use different postgres versions, say 14 and 16, for the `tenant create` and `endpoint create` command will result in the error from the subcommand `endpoint start`: FATAL:  database files are incompatible with server.
So, would it be nice to remove '--pg-version' from `tenant create` and `endpoint create` subcommannd?

## Summary of changes

* add '--pg-version' for `init` subcommand, which has a default value 16
* change '--pg-version' of other subcommands, such as `tenant create`, `endpoint create`