### PR TITLE
safekeeper: invalidate start of interpreted batch on reader resets

### DIFF
--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -173,11 +173,13 @@ impl InterpretedWalReaderState {
     fn maybe_reset(&mut self, new_shard_start_pos: Lsn) -> CurrentPositionUpdate {
         match self {
             InterpretedWalReaderState::Running {
-                current_position, ..
+                current_position,
+                current_batch_wal_start_lsn,
             } => {
                 if new_shard_start_pos < *current_position {
                     let from = *current_position;
                     *current_position = new_shard_start_pos;
+                    *current_batch_wal_start_lsn = None;
                     CurrentPositionUpdate::Reset {
                         from,
                         to: *current_position,

--- a/safekeeper/src/send_wal.rs
+++ b/safekeeper/src/send_wal.rs
@@ -624,8 +624,9 @@ impl SafekeeperPostgresHandler {
                         MAX_SEND_SIZE,
                     );
 
-                    let reader =
-                        InterpretedWalReader::new(wal_reader, start_pos, tx, shard, pg_version);
+                    let reader = InterpretedWalReader::new(
+                        wal_reader, start_pos, tx, shard, pg_version, None,
+                    );
 
                     let sender = InterpretedWalSender {
                         format,


### PR DESCRIPTION
## Problem

The interpreted WAL reader tracks the start of the current logical batch.
This needs to be invalidated when the reader is reset.

This bug caused a couple of WAL gap alerts in staging.

## Summary of changes

* Refactor to make it possible to write a reproducer
* Add repro unit test
* Fix by resetting the start with the reader

Related https://github.com/neondatabase/cloud/issues/23935
