### PR TITLE
Incremenet getpage histogram in prefetch_lookup

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -967,6 +967,7 @@ prefetch_lookupv(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber blocknum, n
 			BITMAP_SET(mask, i);
 
 			hits += 1;
+			inc_getpage_wait(0);
 		}
 	}
 	pgBufferUsage.prefetch.hits += hits;


### PR DESCRIPTION
## Problem

PR https://github.com/neondatabase/neon/pull/10442 added prefetch_lookup function. 
It changed handling of getpage requests in compute.

Before:
1. Lookup in LFC (return if found)
2. Register prefetch buffer
3. Wait prefetch result (increment getpage_hist)
Now:

1. Lookup prefetch ring (return if prefetch request is already completed)
2. Lookup in LFC (return if found)
3. Register prefetch buffer
4. Wait prefetch result (increment getpage_hist)

So if prefetch result is already available, then get page histogram is not incremented.
It case failure of some test_throughtput benchmarks:
https://neondb.slack.com/archives/C033RQ5SPDH/p1740425527249499

## Summary of changes

Increment getpage histogram in `prefetch_lookup` 