### PR TITLE
pgxn: include socket send & recv queue size in slow response logs

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -37,6 +37,7 @@
 #include "walproposer.h"
 
 #ifdef __linux__
+#include <sys/ioctl.h>
 #include <linux/sockios.h>
 #endif
 
@@ -735,8 +736,6 @@ retry:
 			int sndbuf = -1;
 			int recvbuf = -1;
 #ifdef __linux__
-			socklen_t optlen;
-			int ioctl_err;
 			int socketfd;
 #endif
 
@@ -750,12 +749,11 @@ retry:
 			 */
 			socketfd = PQsocket(pageserver_conn);
 			if (socketfd != -1) {
-				optlen = sizeof(sndbuf);
+				int ioctl_err;
 				ioctl_err = ioctl(socketfd, SIOCOUTQ, &sndbuf);
-				if ioctl_err = ( != 0) {
+				if (ioctl_err!= 0) {
 					sndbuf = -errno;
 				}
-				optlen = sizeof(recvbuf);
 				ioctl_err = ioctl(socketfd, FIONREAD, &recvbuf);
 				if (ioctl_err != 0) {
 					recvbuf = -errno;

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -744,8 +744,8 @@ retry:
 
 #ifdef __linux__
 			/*
-			 * get kernel's send and recv queue size via sockopt
-			 * https://elixir.bootlin.com/linux/v6.13.1/source/include/uapi/linux/sockios.h#L26-L27
+			 * get kernel's send and recv queue size via ioctl
+			 * https://elixir.bootlin.com/linux/v6.1.128/source/include/uapi/linux/sockios.h#L25-L27
 			 */
 			socketfd = PQsocket(pageserver_conn);
 			if (socketfd != -1) {


### PR DESCRIPTION
# Problem

When we see an apparent slow request, one possible cause is that the client is failing to consume responses, but we don't have a clear way to see that.

# Solution

- Log the socket queue depths on slow/stuck connections, so that we have an indication of whether the compute is keeping up with processing the connection's responses.

refs
- slack https://neondb.slack.com/archives/C036U0GRMRB/p1738652644396329
- refs https://github.com/neondatabase/cloud/issues/23515
- refs https://github.com/neondatabase/cloud/issues/23486
