### PR TITLE
feat(pageserver): l0->l0 compaction

### DIFF
--- a/pageserver/src/tenant/layer_map.rs
+++ b/pageserver/src/tenant/layer_map.rs
@@ -95,6 +95,8 @@ pub struct LayerMap {
     /// So L0 layers are held in l0_delta_layers vector, in addition to the R-tree.
     ///
     /// NB: make sure to notify `watch_l0_deltas` on changes.
+    /// NB: this is not sorted by LSN, but by the order of insertion; always use the historic layer info to
+    /// retrieve L0 layers in order.
     l0_delta_layers: Vec<Arc<PersistentLayerDesc>>,
 
     /// Notifies about L0 delta layer changes, sending the current number of L0 layers.

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -5433,7 +5433,8 @@ impl Timeline {
                 // because we have not implemented L0 => L0 compaction.
                 duplicated_layers.insert(l.layer_desc().key());
             } else if LayerMap::is_l0(&l.layer_desc().key_range, l.layer_desc().is_delta) {
-                return Err(CompactionError::Other(anyhow::anyhow!("compaction generates a L0 layer file as output, which will cause infinite compaction.")));
+                // This is not an error any more because we allow L0-L0 compaction.
+                // return Err(CompactionError::Other(anyhow::anyhow!("compaction generates a L0 layer file as output, which will cause infinite compaction.")));
             } else {
                 insert_layers.push(l.clone());
             }


### PR DESCRIPTION
## Problem

In the case of a tenant/timeline does not have a lot of write traffic, we would accumulate a lot of small L0 layers every time we restart the pageserver. This would cause problems for a tenant where it has a large base branch (1TB?) but hundreds of child branches with a small amount of WALs. We would do image compaction once we produce a L1 level and it would have created image layers fully covering the keyspace for each of the child branch.

## Summary of changes

If we don't accumulate enough data in L0, don't produce L1 layers.

This is currently limited to the size of 1 L0, though in theory, we should allow L0 as large as "compaction_threshold * target_size" to stay in L0. However, we identify L0 layers by key_range = MIN..MAX, which means that we cannot create L0 layers that only cover part of the key range.

An alternative solution is to tune image layer compaction not to create image layers in the case described above.