### PR TITLE
pageserver: persist stripe size in tenant manifest for tenant_import

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1680,6 +1680,7 @@ pub struct SecondaryProgress {
 pub struct TenantScanRemoteStorageShard {
     pub tenant_shard_id: TenantShardId,
     pub generation: Option<u32>,
+    pub stripe_size: Option<ShardStripeSize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/libs/pageserver_api/src/shard.rs
+++ b/libs/pageserver_api/src/shard.rs
@@ -78,6 +78,12 @@ impl Default for ShardStripeSize {
     }
 }
 
+impl std::fmt::Display for ShardStripeSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// Layout version: for future upgrades where we might change how the key->shard mapping works
 #[derive(Clone, Copy, Serialize, Deserialize, Eq, PartialEq, Hash, Debug)]
 pub struct ShardLayout(u8);

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -4079,6 +4079,7 @@ impl Tenant {
 
         TenantManifest {
             version: LATEST_TENANT_MANIFEST_VERSION,
+            stripe_size: Some(self.get_shard_stripe_size()),
             offloaded_timelines,
         }
     }

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -492,6 +492,13 @@ HISTORIC_DATA_SETS = [
         PgVersion.V17,
         "https://neon-github-public-dev.s3.eu-central-1.amazonaws.com/compatibility-data-snapshots/2025-02-07-pgv17-nogenerations.tar.zst",
     ),
+    # Tenant manifest v1.
+    HistoricDataSet(
+        "2025-04-08-tenant-manifest-v1",
+        TenantId("9c2b73dec63b071189d6166a99be0ef2"),
+        PgVersion.V17,
+        "https://neon-github-public-dev.s3.eu-central-1.amazonaws.com/compatibility-data-snapshots/2025-04-08-pgv17-tenant-manifest-v1.tar.zst",
+    ),
 ]
 
 

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -495,7 +495,7 @@ HISTORIC_DATA_SETS = [
     # Tenant manifest v1.
     HistoricDataSet(
         "2025-04-08-tenant-manifest-v1",
-        TenantId("a127b34db7091665f0d4fa2196d60860"),
+        TenantId("c547c28588abf1d7b7139ff1f1158345"),
         PgVersion.V17,
         "https://neon-github-public-dev.s3.eu-central-1.amazonaws.com/compatibility-data-snapshots/2025-04-08-pgv17-tenant-manifest-v1.tar.zst",
     ),
@@ -504,7 +504,6 @@ HISTORIC_DATA_SETS = [
 
 @pytest.mark.parametrize("dataset", HISTORIC_DATA_SETS)
 @pytest.mark.xdist_group("compatibility")
-@pytest.mark.timeout(900) # snapshot downloads and extraction can be slow
 def test_historic_storage_formats(
     neon_env_builder: NeonEnvBuilder,
     test_output_dir: Path,

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -495,7 +495,7 @@ HISTORIC_DATA_SETS = [
     # Tenant manifest v1.
     HistoricDataSet(
         "2025-04-08-tenant-manifest-v1",
-        TenantId("9c2b73dec63b071189d6166a99be0ef2"),
+        TenantId("a127b34db7091665f0d4fa2196d60860"),
         PgVersion.V17,
         "https://neon-github-public-dev.s3.eu-central-1.amazonaws.com/compatibility-data-snapshots/2025-04-08-pgv17-tenant-manifest-v1.tar.zst",
     ),

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -504,6 +504,7 @@ HISTORIC_DATA_SETS = [
 
 @pytest.mark.parametrize("dataset", HISTORIC_DATA_SETS)
 @pytest.mark.xdist_group("compatibility")
+@pytest.mark.timeout(900) # snapshot downloads and extraction can be slow
 def test_historic_storage_formats(
     neon_env_builder: NeonEnvBuilder,
     test_output_dir: Path,


### PR DESCRIPTION
## Problem

`tenant_import`, used to import an existing tenant from remote storage into a storage controller for support and debugging, assumed `DEFAULT_STRIPE_SIZE` since this can't be recovered from remote storage. In #11168, we are changing the stripe size, which will break `tenant_import`.

Resolves #11175.

## Summary of changes

* Add `stripe_size` to the tenant manifest.
* Add `TenantScanRemoteStorageShard::stripe_size` and return from `tenant_scan_remote` if present.
* Recover the stripe size during`tenant_import`, or fall back to 32768 (the original default stripe size).
* Add tenant manifest compatibility snapshot: `2025-04-08-pgv17-tenant-manifest-v1.tar.zst`

There are no cross-version concerns here, since unknown fields are ignored during deserialization where relevant.