### PR TITLE
fix(compute_ctl): Dollar escaping helper fixes

### DIFF
--- a/compute_tools/src/pg_helpers.rs
+++ b/compute_tools/src/pg_helpers.rs
@@ -208,8 +208,8 @@ impl Escaping for PgIdent {
     /// Here we somewhat mimic the logic of Postgres' `pg_get_functiondef()`,
     /// <https://github.com/postgres/postgres/blob/8b49392b270b4ac0b9f5c210e2a503546841e832/src/backend/utils/adt/ruleutils.c#L2924>
     fn pg_quote_dollar(&self) -> (String, String) {
-        let mut tag: String = "".to_string();
-        let mut outer_tag = "x".to_string();
+        let mut tag: String = "x".to_string();
+        let mut outer_tag = "xx".to_string();
 
         // Find the first suitable tag that is not present in the string.
         // Postgres' max role/DB name length is 63 bytes, so even in the

--- a/compute_tools/tests/pg_helpers_tests.rs
+++ b/compute_tools/tests/pg_helpers_tests.rs
@@ -64,7 +64,8 @@ test.escaping = 'here''s a backslash \\ and a quote '' and a double-quote " hoor
     #[test]
     fn ident_pg_quote_dollar() {
         let test_cases = vec![
-            ("name", ("$$name$$", "x")),
+            ("name", ("$x$name$x$", "xx")),
+            ("name$", ("$x$name$$x$", "xx")),
             ("name$$", ("$x$name$$$x$", "xx")),
             ("name$$$", ("$x$name$$$$x$", "xx")),
             ("name$$$$", ("$x$name$$$$$x$", "xx")),

--- a/test_runner/regress/test_compute_catalog.py
+++ b/test_runner/regress/test_compute_catalog.py
@@ -16,6 +16,9 @@ TEST_ROLE_NAMES = [
     {"name": "role \";with ';injections $$ $x$ $ %I !/\\&#@"},
     {"name": '"role in double quotes"'},
     {"name": "'role in single quotes'"},
+    {"name": "role$"},
+    {"name": "role$$"},
+    {"name": "role$x$"},
 ]
 
 TEST_DB_NAMES = [
@@ -58,6 +61,18 @@ TEST_DB_NAMES = [
     {
         "name": "'db in single quotes'",
         "owner": "'role in single quotes'",
+    },
+    {
+        "name": "db name$",
+        "owner": "role$",
+    },
+    {
+        "name": "db name$$",
+        "owner": "role$$",
+    },
+    {
+        "name": "db name$x$",
+        "owner": "role$x$",
     },
 ]
 


### PR DESCRIPTION
## Problem

In the previous PR #11045, one edge-case wasn't covered, when an ident contains only one `$`, we were picking `$$` as a 'wrapper'. Yet, when this `$` is at the beginning or at the end of the ident, then we end up with `$$$` in a row which breaks the escaping.

## Summary of changes

Start from `x` tag instead of a blank string.

Slack: https://neondb.slack.com/archives/C08HV951W2W/p1742076675079769?thread_ts=1742004205.461159&cid=C08HV951W2W
