### PR TITLE
pageserver: tweak slow GetPage logging (#10956)

### DIFF
--- a/libs/utils/benches/README.md
+++ b/libs/utils/benches/README.md
@@ -10,14 +10,14 @@ cargo bench --package utils
 cargo bench --package utils --bench benchmarks
 
 # Specific benchmark.
-cargo bench --package utils --bench benchmarks warn_slow/enabled=true
+cargo bench --package utils --bench benchmarks log_slow/enabled=true
 
 # List available benchmarks.
 cargo bench --package utils --benches -- --list
 
 # Generate flamegraph profiles using pprof-rs, profiling for 10 seconds.
 # Output in target/criterion/*/profile/flamegraph.svg.
-cargo bench --package utils --bench benchmarks warn_slow/enabled=true --profile-time 10
+cargo bench --package utils --bench benchmarks log_slow/enabled=true --profile-time 10
 ```
 
 Additional charts and statistics are available in `target/criterion/report/index.html`.

--- a/libs/utils/benches/benchmarks.rs
+++ b/libs/utils/benches/benchmarks.rs
@@ -3,14 +3,14 @@ use std::time::Duration;
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 use utils::id;
-use utils::logging::warn_slow;
+use utils::logging::log_slow;
 
 // Register benchmarks with Criterion.
 criterion_group!(
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = bench_id_stringify,
-    bench_warn_slow,
+    bench_log_slow,
 );
 criterion_main!(benches);
 
@@ -29,9 +29,9 @@ pub fn bench_id_stringify(c: &mut Criterion) {
     });
 }
 
-pub fn bench_warn_slow(c: &mut Criterion) {
+pub fn bench_log_slow(c: &mut Criterion) {
     for enabled in [false, true] {
-        c.bench_function(&format!("warn_slow/enabled={enabled}"), |b| {
+        c.bench_function(&format!("log_slow/enabled={enabled}"), |b| {
             run_bench(b, enabled).unwrap()
         });
     }
@@ -45,11 +45,11 @@ pub fn bench_warn_slow(c: &mut Criterion) {
             .enable_all()
             .build()?;
 
-        // Test both with and without warn_slow, since we're essentially measuring Tokio scheduling
+        // Test both with and without log_slow, since we're essentially measuring Tokio scheduling
         // performance too. Use a simple noop future that yields once, to avoid any scheduler fast
         // paths for a ready future.
         if enabled {
-            b.iter(|| runtime.block_on(warn_slow("ready", THRESHOLD, tokio::task::yield_now())));
+            b.iter(|| runtime.block_on(log_slow("ready", THRESHOLD, tokio::task::yield_now())));
         } else {
             b.iter(|| runtime.block_on(tokio::task::yield_now()));
         }

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -7,7 +7,7 @@ use metrics::{IntCounter, IntCounterVec};
 use once_cell::sync::Lazy;
 use strum_macros::{EnumString, VariantNames};
 use tokio::time::Instant;
-use tracing::warn;
+use tracing::info;
 
 /// Logs a critical error, similarly to `tracing::error!`. This will:
 ///
@@ -322,11 +322,13 @@ impl std::fmt::Debug for SecretString {
     }
 }
 
-/// Logs a periodic warning if a future is slow to complete.
+/// Logs a periodic message if a future is slow to complete.
 ///
 /// This is performance-sensitive as it's used on the GetPage read path.
+///
+/// TODO: consider upgrading this to a warning, but currently it fires too often.
 #[inline]
-pub async fn warn_slow<O>(name: &str, threshold: Duration, f: impl Future<Output = O>) -> O {
+pub async fn log_slow<O>(name: &str, threshold: Duration, f: impl Future<Output = O>) -> O {
     // TODO: we unfortunately have to pin the future on the heap, since GetPage futures are huge and
     // won't fit on the stack.
     let mut f = Box::pin(f);
@@ -345,13 +347,13 @@ pub async fn warn_slow<O>(name: &str, threshold: Duration, f: impl Future<Output
             // false negatives.
             let elapsed = started.elapsed();
             if elapsed >= threshold {
-                warn!("slow {name} completed after {:.3}s", elapsed.as_secs_f64());
+                info!("slow {name} completed after {:.3}s", elapsed.as_secs_f64());
             }
             return output;
         }
 
         let elapsed = started.elapsed().as_secs_f64();
-        warn!("slow {name} still running after {elapsed:.3}s",);
+        info!("slow {name} still running after {elapsed:.3}s",);
 
         attempt += 1;
     }


### PR DESCRIPTION
Cherrypick of #10956 onto `release-7930`.

## Problem

We recently added slow GetPage request logging. However, this unintentionally included the flush time when logging (which we already have separate logging for). It also logs at WARN level, which is a bit aggressive since we see this fire quite frequently.

Follows https://github.com/neondatabase/neon/pull/10906.

## Summary of changes

* Only log the request execution time, not the flush time.
* Extract a `pagestream_dispatch_batched_message()` helper.
* Rename `warn_slow()` to `log_slow()` and downgrade to INFO.