### PR TITLE
test_runner: fix mismatch versions tests on linux

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -705,7 +705,7 @@ class NeonEnvBuilder:
         assert self.version_combination is not None, "version combination must be set"
 
         # Always use a newer version of `neon_local`
-        (self.mixdir / "neon_local").symlink_to(self.neon_binpath / "neon_local")
+        (self.mixdir / "neon_local").hardlink_to(self.neon_binpath / "neon_local")
         self.neon_local_binpath = self.mixdir
 
         for component, paths in COMPONENT_BINARIES.items():
@@ -716,7 +716,7 @@ class NeonEnvBuilder:
             )
             for filename in paths:
                 destination = self.mixdir / filename
-                destination.symlink_to(directory / filename)
+                destination.hardlink_to(directory / filename)
         self.neon_binpath = self.mixdir
 
         if self.version_combination["compute"] == "old":


### PR DESCRIPTION
## Problem

Tests with mixed-version binaries always use the latest binaries on CI ([an example](https://neon-github-public-dev.s3.amazonaws.com/reports/pr-10848/13378137061/index.html#suites/8fc5d1648d2225380766afde7c428d81/1ccefc4cfd4ef176/)):

The versions of new `storage_broker` and old `pageserver` are the same: `b45254a5605f6fdafdf475cdd3e920fe00898543`.

This affects only Linux, on macOS the version mixed correctly.

## Summary of changes
- Use hardlinks instead of symlinks to create a directory with mixed-version binaries
