### PR TITLE
fix(ci): fix syntax of lint-release-pr

### DIFF
--- a/.github/scripts/lint-release-pr.sh
+++ b/.github/scripts/lint-release-pr.sh
@@ -90,7 +90,7 @@ while [[ "${CURRENT_COMMIT}" != "${MERGE_BASE}" && "${CURRENT_COMMIT}" != "${EXP
   if [[ "${NEXT_COMMIT}" == "${MERGE_BASE}" ]]; then
     echo "✅ Reached merge base (${MERGE_BASE})"
     PR_BASE="${MERGE_BASE}"
-  if [[ "${NEXT_COMMIT}" == "${EXPECTED_RELEASE_HEAD}" ]]; then
+  elif [[ "${NEXT_COMMIT}" == "${EXPECTED_RELEASE_HEAD}" ]]; then
     echo "✅ Reached release branch (${EXPECTED_RELEASE_HEAD})"
     PR_BASE="${EXPECTED_RELEASE_HEAD}"
   elif [[ -z "${NEXT_COMMIT}" ]]; then


### PR DESCRIPTION
## Problem
A small adjustment in #11061 broke the lint-release-pr.sh script, and the new version was neither tested nor linted. This has been done now, the script is once again tested and passing `shellcheck`.

## Summary of changes
Add missing `el` of `elif` condition chain.
