### PR TITLE
DNM: storcon:  Skip the queue for request-initiated reconciles

### DIFF
--- a/storage_controller/src/service/chaos_injector.rs
+++ b/storage_controller/src/service/chaos_injector.rs
@@ -88,7 +88,7 @@ impl ChaosInjector {
 
         shard.intent.demote_attached(scheduler, old_location);
         shard.intent.promote_attached(scheduler, new_location);
-        self.service.maybe_reconcile_shard(shard, nodes);
+        self.service.maybe_reconcile_shard(shard, nodes, false);
     }
 
     async fn inject_chaos(&mut self) {


### PR DESCRIPTION
## Problem

Under some circumstances, we may enqueue reconciles for large numbers of shards.  That queue may prevent incoming requests being handled properly, if some other issue is also causing us to drain it more slowly than usual.

## Summary of changes

Separate semaphores for background/delayed reconciles vs. those started by incoming requests