### PR TITLE
pagesever: include visible layers in heatmaps after unarchival

### DIFF
--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -15,8 +15,8 @@ use crate::{
     tenant::{
         layer_map::{BatchedUpdates, LayerMap},
         storage_layer::{
-            AsLayerDesc, InMemoryLayer, Layer, PersistentLayerDesc, PersistentLayerKey,
-            ResidentLayer,
+            AsLayerDesc, InMemoryLayer, Layer, LayerVisibilityHint, PersistentLayerDesc,
+            PersistentLayerKey, ResidentLayer,
         },
     },
 };
@@ -116,6 +116,12 @@ impl LayerManager {
 
     pub(crate) fn likely_resident_layers(&self) -> impl Iterator<Item = &'_ Layer> + '_ {
         self.layers().values().filter(|l| l.is_likely_resident())
+    }
+
+    pub(crate) fn visible_layers(&self) -> impl Iterator<Item = &'_ Layer> + '_ {
+        self.layers()
+            .values()
+            .filter(|l| l.visibility() == LayerVisibilityHint::Visible)
     }
 
     pub(crate) fn contains(&self, layer: &Layer) -> bool {


### PR DESCRIPTION
## Problem

https://github.com/neondatabase/neon/pull/10788 introduced an API for warming up attached locations
by downloading all layers in the heatmap. We intend to use it for warming up timelines after unarchival too,
but it doesn't work. Any heatmap generated after the unarchival will not include our timeline, so we've lost
all those layers.

## Summary of changes

Generate a cheeky heatmap on unarchival. It includes all the visible layers.
Use that as the `PreviousHeatmap` which inputs into actual heatmap generation.