### PR TITLE
Fix effective_lsn calculation for prefetch

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -2238,8 +2238,19 @@ neon_get_request_lsns(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber blkno,
 					  neon_request_lsns *output, BlockNumber nblocks)
 {
 	XLogRecPtr	last_written_lsns[PG_IOV_MAX];
+	XLogRecPtr	flush_lsn;
 
 	Assert(nblocks <= PG_IOV_MAX);
+
+	if (!RecoveryInProgress())
+	{
+		/* It is critical to prevent stale reads to obtain LwLSN after flush LSN */
+#if PG_VERSION_NUM >= 150000
+		flush_lsn = GetFlushRecPtr(NULL);
+#else
+		flush_lsn = GetFlushRecPtr();
+#endif
+	}
 
 	GetLastWrittenLSNv(rinfo, forknum, blkno, (int) nblocks, last_written_lsns);
 
@@ -2353,17 +2364,11 @@ neon_get_request_lsns(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber blkno,
 	}
 	else
 	{
-		XLogRecPtr	flushlsn;
-#if PG_VERSION_NUM >= 150000
-		flushlsn = GetFlushRecPtr(NULL);
-#else
-		flushlsn = GetFlushRecPtr();
-#endif
-
 		for (int i = 0; i < nblocks; i++)
 		{
 			neon_request_lsns *result = &output[i];
 			XLogRecPtr	last_written_lsn = last_written_lsns[i];
+			XLogRecPtr effective_lsn = flush_lsn;
 
 			/*
 			 * Use the latest LSN that was evicted from the buffer cache as the
@@ -2382,13 +2387,13 @@ neon_get_request_lsns(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber blkno,
 			 * building, _bt_blwritepage logs the full page without flushing WAL
 			 * before smgrextend (files are fsynced before build ends).
 			 */
-			if (last_written_lsn > flushlsn)
+			if (last_written_lsn > flush_lsn)
 			{
 				neon_log(DEBUG5, "last-written LSN %X/%X is ahead of last flushed LSN %X/%X",
 						 LSN_FORMAT_ARGS(last_written_lsn),
-						 LSN_FORMAT_ARGS(flushlsn));
+						 LSN_FORMAT_ARGS(flush_lsn));
 				XLogFlush(last_written_lsn);
-				flushlsn = last_written_lsn;
+				effective_lsn = last_written_lsn;
 			}
 
 			/*
@@ -2408,14 +2413,14 @@ neon_get_request_lsns(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber blkno,
 			 * correctly determine if the response to the request is still
 			 * valid. The most up-to-date LSN we could use for that purpose
 			 * would be the current insert LSN, but to avoid the overhead of
-			 * looking it up, use 'flushlsn' instead. This relies on the
+			 * looking it up, use 'effetive_lsn' instead. This relies on the
 			 * assumption that if the page was modified since the last WAL
 			 * flush, it should still be in the buffer cache, and we
 			 * wouldn't be requesting it.
 			 */
 			result->request_lsn = UINT64_MAX;
 			result->not_modified_since = last_written_lsn;
-			result->effective_request_lsn = flushlsn;
+			result->effective_request_lsn = effective_lsn;
 		}
 	}
 }

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -2238,7 +2238,7 @@ neon_get_request_lsns(NRelFileInfo rinfo, ForkNumber forknum, BlockNumber blkno,
 					  neon_request_lsns *output, BlockNumber nblocks)
 {
 	XLogRecPtr	last_written_lsns[PG_IOV_MAX];
-	XLogRecPtr	flush_lsn;
+	XLogRecPtr	flush_lsn = InvalidXLogRecPtr;
 
 	Assert(nblocks <= PG_IOV_MAX);
 


### PR DESCRIPTION
## Problem

See  https://neondb.slack.com/archives/C04DGM6SMTM/p1741594233757489

Consider the following scenario:

1. Backend A wants to prefetch some block B
2. Backend A checks that block B is not present in shared buffer
3. Backend A registers new prefetch request and calls prefetch_do_request
4. prefetch_do_request calls neon_get_request_lsns
5. neon_get_request_lsns obtains LwLSN for block B
6. Backend B downloads B, updates and wallogs it (let say to Lsn1)
7. Block B is once again thrown from shared buffers, its LwLSN is set to Lsn1
8. Backend A obtains current flush LSN, let's say that it is Lsn1
9. Backend A stores Lsn1 as effective_lsn in prefetch slot.
10. Backend A reads page B with LwLSN=Lsn1
11. Backend A finds in prefetch ring response for prefetch request for block B with effective_lsn=Lsn1, so that it satisfies neon_prefetch_response_usable condition
12. Backend A uses deteriorated version of the page!

## Summary of changes

Use `not_modified_since` as `effective_lsn`. 
It should not cause some degrade of performance because we store LwLSN when it was not found in LwLSN hash, so if page is not changed till prefetch response is arrived, then LwLSN should not be changed.