### PR TITLE
fast_import: put job status to s3

### DIFF
--- a/test_runner/regress/test_import_pgdata.py
+++ b/test_runner/regress/test_import_pgdata.py
@@ -449,6 +449,17 @@ def test_fast_import_with_pageserver_ingest(
     fast_import.extra_env["RUST_LOG"] = "aws_config=debug,aws_sdk_kms=debug"
     pg_port = port_distributor.get_port()
     fast_import.run_pgdata(pg_port=pg_port, s3prefix=f"s3://{bucket}/{key_prefix}")
+
+    pgdata_status_obj = mock_s3_client.get_object(Bucket=bucket, Key=f"{key_prefix}/status/pgdata")
+    pgdata_status = pgdata_status_obj["Body"].read().decode("utf-8")
+    assert json.loads(pgdata_status) == {"done": True}, f"got status: {pgdata_status}"
+
+    job_status_obj = mock_s3_client.get_object(
+        Bucket=bucket, Key=f"{key_prefix}/status/fast_import"
+    )
+    job_status = job_status_obj["Body"].read().decode("utf-8")
+    assert json.loads(job_status) == {"done": True}, f"got status: {job_status}"
+
     vanilla_pg.stop()
 
     def validate_vanilla_equivalence(ep):
@@ -674,9 +685,11 @@ def test_fast_import_restore_to_connstring_from_s3_spec(
             ).decode("utf-8"),
         }
 
-        mock_s3_client.create_bucket(Bucket="test-bucket")
+        bucket = "test-bucket"
+        key_prefix = "test-prefix"
+        mock_s3_client.create_bucket(Bucket=bucket)
         mock_s3_client.put_object(
-            Bucket="test-bucket", Key="test-prefix/spec.json", Body=json.dumps(spec)
+            Bucket=bucket, Key=f"{key_prefix}/spec.json", Body=json.dumps(spec)
         )
 
         # Run fast_import
@@ -688,7 +701,13 @@ def test_fast_import_restore_to_connstring_from_s3_spec(
         fast_import.extra_env["AWS_REGION"] = mock_s3_server.region()
         fast_import.extra_env["AWS_ENDPOINT_URL"] = mock_s3_server.endpoint()
         fast_import.extra_env["RUST_LOG"] = "aws_config=debug,aws_sdk_kms=debug"
-        fast_import.run_dump_restore(s3prefix="s3://test-bucket/test-prefix")
+        fast_import.run_dump_restore(s3prefix=f"s3://{bucket}/{key_prefix}")
+
+        job_status_obj = mock_s3_client.get_object(
+            Bucket=bucket, Key=f"{key_prefix}/status/fast_import"
+        )
+        job_status = job_status_obj["Body"].read().decode("utf-8")
+        assert json.loads(job_status) == {"done": True}, f"got status: {job_status}"
         vanilla_pg.stop()
 
         res = destination_vanilla_pg.safe_psql("SELECT count(*) FROM foo;")
@@ -696,9 +715,67 @@ def test_fast_import_restore_to_connstring_from_s3_spec(
         assert res[0][0] == 10
 
 
-# TODO: Maybe test with pageserver?
-# 1. run whole neon env
-# 2. create timeline with some s3 path???
-# 3. run fast_import with s3 prefix
-# 4. ??? mock http where pageserver will report progress
-# 5. run compute on this timeline and check if data is there
+def test_fast_import_restore_to_connstring_error_to_s3(
+    test_output_dir,
+    vanilla_pg: VanillaPostgres,
+    port_distributor: PortDistributor,
+    fast_import: FastImport,
+    pg_distrib_dir: Path,
+    pg_version: PgVersion,
+    mock_s3_server: MockS3Server,
+    mock_kms: KMSClient,
+    mock_s3_client: S3Client,
+):
+    # Prepare KMS and S3
+    key_response = mock_kms.create_key(
+        Description="Test key",
+        KeyUsage="ENCRYPT_DECRYPT",
+        Origin="AWS_KMS",
+    )
+    key_id = key_response["KeyMetadata"]["KeyId"]
+
+    def encrypt(x: str) -> EncryptResponseTypeDef:
+        return mock_kms.encrypt(KeyId=key_id, Plaintext=x)
+
+    # Start source postgres and ingest data
+    vanilla_pg.start()
+    vanilla_pg.safe_psql("CREATE TABLE foo (a int); INSERT INTO foo SELECT generate_series(1, 10);")
+
+    # Encrypt connstrings and put spec into S3
+    source_connstring_encrypted = encrypt(vanilla_pg.connstr())
+    destination_connstring_encrypted = encrypt("postgres://random:connection@string:5432/neondb")
+    spec = {
+        "encryption_secret": {"KMS": {"key_id": key_id}},
+        "source_connstring_ciphertext_base64": base64.b64encode(
+            source_connstring_encrypted["CiphertextBlob"]
+        ).decode("utf-8"),
+        "destination_connstring_ciphertext_base64": base64.b64encode(
+            destination_connstring_encrypted["CiphertextBlob"]
+        ).decode("utf-8"),
+    }
+
+    bucket = "test-bucket"
+    key_prefix = "test-prefix"
+    mock_s3_client.create_bucket(Bucket=bucket)
+    mock_s3_client.put_object(Bucket=bucket, Key=f"{key_prefix}/spec.json", Body=json.dumps(spec))
+
+    # Run fast_import
+    if fast_import.extra_env is None:
+        fast_import.extra_env = {}
+    fast_import.extra_env["AWS_ACCESS_KEY_ID"] = mock_s3_server.access_key()
+    fast_import.extra_env["AWS_SECRET_ACCESS_KEY"] = mock_s3_server.secret_key()
+    fast_import.extra_env["AWS_SESSION_TOKEN"] = mock_s3_server.session_token()
+    fast_import.extra_env["AWS_REGION"] = mock_s3_server.region()
+    fast_import.extra_env["AWS_ENDPOINT_URL"] = mock_s3_server.endpoint()
+    fast_import.extra_env["RUST_LOG"] = "aws_config=debug,aws_sdk_kms=debug"
+    fast_import.run_dump_restore(s3prefix=f"s3://{bucket}/{key_prefix}")
+
+    job_status_obj = mock_s3_client.get_object(
+        Bucket=bucket, Key=f"{key_prefix}/status/fast_import"
+    )
+    job_status = job_status_obj["Body"].read().decode("utf-8")
+    assert json.loads(job_status) == {
+        "done": False,
+        "error": "pg_restore failed",
+    }, f"got status: {job_status}"
+    vanilla_pg.stop()


### PR DESCRIPTION
## Problem

`fast_import` binary is being run inside neonvms, and they do not support proper `kubectl describe logs` now, there are a bunch of other caveats as well: https://github.com/neondatabase/autoscaling/issues/1320

Anyway, we needed a signal if job finished successfully or not, and if not — at least some error message for the cplane operation. And after [a short discussion](https://neondb.slack.com/archives/C07PG8J1L0P/p1741954251813609), that s3 object is the most convenient at the moment.

## Summary of changes

If `s3_prefix` was provided to `fast_import` call, any job run puts a status object file into `{s3_prefix}/status/fast_import` with contents `{"done": true}` or `{"done": false, "error": "..."}`. Added a test as well
