### PR TITLE
Perform seqscan to fill LFC chunks with data so that on-disk file size included size of table

### DIFF
--- a/test_runner/regress/test_lfc_resize.py
+++ b/test_runner/regress/test_lfc_resize.py
@@ -72,6 +72,11 @@ def test_lfc_resize(neon_simple_env: NeonEnv, pg_bin: PgBin):
 
     thread.join()
 
+    # Fill LFC: seqscan should fetch the whole table in cache.
+    # It is needed for further correct calculation of LFC file size in blocks:
+    # otherwise sparse chunks of LFC will be calculated incorrectly.
+    cur.execute("select sum(abalance) from pgbench_accounts")
+
     # Before shrinking the cache, check that it really is large now
     (lfc_file_size, lfc_file_blocks) = get_lfc_size()
     assert int(lfc_file_blocks) > 128 * 1024

--- a/test_runner/regress/test_lfc_resize.py
+++ b/test_runner/regress/test_lfc_resize.py
@@ -73,8 +73,8 @@ def test_lfc_resize(neon_simple_env: NeonEnv, pg_bin: PgBin):
     thread.join()
 
     # Fill LFC: seqscan should fetch the whole table in cache.
-    # It is needed for further correct calculation of LFC file size in blocks:
-    # otherwise sparse chunks of LFC will be calculated incorrectly.
+    # It is needed for further correct evaluation of LFC file size
+    # (a sparse chunk of LFC takes less than 1 MB on disk).
     cur.execute("select sum(abalance) from pgbench_accounts")
 
     # Before shrinking the cache, check that it really is large now


### PR DESCRIPTION
## Problem

See https://github.com/neondatabase/neon/issues/10755

Random access pattern of pgbench leaves sparse chunks, which makes the on-disk size of file.cache unpredictable.

## Summary of changes

Perform seqscan to fill LFC chunks with data so that on-disk file size included size of table.
