### PR TITLE
storcon: initial autosplit tweaks

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -370,8 +370,12 @@ pub struct Config {
     /// tenant-scoped API endpoints. Further API requests queue until ready.
     pub tenant_rate_limit: NonZeroU32,
 
-    /// How large must a shard grow in bytes before we split it?
-    /// None disables auto-splitting.
+    /// The size at which an unsharded tenant should be split (into 8 shards). This uses the logical size of the
+    /// largest timeline in the shard (i.e. max_logical_size).
+    ///
+    /// None or 0 disables auto-splitting.
+    ///
+    /// TODO: consider using total logical size of all timelines instead.
     pub split_threshold: Option<u64>,
 
     // TODO: make this cfg(feature  = "testing")

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -370,8 +370,8 @@ pub struct Config {
     /// tenant-scoped API endpoints. Further API requests queue until ready.
     pub tenant_rate_limit: NonZeroU32,
 
-    /// The size at which an unsharded tenant should be split (into 8 shards). This uses the logical size of the
-    /// largest timeline in the shard (i.e. max_logical_size).
+    /// The size at which an unsharded tenant should be split (into 8 shards). This uses the logical
+    /// size of the largest timeline in the shard (i.e. max_logical_size).
     ///
     /// None or 0 disables auto-splitting.
     ///

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7250,6 +7250,9 @@ impl Service {
         let Some(split_threshold) = self.config.split_threshold else {
             return; // auto-splits are disabled
         };
+        if split_threshold == 0 {
+            return;
+        }
 
         // Fetch the largest eligible shards by logical size.
         const MAX_SHARDS: ShardCount = ShardCount::new(8);

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7268,9 +7268,9 @@ impl Service {
 
         // Filter out tenants in a prohibiting scheduling mode.
         {
-            let locked = self.inner.read().unwrap();
+            let state = self.inner.read().unwrap();
             top_n.retain(|i| {
-                let policy = locked.tenants.get(&i.id).map(|s| s.get_scheduling_policy());
+                let policy = state.tenants.get(&i.id).map(|s| s.get_scheduling_policy());
                 policy == Some(ShardSchedulingPolicy::Active)
             });
         }

--- a/storage_controller/src/tenant_shard.rs
+++ b/storage_controller/src/tenant_shard.rs
@@ -1710,8 +1710,8 @@ impl TenantShard {
         self.scheduling_policy = p;
     }
 
-    pub(crate) fn get_scheduling_policy(&self) -> &ShardSchedulingPolicy {
-        &self.scheduling_policy
+    pub(crate) fn get_scheduling_policy(&self) -> ShardSchedulingPolicy {
+        self.scheduling_policy
     }
 
     pub(crate) fn set_last_error(&mut self, sequence: Sequence, error: ReconcileError) {


### PR DESCRIPTION
## Problem

This patch makes some initial tweaks as preparation for https://github.com/neondatabase/cloud/issues/22532, where we will be introducing additional autosplit logic.

The plan is outlined in https://github.com/neondatabase/cloud/issues/22532#issuecomment-2706215907.

## Summary of changes

Minor code cleanups and behavioral changes:

* Decide that we'll split based on `max_logical_size` (later possibly `total_logical_size`).
* Fix a bug that would split the smallest candidate rather than the largest.
* Pick the largest candidate by `max_logical_size` rather than `resident_size`, for consistency (debatable).
* Split out `get_top_tenant_shards()` to fetch split candidates.
* Fetch candidates concurrently from all nodes.
* Make `TenantShard.get_scheduling_policy()` return a copy instead of a reference.