### PR TITLE
feat(proxy): add batching to cancellation queue processing

### DIFF
--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -193,7 +193,7 @@ pub async fn handle_cancel_messages(
         }
 
         match client.query(pipe).await {
-            Ok(Value::Array(values)) if values.len() == buffer.len() => {
+            Ok(Value::Array(values)) if values.len() == replies.len() => {
                 debug!(n = buffer.len(), "successfully completed cancellation jobs");
                 for (value, reply) in std::iter::zip(values, replies.drain(..)) {
                     reply.send_value(value);

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -176,7 +176,7 @@ pub async fn handle_cancel_messages(
     loop {
         if rx.recv_many(&mut batch, BATCH_SIZE).await == 0 {
             warn!("shutting down cancellation queue");
-            break Ok(())
+            break Ok(());
         }
 
         let batch_size = batch.len();

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -216,7 +216,7 @@ pub async fn handle_cancel_messages(
                     reply.send_err(anyhow!("could not send cmd to redis: {err}"));
                 }
             }
-        };
+        }
 
         replies.clear();
     }

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -1,4 +1,3 @@
-use std::convert::Infallible;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
@@ -170,14 +169,14 @@ impl CancelReplyOp {
 pub async fn handle_cancel_messages(
     client: &mut RedisKVClient,
     mut rx: mpsc::Receiver<CancelKeyOp>,
-) -> anyhow::Result<Infallible> {
+) -> anyhow::Result<()> {
     let mut batch = Vec::new();
     let mut replies = vec![];
 
     loop {
         if rx.recv_many(&mut batch, BATCH_SIZE).await == 0 {
             warn!("shutting down cancellation queue");
-            break std::future::pending().await;
+            break Ok(())
         }
 
         let batch_size = batch.len();

--- a/proxy/src/redis/kv_ops.rs
+++ b/proxy/src/redis/kv_ops.rs
@@ -57,7 +57,7 @@ impl RedisKVClient {
         match q.query(&mut self.client).await {
             Ok(t) => return Ok(t),
             Err(e) => {
-                tracing::error!("failed to set a key-value pair: {e}");
+                tracing::error!("failed to run query: {e}");
             }
         }
 

--- a/proxy/src/redis/kv_ops.rs
+++ b/proxy/src/redis/kv_ops.rs
@@ -50,7 +50,7 @@ impl RedisKVClient {
         q: impl Queryable,
     ) -> anyhow::Result<T> {
         if !self.limiter.check() {
-            tracing::info!("Rate limit exceeded. Skipping hset");
+            tracing::info!("Rate limit exceeded. Skipping query");
             return Err(anyhow::anyhow!("Rate limit exceeded"));
         }
 

--- a/proxy/src/redis/kv_ops.rs
+++ b/proxy/src/redis/kv_ops.rs
@@ -1,5 +1,5 @@
 use redis::aio::ConnectionLike;
-use redis::{Cmd, FromRedisValue, Pipeline, RedisResult, ToRedisArgs};
+use redis::{Cmd, FromRedisValue, Pipeline, RedisResult};
 
 use super::connection_with_credentials_provider::ConnectionWithCredentialsProvider;
 use crate::rate_limiter::{GlobalRateLimiter, RateBucketInfo};
@@ -64,61 +64,5 @@ impl RedisKVClient {
         tracing::info!("Redis client is disconnected. Reconnecting...");
         self.try_connect().await?;
         Ok(q.query(&mut self.client).await?)
-    }
-
-    pub(crate) async fn hset<K, F, V>(&mut self, key: K, field: F, value: V) -> anyhow::Result<()>
-    where
-        K: ToRedisArgs + Send + Sync,
-        F: ToRedisArgs + Send + Sync,
-        V: ToRedisArgs + Send + Sync,
-    {
-        self.query(Cmd::hset(key, field, value)).await
-    }
-
-    #[allow(dead_code)]
-    pub(crate) async fn hset_multiple<K, V>(
-        &mut self,
-        key: &str,
-        items: &[(K, V)],
-    ) -> anyhow::Result<()>
-    where
-        K: ToRedisArgs + Send + Sync,
-        V: ToRedisArgs + Send + Sync,
-    {
-        self.query(Cmd::hset_multiple(key, items)).await
-    }
-
-    #[allow(dead_code)]
-    pub(crate) async fn expire<K>(&mut self, key: K, seconds: i64) -> anyhow::Result<()>
-    where
-        K: ToRedisArgs + Send + Sync,
-    {
-        self.query(Cmd::expire(key, seconds)).await
-    }
-
-    #[allow(dead_code)]
-    pub(crate) async fn hget<K, F, V>(&mut self, key: K, field: F) -> anyhow::Result<V>
-    where
-        K: ToRedisArgs + Send + Sync,
-        F: ToRedisArgs + Send + Sync,
-        V: redis::FromRedisValue,
-    {
-        self.query(Cmd::hget(key, field)).await
-    }
-
-    pub(crate) async fn hget_all<K, V>(&mut self, key: K) -> anyhow::Result<V>
-    where
-        K: ToRedisArgs + Send + Sync,
-        V: redis::FromRedisValue,
-    {
-        self.query(Cmd::hgetall(key)).await
-    }
-
-    pub(crate) async fn hdel<K, F>(&mut self, key: K, field: F) -> anyhow::Result<()>
-    where
-        K: ToRedisArgs + Send + Sync,
-        F: ToRedisArgs + Send + Sync,
-    {
-        self.query(Cmd::hdel(key, field)).await
     }
 }


### PR DESCRIPTION
Add batching to the redis queue, which allows us to clear it out quicker should it slow down temporarily.