### PR TITLE
Warn on basebackups for archived timelines

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -2037,6 +2037,10 @@ impl PageServerHandler {
             .get(tenant_id, timeline_id, ShardSelector::Zero)
             .await?;
 
+        if timeline.is_archived() == Some(true) {
+            return Err(QueryError::NotFound("timeline is archived".into()))
+        }
+
         let latest_gc_cutoff_lsn = timeline.get_latest_gc_cutoff_lsn();
         if let Some(lsn) = lsn {
             // Backup was requested at a particular LSN. Wait for it to arrive.

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -2038,7 +2038,9 @@ impl PageServerHandler {
             .await?;
 
         if timeline.is_archived() == Some(true) {
-            return Err(QueryError::NotFound("timeline is archived".into()))
+            // TODO after a grace period, turn this log line into a hard error
+            tracing::warn!("timeline {tenant_id}/{timeline_id} is archived, but got basebackup request for it.");
+            //return Err(QueryError::NotFound("timeline is archived".into()))
         }
 
         let latest_gc_cutoff_lsn = timeline.get_latest_gc_cutoff_lsn();


### PR DESCRIPTION
We don't want any external requests for an archived timeline. This includes basebackup requests, i.e. when a compute is being started up.

Therefore, we'd like to forbid such basebackup requests: any attempt to get a basebackup on an archived timeline (or any getpage request really) is a cplane bug. Make this a warning for now so that, if there is potentially a bug, we can detect cases in the wild before they cause stuck operations, but the intention is to return an error eventually.

Related: #9548