### PR TITLE
pageserver: don't try and ingest `XLOG_CHECKPOINT_SHUTDOWN` on nonzero shards

### DIFF
--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -1157,6 +1157,7 @@ impl WalIngest {
                 // See also the neon code changes in the InitWalRecovery() function.
                 if xlog_checkpoint.oldestActiveXid == pg_constants::INVALID_TRANSACTION_ID
                     && info == pg_constants::XLOG_CHECKPOINT_SHUTDOWN
+                    && self.shard.is_shard_zero()
                 {
                     let oldest_active_xid = if pg_version >= 17 {
                         let mut oldest_active_full_xid = cp.nextXid.value;


### PR DESCRIPTION
## Problem

Shutdown checkpoints caused non-zero shards to try reading their TWOPHASEDIR_KEY, but that key may not be present on shards with shard number != 0

TODO:
- [ ] it is not obvious why this key is dropped on shard !=0, it should be preserved by ShardIdentity.is_key_global

Closes: https://github.com/neondatabase/neon/issues/10720

## Summary of changes

- Skip this code if shard number is nonzero
