### PR TITLE
compute_ctl: Fix comment on start_postgres

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -788,8 +788,9 @@ impl ComputeNode {
         Ok(())
     }
 
-    /// Start Postgres as a child process and manage DBs/roles.
-    /// After that this will hang waiting on the postmaster process to exit.
+    /// Start Postgres as a child process and wait for it to start accepting
+    /// connections.
+    ///
     /// Returns a handle to the child process and a handle to the logs thread.
     #[instrument(skip_all)]
     pub fn start_postgres(


### PR DESCRIPTION
The comment was woefully outdated and outright wrong. It applied a long time ago (before commit e5cc2f92c4 to be precise), but nowadays the function just launches postgres and waits until it starts accepting connections. The other things the comment talked about are done in other functions.
