### PR TITLE
feat(pageserver): dump read path on missing key error

### DIFF
--- a/libs/pageserver_api/src/config.rs
+++ b/libs/pageserver_api/src/config.rs
@@ -121,6 +121,7 @@ pub struct ConfigToml {
     pub wal_receiver_protocol: PostgresClientProtocol,
     pub page_service_pipelining: PageServicePipeliningConfig,
     pub get_vectored_concurrent_io: GetVectoredConcurrentIo,
+    pub enable_read_path_debugging: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -509,6 +510,11 @@ impl Default for ConfigToml {
                 GetVectoredConcurrentIo::Sequential
             } else {
                 GetVectoredConcurrentIo::SidecarTask
+            },
+            enable_read_path_debugging: if cfg!(test) || cfg!(feature = "testing") {
+                Some(true)
+            } else {
+                None
             },
         }
     }

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -193,6 +193,10 @@ pub struct PageServerConf {
     pub page_service_pipelining: pageserver_api::config::PageServicePipeliningConfig,
 
     pub get_vectored_concurrent_io: pageserver_api::config::GetVectoredConcurrentIo,
+
+    /// Enable read path debugging. If enabled, read key errors will print a backtrace of the layer
+    /// files read.
+    pub enable_read_path_debugging: bool,
 }
 
 /// Token for authentication to safekeepers
@@ -355,6 +359,7 @@ impl PageServerConf {
             wal_receiver_protocol,
             page_service_pipelining,
             get_vectored_concurrent_io,
+            enable_read_path_debugging,
         } = config_toml;
 
         let mut conf = PageServerConf {
@@ -440,6 +445,7 @@ impl PageServerConf {
                 .unwrap_or_default(),
             virtual_file_io_mode: virtual_file_io_mode.unwrap_or(virtual_file::IoMode::preferred()),
             no_sync: no_sync.unwrap_or(false),
+            enable_read_path_debugging: enable_read_path_debugging.unwrap_or(false),
         };
 
         // ------------------------------------------------------------

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -44,7 +44,7 @@ pub(crate) use layer::{EvictionError, Layer, ResidentLayer};
 
 use self::inmemory_layer::InMemoryLayerFileId;
 
-use super::timeline::GetVectoredError;
+use super::timeline::{GetVectoredError, ReadPath};
 use super::PageReconstructError;
 
 pub fn range_overlaps<T>(a: &Range<T>, b: &Range<T>) -> bool
@@ -262,6 +262,8 @@ pub(crate) struct ValuesReconstructState {
 
     pub(crate) io_concurrency: IoConcurrency,
     num_active_ios: Arc<AtomicUsize>,
+
+    pub(crate) read_path: Option<ReadPath>,
 }
 
 /// The level of IO concurrency to be used on the read path
@@ -601,6 +603,13 @@ impl Drop for ValuesReconstructState {
 
 impl ValuesReconstructState {
     pub(crate) fn new(io_concurrency: IoConcurrency) -> Self {
+        Self::new_with_read_path(io_concurrency, None)
+    }
+
+    pub(crate) fn new_with_read_path(
+        io_concurrency: IoConcurrency,
+        read_path: Option<ReadPath>,
+    ) -> Self {
         Self {
             keys: HashMap::new(),
             keys_done: KeySpaceRandomAccum::new(),
@@ -609,6 +618,7 @@ impl ValuesReconstructState {
             delta_layers_visited: 0,
             io_concurrency,
             num_active_ios: Arc::new(AtomicUsize::new(0)),
+            read_path,
         }
     }
 

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -603,13 +603,6 @@ impl Drop for ValuesReconstructState {
 
 impl ValuesReconstructState {
     pub(crate) fn new(io_concurrency: IoConcurrency) -> Self {
-        Self::new_with_read_path(io_concurrency, None)
-    }
-
-    pub(crate) fn new_with_read_path(
-        io_concurrency: IoConcurrency,
-        read_path: Option<ReadPath>,
-    ) -> Self {
         Self {
             keys: HashMap::new(),
             keys_done: KeySpaceRandomAccum::new(),
@@ -618,7 +611,7 @@ impl ValuesReconstructState {
             delta_layers_visited: 0,
             io_concurrency,
             num_active_ios: Arc::new(AtomicUsize::new(0)),
-            read_path,
+            read_path: None,
         }
     }
 
@@ -718,15 +711,6 @@ impl ValuesReconstructState {
 pub(crate) enum LayerId {
     PersitentLayerId(PersistentLayerKey),
     InMemoryLayerId(InMemoryLayerFileId),
-}
-
-impl std::fmt::Display for LayerId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LayerId::PersitentLayerId(key) => write!(f, "{}", key),
-            LayerId::InMemoryLayerId(_) => write!(f, "<in-memory layer>"),
-        }
-    }
 }
 
 /// Uniquely identify a layer visit by the layer

--- a/pageserver/src/tenant/storage_layer.rs
+++ b/pageserver/src/tenant/storage_layer.rs
@@ -710,6 +710,15 @@ pub(crate) enum LayerId {
     InMemoryLayerId(InMemoryLayerFileId),
 }
 
+impl std::fmt::Display for LayerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LayerId::PersitentLayerId(key) => write!(f, "{}", key),
+            LayerId::InMemoryLayerId(_) => write!(f, "<in-memory layer>"),
+        }
+    }
+}
+
 /// Uniquely identify a layer visit by the layer
 /// and LSN floor (or start LSN) of the reads.
 /// The layer itself is not enough since we may

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -622,6 +622,8 @@ impl From<layer_manager::Shutdown> for GetVectoredError {
     }
 }
 
+/// A layer identifier when used in the [`ReadPath`] structure. This enum is for observability purposes
+/// only and not used by the "real read path".
 pub enum ReadPathLayerId {
     PersistentLayer(PersistentLayerKey),
     InMemoryLayer(Range<Lsn>),
@@ -652,7 +654,7 @@ impl ReadPath {
         }
     }
 
-    pub fn record_read_op(
+    pub fn record_layer_visit(
         &mut self,
         layer_to_read: &ReadableLayer,
         keyspace_to_read: &KeySpace,
@@ -3696,7 +3698,7 @@ impl Timeline {
 
             if let Some((layer_to_read, keyspace_to_read, lsn_range)) = fringe.next_layer() {
                 if let Some(ref mut read_path) = reconstruct_state.read_path {
-                    read_path.record_read_op(&layer_to_read, &keyspace_to_read, &lsn_range);
+                    read_path.record_layer_visit(&layer_to_read, &keyspace_to_read, &lsn_range);
                 }
                 let next_cont_lsn = lsn_range.start;
                 layer_to_read

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1262,7 +1262,7 @@ impl Timeline {
         reconstruct_state: &mut ValuesReconstructState,
         ctx: &RequestContext,
     ) -> Result<BTreeMap<Key, Result<Bytes, PageReconstructError>>, GetVectoredError> {
-        let read_path = if cfg!(feature = "testing") || cfg!(debug_assertions) {
+        let read_path = if self.conf.enable_read_path_debugging {
             Some(ReadPath::new(keyspace.clone(), lsn))
         } else {
             None


### PR DESCRIPTION
## Problem

helps investigate https://github.com/neondatabase/neon/issues/10482

## Summary of changes

In debug mode and testing mode, we will record all files visited by a read operation, and print it out when it errors.