### PR TITLE
remove CODEOWNER assignement for the test_runner/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,6 @@
 
 # DevProd & PerfCorr
 /.github/ @neondatabase/developer-productivity @neondatabase/performance-correctness
-/test_runner/	@neondatabase/performance-correctness
 
 # Compute
 /pgxn/ @neondatabase/compute


### PR DESCRIPTION
## Problem
That adds an extra unnecessary load to the PerfCorr team

## Summary of changes
Remove `CODEOWNERS` assignment for the `test_runner/` folder