### PR TITLE
Add configuration options to disable prevlink checks

### DIFF
--- a/pgxn/neon/neon.c
+++ b/pgxn/neon/neon.c
@@ -457,6 +457,15 @@ _PG_init(void)
 							PGC_SIGHUP,
 							0,
 							NULL, NULL, NULL);
+	DefineCustomBoolVariable(
+							"neon.disable_wal_prevlink_checks",
+							"Disable validation of prev link in WAL records",
+							NULL,
+							&disable_wal_prev_lsn_checks,
+							false,
+							PGC_SIGHUP,
+							0,
+							NULL, NULL, NULL);
 
 	DefineCustomBoolVariable(
 							"neon.allow_replica_misconfig",

--- a/pgxn/neon/neon.h
+++ b/pgxn/neon/neon.h
@@ -23,6 +23,7 @@ extern char *wal_acceptors_list;
 extern int	wal_acceptor_reconnect_timeout;
 extern int	wal_acceptor_connection_timeout;
 extern int	readahead_getpage_pull_timeout_ms;
+extern bool	disable_wal_prev_lsn_checks;
 
 #if PG_MAJORVERSION_NUM >= 17
 extern uint32		WAIT_EVENT_NEON_LFC_MAINTENANCE;

--- a/pgxn/neon/walsender_hooks.c
+++ b/pgxn/neon/walsender_hooks.c
@@ -32,6 +32,8 @@ extern XLogRecPtr WalSndWaitForWal(XLogRecPtr loc);
 extern bool GetDonorShmem(XLogRecPtr *donor_lsn);
 extern XLogRecPtr GetXLogReplayRecPtr(TimeLineID *replayTLI);
 
+bool disable_wal_prev_lsn_checks = false;
+
 static XLogRecPtr
 NeonWALReadWaitForWAL(XLogRecPtr loc)
 {
@@ -81,6 +83,8 @@ NeonWALPageRead(
 
 	if (flushptr < targetPagePtr + reqLen)
 		return -1;
+
+	xlogreader->skip_lsn_checks = disable_wal_prev_lsn_checks;
 
 	/* Read at most XLOG_BLCKSZ bytes */
 	if (targetPagePtr + XLOG_BLCKSZ <= flushptr)


### PR DESCRIPTION
This allows for improved decoding of otherwise broken WAL.

## Problem

Currently, if (or when) a WAL record has a wrong prevptr, that breaks decoding. With this, we don't have to break on that if we decide it's OK to proceed after that.

## Summary of changes

Use a Neon GUC to allow the system to enable the NEON-specific skip_lsn_checks option in XLogReader.