### PR TITLE
pageserver: exclude archived timelines from freeze+flush on shutdown

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1816,8 +1816,8 @@ impl Timeline {
                     true
                 }
             } else {
-                // this is double-shutdown, ignore it
-                false
+                // this is double-shutdown, it'll be a no-op
+                true
             };
 
             // we shut down walreceiver above, so, we won't add anything more


### PR DESCRIPTION
## Problem

If offloading races with normal shutdown, we get a "failed to freeze and flush: cannot flush frozen layers when flush_loop is not running, state is Exited".  This is harmless but points to it being quite strange to try and freeze and flush such a timeline.  flushing on shutdown for an archived timeline isn't useful.

Related: https://github.com/neondatabase/neon/issues/10389

## Summary of changes

- During Timeline::shutdown, ignore ShutdownMode::FreezeAndFlush if the timeline is archived
