### PR TITLE
feat(compute_ctl): pass compute type to pageserver with pg_options

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -858,7 +858,7 @@ impl ComputeNode {
         config.application_name("compute_ctl");
         if let Some(spec) = &compute_state.pspec {
             config.options(&format!(
-                "-c neon.endpoint_type={}",
+                "-c neon.compute_mode={}",
                 spec.spec.mode.to_type_str()
             ));
         }

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -855,6 +855,14 @@ impl ComputeNode {
             info!("Storage auth token not set");
         }
 
+        config.application_name("compute_ctl");
+        if let Some(spec) = &compute_state.pspec {
+            config.options(&format!(
+                "-c neon.endpoint_type={}",
+                spec.spec.mode.to_type_str()
+            ));
+        }
+
         // Connect to pageserver
         let mut client = config.connect(NoTls)?;
         let pageserver_connect_micros = start_time.elapsed().as_micros() as u64;

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -99,7 +99,7 @@ pub fn write_postgres_conf(
         writeln!(file, "lc_numeric='C.UTF-8'")?;
     }
 
-    writeln!(file, "neon.endpoint_type={}", spec.mode.to_type_str())?;
+    writeln!(file, "neon.compute_mode={}", spec.mode.to_type_str())?;
     match spec.mode {
         ComputeMode::Primary => {}
         ComputeMode::Static(lsn) => {

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -99,6 +99,7 @@ pub fn write_postgres_conf(
         writeln!(file, "lc_numeric='C.UTF-8'")?;
     }
 
+    writeln!(file, "neon.endpoint_type={}", spec.mode.to_type_str())?;
     match spec.mode {
         ComputeMode::Primary => {}
         ComputeMode::Static(lsn) => {

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -272,6 +272,18 @@ pub enum ComputeMode {
     Replica,
 }
 
+impl ComputeMode {
+    /// Convert the compute mode to a string that can be used to identify the type of compute,
+    /// which means that if it's a static compute, the LSN will not be included.
+    pub fn to_type_str(&self) -> &'static str {
+        match self {
+            ComputeMode::Primary => "primary",
+            ComputeMode::Static(_) => "static",
+            ComputeMode::Replica => "replica",
+        }
+    }
+}
+
 /// Log level for audit logging
 /// Disabled, log, hipaa
 /// Default is Disabled

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -2560,12 +2560,20 @@ where
                             tracing::warn!("failed to parse the startup options: {options}");
                             break;
                         }
-                    } else if parsing_config {
-                        let Some((key, value)) = item.split_once('=') else {
+                    } else if item.starts_with("-c") || parsing_config {
+                        let Some((mut key, value)) = item.split_once('=') else {
                             // "-c" followed with an invalid option
                             tracing::warn!("failed to parse the startup options: {options}");
                             break;
                         };
+                        if !parsing_config {
+                            // Parse "-coptions=X"
+                            let Some(stripped_key) = key.strip_prefix("-c") else {
+                                tracing::warn!("failed to parse the startup options: {options}");
+                                break;
+                            };
+                            key = stripped_key;
+                        }
                         if key == "neon.endpoint_type" {
                             Span::current().record("endpoint_type", field::display(value));
                         } else {

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -51,16 +51,16 @@
 #define MAX_RECONNECT_INTERVAL_USEC 1000000
 
 
-enum NeonEndpointType {
-	EP_TYPE_PRIMARY = 0,
-	EP_TYPE_REPLICA,
-	EP_TYPE_STATIC
+enum NeonComputeMode {
+	CP_MODE_PRIMARY = 0,
+	CP_MODE_REPLICA,
+	CP_MODE_STATIC
 };
 
-static const struct config_enum_entry neon_endpoint_types[] = {
-	{"primary", EP_TYPE_PRIMARY, false},
-	{"replica", EP_TYPE_REPLICA, false},
-	{"static", EP_TYPE_STATIC, false},
+static const struct config_enum_entry neon_compute_modes[] = {
+	{"primary", CP_MODE_PRIMARY, false},
+	{"replica", CP_MODE_REPLICA, false},
+	{"static", CP_MODE_STATIC, false},
 	{NULL, 0, false}
 };
 
@@ -76,7 +76,7 @@ int			flush_every_n_requests = 8;
 
 int         neon_protocol_version = 2;
 
-static int	neon_endpoint_type = 0;
+static int	neon_compute_mode = 0;
 static int	max_reconnect_attempts = 60;
 static int	stripe_size;
 
@@ -482,18 +482,18 @@ pageserver_connect(shardno_t shard_no, int elevel)
 
 		{
 			bool param_set = false;
-			switch (neon_endpoint_type)
+			switch (neon_compute_mode)
 			{
-				case EP_TYPE_PRIMARY:
-					strncpy(endpoint_str, "-c neon.endpoint_type=primary", sizeof(endpoint_str));
+				case CP_MODE_PRIMARY:
+					strncpy(endpoint_str, "-c neon.compute_mode=primary", sizeof(endpoint_str));
 					param_set = true;
 					break;
-				case EP_TYPE_REPLICA:
-					strncpy(endpoint_str, "-c neon.endpoint_type=replica", sizeof(endpoint_str));
+				case CP_MODE_REPLICA:
+					strncpy(endpoint_str, "-c neon.compute_mode=replica", sizeof(endpoint_str));
 					param_set = true;
 					break;
-				case EP_TYPE_STATIC:
-					strncpy(endpoint_str, "-c neon.endpoint_type=static", sizeof(endpoint_str));
+				case CP_MODE_STATIC:
+					strncpy(endpoint_str, "-c neon.compute_mode=static", sizeof(endpoint_str));
 					param_set = true;
 					break;
 			}
@@ -1412,12 +1412,12 @@ pg_init_libpagestore(void)
 							NULL, NULL, NULL);
 
 	DefineCustomEnumVariable(
-							"neon.endpoint_type",
+							"neon.compute_mode",
 							"The compute endpoint node type",
 							NULL,
-							&neon_endpoint_type,
-							EP_TYPE_PRIMARY,
-							neon_endpoint_types,
+							&neon_compute_mode,
+							CP_MODE_PRIMARY,
+							neon_compute_modes,
 							PGC_POSTMASTER,
 							0,
 							NULL, NULL, NULL);

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -407,8 +407,8 @@ pageserver_connect(shardno_t shard_no, int elevel)
 	{
 		const char *keywords[5];
 		const char *values[5];
-		char pid_str[16];
-		char endpoint_str[36];
+		char pid_str[16] = { 0 };
+		char endpoint_str[36] = { 0 };
 		int			n_pgsql_params;
 		TimestampTz	now;
 		int64		us_since_last_attempt;
@@ -481,25 +481,22 @@ pageserver_connect(shardno_t shard_no, int elevel)
 		}
 
 		{
-			int ret = 0;
 			bool param_set = false;
 			switch (neon_endpoint_type)
 			{
 				case EP_TYPE_PRIMARY:
-					ret = snprintf(endpoint_str, sizeof(endpoint_str), "-c neon.endpoint_type=primary");
+					strncpy(endpoint_str, "-c neon.endpoint_type=primary", sizeof(endpoint_str));
 					param_set = true;
 					break;
 				case EP_TYPE_REPLICA:
-					ret = snprintf(endpoint_str, sizeof(endpoint_str), "-c neon.endpoint_type=replica");
+					strncpy(endpoint_str, "-c neon.endpoint_type=replica", sizeof(endpoint_str));
 					param_set = true;
 					break;
 				case EP_TYPE_STATIC:
-					ret = snprintf(endpoint_str, sizeof(endpoint_str), "-c neon.endpoint_type=static");
+					strncpy(endpoint_str, "-c neon.endpoint_type=static", sizeof(endpoint_str));
 					param_set = true;
 					break;
 			}
-			if (ret < 0 || ret >= (int)(sizeof(endpoint_str)))
-				elog(FATAL, "stack-allocated buffer too small to hold endpoint type");
 			if (param_set)
 			{
 				keywords[n_pgsql_params] = "options";


### PR DESCRIPTION
## Problem

second try of https://github.com/neondatabase/neon/pull/11185, part of https://github.com/neondatabase/cloud/issues/24706

## Summary of changes

Tristan reminded me of the `options` field of the pg wire protocol, which can be used to pass configurations. This patch adds the parsing on the pageserver side, and supplies `neon.endpoint_type` as part of the `options`.