### PR TITLE
storcon: don't enqueue reconciles on failed startup compute hook

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -5034,12 +5034,13 @@ impl Service {
 
         // If we failed any compute notifications, make a note to retry later.
         if !failed_notifications.is_empty() {
-            let mut locked = self.inner.write().unwrap();
-            for failed in failed_notifications {
-                if let Some(shard) = locked.tenants.get_mut(&failed) {
-                    shard.pending_compute_notification = true;
-                }
-            }
+            tracing::warn!("Failed to notify compute of {} shards, not enqueueing for retry to avoid blocking other work.  Some computes might miss updates.", failed_notifications.len());
+            // let mut locked = self.inner.write().unwrap();
+            // for failed in failed_notifications {
+            //     if let Some(shard) = locked.tenants.get_mut(&failed) {
+            //         shard.pending_compute_notification = true;
+            //     }
+            // }
         }
 
         Ok((response, waiters))


### PR DESCRIPTION
## Problem

This is necessary for correctness in edge cases but creates a huge queue that can be a worse problem.

## Summary of changes
