### PR TITLE
Make it easy to build only a subset of extensions into compute image

### DIFF
--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -86,7 +86,7 @@ ARG DEBIAN_FLAVOR=${DEBIAN_VERSION}-slim
 ARG ALPINE_CURL_VERSION=8.11.1
 
 # By default, build all PostgreSQL extensions. For quick local testing when you don't
-# care about the extensions, pass EXTENSIONS=none
+# care about the extensions, pass EXTENSIONS=none or EXTENSIONS=minimal
 ARG EXTENSIONS=all
 
 #########################################################################################


### PR DESCRIPTION
The full build of all extensions takes a long time. When working locally on parts that don't need extensions, you can iterate more quickly by skipping the unnecessary extensions.

This adds a build argument to the dockerfile to specify extensions to build. There are three options:

- EXTENSIONS=all (default)
- EXTENSIONS=minimal: Build only a few extensions that are listed in shared_preload_libraries in the default neon config.
- EXTENSIONS=none: Build no extensions (except for the mandatory 'neon' extension).
