### PR TITLE
fix(proxy): Use testodrome query id for latency measurement

### DIFF
--- a/proxy/src/compute.rs
+++ b/proxy/src/compute.rs
@@ -287,9 +287,10 @@ impl ConnCfg {
         // TODO: lots of useful info but maybe we can move it elsewhere (eg traces?)
         info!(
             cold_start_info = ctx.cold_start_info().as_str(),
-            "connected to compute node at {host} ({socket_addr}) sslmode={:?}, latency={}",
+            "connected to compute node at {host} ({socket_addr}) sslmode={:?}, latency={}, query_id={}",
             self.0.get_ssl_mode(),
             ctx.get_proxy_latency(),
+            ctx.get_testodrome_id(),
         );
 
         // NB: CancelToken is supposed to hold socket_addr, but we use connect_raw.

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -406,8 +406,11 @@ impl std::fmt::Display for LatencyAccumulated {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "client: {:?}, cplane: {:?}, compute: {:?}, retry: {:?}",
-            self.client, self.cplane, self.compute, self.retry
+            "client: {}, cplane: {}, compute: {}, retry: {}",
+            self.client.as_micros(),
+            self.cplane.as_micros(),
+            self.compute.as_micros(),
+            self.retry.as_micros()
         )
     }
 }


### PR DESCRIPTION
Add a new neon option "neon_query_id" to glue data with testodrome queries. Log latency in microseconds always.

Relates to the #22486