### PR TITLE
pageserver: add tenant debug API with last compaction loop result

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1135,6 +1135,14 @@ pub struct TenantDetails {
     pub timelines: Vec<TimelineId>,
 }
 
+/// Tenant debug information. This is unstable, and intended for human consumption.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TenantDebug {
+    /// The last compaction loop result. None if it hasn't run an iteration yet.
+    pub compaction_loop_result: Option<Result<String, String>>,
+    pub compaction_loop_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Debug)]
 pub enum TimelineArchivalState {
     Archived,

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -795,7 +795,7 @@ impl CompactionStatistics {
     }
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, strum_macros::Display)]
 pub enum CompactionOutcome {
     #[default]
     /// No layers need to be compacted after this round. Compaction doesn't need


### PR DESCRIPTION
## Problem

We're seeing occasional tenants which aren't running L0 compaction, but have limited observability to debug the cause.

## Summary of changes

Add a route `/v1/tenant/:tenant_shard_id/debug` with the fields `compaction_loop_result` and `compaction_loop_timestamp`, containing the result of the last compaction loop iteration.