### PR TITLE
feat(pageserver): preempt image creation across timelines

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -295,6 +295,7 @@ pub struct CompactionNotifier {
 }
 
 impl CompactionNotifier {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             notify: Notify::new(),


### PR DESCRIPTION
## Problem

In the current codebase, it is possible that one timeline is stuck on long image layer generation while the other is starving on L0 compaction.

## Summary of changes

Image layer creation will be preempted by L0 accumulated on other timelines.

* Refactor l0_trigger to a compound structure that stores both L0 layer count for each active timeline and the current notifier. As timeline cannot directly access the tenant and other timelines, we have to put the L0 count value into some centralized place.
* On the write path, we will update the value.
* Image layer compaction now reads these values.