### PR TITLE
pageserver: retry wrapper on manifest upload

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -5330,15 +5330,9 @@ impl Tenant {
         )
         .await
         {
-            None => {
-                Err(TenantManifestError::Cancelled)
-            }
-            Some(Err(_)) if self.cancel.is_cancelled() => {
-                Err(TenantManifestError::Cancelled)
-            }
-            Some(Err(e)) => {
-                Err(TenantManifestError::RemoteStorage(e))
-            },
+            None => Err(TenantManifestError::Cancelled),
+            Some(Err(_)) if self.cancel.is_cancelled() => Err(TenantManifestError::Cancelled),
+            Some(Err(e)) => Err(TenantManifestError::RemoteStorage(e)),
             Some(Ok(_)) => {
                 // Store the successfully uploaded manifest, so that future callers can avoid
                 // re-uploading the same thing.


### PR DESCRIPTION
## Problem

On remote storage errors (e.g. I/O timeout) uploading tenant manifest, all of compaction could fail.  This is a problem IRL because we shouldn't abort compaction on a single IO error, and in tests because it generates spurious failures.

Related: https://github.com/orgs/neondatabase/projects/51/views/2?sliceBy%5Bvalue%5D=jcsp&pane=issue&itemId=93692919&issue=neondatabase%7Cneon%7C10389

## Summary of changes

- Use `backoff::retry` when uploading tenant manifest