### PR TITLE
pageserver: better observability for slow wait_lsn

### DIFF
--- a/libs/utils/benches/benchmarks.rs
+++ b/libs/utils/benches/benchmarks.rs
@@ -49,7 +49,14 @@ pub fn bench_log_slow(c: &mut Criterion) {
         // performance too. Use a simple noop future that yields once, to avoid any scheduler fast
         // paths for a ready future.
         if enabled {
-            b.iter(|| runtime.block_on(log_slow("ready", THRESHOLD, tokio::task::yield_now())));
+            b.iter(|| {
+                runtime.block_on(log_slow(
+                    "ready",
+                    THRESHOLD,
+                    |_| (),
+                    std::pin::pin!(tokio::task::yield_now()),
+                ))
+            });
         } else {
             b.iter(|| runtime.block_on(tokio::task::yield_now()));
         }

--- a/libs/utils/benches/benchmarks.rs
+++ b/libs/utils/benches/benchmarks.rs
@@ -53,7 +53,6 @@ pub fn bench_log_slow(c: &mut Criterion) {
                 runtime.block_on(log_slow(
                     "ready",
                     THRESHOLD,
-                    |_| (),
                     std::pin::pin!(tokio::task::yield_now()),
                 ))
             });

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -407,6 +407,7 @@ pub struct MonitorSlowFutureCallback {
     /// The time elapsed since the [`monitor_slow_future`] was first polled.
     pub elapsed_total: Duration,
     /// The time elapsed since the last callback invocation.
+    /// For the initial callback invocation, the time elapsed since the [`monitor_slow_future`] was first polled.
     pub elapsed_since_last_callback: Duration,
 }
 

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -365,7 +365,8 @@ where
     .await
 }
 
-/// Poll future `fut` to completion, invoking callback `cb` at the given `period` and once after the future completes.
+/// Poll future `fut` to completion, invoking callback `cb` at the given `threshold` and every
+/// `period` afterwards, and also unconditionally when the future completes.
 #[inline]
 pub async fn monitor_slow_future<F, O>(
     threshold: Duration,

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -352,110 +352,33 @@ where
         let res = tokio::time::timeout_at(deadline, &mut f).await;
         let now = Instant::now();
         cb(LogSlowCallback {
-            incremental_time_spent_waiting: now - last_cb,
+            elapsed_since_last_callback: now - last_cb,
         });
         last_cb = now;
+        let elapsed = now - started;
         if let Ok(output) = res {
+            // NB: we check if we exceeded the threshold even if the timeout never fired, because
+            // scheduling or execution delays may cause the future to succeed even if it exceeds the
+            // timeout. This costs an extra unconditional clock reading, but seems worth it to avoid
+            // false negatives.
             if elapsed >= threshold {
                 info!("slow {name} completed after {:.3}s", elapsed.as_secs_f64());
             }
             return output;
         }
+        info!(
+            "slow {name} still running after {:.3}s",
+            elapsed.as_secs_f64()
+        );
 
         attempt += 1;
     }
-    log_slow2(started, threshold, f, |arg| {
-        let LogSlowCallback {
-            reason,
-            now,
-            incremental_time_spent_waiting: _,
-        } = arg;
-        let elapsed = now - started;
-        match reason {
-            LogSlowCallbackReason::Timeout => {
-                info!(
-                    "slow {name} still running after {:.3}s",
-                    elapsed.as_secs_f64()
-                );
-            }
-            LogSlowCallbackReason::CompletedAfterHittingTimeout => {
-                info!("slow {name} completed after {:.3}s", elapsed.as_secs_f64());
-            }
-            LogSlowCallbackReason::CompletedWithoutHittingTimeout => {}
-        }
-    })
-    .await
 }
 
-#[derive(Debug)]
-pub enum LogSlowCallbackReason {
-    Timeout,
-    CompletedAfterHittingTimeout,
-    CompletedWithoutHittingTimeout,
-}
-
+/// See [`log_slow`].
 pub struct LogSlowCallback {
-    pub reason: LogSlowCallbackReason,
-    pub now: Instant,
     /// The time elapsed since the last callback invocation.
-    pub incremental_time_spent_waiting: Duration,
-}
-
-pub async fn log_slow2<Fut, O>(
-    started_at: Instant,
-    period: Duration,
-    mut fut: Fut,
-    cb: impl FnMut(LogSlowCallback),
-) -> O
-where
-    Fut: std::future::Future<Output = O>,
-{
-    let mut fut = std::pin::pin!(fut);
-
-    let mut last_why = None;
-    let mut last_callback_at = started_at;
-    #[derive(Debug)]
-    enum Why {
-        HitTimeout,
-        Drop,
-    }
-    let mut observe_guard = scopeguard::guard(
-        |why| {
-            let now = Instant::now();
-            use Why::*;
-            let reason = match (last_why, why) {
-                (None, HitTimeout) | (Some(HitTimeout), HitTimeout) => {
-                    LogSlowCallbackReason::Timeout
-                }
-                (None, Drop) => LogSlowCallbackReason::CompletedWithoutHittingTimeout,
-                (Some(HitTimeout), Drop) => LogSlowCallbackReason::CompletedAfterHittingTimeout,
-                (Some(Drop), _) => {
-                    unreachable!("can only drop once: last_why={last_why:?}, why={why:?}");
-                }
-            };
-            last_why = Some(why);
-            let arg = LogSlowCallback {
-                reason,
-                now,
-                incremental_time_spent_waiting: elapsed_since_last_observe,
-            };
-            let elapsed_since_last_observe = now - last_callback_at;
-            cb(arg);
-            last_callback_at = now;
-        },
-        |mut observe| {
-            observe(Why::Drop);
-        },
-    );
-
-    loop {
-        match tokio::time::timeout(period, &mut fut).await {
-            Ok(v) => return v,
-            Err(_timeout) => {
-                (*observe_guard)(Why::HitTimeout);
-            }
-        }
-    }
+    pub elapsed_since_last_callback: Duration,
 }
 
 #[cfg(test)]

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -383,11 +383,7 @@ where
     loop {
         // NB: use timeout_at() instead of timeout() to avoid an extra clock reading in the common
         // case where the timeout doesn't fire.
-        let deadline = if attempt == 1 {
-            started + threshold
-        } else {
-            started + threshold + attempt * period
-        };
+        let deadline = started + threshold + (attempt - 1) * period;
         // TODO: still call the callback if the future panics? Copy how we do it for the page_service flush_in_progress counter.
         let res = tokio::time::timeout_at(deadline, &mut fut).await;
         let now = Instant::now();

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -344,10 +344,6 @@ where
              elapsed_since_last_callback: _,
          }| {
             if ready {
-                // NB: we check if we exceeded the threshold even if the timeout never fired, because
-                // scheduling or execution delays may cause the future to succeed even if it exceeds the
-                // timeout. This costs an extra unconditional clock reading, but seems worth it to avoid
-                // false negatives.
                 if elapsed_total >= threshold {
                     info!(
                         "slow {name} completed after {:.3}s",

--- a/libs/utils/src/logging.rs
+++ b/libs/utils/src/logging.rs
@@ -324,6 +324,20 @@ impl std::fmt::Debug for SecretString {
     }
 }
 
+/// Like [`log_slow_with`], but without the callback.
+#[inline]
+pub async fn log_slow<F, O>(
+    name: &str,
+    threshold: Duration,
+    mut cb: impl FnMut(LogSlowCallback),
+    mut f: std::pin::Pin<&mut F>,
+) -> O
+where
+    F: Future<Output = O>,
+{
+    log_slow_with(name, threshold, || (), f).await
+}
+
 /// Logs a periodic message if a future is slow to complete.
 ///
 /// The callback is called at the same frequency.
@@ -332,7 +346,7 @@ impl std::fmt::Debug for SecretString {
 ///
 /// TODO: consider upgrading this to a warning, but currently it fires too often.
 #[inline]
-pub async fn log_slow<F, O>(
+pub async fn log_slow_with<F, O>(
     name: &str,
     threshold: Duration,
     mut cb: impl FnMut(LogSlowCallback),

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -465,7 +465,7 @@ pub(crate) fn page_cache_errors_inc(error_kind: PageCacheErrorKind) {
 pub(crate) static WAIT_LSN_TIME: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "pageserver_wait_lsn_seconds",
-        "Time spent waiting for WAL to arrive. Updated after ",
+        "Time spent waiting for WAL to arrive. Updated on completion of the wait_lsn operation.",
         CRITICAL_OP_BUCKETS.into(),
     )
     .expect("failed to define a metric")

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -465,8 +465,25 @@ pub(crate) fn page_cache_errors_inc(error_kind: PageCacheErrorKind) {
 pub(crate) static WAIT_LSN_TIME: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "pageserver_wait_lsn_seconds",
-        "Time spent waiting for WAL to arrive",
+        "Time spent waiting for WAL to arrive. Updated after ",
         CRITICAL_OP_BUCKETS.into(),
+    )
+    .expect("failed to define a metric")
+});
+
+pub(crate) static WAIT_LSN_IN_PROGRESS_MICROS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "pageserver_wait_lsn_in_progress_micros",
+        "Time spent waiting for WAL to arrive, by timeline_id. Updated periodically while waiting.",
+        &["tenant_id", "shard_id", "timeline_id"],
+    )
+    .expect("failed to define a metric")
+});
+
+pub(crate) static WAIT_LSN_IN_PROGRESS_GLOBAL_MICROS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "pageserver_wait_lsn_in_progress_micros_global",
+        "Time spent waiting for WAL to arrive, globally. Updated periodically while waiting."
     )
     .expect("failed to define a metric")
 });
@@ -2830,7 +2847,6 @@ impl StorageTimeMetrics {
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct TimelineMetrics {
     tenant_id: String,
     shard_id: String,
@@ -2863,6 +2879,7 @@ pub(crate) struct TimelineMetrics {
     pub valid_lsn_lease_count_gauge: UIntGauge,
     pub wal_records_received: IntCounter,
     pub storage_io_size: StorageIoSizeMetrics,
+    pub wait_lsn_in_progress_micros: GlobalAndPerTenantIntCounter,
     shutdown: std::sync::atomic::AtomicBool,
 }
 
@@ -3000,6 +3017,13 @@ impl TimelineMetrics {
 
         let storage_io_size = StorageIoSizeMetrics::new(&tenant_id, &shard_id, &timeline_id);
 
+        let wait_lsn_in_progress_micros = GlobalAndPerTenantIntCounter {
+            global: WAIT_LSN_IN_PROGRESS_GLOBAL_MICROS.clone(),
+            per_tenant: WAIT_LSN_IN_PROGRESS_MICROS
+                .get_metric_with_label_values(&[&tenant_id, &shard_id, &timeline_id])
+                .unwrap(),
+        };
+
         TimelineMetrics {
             tenant_id,
             shard_id,
@@ -3032,6 +3056,7 @@ impl TimelineMetrics {
             storage_io_size,
             valid_lsn_lease_count_gauge,
             wal_records_received,
+            wait_lsn_in_progress_micros,
             shutdown: std::sync::atomic::AtomicBool::default(),
         }
     }
@@ -3223,6 +3248,9 @@ impl TimelineMetrics {
         for op in StorageIoSizeOperation::VARIANTS {
             let _ = STORAGE_IO_SIZE.remove_label_values(&[op, tenant_id, shard_id, timeline_id]);
         }
+
+        let _ =
+            WAIT_LSN_IN_PROGRESS_MICROS.remove_label_values(&[tenant_id, shard_id, timeline_id]);
 
         let _ = SMGR_QUERY_STARTED_PER_TENANT_TIMELINE.remove_label_values(&[
             SmgrQueryType::GetPageAtLsn.into(),
@@ -3836,27 +3864,29 @@ pub mod tokio_epoll_uring {
     });
 }
 
+pub(crate) struct GlobalAndPerTenantIntCounter {
+    global: IntCounter,
+    per_tenant: IntCounter,
+}
+
+impl GlobalAndPerTenantIntCounter {
+    #[inline(always)]
+    pub(crate) fn inc(&self) {
+        self.inc_by(1)
+    }
+    #[inline(always)]
+    pub(crate) fn inc_by(&self, n: u64) {
+        self.global.inc_by(n);
+        self.per_tenant.inc_by(n);
+    }
+}
+
 pub(crate) mod tenant_throttling {
-    use metrics::{IntCounter, register_int_counter_vec};
+    use metrics::register_int_counter_vec;
     use once_cell::sync::Lazy;
     use utils::shard::TenantShardId;
 
-    pub(crate) struct GlobalAndPerTenantIntCounter {
-        global: IntCounter,
-        per_tenant: IntCounter,
-    }
-
-    impl GlobalAndPerTenantIntCounter {
-        #[inline(always)]
-        pub(crate) fn inc(&self) {
-            self.inc_by(1)
-        }
-        #[inline(always)]
-        pub(crate) fn inc_by(&self, n: u64) {
-            self.global.inc_by(n);
-            self.per_tenant.inc_by(n);
-        }
-    }
+    use super::GlobalAndPerTenantIntCounter;
 
     pub(crate) struct Metrics<const KIND: usize> {
         pub(super) count_accounted_start: GlobalAndPerTenantIntCounter,
@@ -4102,6 +4132,7 @@ pub fn preinitialize_metrics(conf: &'static PageServerConf) {
         &CIRCUIT_BREAKERS_BROKEN,
         &CIRCUIT_BREAKERS_UNBROKEN,
         &PAGE_SERVICE_SMGR_FLUSH_INPROGRESS_MICROS_GLOBAL,
+        &WAIT_LSN_IN_PROGRESS_GLOBAL_MICROS,
     ]
     .into_iter()
     .for_each(|c| {

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -29,6 +29,7 @@ use pq_proto::framed::ConnectionError;
 use strum::{EnumCount, IntoEnumIterator as _, VariantNames};
 use strum_macros::{IntoStaticStr, VariantNames};
 use utils::id::TimelineId;
+use utils::logging::{LogSlowCallback, LogSlowCallbackReason};
 
 use crate::config::PageServerConf;
 use crate::context::{PageContentKind, RequestContext};
@@ -1535,27 +1536,26 @@ impl SmgrOpFlushInProgress {
     where
         Fut: std::future::Future<Output = O>,
     {
-        let mut fut = std::pin::pin!(fut);
+        utils::logging::log_slow2(started_at, Duration::from_secs(10), fut, |cb| {
+            let LogSlowCallback {
+                reason,
+                now,
+                incremental_time_spent_waiting,
+            } = cb;
+            // Always increment the counter
+            {
+                let elapsed_since_last_observe = incremental_time_spent_waiting;
+                self.global_micros
+                    .inc_by(u64::try_from(elapsed_since_last_observe.as_micros()).unwrap());
+                self.per_timeline_micros
+                    .inc_by(u64::try_from(elapsed_since_last_observe.as_micros()).unwrap());
+                last_counter_increment_at = now;
+            }
 
-        let mut logged = false;
-        let mut last_counter_increment_at = started_at;
-        let mut observe_guard = scopeguard::guard(
-            |is_timeout| {
-                let now = Instant::now();
-
-                // Increment counter
-                {
-                    let elapsed_since_last_observe = now - last_counter_increment_at;
-                    self.global_micros
-                        .inc_by(u64::try_from(elapsed_since_last_observe.as_micros()).unwrap());
-                    self.per_timeline_micros
-                        .inc_by(u64::try_from(elapsed_since_last_observe.as_micros()).unwrap());
-                    last_counter_increment_at = now;
-                }
-
-                // Log something on every timeout, and on completion but only if we hit a timeout.
-                if is_timeout || logged {
-                    logged = true;
+            // Log something on every timeout, and on completion but only if we hit a timeout.
+            match reason {
+                LogSlowCallbackReason::Timeout
+                | LogSlowCallbackReason::CompletedAfterHittingTimeout => {
                     let elapsed_total = now - started_at;
                     let msg = if is_timeout {
                         "slow flush ongoing"
@@ -1582,20 +1582,10 @@ impl SmgrOpFlushInProgress {
                     let elapsed_total_secs = format!("{:.6}", elapsed_total.as_secs_f64());
                     tracing::info!(elapsed_total_secs, inq, outq, msg);
                 }
-            },
-            |mut observe| {
-                observe(false);
-            },
-        );
-
-        loop {
-            match tokio::time::timeout(Duration::from_secs(10), &mut fut).await {
-                Ok(v) => return v,
-                Err(_timeout) => {
-                    (*observe_guard)(true);
-                }
+                LogSlowCallbackReason::CompletedBeforeTimeout => {}
             }
-        }
+        })
+        .await;
     }
 }
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1115,7 +1115,6 @@ impl PageServerHandler {
             log_slow(
                 log_slow_name,
                 LOG_SLOW_GETPAGE_THRESHOLD,
-                |_| (),
                 boxpinned.as_mut(),
             )
             .await?

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -1115,6 +1115,7 @@ impl PageServerHandler {
             log_slow(
                 log_slow_name,
                 LOG_SLOW_GETPAGE_THRESHOLD,
+                |_| (),
                 boxpinned.as_mut(),
             )
             .await?

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1485,7 +1485,7 @@ impl Timeline {
         let wait_for_timeout = self.last_record_lsn.wait_for_timeout(lsn, timeout);
         let wait_for_timeout = std::pin::pin!(wait_for_timeout);
         let update_metric = |LogSlowCallback {
-                                 elapsed_since_last_callback,
+                                 incremental_time_spent_waiting: elapsed_since_last_callback,
                              }| {
             self.metrics
                 .wait_lsn_in_progress_micros

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1526,7 +1526,7 @@ impl Timeline {
                     }
                 } else if elapsed_total > log_slow_threshold {
                     info!(
-                        "slow wait_lsn still running for{:.3}s",
+                        "slow wait_lsn still running for {:.3}s",
                         elapsed_total.as_secs_f64()
                     );
                 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1485,7 +1485,7 @@ impl Timeline {
         let wait_for_timeout = self.last_record_lsn.wait_for_timeout(lsn, timeout);
         let wait_for_timeout = std::pin::pin!(wait_for_timeout);
         let update_metric = |LogSlowCallback {
-                                 incremental_time_spent_waiting: elapsed_since_last_callback,
+                                 elapsed_since_last_callback,
                              }| {
             self.metrics
                 .wait_lsn_in_progress_micros

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1483,6 +1483,7 @@ impl Timeline {
         };
 
         let timer = crate::metrics::WAIT_LSN_TIME.start_timer();
+        let start_finish_counterpair_guard = self.metrics.wait_lsn_start_finish_counterpair.guard();
 
         let wait_for_timeout = self.last_record_lsn.wait_for_timeout(lsn, timeout);
         let wait_for_timeout = std::pin::pin!(wait_for_timeout);
@@ -1534,6 +1535,7 @@ impl Timeline {
         let res = wait_for_timeout.await;
         // don't count the time spent waiting for lock below, and also in walreceiver.status(), towards the wait_lsn_time_histo
         drop(logging_permit);
+        drop(start_finish_counterpair_guard);
         drop(timer);
         match res {
             Ok(()) => Ok(()),

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1497,14 +1497,15 @@ impl Timeline {
             log_slow_period,
             wait_for_timeout,
             |MonitorSlowFutureCallback {
-                 elapsed_since_last_callback,
                  ready,
+                 is_slow,
                  elapsed_total,
+                 elapsed_since_last_callback,
              }| {
                 self.metrics
                     .wait_lsn_in_progress_micros
                     .inc_by(u64::try_from(elapsed_since_last_callback.as_micros()).unwrap());
-                if elapsed_total < log_slow_threshold {
+                if !is_slow {
                     return;
                 }
                 // It's slow, see if we should log it.

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1492,7 +1492,7 @@ impl Timeline {
                 .inc_by(u64::try_from(elapsed_since_last_callback.as_micros()).unwrap());
         };
         // 1s threshold would have resulted in at most 1 log msg/second in prod, in the 30d trailing from Mar 11, 2025
-        let wait_for_timeout = log_slow(
+        let wait_for_timeout = log_slow_with(
             "wait_lsn",
             Duration::from_secs(1),
             update_metric,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -1518,13 +1518,11 @@ impl Timeline {
                 }
                 // We log it.
                 if ready {
-                    if elapsed_total >= log_slow_threshold {
-                        info!(
-                            "slow wait_lsn completed after {:.3}s",
-                            elapsed_total.as_secs_f64()
-                        );
-                    }
-                } else if elapsed_total > log_slow_threshold {
+                    info!(
+                        "slow wait_lsn completed after {:.3}s",
+                        elapsed_total.as_secs_f64()
+                    );
+                } else {
                     info!(
                         "slow wait_lsn still running for {:.3}s",
                         elapsed_total.as_secs_f64()

--- a/test_runner/fixtures/metrics.py
+++ b/test_runner/fixtures/metrics.py
@@ -176,6 +176,8 @@ PAGESERVER_PER_TENANT_METRICS: tuple[str, ...] = (
     counter("pageserver_timeline_wal_records_received"),
     counter("pageserver_page_service_pagestream_flush_in_progress_micros"),
     counter("pageserver_wait_lsn_in_progress_micros"),
+    counter("pageserver_wait_lsn_started_count"),
+    counter("pageserver_wait_lsn_finished_count"),
     *histogram("pageserver_page_service_batch_size"),
     *histogram("pageserver_page_service_pagestream_batch_wait_time_seconds"),
     *PAGESERVER_PER_TENANT_REMOTE_TIMELINE_CLIENT_METRICS,

--- a/test_runner/fixtures/metrics.py
+++ b/test_runner/fixtures/metrics.py
@@ -175,6 +175,7 @@ PAGESERVER_PER_TENANT_METRICS: tuple[str, ...] = (
     counter("pageserver_tenant_throttling_count"),
     counter("pageserver_timeline_wal_records_received"),
     counter("pageserver_page_service_pagestream_flush_in_progress_micros"),
+    counter("pageserver_wait_lsn_in_progress_micros"),
     *histogram("pageserver_page_service_batch_size"),
     *histogram("pageserver_page_service_pagestream_batch_wait_time_seconds"),
     *PAGESERVER_PER_TENANT_REMOTE_TIMELINE_CLIENT_METRICS,


### PR DESCRIPTION
# Problem

We leave too few observability breadcrumbs in the case where wait_lsn is exceptionally slow.

# Changes

- refactor: extract the monitoring logic out of `log_slow` into `monitor_slow_future`
- add global + per-timeline counter for time spent waiting for wait_lsn
  - It is updated while we're still waiting, similar to what we do for page_service response flush.
- add per-timeline counterpair for started & finished wait_lsn count
- add slow-logging to leave breadcrumbs in logs, not just metrics

For the slow-logging, we need to consider not flooding the logs during a broker or network outage/blip.
The solution is a "log-streak-level" concurrency limit per timeline.
At any given time, there is at most one slow wait_lsn that is logging the "still running" and "completed" sequence of logs.
Other concurrent slow wait_lsn's don't log at all.
This leaves at least one breadcrumb in each timeline's logs if some wait_lsn was exceptionally slow during a given period.
The full degree of slowness can then be determined by looking at the per-timeline metric.

# Performance

Reran the `bench_log_slow` benchmark, no difference, so, existing call sites are fine.

We do use a Semaphore, but only try_acquire it _after_ things have already been determined to be slow. So, no baseline overhead anticipated.

# Refs

- https://github.com/neondatabase/cloud/issues/23486#issuecomment-2711587222