### PR TITLE
Use num_cpus from the workspace in pageserver

### DIFF
--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -36,7 +36,7 @@ itertools.workspace = true
 md5.workspace = true
 nix.workspace = true
 # hack to get the number of worker threads tokio uses
-num_cpus = { version = "1.15" }
+num_cpus.workspace = true
 num-traits.workspace = true
 once_cell.workspace = true
 pin-project-lite.workspace = true


### PR DESCRIPTION
Luckily they were the same version, so we didn't spend time compiling two versions, which could have been the case in the future.
