### PR TITLE
test(pageserver): add reldir v2 into tests

### DIFF
--- a/test_runner/performance/test_perf_many_relations.py
+++ b/test_runner/performance/test_perf_many_relations.py
@@ -75,7 +75,13 @@ def test_perf_simple_many_relations_reldir_v2(
     Test creating many relations in a single database.
     """
     env = neon_env_builder.init_start(initial_tenant_conf={"rel_size_v2_enabled": "true"})
-    ep = env.endpoints.create_start("main")
+    ep = env.endpoints.create_start(
+        "main",
+        config_lines=[
+            "shared_buffers=1000MB",
+            "max_locks_per_transaction=16384",
+        ],
+    )
 
     n = 100000
     step = 5000

--- a/test_runner/performance/test_perf_many_relations.py
+++ b/test_runner/performance/test_perf_many_relations.py
@@ -88,6 +88,8 @@ def test_perf_simple_many_relations_reldir_v2(
     # Create many relations
     log.info(f"Creating {n} relations...")
     begin = 0
+    with zenbenchmark.record_duration("create_first_relation"):
+        ep.safe_psql("CREATE TABLE IF NOT EXISTS table_begin (id SERIAL PRIMARY KEY, data TEXT)")
     with zenbenchmark.record_duration("create_many_relations"):
         while True:
             end = begin + step
@@ -111,3 +113,5 @@ def test_perf_simple_many_relations_reldir_v2(
             begin = end
             if begin >= n:
                 break
+    with zenbenchmark.record_duration("create_last_relation"):
+        ep.safe_psql(f"CREATE TABLE IF NOT EXISTS table_{begin} (id SERIAL PRIMARY KEY, data TEXT)")


### PR DESCRIPTION
## Problem

We have `test_perf_many_relations` but it only runs on remote clusters, and we cannot directly modify tenant config. Therefore, I patched one of the current tests to benchmark relv2 performance.

close https://github.com/neondatabase/neon/issues/9986

## Summary of changes

* Add `v1/v2` selector to `test_tx_abort_with_many_relations`.