### PR TITLE
tests: suppress "Cancelled request finished with an error" in test_timeline_archive

### DIFF
--- a/test_runner/regress/test_timeline_archive.py
+++ b/test_runner/regress/test_timeline_archive.py
@@ -46,8 +46,11 @@ def test_timeline_archive(neon_env_builder: NeonEnvBuilder, shard_count: int):
         # We make /archival_config requests that are intended to fail.
         # It's expected that storcon drops requests to other pageservers after
         # it gets the first error (https://github.com/neondatabase/neon/issues/11177)
-        ps.allowed_errors.append(
-            ".*WARN.* path=/v1/tenant/.*/archival_config .*request was dropped before completing",
+        ps.allowed_errors.extend(
+            [
+                ".*WARN.* path=/v1/tenant/.*/archival_config .*request was dropped before completing",
+                ".*ERROR.* path=/v1/tenant/.*/archival_config .*Cancelled request finished with an error.*",
+            ]
         )
 
     # first try to archive a non existing timeline for an existing tenant:


### PR DESCRIPTION
## Problem

Previous PR https://github.com/neondatabase/neon/pull/11190 didn't suppress `Cancelled request finished with an error` messages, which are also expected, so the test https://github.com/neondatabase/neon/issues/11177 is still flaky.

## Summary of changes
- Suppress `Cancelled request finished with an error` in `test_timeline_archive`
