### PR TITLE
Suppress "request was dropped" errors in test_timeline_archive

### DIFF
--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -42,6 +42,14 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
         # If we run the unsharded version, talk to the storage controller
         ps_http = env.storage_controller.pageserver_api()
 
+    for ps in env.pageservers:
+        # We make /archival_config requests that are intended to fail.
+        # It's expected that storcon drops requests to other pageservers after
+        # it gets the first error (https://github.com/neondatabase/neon/issues/11177)
+        ps.allowed_errors.append(
+            ".*WARN.* path=/v1/tenant/.*/archival_config .*request was dropped before completing",
+        )
+
     # first try to archive a non existing timeline for an existing tenant:
     invalid_timeline_id = TimelineId.generate()
     with pytest.raises(PageserverApiException, match="timeline not found") as exc:


### PR DESCRIPTION
## Problem

Test `test_timeline_archive` is flaky because it makes requests that are intended to fail. It sometimes leads to warning in pageserver's logs. More details are in the issue.

- Closes: https://github.com/neondatabase/neon/issues/11177

## Summary of changes
- Suppress such errors.