### PR TITLE
Reject basebackup requests for archived timelines

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -2067,9 +2067,8 @@ impl PageServerHandler {
         set_tracing_field_shard_id(&timeline);
 
         if timeline.is_archived() == Some(true) {
-            // TODO after a grace period, turn this log line into a hard error
-            tracing::warn!("timeline {tenant_id}/{timeline_id} is archived, but got basebackup request for it.");
-            //return Err(QueryError::NotFound("timeline is archived".into()))
+            tracing::info!("timeline {tenant_id}/{timeline_id} is archived, but got basebackup request for it.");
+            return Err(QueryError::NotFound("timeline is archived".into()))
         }
 
         let latest_gc_cutoff_lsn = timeline.get_applied_gc_cutoff_lsn();


### PR DESCRIPTION
For archived timelines, we would like to prevent all non-pageserver issued getpage requests, as users are not supposed to send these. Instead, they should unarchive a timeline before issuing any external read traffic.

As this is non-trivial to do, at least prevent launches of new computes, by errorring on basebackup requests for archived timelines. In #10688, we started issuing a warning instead of an error, because an error would mean a stuck project. Now after we can confirm the the warning is not present in the logs for about a week, we can issue errors.

Follow-up of #10688 
Related: #9548