### PR TITLE
refactor(pageserver): propagate RequestContext to layer downloads

### DIFF
--- a/pageserver/compaction/src/compact_tiered.rs
+++ b/pageserver/compaction/src/compact_tiered.rs
@@ -307,7 +307,7 @@ where
                 let mut layer_ids: Vec<LayerId> = Vec::new();
                 for layer_id in &job.input_layers {
                     let layer = &self.layers[layer_id.0].layer;
-                    if let Some(dl) = self.executor.downcast_delta_layer(layer).await? {
+                    if let Some(dl) = self.executor.downcast_delta_layer(layer, ctx).await? {
                         deltas.push(dl.clone());
                         layer_ids.push(*layer_id);
                     }
@@ -536,7 +536,7 @@ where
         let mut deltas: Vec<E::DeltaLayer> = Vec::new();
         for layer_id in &job.input_layers {
             let l = &self.layers[layer_id.0];
-            if let Some(dl) = self.executor.downcast_delta_layer(&l.layer).await? {
+            if let Some(dl) = self.executor.downcast_delta_layer(&l.layer, ctx).await? {
                 deltas.push(dl.clone());
             }
         }

--- a/pageserver/compaction/src/interface.rs
+++ b/pageserver/compaction/src/interface.rs
@@ -55,6 +55,7 @@ pub trait CompactionJobExecutor {
     fn downcast_delta_layer(
         &self,
         layer: &Self::Layer,
+        ctx: &Self::RequestContext,
     ) -> impl Future<Output = anyhow::Result<Option<Self::DeltaLayer>>> + Send;
 
     // ----

--- a/pageserver/compaction/src/simulator.rs
+++ b/pageserver/compaction/src/simulator.rs
@@ -487,6 +487,7 @@ impl interface::CompactionJobExecutor for MockTimeline {
     async fn downcast_delta_layer(
         &self,
         layer: &MockLayer,
+        _ctx: &MockRequestContext,
     ) -> anyhow::Result<Option<Arc<MockDeltaLayer>>> {
         Ok(match layer {
             MockLayer::Delta(l) => Some(l.clone()),

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -927,11 +927,10 @@ async fn get_lsn_by_timestamp_handler(
 
     let with_lease = parse_query_param(&request, "with_lease")?.unwrap_or(false);
 
-    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
-
     let timeline =
         active_timeline_of_active_tenant(&state.tenant_manager, tenant_shard_id, timeline_id)
             .await?;
+    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
     let result = timeline
         .find_lsn_for_timestamp(timestamp_pg, &cancel, &ctx)
         .await?;
@@ -1000,10 +999,10 @@ async fn get_timestamp_of_lsn_handler(
         .with_context(|| format!("Invalid LSN: {lsn_str:?}"))
         .map_err(ApiError::BadRequest)?;
 
-    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
     let timeline =
         active_timeline_of_active_tenant(&state.tenant_manager, tenant_shard_id, timeline_id)
             .await?;
+    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
     let result = timeline.get_timestamp_for_lsn(lsn, &ctx).await?;
 
     match result {
@@ -1368,7 +1367,7 @@ async fn timeline_layer_scan_disposable_keys(
     };
 
     let resident_layer = layer
-        .download_and_keep_resident()
+        .download_and_keep_resident(&ctx)
         .await
         .map_err(|err| match err {
             tenant::storage_layer::layer::DownloadError::TimelineShutdown
@@ -1443,6 +1442,7 @@ async fn timeline_download_heatmap_layers_handler(
     let timeline =
         active_timeline_of_active_tenant(&state.tenant_manager, tenant_shard_id, timeline_id)
             .await?;
+    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
 
     let max_concurrency = get_config(&request)
         .remote_storage_config
@@ -1451,7 +1451,9 @@ async fn timeline_download_heatmap_layers_handler(
         .unwrap_or(DEFAULT_MAX_CONCURRENCY);
     let concurrency = std::cmp::min(max_concurrency, desired_concurrency);
 
-    timeline.start_heatmap_layers_download(concurrency).await?;
+    timeline
+        .start_heatmap_layers_download(concurrency, &ctx)
+        .await?;
 
     json_response(StatusCode::ACCEPTED, ())
 }
@@ -1490,8 +1492,9 @@ async fn layer_download_handler(
     let timeline =
         active_timeline_of_active_tenant(&state.tenant_manager, tenant_shard_id, timeline_id)
             .await?;
+    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
     let downloaded = timeline
-        .download_layer(&layer_name)
+        .download_layer(&layer_name, &ctx)
         .await
         .map_err(|e| match e {
             tenant::storage_layer::layer::DownloadError::TimelineShutdown
@@ -2389,7 +2392,8 @@ async fn timeline_download_remote_layers_handler_post(
     let timeline =
         active_timeline_of_active_tenant(&state.tenant_manager, tenant_shard_id, timeline_id)
             .await?;
-    match timeline.spawn_download_all_remote_layers(body).await {
+    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
+    match timeline.spawn_download_all_remote_layers(body, &ctx).await {
         Ok(st) => json_response(StatusCode::ACCEPTED, st),
         Err(st) => json_response(StatusCode::CONFLICT, st),
     }

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -2083,7 +2083,7 @@ pub(crate) mod test {
             .await
             .unwrap();
 
-            let new_layer = new_layer.download_and_keep_resident().await.unwrap();
+            let new_layer = new_layer.download_and_keep_resident(ctx).await.unwrap();
 
             new_layer
                 .copy_delta_prefix(&mut writer, truncate_at, ctx)

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -591,7 +591,7 @@ async fn copy_lsn_prefix(
     .with_context(|| format!("prepare to copy lsn prefix of ancestors {layer}"))
     .map_err(Error::Prepare)?;
 
-    let resident = layer.download_and_keep_resident().await.map_err(|e| {
+    let resident = layer.download_and_keep_resident(ctx).await.map_err(|e| {
         if e.is_cancelled() {
             Error::ShuttingDown
         } else {

--- a/pageserver/src/tenant/timeline/heatmap_layers_downloader.rs
+++ b/pageserver/src/tenant/timeline/heatmap_layers_downloader.rs
@@ -10,6 +10,8 @@ use http_utils::error::ApiError;
 use tokio_util::sync::CancellationToken;
 use utils::sync::gate::Gate;
 
+use crate::context::RequestContext;
+
 use super::Timeline;
 
 // This status is not strictly necessary now, but gives us a nice place
@@ -30,6 +32,7 @@ impl HeatmapLayersDownloader {
     fn new(
         timeline: Arc<Timeline>,
         concurrency: usize,
+        ctx: RequestContext,
     ) -> Result<HeatmapLayersDownloader, ApiError> {
         let tl_guard = timeline.gate.enter().map_err(|_| ApiError::Cancelled)?;
 
@@ -63,6 +66,7 @@ impl HeatmapLayersDownloader {
 
                 let stream = futures::stream::iter(heatmap.layers.into_iter().filter_map(
                     |layer| {
+                        let ctx = ctx.attached_child();
                         let tl = timeline.clone();
                         let dl_guard = match downloads_guard.enter() {
                             Ok(g) => g,
@@ -75,7 +79,7 @@ impl HeatmapLayersDownloader {
                         Some(async move {
                             let _dl_guard = dl_guard;
 
-                            let res = tl.download_layer(&layer.name).await;
+                            let res = tl.download_layer(&layer.name, &ctx).await;
                             if let Err(err) = res {
                                 if !err.is_cancelled() {
                                     tracing::warn!(layer=%layer.name,"Failed to download heatmap layer: {err}")
@@ -139,10 +143,11 @@ impl Timeline {
     pub(crate) async fn start_heatmap_layers_download(
         self: &Arc<Self>,
         concurrency: usize,
+        ctx: &RequestContext,
     ) -> Result<(), ApiError> {
         let mut locked = self.heatmap_layers_downloader.lock().unwrap();
         if locked.as_ref().map(|dl| dl.is_complete()).unwrap_or(true) {
-            let dl = HeatmapLayersDownloader::new(self.clone(), concurrency)?;
+            let dl = HeatmapLayersDownloader::new(self.clone(), concurrency, ctx.attached_child())?;
             *locked = Some(dl);
             Ok(())
         } else {


### PR DESCRIPTION
For some reason the layer download API never fully got `RequestContext`-infected.

This PR fixes that as a precursor to
- https://github.com/neondatabase/neon/issues/6107

