### PR TITLE
Fix caclulation of LFC used_pages

### DIFF
--- a/pgxn/neon/file_cache.c
+++ b/pgxn/neon/file_cache.c
@@ -1195,9 +1195,10 @@ lfc_writev(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno,
 				state = GET_STATE(entry, chunk_offs + i);
 				if (state == PENDING) {
 					SET_STATE(entry, chunk_offs + i, REQUESTED);
-				} else if (state != REQUESTED) {
-					lfc_ctl->used_pages -= state == AVAILABLE;
+				} else if (state == UNAVAILABLE) {
 					SET_STATE(entry, chunk_offs + i, PENDING);
+					break;
+				} else if (state == AVAILABLE) {
 					break;
 				}
 				if (!sleeping)

--- a/pgxn/neon/file_cache.c
+++ b/pgxn/neon/file_cache.c
@@ -1196,6 +1196,7 @@ lfc_writev(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber blkno,
 				if (state == PENDING) {
 					SET_STATE(entry, chunk_offs + i, REQUESTED);
 				} else if (state != REQUESTED) {
+					lfc_ctl->used_pages -= state == AVAILABLE;
 					SET_STATE(entry, chunk_offs + i, PENDING);
 					break;
 				}


### PR DESCRIPTION
## Problem

Async prefetch in LFC PR cause incorrect calculation of LFC `used_pages`when page is overwritten

## Summary of changes

Decrement `used_pages` is page is overwritten. 