### PR TITLE
Fix bugs in lfc_cache_containsv

### DIFF
--- a/pgxn/neon/file_cache.c
+++ b/pgxn/neon/file_cache.c
@@ -336,10 +336,11 @@ lfc_change_limit_hook(int newval, void *extra)
 {
 	uint32		new_size = SIZE_MB_TO_CHUNKS(newval);
 
-	if (!is_normal_backend())
+	if (!lfc_ctl || !is_normal_backend())
 		return;
 
-	if (!lfc_ensure_opened())
+	/* Open LFC file only if LFC was  enabled or we are going to reenable it */
+	if ((newval > 0 || LFC_ENABLED()) && !lfc_ensure_opened())
 		return;
 
 	LWLockAcquire(lfc_lock, LW_EXCLUSIVE);


### PR DESCRIPTION
## Problem

I have found one problem and two bugs in current LFC implementation.
1. If LFC is intentionally disabled by setting `neon.file_cache_size_limit=0` then it can not be reenabled, because  `lfc_change_limit_hook` immediately exit if  `!lfc_ensure_opened())` and it is true in case of `neon.file_cache_size_limit=0`.
2. I believe that there are two bugs in `lfc_cache_containsv` (and so affecting only pg17).

## Summary of changes 

1. Remove `lfc_maybe_disabled` check from `lfc_ensure_opened`
2.
```
-		int		this_chunk = Min(nblocks, BLOCKS_PER_CHUNK - chunk_offs);
+		int		this_chunk = Min(nblocks - i, BLOCKS_PER_CHUNK - chunk_offs);		int		this_chunk = ```
```
3.
```
-		if (i + 1 >= nblocks)
+		if (i >= nblocks)
```
