### PR TITLE
fix(ci): pass emtpy body when creating release PRs

### DIFF
--- a/.github/workflows/_create-release-pr.yml
+++ b/.github/workflows/_create-release-pr.yml
@@ -86,5 +86,6 @@ jobs:
         TITLE: ${{ steps.vars.outputs.title }}
       run: |
         gh pr create --title "${TITLE}" \
+                     --body "" \
                      --head "${RC_BRANCH}" \
                      --base "${RELEASE_BRANCH}"


### PR DESCRIPTION
## Problem
#11061 changed release pr creation, and I missed that creating PRs using `gh` in non-interactive environments *requires* `--body` instead of defaulting to an empty body.

## Summary of changes
Explicitly set an empty body when creating release PRs.
