### PR TITLE
Fix utilization URL and ensure heartbeats work

### DIFF
--- a/safekeeper/src/http/routes.rs
+++ b/safekeeper/src/http/routes.rs
@@ -626,7 +626,7 @@ pub fn make_router(
                 failpoints_handler(r, cancel).await
             })
         })
-        .get("/v1/uzilization", |r| request_span(r, utilization_handler))
+        .get("/v1/utilization", |r| request_span(r, utilization_handler))
         .delete("/v1/tenant/:tenant_id", |r| {
             request_span(r, tenant_delete_handler)
         })


### PR DESCRIPTION
There was a typo in the name of the utilization endpoint URL, fix it. Also, ensure that the heartbeat mechanism actually works.

Related: #10583, #10429

Part of #9011