### PR TITLE
storcon: also support tenant deletion for safekeepers

### DIFF
--- a/safekeeper/client/src/mgmt_api.rs
+++ b/safekeeper/client/src/mgmt_api.rs
@@ -120,6 +120,12 @@ impl Client {
         resp.json().await.map_err(Error::ReceiveBody)
     }
 
+    pub async fn delete_tenant(&self, tenant_id: TenantId) -> Result<models::TimelineDeleteResult> {
+        let uri = format!("{}/v1/tenant/{}", self.mgmt_api_endpoint, tenant_id);
+        let resp = self.request(Method::DELETE, &uri, ()).await?;
+        resp.json().await.map_err(Error::ReceiveBody)
+    }
+
     pub async fn bump_timeline_term(
         &self,
         tenant_id: TenantId,

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1437,7 +1437,7 @@ impl Persistence {
     pub(crate) async fn remove_pending_op(
         &self,
         tenant_id: TenantId,
-        timeline_id: TimelineId,
+        timeline_id: Option<TimelineId>,
         sk_id: NodeId,
         generation: u32,
     ) -> DatabaseResult<()> {
@@ -1446,10 +1446,11 @@ impl Persistence {
         let tenant_id = &tenant_id;
         let timeline_id = &timeline_id;
         self.with_measured_conn(DatabaseOperation::RemoveTimelineReconcile, move |conn| {
+            let timeline_id_str = timeline_id.map(|tid| tid.to_string()).unwrap_or_default();
             Box::pin(async move {
                 diesel::delete(dsl::safekeeper_timeline_pending_ops)
                     .filter(dsl::tenant_id.eq(tenant_id.to_string()))
-                    .filter(dsl::timeline_id.eq(timeline_id.to_string()))
+                    .filter(dsl::timeline_id.eq(timeline_id_str))
                     .filter(dsl::sk_id.eq(sk_id.0 as i64))
                     .filter(dsl::generation.eq(generation as i32))
                     .execute(conn)

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1491,9 +1491,7 @@ impl Persistence {
         Ok(timeline_from_db)
     }
 
-    /// Obtain a list of pending ops for the given timeline.
-    ///
-    /// If the timeline is `None`, it is serialized to the empty string
+    /// Delete all pending ops for the given timeline.
     ///
     /// Use this only at timeline deletion, otherwise use generation based APIs
     pub(crate) async fn remove_pending_ops_for_timeline(

--- a/storage_controller/src/safekeeper_client.rs
+++ b/storage_controller/src/safekeeper_client.rs
@@ -98,6 +98,18 @@ impl SafekeeperClient {
         )
     }
 
+    pub(crate) async fn delete_tenant(
+        &self,
+        tenant_id: TenantId,
+    ) -> Result<models::TimelineDeleteResult> {
+        measured_request!(
+            "delete_tenant",
+            crate::metrics::Method::Delete,
+            &self.node_id_label,
+            self.inner.delete_tenant(tenant_id).await
+        )
+    }
+
     pub(crate) async fn pull_timeline(
         &self,
         req: &PullTimelineRequest,

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -3325,9 +3325,14 @@ impl Service {
         }
     }
 
-    pub(crate) async fn tenant_delete(&self, tenant_id: TenantId) -> Result<StatusCode, ApiError> {
+    pub(crate) async fn tenant_delete(
+        self: &Arc<Self>,
+        tenant_id: TenantId,
+    ) -> Result<StatusCode, ApiError> {
         let _tenant_lock =
             trace_exclusive_lock(&self.tenant_op_locks, tenant_id, TenantOperations::Delete).await;
+
+        self.tenant_delete_safekeepers(tenant_id).await?;
 
         self.maybe_load_tenant(tenant_id, &_tenant_lock).await?;
 

--- a/storage_controller/src/service/safekeeper_reconciler.rs
+++ b/storage_controller/src/service/safekeeper_reconciler.rs
@@ -73,12 +73,21 @@ pub(crate) async fn load_schedule_requests(
         };
         let sk = Box::new(sk.clone());
         let tenant_id = TenantId::from_str(&op_persist.tenant_id)?;
-        let timeline_id = TimelineId::from_str(&op_persist.timeline_id)?;
+        let timeline_id = if !op_persist.timeline_id.is_empty() {
+            Some(TimelineId::from_str(&op_persist.timeline_id)?)
+        } else {
+            None
+        };
         let host_list = match op_persist.op_kind {
             SafekeeperTimelineOpKind::Delete => Vec::new(),
             SafekeeperTimelineOpKind::Exclude => Vec::new(),
             SafekeeperTimelineOpKind::Pull => {
                 // TODO this code is super hacky, it doesn't take migrations into account
+                let Some(timeline_id) = timeline_id else {
+                    anyhow::bail!(
+                        "timeline_id is empty for `pull` schedule request for {tenant_id}"
+                    );
+                };
                 let timeline_persist = service
                     .persistence
                     .get_timeline(tenant_id, timeline_id)
@@ -129,14 +138,15 @@ pub(crate) struct ScheduleRequest {
     pub(crate) safekeeper: Box<Safekeeper>,
     pub(crate) host_list: Vec<(NodeId, String)>,
     pub(crate) tenant_id: TenantId,
-    pub(crate) timeline_id: TimelineId,
+    pub(crate) timeline_id: Option<TimelineId>,
     pub(crate) generation: u32,
     pub(crate) kind: SafekeeperTimelineOpKind,
 }
 
 struct ReconcilerHandle {
     tx: UnboundedSender<(ScheduleRequest, Arc<CancellationToken>)>,
-    ongoing_tokens: Arc<ClashMap<(TenantId, TimelineId), Arc<CancellationToken>>>,
+    #[allow(clippy::type_complexity)]
+    ongoing_tokens: Arc<ClashMap<(TenantId, Option<TimelineId>), Arc<CancellationToken>>>,
     cancel: CancellationToken,
 }
 
@@ -145,7 +155,7 @@ impl ReconcilerHandle {
     fn new_token_slot(
         &self,
         tenant_id: TenantId,
-        timeline_id: TimelineId,
+        timeline_id: Option<TimelineId>,
     ) -> Arc<CancellationToken> {
         let entry = self.ongoing_tokens.entry((tenant_id, timeline_id));
         if let Entry::Occupied(entry) = &entry {
@@ -206,7 +216,7 @@ impl SafekeeperReconciler {
                     "reconcile_one",
                     ?kind,
                     %tenant_id,
-                    %timeline_id
+                    ?timeline_id
                 ))
                 .await;
         }
@@ -215,6 +225,12 @@ impl SafekeeperReconciler {
         let req_host = req.safekeeper.skp.host.clone();
         match req.kind {
             SafekeeperTimelineOpKind::Pull => {
+                let Some(timeline_id) = req.timeline_id else {
+                    tracing::warn!(
+                        "ignoring invalid schedule request: timeline_id is empty for `pull`"
+                    );
+                    return;
+                };
                 let our_id = req.safekeeper.get_id();
                 let http_hosts = req
                     .host_list
@@ -225,7 +241,7 @@ impl SafekeeperReconciler {
                 let pull_req = PullTimelineRequest {
                     http_hosts,
                     tenant_id: req.tenant_id,
-                    timeline_id: req.timeline_id,
+                    timeline_id,
                 };
                 self.reconcile_inner(
                     req,
@@ -243,7 +259,12 @@ impl SafekeeperReconciler {
             SafekeeperTimelineOpKind::Exclude => {
                 // TODO actually exclude instead of delete here
                 let tenant_id = req.tenant_id;
-                let timeline_id = req.timeline_id;
+                let Some(timeline_id) = req.timeline_id else {
+                    tracing::warn!(
+                        "ignoring invalid schedule request: timeline_id is empty for `exclude`"
+                    );
+                    return;
+                };
                 self.reconcile_inner(
                     req,
                     async |client| client.delete_timeline(tenant_id, timeline_id).await,
@@ -256,16 +277,27 @@ impl SafekeeperReconciler {
             }
             SafekeeperTimelineOpKind::Delete => {
                 let tenant_id = req.tenant_id;
-                let timeline_id = req.timeline_id;
-                self.reconcile_inner(
-                    req,
-                    async |client| client.delete_timeline(tenant_id, timeline_id).await,
-                    |_resp| {
-                        tracing::info!("deleted timeline from {req_host}");
-                    },
-                    req_cancel,
-                )
-                .await;
+                if let Some(timeline_id) = req.timeline_id {
+                    self.reconcile_inner(
+                        req,
+                        async |client| client.delete_timeline(tenant_id, timeline_id).await,
+                        |_resp| {
+                            tracing::info!("deleted timeline from {req_host}");
+                        },
+                        req_cancel,
+                    )
+                    .await;
+                } else {
+                    self.reconcile_inner(
+                        req,
+                        async |client| client.delete_tenant(tenant_id).await,
+                        |_resp| {
+                            tracing::info!("deleted tenant from {req_host}");
+                        },
+                        req_cancel,
+                    )
+                    .await;
+                }
             }
         }
     }

--- a/storage_controller/src/service/safekeeper_service.rs
+++ b/storage_controller/src/service/safekeeper_service.rs
@@ -265,7 +265,8 @@ impl Service {
                                 .get(&sk.id)
                                 .ok_or_else(|| {
                                     ApiError::InternalServerError(anyhow::anyhow!(
-                                        "Couldn't find safekeeper with id {remaining_id} to pull from"
+                                        "Couldn't find safekeeper with id {} to pull from",
+                                        sk.id
                                     ))
                                 })?
                                 .base_url(),

--- a/storage_controller/src/service/safekeeper_service.rs
+++ b/storage_controller/src/service/safekeeper_service.rs
@@ -279,7 +279,7 @@ impl Service {
                     safekeeper: Box::new(sk.clone()),
                     host_list,
                     tenant_id,
-                    timeline_id,
+                    timeline_id: Some(timeline_id),
                     generation: timeline_persist.generation as u32,
                     kind: crate::persistence::SafekeeperTimelineOpKind::Pull,
                 };
@@ -340,7 +340,7 @@ impl Service {
                     // we don't use this for this kind, put a dummy value
                     host_list: Vec::new(),
                     tenant_id,
-                    timeline_id,
+                    timeline_id: Some(timeline_id),
                     generation: tl.generation as u32,
                     kind,
                 };

--- a/storage_controller/src/service/safekeeper_service.rs
+++ b/storage_controller/src/service/safekeeper_service.rs
@@ -365,6 +365,7 @@ impl Service {
 
         if timeline_list.is_empty() {
             // Early exit: the tenant is either empty or not migrated to the storcon yet
+            tracing::info!("Skipping tenant delete as the timeline doesn't exist in db");
             return Ok(());
         }
 


### PR DESCRIPTION
If a tenant gets deleted, delete also all of its timelines. We assume that by the time a tenant is being deleted, no new timelines are being created, so we don't need to worry about races with creation in this situation.

Unlike #11233, which was very simple because it listed the timelines and invoked timeline deletion, this PR obtains a list of safekeepers to invoke the tenant deletion on, and then invokes tenant deletion on each safekeeper that has one or multiple timelines.

Alternative to #11233
Builds on #11288
Part of #9011