### PR TITLE
Also check by the planned gc cutoff for lease creation

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1553,6 +1553,7 @@ impl Timeline {
             let lsn = xlog_utils::normalize_lsn(lsn, WAL_SEGMENT_SIZE);
 
             let mut gc_info = self.gc_info.write().unwrap();
+            let planned_cutoff = gc_info.min_cutoff();
 
             let valid_until = SystemTime::now() + length;
 
@@ -1586,10 +1587,8 @@ impl Timeline {
                         if lsn < *latest_gc_cutoff_lsn {
                             bail!("tried to request an lsn lease for an lsn below the latest gc cutoff. requested at {} gc cutoff {}", lsn, *latest_gc_cutoff_lsn);
                         }
-                        let planned_cutoff = gc_info.min_cutoff();
                         if lsn < planned_cutoff {
                             bail!("tried to request an lsn lease for an lsn below the planned gc cutoff. requested at {} planned gc cutoff {}", lsn, planned_cutoff);
-
                         }
                     }
 


### PR DESCRIPTION
We don't want to allow new leases below the planned gc cutoff either. Other APIs like branch creation or getpage requests already enforce this.