### PR TITLE
pageserver: ignore `CollectKeySpaceError::Cancelled` during compaction

### DIFF
--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -779,6 +779,7 @@ impl Timeline {
             // Suppress errors when cancelled.
             Err(_) if self.cancel.is_cancelled() => {}
             Err(CompactionError::ShuttingDown) => {}
+            Err(CompactionError::CollectKeySpaceError(CollectKeySpaceError::Cancelled)) => {}
 
             // Alert on critical errors that indicate data corruption.
             Err(


### PR DESCRIPTION
This pops up a few times during deployment. Not sure why it fires without `self.cancel` being cancelled, but could be e.g. ancestor timelines or sth.