### PR TITLE
feat(pageserver): use vectored_get in collect_keyspace

### DIFF
--- a/libs/pageserver_api/src/key.rs
+++ b/libs/pageserver_api/src/key.rs
@@ -464,6 +464,18 @@ pub fn rel_size_to_key(rel: RelTag) -> Key {
     }
 }
 
+#[inline(always)]
+pub fn rel_size_key_to_rel(key: Key) -> RelTag {
+    assert_eq!(key.field1, 0x00);
+    assert_eq!(key.field6, 0xffff_ffff);
+    RelTag {
+        forknum: key.field5,
+        spcnode: key.field2,
+        dbnode: key.field3,
+        relnode: key.field4,
+    }
+}
+
 impl Key {
     #[inline(always)]
     pub fn is_rel_size_key(&self) -> bool {
@@ -557,6 +569,15 @@ pub fn slru_segment_size_to_key(kind: SlruKind, segno: u32) -> Key {
         field5: 0,
         field6: 0xffff_ffff,
     }
+}
+
+#[inline(always)]
+pub fn slru_segment_size_key_to_segno(key: Key) -> u32 {
+    assert_eq!(key.field1, 0x01);
+    assert_eq!(key.field3, 1);
+    assert_eq!(key.field5, 0);
+    assert_eq!(key.field6, 0xffff_ffff);
+    key.field4
 }
 
 impl Key {

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1157,7 +1157,7 @@ impl Timeline {
         vectored_res
     }
 
-    pub(super) async fn get_vectored_impl(
+    pub(crate) async fn get_vectored_impl(
         &self,
         keyspace: KeySpace,
         lsn: Lsn,


### PR DESCRIPTION
## Problem

This is the first patch for optimizing the L0 compaction. As we know from the previous incident, the most time-consuming thing in the L0 compaction code is at `repartition` before the compaction actually starts. This patch is a very safe that doesn't change any behavior except using vectored get. We refactor the collect_keyspace code to use vectored get so that it's faster to retrieve all the data even if we get hundreds of the L0 piled up.

Next patch: repartition should read from the boundary of L0 and L1 instead of latest data to further accelerate.

## Summary of changes

Use vectored get in `collect_keyspace`.