### PR TITLE
fix(ci): don't have neon-test-extensions release tag push depend on compute-node-image build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1014,7 +1014,7 @@ jobs:
 
   add-release-tag-to-neon-test-extensions-image:
     if: ${{ needs.meta.outputs.run-kind == 'compute-release' }}
-    needs: [ meta, compute-node-image ]
+    needs: [ meta ]
     uses: ./.github/workflows/_push-to-container-registry.yml
     with:
       image-map: |


### PR DESCRIPTION
## Problem
Failures like https://github.com/neondatabase/neon/actions/runs/13901493608/job/38896940612?pr=11272 are caused by the dependency on `compute-node-image`, which was wrong on release jobs anyway.

## Summary of changes
Remove dependency on `compute-node-image` from the job `add-release-tag-to-neon-test-extension-image`.
