### PR TITLE
compute_tools: appease unused lint on macOS

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -468,6 +468,8 @@ impl ComputeNode {
                         // Kills the actual task running the monitor
                         handle.abort();
                     }
+                } else {
+                    _ = vm_monitor; // appease unused lint on macOS
                 }
             }
         }
@@ -791,6 +793,7 @@ impl ComputeNode {
                 };
                 StartVmMonitorResult { token, vm_monitor }
             } else {
+                _ = disable_lfc_resizing; // appease unused lint on macOS
                 StartVmMonitorResult { }
             }
         }


### PR DESCRIPTION
## Problem

On macOS, the `unused` lint complains about two variables not used in `!linux` builds.

These were introduced in #11007.

## Summary of changes

Appease the linter by explicitly using the variables in `!linux` branches.