### PR TITLE
ancestor detach: delete hardlinked layers on error

### DIFF
--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -679,6 +679,7 @@ async fn remote_copy(
         Ok(()) => owned,
         Err(e) => {
             {
+                // Clean up the layer so that on a retry we don't get errors that the file already exists
                 owned.delete_on_drop();
                 std::mem::drop(owned);
             }


### PR DESCRIPTION
Delete layers that we have hardlinked so far when there is an error in `remote_copy`.

Make sure to hold the timeline gate to prevent races with detach&attach&read from the layer file.

Fixes #10970