### PR TITLE
secondary downloader: load metadata on loading of timeline

### DIFF
--- a/pageserver/src/tenant/secondary/downloader.rs
+++ b/pageserver/src/tenant/secondary/downloader.rs
@@ -704,7 +704,7 @@ impl<'a> TenantDownloader<'a> {
         let last_heatmap_timelines = last_heatmap.as_ref().map(|htm| {
             htm.timelines
                 .iter()
-                .map(|tl| (tl.timeline_id, &*tl))
+                .map(|tl| (tl.timeline_id, tl))
                 .collect::<HashMap<_, _>>()
         });
 
@@ -742,9 +742,7 @@ impl<'a> TenantDownloader<'a> {
                         last_heatmap_timelines
                             .as_ref()
                             .and_then(|last_heatmap_timelines| {
-                                last_heatmap_timelines
-                                    .get(&timeline.timeline_id)
-                                    .map(|tl| *tl)
+                                last_heatmap_timelines.get(&timeline.timeline_id).copied()
                             });
                     // We have no existing state: need to scan local disk for layers first.
                     let timeline_state = init_timeline_state(

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -234,6 +234,19 @@ impl VirtualFile {
     ) -> (FullSlice<Buf>, Result<usize, Error>) {
         self.inner.write_all(buf, ctx).await
     }
+
+    async fn read_to_end(&mut self, buf: &mut Vec<u8>, ctx: &RequestContext) -> Result<(), Error> {
+        self.inner.read_to_end(buf, ctx).await
+    }
+
+    pub(crate) async fn read_to_string(
+        &mut self,
+        ctx: &RequestContext,
+    ) -> Result<String, anyhow::Error> {
+        let mut buf = Vec::new();
+        self.read_to_end(&mut buf, ctx).await?;
+        return Ok(String::from_utf8(buf)?);
+    }
 }
 
 /// Indicates whether to enable fsync, fdatasync, or O_SYNC/O_DSYNC when writing
@@ -993,6 +1006,24 @@ impl VirtualFileInner {
             (buf, result)
         })
     }
+
+    async fn read_to_end(&mut self, buf: &mut Vec<u8>, ctx: &RequestContext) -> Result<(), Error> {
+        let mut tmp = vec![0; 128];
+        loop {
+            let slice = tmp.slice(..128);
+            let (slice, res) = self.read_at(slice, self.pos, ctx).await;
+            match res {
+                Ok(0) => return Ok(()),
+                Ok(n) => {
+                    self.pos += n as u64;
+                    buf.extend_from_slice(&slice[..n]);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+            tmp = slice.into_inner();
+        }
+    }
 }
 
 // Adapted from https://doc.rust-lang.org/1.72.0/src/std/os/unix/fs.rs.html#117-135
@@ -1237,10 +1268,6 @@ impl VirtualFile {
     ) -> Result<crate::tenant::block_io::BlockLease<'_>, std::io::Error> {
         self.inner.read_blk(blknum, ctx).await
     }
-
-    async fn read_to_end(&mut self, buf: &mut Vec<u8>, ctx: &RequestContext) -> Result<(), Error> {
-        self.inner.read_to_end(buf, ctx).await
-    }
 }
 
 #[cfg(test)]
@@ -1259,24 +1286,6 @@ impl VirtualFileInner {
         Ok(crate::tenant::block_io::BlockLease::IoBufferMut(
             slice.into_inner(),
         ))
-    }
-
-    async fn read_to_end(&mut self, buf: &mut Vec<u8>, ctx: &RequestContext) -> Result<(), Error> {
-        let mut tmp = vec![0; 128];
-        loop {
-            let slice = tmp.slice(..128);
-            let (slice, res) = self.read_at(slice, self.pos, ctx).await;
-            match res {
-                Ok(0) => return Ok(()),
-                Ok(n) => {
-                    self.pos += n as u64;
-                    buf.extend_from_slice(&slice[..n]);
-                }
-                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
-                Err(e) => return Err(e),
-            }
-            tmp = slice.into_inner();
-        }
     }
 }
 

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -245,7 +245,7 @@ impl VirtualFile {
     ) -> Result<String, anyhow::Error> {
         let mut buf = Vec::new();
         self.read_to_end(&mut buf, ctx).await?;
-        return Ok(String::from_utf8(buf)?);
+        Ok(String::from_utf8(buf)?)
     }
 }
 


### PR DESCRIPTION
Related to #10308, we might have legitimate changes in file size or generation. Those changes should not cause warn log lines.

In order to detect changes of the generation number while the file size stayed the same, load the metadata that we store on disk on loading of the timeline.

Still do a comparison with the on-disk layer sizes to find any discrepancies that might occur due to race conditions (new metadata file gets written but layer file has not been updated yet, and PS shuts down). However, as it's possible to hit it in a race conditon, downgrade it to a warning.

Also fix a mistake in #10529: we want to compare the old with the new metadata, not the old metadata with itself.