### PR TITLE
storcon: only allow errrors of the server cert verification

### DIFF
--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1296,7 +1296,7 @@ fn client_config_with_root_certs() -> anyhow::Result<rustls::ClientConfig> {
             .with_root_certificates(load_certs()?)
             .with_no_client_auth()
     } else {
-        use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified};
+        use rustls::client::danger::ServerCertVerified;
         #[derive(Debug)]
         struct AcceptAll(Arc<WebPkiServerVerifier>);
         impl ServerCertVerifier for AcceptAll {
@@ -1331,14 +1331,7 @@ fn client_config_with_root_certs() -> anyhow::Result<rustls::ClientConfig> {
                 dss: &rustls::DigitallySignedStruct,
             ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
             {
-                let r = self.0.verify_tls12_signature(message, cert, dss);
-                if let Err(err) = r {
-                    tracing::info!(
-                        "ignoring db connection 1.2 signature TLS validation error: {err:?}"
-                    );
-                    return Ok(HandshakeSignatureValid::assertion());
-                }
-                r
+                self.0.verify_tls12_signature(message, cert, dss)
             }
             fn verify_tls13_signature(
                 &self,
@@ -1347,14 +1340,7 @@ fn client_config_with_root_certs() -> anyhow::Result<rustls::ClientConfig> {
                 dss: &rustls::DigitallySignedStruct,
             ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
             {
-                let r = self.0.verify_tls13_signature(message, cert, dss);
-                if let Err(err) = r {
-                    tracing::info!(
-                        "ignoring db connection 1.3 signature TLS validation error: {err:?}"
-                    );
-                    return Ok(HandshakeSignatureValid::assertion());
-                }
-                r
+                self.0.verify_tls13_signature(message, cert, dss)
             }
             fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
                 self.0.supported_verify_schemes()

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1390,6 +1390,7 @@ fn log_postgres_connstr_info(config_str: &str) -> anyhow::Result<()> {
     // To make extra sure the test gets ran, run it every time the function is called
     // (this is rather cold code, we can afford it).
     #[cfg(not(test))]
+    #[allow(clippy::let_unit_value)]
     let _ = test_config_debug_censors_password();
     tracing::info!("database connection config: {config:?}");
     Ok(())

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1390,8 +1390,7 @@ fn log_postgres_connstr_info(config_str: &str) -> anyhow::Result<()> {
     // To make extra sure the test gets ran, run it every time the function is called
     // (this is rather cold code, we can afford it).
     #[cfg(not(test))]
-    #[allow(clippy::let_unit_value)]
-    let _ = test_config_debug_censors_password();
+    test_config_debug_censors_password();
     tracing::info!("database connection config: {config:?}");
     Ok(())
 }

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1337,7 +1337,7 @@ fn client_config_with_root_certs() -> anyhow::Result<rustls::ClientConfig> {
             .expect("ring should support the default protocol versions");
     static DO_CERT_CHECKS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     let do_cert_checks =
-        DO_CERT_CHECKS.get_or_init(|| std::env::var("STORCON_CERT_CHECKS").is_ok());
+        DO_CERT_CHECKS.get_or_init(|| std::env::var("STORCON_DB_CERT_CHECKS").is_ok());
     Ok(if *do_cert_checks {
         client_config
             .with_root_certificates(load_certs()?)


### PR DESCRIPTION
This PR does a bunch of things:

* only allow errors of the server cert verification, not of the TLS handshake. The TLS handshake doesn't cause any errors for us so we can just always require it to be valid. This simplifies the code a little.
* As the solution is more permanent than originally anticipated, I think it makes sense to move the `AcceptAll` verifier outside.
* log the connstr information. this helps with figuring out which domain names are configured in the connstr, etc. I think it is generally useful to print it. make extra sure that the password is not leaked.

Follow-up of #10640