### PR TITLE
pageserver: guard against WAL gaps in the interpreted protocol

### DIFF
--- a/libs/pageserver_api/src/config.rs
+++ b/libs/pageserver_api/src/config.rs
@@ -122,6 +122,8 @@ pub struct ConfigToml {
     pub page_service_pipelining: PageServicePipeliningConfig,
     pub get_vectored_concurrent_io: GetVectoredConcurrentIo,
     pub enable_read_path_debugging: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validate_wal_contiguity: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -521,6 +523,7 @@ impl Default for ConfigToml {
             } else {
                 None
             },
+            validate_wal_contiguity: None,
         }
     }
 }

--- a/libs/wal_decoder/proto/interpreted_wal.proto
+++ b/libs/wal_decoder/proto/interpreted_wal.proto
@@ -5,6 +5,7 @@ package interpreted_wal;
 message InterpretedWalRecords {
   repeated InterpretedWalRecord records = 1;
   optional uint64 next_record_lsn = 2;
+  optional uint64 raw_wal_start_lsn = 3;
 }
 
 message InterpretedWalRecord {

--- a/libs/wal_decoder/src/models.rs
+++ b/libs/wal_decoder/src/models.rs
@@ -61,7 +61,7 @@ pub struct InterpretedWalRecords {
     // Start LSN of the next record after the batch.
     // Note that said record may not belong to the current shard.
     pub next_record_lsn: Lsn,
-    // Inclusive start LSN of the PG WAL from which this the interpreted
+    // Inclusive start LSN of the PG WAL from which the interpreted
     // WAL records were extracted. Note that this is not necessarily the
     // start LSN of the first interpreted record in the batch.
     pub raw_wal_start_lsn: Option<Lsn>,

--- a/libs/wal_decoder/src/models.rs
+++ b/libs/wal_decoder/src/models.rs
@@ -61,6 +61,10 @@ pub struct InterpretedWalRecords {
     // Start LSN of the next record after the batch.
     // Note that said record may not belong to the current shard.
     pub next_record_lsn: Option<Lsn>,
+    // Inclusive start LSN of the PG WAL from which this the interpreted
+    // WAL records were extracted. Note that this is not necessarily the
+    // start LSN of the first interpreted record in the batch.
+    pub raw_wal_start_lsn: Option<Lsn>,
 }
 
 /// An interpreted Postgres WAL record, ready to be handled by the pageserver

--- a/libs/wal_decoder/src/models.rs
+++ b/libs/wal_decoder/src/models.rs
@@ -60,7 +60,7 @@ pub struct InterpretedWalRecords {
     pub records: Vec<InterpretedWalRecord>,
     // Start LSN of the next record after the batch.
     // Note that said record may not belong to the current shard.
-    pub next_record_lsn: Option<Lsn>,
+    pub next_record_lsn: Lsn,
     // Inclusive start LSN of the PG WAL from which this the interpreted
     // WAL records were extracted. Note that this is not necessarily the
     // start LSN of the first interpreted record in the batch.

--- a/libs/wal_decoder/src/wire_format.rs
+++ b/libs/wal_decoder/src/wire_format.rs
@@ -168,6 +168,7 @@ impl TryFrom<InterpretedWalRecords> for proto::InterpretedWalRecords {
         Ok(proto::InterpretedWalRecords {
             records,
             next_record_lsn: value.next_record_lsn.map(|l| l.0),
+            raw_wal_start_lsn: value.raw_wal_start_lsn.map(|l| l.0),
         })
     }
 }
@@ -255,6 +256,7 @@ impl TryFrom<proto::InterpretedWalRecords> for InterpretedWalRecords {
         Ok(InterpretedWalRecords {
             records,
             next_record_lsn: value.next_record_lsn.map(Lsn::from),
+            raw_wal_start_lsn: value.raw_wal_start_lsn.map(Lsn::from),
         })
     }
 }

--- a/libs/wal_decoder/src/wire_format.rs
+++ b/libs/wal_decoder/src/wire_format.rs
@@ -167,7 +167,7 @@ impl TryFrom<InterpretedWalRecords> for proto::InterpretedWalRecords {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(proto::InterpretedWalRecords {
             records,
-            next_record_lsn: value.next_record_lsn.map(|l| l.0),
+            next_record_lsn: Some(value.next_record_lsn.0),
             raw_wal_start_lsn: value.raw_wal_start_lsn.map(|l| l.0),
         })
     }
@@ -255,7 +255,10 @@ impl TryFrom<proto::InterpretedWalRecords> for InterpretedWalRecords {
 
         Ok(InterpretedWalRecords {
             records,
-            next_record_lsn: value.next_record_lsn.map(Lsn::from),
+            next_record_lsn: value
+                .next_record_lsn
+                .map(Lsn::from)
+                .expect("Always provided"),
             raw_wal_start_lsn: value.raw_wal_start_lsn.map(Lsn::from),
         })
     }

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -134,6 +134,7 @@ fn main() -> anyhow::Result<()> {
     info!(?conf.virtual_file_io_engine, "starting with virtual_file IO engine");
     info!(?conf.virtual_file_io_mode, "starting with virtual_file IO mode");
     info!(?conf.wal_receiver_protocol, "starting with WAL receiver protocol");
+    info!(?conf.validate_wal_contiguity, "starting with WAL contiguity validation");
     info!(?conf.page_service_pipelining, "starting with page service pipelining config");
     info!(?conf.get_vectored_concurrent_io, "starting with get_vectored IO concurrency config");
 

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -197,6 +197,10 @@ pub struct PageServerConf {
     /// Enable read path debugging. If enabled, read key errors will print a backtrace of the layer
     /// files read.
     pub enable_read_path_debugging: bool,
+
+    /// Interpreted protocol feature: if enabled, validate that the logical WAL received from
+    /// safekeepers does not have gaps.
+    pub validate_wal_contiguity: bool,
 }
 
 /// Token for authentication to safekeepers
@@ -360,6 +364,7 @@ impl PageServerConf {
             page_service_pipelining,
             get_vectored_concurrent_io,
             enable_read_path_debugging,
+            validate_wal_contiguity,
         } = config_toml;
 
         let mut conf = PageServerConf {
@@ -446,6 +451,7 @@ impl PageServerConf {
             virtual_file_io_mode: virtual_file_io_mode.unwrap_or(virtual_file::IoMode::preferred()),
             no_sync: no_sync.unwrap_or(false),
             enable_read_path_debugging: enable_read_path_debugging.unwrap_or(false),
+            validate_wal_contiguity: validate_wal_contiguity.unwrap_or(false),
         };
 
         // ------------------------------------------------------------

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2873,6 +2873,7 @@ impl Timeline {
                 auth_token: crate::config::SAFEKEEPER_AUTH_TOKEN.get().cloned(),
                 availability_zone: self.conf.availability_zone.clone(),
                 ingest_batch_size: self.conf.ingest_batch_size,
+                validate_wal_contiguity: self.conf.validate_wal_contiguity,
             },
             broker_client,
             ctx,

--- a/pageserver/src/tenant/timeline/walreceiver.rs
+++ b/pageserver/src/tenant/timeline/walreceiver.rs
@@ -56,6 +56,7 @@ pub struct WalReceiverConf {
     pub auth_token: Option<Arc<String>>,
     pub availability_zone: Option<String>,
     pub ingest_batch_size: u64,
+    pub validate_wal_contiguity: bool,
 }
 
 pub struct WalReceiver {

--- a/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/connection_manager.rs
@@ -537,6 +537,7 @@ impl ConnectionManagerState {
         let connect_timeout = self.conf.wal_connect_timeout;
         let ingest_batch_size = self.conf.ingest_batch_size;
         let protocol = self.conf.protocol;
+        let validate_wal_contiguity = self.conf.validate_wal_contiguity;
         let timeline = Arc::clone(&self.timeline);
         let ctx = ctx.detached_child(
             TaskKind::WalReceiverConnectionHandler,
@@ -558,6 +559,7 @@ impl ConnectionManagerState {
                     ctx,
                     node_id,
                     ingest_batch_size,
+                    validate_wal_contiguity,
                 )
                 .await;
 
@@ -1563,6 +1565,7 @@ mod tests {
                 auth_token: None,
                 availability_zone: None,
                 ingest_batch_size: 1,
+                validate_wal_contiguity: false,
             },
             wal_connection: None,
             wal_stream_candidates: HashMap::new(),

--- a/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
@@ -343,6 +343,7 @@ pub(super) async fn handle_walreceiver_connection(
                 let InterpretedWalRecords {
                     records,
                     next_record_lsn,
+                    raw_wal_start_lsn: _,
                 } = batch;
 
                 tracing::debug!(

--- a/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
@@ -360,9 +360,9 @@ pub(super) async fn handle_walreceiver_connection(
                             // This is valid, but check that we received records
                             // that we haven't seen before.
                             if let Some(first_rec) = batch.records.first() {
-                                if first_rec.next_record_lsn > last_rec_lsn {
+                                if first_rec.next_record_lsn < last_rec_lsn {
                                     let msg = format!(
-                                        "Received record with next_record_lsn multiple times ({} <= {})",
+                                        "Received record with next_record_lsn multiple times ({} < {})",
                                         first_rec.next_record_lsn, expected_wal_start
                                     );
                                     critical!("{msg}");

--- a/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
@@ -360,10 +360,10 @@ pub(super) async fn handle_walreceiver_connection(
                             // This is valid, but check that we received records
                             // that we haven't seen before.
                             if let Some(first_rec) = batch.records.first() {
-                                if first_rec.next_record_lsn > expected_wal_start {
+                                if first_rec.next_record_lsn > last_rec_lsn {
                                     let msg = format!(
-                                        "Received record with next_record_lsn {} multiple times",
-                                        first_rec.next_record_lsn
+                                        "Received record with next_record_lsn multiple times ({} <= {})",
+                                        first_rec.next_record_lsn, expected_wal_start
                                     );
                                     critical!("{msg}");
                                     return Err(WalReceiverError::Other(anyhow!(msg)));

--- a/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
+++ b/pageserver/src/tenant/timeline/walreceiver/walreceiver_connection.rs
@@ -346,13 +346,31 @@ pub(super) async fn handle_walreceiver_connection(
                 // the end of the previous batch (or the starting point for the first batch),
                 // then kill this WAL receiver connection and start a new one.
                 if let Some(raw_wal_start_lsn) = batch.raw_wal_start_lsn {
-                    if raw_wal_start_lsn != expected_wal_start {
-                        let msg = format!(
-                            "Received batch from raw WAL start LSN {}. Expected {}",
-                            raw_wal_start_lsn, expected_wal_start,
-                        );
-                        critical!("{msg}");
-                        return Err(WalReceiverError::Other(anyhow!(msg)));
+                    match raw_wal_start_lsn.cmp(&expected_wal_start) {
+                        std::cmp::Ordering::Greater => {
+                            let msg = format!(
+                                "Gap in streamed WAL: [{}, {})",
+                                expected_wal_start, raw_wal_start_lsn
+                            );
+                            critical!("{msg}");
+                            return Err(WalReceiverError::Other(anyhow!(msg)));
+                        }
+                        std::cmp::Ordering::Less => {
+                            // Other shards are reading WAL behind us.
+                            // This is valid, but check that we received records
+                            // that we haven't seen before.
+                            if let Some(first_rec) = batch.records.first() {
+                                if first_rec.next_record_lsn > expected_wal_start {
+                                    let msg = format!(
+                                        "Received record with next_record_lsn {} multiple times",
+                                        first_rec.next_record_lsn
+                                    );
+                                    critical!("{msg}");
+                                    return Err(WalReceiverError::Other(anyhow!(msg)));
+                                }
+                            }
+                        }
+                        std::cmp::Ordering::Equal => {}
                     }
                 }
 

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -302,7 +302,7 @@ impl InterpretedWalReader {
                     let wal = wal_or_reset.map(|wor| wor.get_wal().expect("reset handled in select branch below"));
                     let WalBytes {
                         wal,
-                        wal_start_lsn: _,
+                        wal_start_lsn,
                         wal_end_lsn,
                         available_wal_end_lsn,
                     } = match wal {
@@ -392,6 +392,7 @@ impl InterpretedWalReader {
                             let batch = InterpretedWalRecords {
                                 records,
                                 next_record_lsn: Some(max_next_record_lsn),
+                                raw_wal_start_lsn: Some(wal_start_lsn),
                             };
 
                             let res = state.tx.send(Batch {

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -411,7 +411,7 @@ impl InterpretedWalReader {
                             } else if wal_end_lsn > state.next_record_lsn {
                                 // All the records in this batch were seen by the shard
                                 // However, the batch maps to a chunk of WAL that the
-                                // shard has not yet seen. Notify if of the start LSN
+                                // shard has not yet seen. Notify it of the start LSN
                                 // of the PG WAL chunk such that it doesn't look like a gap.
                                 InterpretedWalRecords {
                                     records: Vec::default(),

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -391,7 +391,7 @@ impl InterpretedWalReader {
 
                             let batch = InterpretedWalRecords {
                                 records,
-                                next_record_lsn: Some(max_next_record_lsn),
+                                next_record_lsn: max_next_record_lsn,
                                 raw_wal_start_lsn: Some(wal_start_lsn),
                             };
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1157,6 +1157,8 @@ class NeonEnv:
                 # Disable pageserver disk syncs in tests: when running tests concurrently, this avoids
                 # the pageserver taking a long time to start up due to syncfs flushing other tests' data
                 "no_sync": True,
+                # Look for gaps in WAL received from safekeepeers
+                "validate_wal_contiguity": True,
             }
 
             # Batching (https://github.com/neondatabase/neon/issues/9377):

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1175,15 +1175,7 @@ class NeonEnv:
                 # Look for gaps in WAL received from safekeepeers
                 ps_cfg["validate_wal_contiguity"] = True
 
-            # Concurrent IO (https://github.com/neondatabase/neon/issues/9378):
-            # enable concurrent IO by default in tests and benchmarks.
-            # Compat tests are exempt because old versions fail to parse the new config.
             get_vectored_concurrent_io = self.pageserver_get_vectored_concurrent_io
-            if config.test_may_use_compatibility_snapshot_binaries:
-                log.info(
-                    "Forcing use of binary-built-in default to avoid forward-compatibility related test failures"
-                )
-                get_vectored_concurrent_io = None
             if get_vectored_concurrent_io is not None:
                 ps_cfg["get_vectored_concurrent_io"] = {
                     "mode": self.pageserver_get_vectored_concurrent_io,

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1157,8 +1157,6 @@ class NeonEnv:
                 # Disable pageserver disk syncs in tests: when running tests concurrently, this avoids
                 # the pageserver taking a long time to start up due to syncfs flushing other tests' data
                 "no_sync": True,
-                # Look for gaps in WAL received from safekeepeers
-                "validate_wal_contiguity": True,
             }
 
             # Batching (https://github.com/neondatabase/neon/issues/9377):
@@ -1168,6 +1166,14 @@ class NeonEnv:
                 "execution": "concurrent-futures",
                 "max_batch_size": 32,
             }
+
+            if config.test_may_use_compatibility_snapshot_binaries:
+                log.info(
+                    "Skipping WAL contiguity validation to avoid forward-compatibility related test failures"
+                )
+            else:
+                # Look for gaps in WAL received from safekeepeers
+                ps_cfg["validate_wal_contiguity"] = True
 
             # Concurrent IO (https://github.com/neondatabase/neon/issues/9378):
             # enable concurrent IO by default in tests and benchmarks.


### PR DESCRIPTION
## Problem

The interpreted SK <-> PS protocol does not guard against gaps (neither does the Vanilla one, but that's beside the point).

## Summary of changes

Extend the protocol to include the start LSN of the PG WAL section from which the records were interpreted.
Validation is enabled via a config flag on the pageserver and works as follows:

**Case 1**: `raw_wal_start_lsn` is smaller than the requested LSN
There can't be gaps here, but we check that the shard received records which it hasn't seen before.

**Case 2**: `raw_wal_start_lsn` is equal to the requested LSN
This is the happy case. No gap and nothing to check

**Case 3**: `raw_wal_start_lsn` is greater than the requested LSN
This is a gap.

To make Case 3 work I had to bend the protocol a bit.
We read record chunks of WAL which aren't record aligned and feed them to the decoder.
The picture below shows a shard which subscribes at a position somewhere within Record 2.
We already have a wal reader which is below that position so we wait to catch up.
We read some wal in Read 1 (all of Record 1 and some of Record 2). The new shard doesn't
need Record 1 (it has already processed it according to the starting position), but we read
past it's starting position. When we do Read 2, we decode Record 2 and ship it off to the shard,
but the starting position of Read 2 is greater than the starting position the shard requested.
This looks like a gap.

![image](https://github.com/user-attachments/assets/8aed292e-5d62-46a3-9b01-fbf9dc25efe0)

To make it work, we extend the protocol to send an empty `InterpretedWalRecords` to shards
if the WAL the records originated from ends the requested start position. On the pageserver,
that just updates the tracking LSNs in memory (no-op really). This gives us a workaround for
the fake gap.

As a drive by, make `InterpretedWalRecords::next_record_lsn` mandatory in the application level definition.
It's always included.

Related: https://github.com/neondatabase/cloud/issues/23935