### PR TITLE
pageserver: deflake compaction tests

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -6559,7 +6559,11 @@ mod tests {
 
         tline.freeze_and_flush().await?;
         tline
-            .compact(&CancellationToken::new(), EnumSet::empty(), &ctx)
+            .compact(
+                &CancellationToken::new(),
+                CompactFlags::NoYield.into(),
+                &ctx,
+            )
             .await?;
 
         let mut writer = tline.writer().await;
@@ -6576,7 +6580,11 @@ mod tests {
 
         tline.freeze_and_flush().await?;
         tline
-            .compact(&CancellationToken::new(), EnumSet::empty(), &ctx)
+            .compact(
+                &CancellationToken::new(),
+                CompactFlags::NoYield.into(),
+                &ctx,
+            )
             .await?;
 
         let mut writer = tline.writer().await;
@@ -6593,7 +6601,11 @@ mod tests {
 
         tline.freeze_and_flush().await?;
         tline
-            .compact(&CancellationToken::new(), EnumSet::empty(), &ctx)
+            .compact(
+                &CancellationToken::new(),
+                CompactFlags::NoYield.into(),
+                &ctx,
+            )
             .await?;
 
         let mut writer = tline.writer().await;
@@ -6610,7 +6622,11 @@ mod tests {
 
         tline.freeze_and_flush().await?;
         tline
-            .compact(&CancellationToken::new(), EnumSet::empty(), &ctx)
+            .compact(
+                &CancellationToken::new(),
+                CompactFlags::NoYield.into(),
+                &ctx,
+            )
             .await?;
 
         assert_eq!(
@@ -6693,7 +6709,9 @@ mod tests {
             timeline.freeze_and_flush().await?;
             if compact {
                 // this requires timeline to be &Arc<Timeline>
-                timeline.compact(&cancel, EnumSet::empty(), ctx).await?;
+                timeline
+                    .compact(&cancel, CompactFlags::NoYield.into(), ctx)
+                    .await?;
             }
 
             // this doesn't really need to use the timeline_id target, but it is closer to what it
@@ -7399,7 +7417,9 @@ mod tests {
 
             // Perform a cycle of flush, compact, and GC
             tline.freeze_and_flush().await?;
-            tline.compact(&cancel, EnumSet::empty(), &ctx).await?;
+            tline
+                .compact(&cancel, CompactFlags::NoYield.into(), &ctx)
+                .await?;
             tenant
                 .gc_iteration(Some(tline.timeline_id), 0, Duration::ZERO, &cancel, &ctx)
                 .await?;
@@ -7779,7 +7799,9 @@ mod tests {
         let before_num_l0_delta_files =
             tline.layers.read().await.layer_map()?.level0_deltas().len();
 
-        tline.compact(&cancel, EnumSet::empty(), &ctx).await?;
+        tline
+            .compact(&cancel, CompactFlags::NoYield.into(), &ctx)
+            .await?;
 
         let after_num_l0_delta_files = tline.layers.read().await.layer_map()?.level0_deltas().len();
 


### PR DESCRIPTION
These need to set `NoYield`, otherwise they may be preempted by pending L0 compaction.