### PR TITLE
fix grafana dashboard link for pooler endoints

### DIFF
--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -337,6 +337,9 @@ def allure_add_grafana_link(host: str, timeline_id: TimelineId, start_ms: int, e
     """
     # We expect host to be in format like ep-holy-mouse-w2u462gi.us-east-2.aws.neon.build
     endpoint_id, region_id, _ = host.split(".", 2)
+    # Remove "-pooler" suffix if present
+    if endpoint_id.endswith("-pooler"):
+        endpoint_id = endpoint_id[:-7]
 
     params = {
         "orgId": 1,

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -338,8 +338,7 @@ def allure_add_grafana_link(host: str, timeline_id: TimelineId, start_ms: int, e
     # We expect host to be in format like ep-holy-mouse-w2u462gi.us-east-2.aws.neon.build
     endpoint_id, region_id, _ = host.split(".", 2)
     # Remove "-pooler" suffix if present
-    if endpoint_id.endswith("-pooler"):
-        endpoint_id = endpoint_id[:-7]
+    endpoint_id = endpoint_id.removesuffix("-pooler")
 
     params = {
         "orgId": 1,


### PR DESCRIPTION
## Problem

Our benchmarking workflows contain links to grafana dashboards to troubleshoot problems.
This works fine for non-pooled endpoints.
For pooled endpoints we need to remove the `-pooler` suffix from the endpoint's hostname to get a valid endpoint ID. 

Example link that doesn't work in this run

https://github.com/neondatabase/neon/actions/runs/13678933253/job/38246028316#step:8:311

## Summary of changes

Check if connection string is a -pooler connection string and if so remove this suffix from the endpoint ID.


