### PR TITLE
Added `fsigned-char` to treat all chars as signed across different platform architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,16 @@ ICU_PREFIX_DIR := /usr/local/icu
 #
 BUILD_TYPE ?= debug
 WITH_SANITIZERS ?= no
+PG_CFLAGS = -fsigned-char
 ifeq ($(BUILD_TYPE),release)
 	PG_CONFIGURE_OPTS = --enable-debug --with-openssl
-	PG_CFLAGS = -O2 -g3 $(CFLAGS)
+	PG_CFLAGS += -O2 -g3 $(CFLAGS)
 	PG_LDFLAGS = $(LDFLAGS)
 	# Unfortunately, `--profile=...` is a nightly feature
 	CARGO_BUILD_FLAGS += --release
 else ifeq ($(BUILD_TYPE),debug)
 	PG_CONFIGURE_OPTS = --enable-debug --with-openssl --enable-cassert --enable-depend
-	PG_CFLAGS = -O0 -g3 $(CFLAGS)
+	PG_CFLAGS += -O0 -g3 $(CFLAGS)
 	PG_LDFLAGS = $(LDFLAGS)
 else
 	$(error Bad build type '$(BUILD_TYPE)', see Makefile for options)


### PR DESCRIPTION
## Problem

The default behaviour of `char` is signed on x86 and unsigned on arm which can cause issues when data is accessed across different architectures.

## Summary of changes

Added an `-fsigned-char` flag in the makefile to tell the C compiler to treat all chars as signed by default. [Source](https://gcc.gnu.org/onlinedocs/gcc-4.0.4/gcc/C-Dialect-Options.html)