### PR TITLE
fix(test): reduce number of relations in test_tx_abort_with_many_relations

### DIFF
--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -364,7 +364,7 @@ def test_tx_abort_with_many_relations(
         n = 4000
         step = 4000
     else:
-        n = 100000
+        n = 20000
         step = 5000
 
     def create():


### PR DESCRIPTION
## Problem

I see a lot of timeout errors, which indicates that this test is too slow. It seems that create relations are fast, but the subsequent truncating step is slow.

## Summary of changes

Reduce number of relations for now, and investigate later.