### PR TITLE
fix(ci): run lint-release-pr on head-ref

### DIFF
--- a/.github/workflows/lint-release-pr.yml
+++ b/.github/workflows/lint-release-pr.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch full history for git operations
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Run lint script
         env:


### PR DESCRIPTION
## Problem
#11061 changed release pr creation, and I missed that the workflow will checkout a would-be-merge of the rc branch and the release branch instead of the head ref, unless explicitly instructed otherwise.

## Summary of changes
Check out head ref for linting the release PRs.