### PR TITLE
storcon: retain stripe size when autosplitting sharded tenants

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7927,7 +7927,8 @@ impl Service {
         // and if we change the default stripe size we want to use the new default rather than an
         // old, persisted stripe size.
         let new_stripe_size = match split_candidate.id.shard_count.count() {
-            0 | 1 => Some(ShardParameters::DEFAULT_STRIPE_SIZE),
+            0 => panic!("invalid shard count 0"),
+            1 => Some(ShardParameters::DEFAULT_STRIPE_SIZE),
             2.. => None,
         };
 


### PR DESCRIPTION
## Problem

Autosplits always request `DEFAULT_STRIPE_SIZE` for splits. However, splits do not allow changing the stripe size of already-sharded tenants, and will error out if it differs.

In #11168, we are changing the stripe size, which could hit this when attempting to autosplit already sharded tenants.

Touches #11168.

## Summary of changes

Pass `new_stripe_size: None` when autosplitting already sharded tenants. Otherwise, pass `DEFAULT_STRIPE_SIZE` instead of the shard identity's stripe size, since we want to use the current default rather than an old, persisted default.