### PR TITLE
fix(pageserver): clean up aux files before detaching

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -3178,7 +3178,8 @@ async fn list_aux_files(
         timeline.gate.enter().map_err(|_| ApiError::Cancelled)?,
     );
 
-    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download);
+    let ctx = RequestContext::new(TaskKind::MgmtRequest, DownloadBehavior::Download)
+        .with_scope_timeline(&timeline);
     let files = timeline
         .list_aux_files(body.lsn, &ctx, io_concurrency)
         .await?;

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -192,7 +192,7 @@ async fn generate_tombstone_image_layer(
     );
     let mut reconstruct_state = ValuesReconstructState::new(io_concurrency);
     // Directly use `get_vectored_impl` to skip the max_vectored_read_key limit check. Note that the keyspace should
-    // not contain too many keys, otherwise this takes a lot of memory.
+    // not contain too many keys, otherwise this takes a lot of memory. Currently we limit it to 10k keys in the compute.
     let key_range = Key::sparse_non_inherited_keyspace();
     // avoid generating a "future layer" which will then be removed
     let image_lsn = ancestor_lsn;

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -182,7 +182,9 @@ async fn generate_tombstone_image_layer(
     ancestor_lsn: Lsn,
     ctx: &RequestContext,
 ) -> Result<Option<ResidentLayer>, Error> {
-    tracing::info!("removing non-inherited keys by writing an image layer at the detach LSN");
+    tracing::info!(
+        "removing non-inherited keys by writing an image layer with tombstones at the detach LSN"
+    );
     let io_concurrency = IoConcurrency::spawn_from_conf(
         detached.conf,
         detached.gate.enter().map_err(|_| Error::ShuttingDown)?,

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -430,7 +430,11 @@ pub(super) async fn prepare(
     let mut new_layers: Vec<Layer> =
         Vec::with_capacity(straddling_branchpoint.len() + rest_of_historic.len() + 1);
 
-    generate_tombstone_image_layer(detached, &ancestor, ancestor_lsn, ctx).await?;
+    if let Some(tombstone_layer) =
+        generate_tombstone_image_layer(detached, &ancestor, ancestor_lsn, ctx).await?
+    {
+        new_layers.push(tombstone_layer.into());
+    }
 
     {
         tracing::info!(to_rewrite = %straddling_branchpoint.len(), "copying prefix of delta layers");

--- a/pageserver/src/tenant/timeline/detach_ancestor.rs
+++ b/pageserver/src/tenant/timeline/detach_ancestor.rs
@@ -439,10 +439,7 @@ pub(super) async fn prepare(
             let span = tracing::info_span!("upload_rewritten_layer", %layer);
             tasks.spawn(
                 async move {
-                    let _permit: Result<
-                        tokio::sync::SemaphorePermit<'_>,
-                        tokio::sync::AcquireError,
-                    > = limiter.acquire().await;
+                    let _permit = limiter.acquire().await;
                     let copied =
                         upload_rewritten_layer(end_lsn, &layer, &timeline, &timeline.cancel, &ctx)
                             .await?;

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -1190,14 +1190,11 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         return res.json()
 
     def list_aux_files(
-        self,
-        tenant_id: TenantId | TenantShardId,
-        timeline_id: TimelineId,
-        lsn: Lsn
+        self, tenant_id: TenantId | TenantShardId, timeline_id: TimelineId, lsn: Lsn
     ) -> list[dict[str, Any]]:
         res = self.post(
             f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/list_aux_files",
-            json={"lsn": str(lsn)}
+            json={"lsn": str(lsn)},
         )
         self.verbose_error(res)
         return res.json()

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -1191,7 +1191,7 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
 
     def list_aux_files(
         self, tenant_id: TenantId | TenantShardId, timeline_id: TimelineId, lsn: Lsn
-    ) -> dict[str, Any]:
+    ) -> Any:
         res = self.post(
             f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/list_aux_files",
             json={"lsn": str(lsn)},

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -1191,7 +1191,7 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
 
     def list_aux_files(
         self, tenant_id: TenantId | TenantShardId, timeline_id: TimelineId, lsn: Lsn
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         res = self.post(
             f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/list_aux_files",
             json={"lsn": str(lsn)},

--- a/test_runner/fixtures/pageserver/http.py
+++ b/test_runner/fixtures/pageserver/http.py
@@ -1173,3 +1173,31 @@ class PageserverHttpClient(requests.Session, MetricsGetter):
         log.info(f"Got perf info response code: {res.status_code}")
         self.verbose_error(res)
         return res.json()
+
+    def ingest_aux_files(
+        self,
+        tenant_id: TenantId | TenantShardId,
+        timeline_id: TimelineId,
+        aux_files: dict[str, bytes],
+    ):
+        res = self.post(
+            f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/ingest_aux_files",
+            json={
+                "aux_files": aux_files,
+            },
+        )
+        self.verbose_error(res)
+        return res.json()
+
+    def list_aux_files(
+        self,
+        tenant_id: TenantId | TenantShardId,
+        timeline_id: TimelineId,
+        lsn: Lsn
+    ) -> list[dict[str, Any]]:
+        res = self.post(
+            f"http://localhost:{self.port}/v1/tenant/{tenant_id}/timeline/{timeline_id}/list_aux_files",
+            json={"lsn": str(lsn)}
+        )
+        self.verbose_error(res)
+        return res.json()

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1772,7 +1772,11 @@ def test_timeline_detach_with_aux_files_with_detach_v1(
     neon_env_builder: NeonEnvBuilder,
 ):
     """
-    Make sure inherited/non-inherited keyspaces are handled correctly during detach, with the detach v1 restore workflow.
+    Validate that "branches do not inherit their parent" is invariant over detach_ancestor.
+
+    Branches hide parent branch aux files etc by stopping lookup of non-inherited keyspace at the parent-child boundary.
+    We had a bug where detach_ancestor running on a child branch would copy aux files key range from child to parent,
+    thereby making parent aux files reappear.
     """
     env = neon_env_builder.init_start(
         initial_tenant_conf={

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1838,7 +1838,7 @@ def test_timeline_detach_with_aux_files_with_detach_v1(
     wait_for_last_flush_lsn(env, endpoint, env.initial_tenant, branch_timeline_id)
     assert set(http.list_aux_files(env.initial_tenant, env.initial_timeline, lsn2).keys()) == set(
         ["pg_replslot/test_slot_parent_1/state", "pg_replslot/test_slot_parent_2/state"]
-    )
+    ), "main branch unaffected"
     assert set(http.list_aux_files(env.initial_tenant, branch_timeline_id, lsn3).keys()) == set(
         ["pg_replslot/test_slot_restore/state"]
     )

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -1767,6 +1767,42 @@ def test_pageserver_compaction_detach_ancestor_smoke(neon_env_builder: NeonEnvBu
     workload_parent.validate(env.pageserver.id)
     workload_child.validate(env.pageserver.id)
 
+def test_timeline_detach_with_aux_files_with_detach_v1(
+    neon_env_builder: NeonEnvBuilder,
+):
+    """
+    Make sure inherited/non-inherited keyspaces are handled correctly during detach, with the detach v1 restore workflow.
+    """
+    env = neon_env_builder.init_start(
+        initial_tenant_conf={
+            "gc_period": "1s",
+            "lsn_lease_length": "0s",
+        }
+    )
+
+    env.pageserver.allowed_errors.extend(SHUTDOWN_ALLOWED_ERRORS)
+
+    http = env.pageserver.http_client()
+
+    endpoint = env.endpoints.create_start("main", tenant_id=env.initial_tenant)
+    lsn0 = wait_for_last_flush_lsn(env, endpoint, env.initial_tenant, env.initial_timeline)
+    endpoint.safe_psql("SELECT pg_create_logical_replication_slot('test_slot_parent_1', 'pgoutput')")
+    lsn1 = wait_for_last_flush_lsn(env, endpoint, env.initial_tenant, env.initial_timeline)
+    endpoint.safe_psql("SELECT pg_create_logical_replication_slot('test_slot_parent_2', 'pgoutput')")
+    lsn2 = wait_for_last_flush_lsn(env, endpoint, env.initial_tenant, env.initial_timeline)
+    wait_for_last_flush_lsn(env, endpoint, env.initial_tenant, env.initial_timeline)
+    assert set(http.list_aux_files(env.initial_tenant, env.initial_timeline, lsn0).keys()) == set([])
+    assert set(http.list_aux_files(env.initial_tenant, env.initial_timeline, lsn1).keys()) == set(["pg_replslot/test_slot_parent_1/state"])
+    assert set(http.list_aux_files(env.initial_tenant, env.initial_timeline, lsn2).keys()) == set(["pg_replslot/test_slot_parent_1/state", "pg_replslot/test_slot_parent_2/state"])
+
+    # Restore at LSN1
+    branch_timeline_id = env.create_branch("restore", env.initial_tenant, "main", lsn1)
+    assert set(http.list_aux_files(env.initial_tenant, branch_timeline_id, lsn0).keys()) == set([])
+
+    # Detach the restore branch so that main doesn't have any child
+    http.detach_ancestor(env.initial_tenant, branch_timeline_id, detach_behavior="v1")
+    assert set(http.list_aux_files(env.initial_tenant, env.initial_timeline, lsn2).keys()) == set(["pg_replslot/test_slot_parent_1/state", "pg_replslot/test_slot_parent_2/state"])
+    assert set(http.list_aux_files(env.initial_tenant, branch_timeline_id, lsn1).keys()) == set([])
 
 # TODO:
 # - branch near existing L1 boundary, image layers?


### PR DESCRIPTION
## Problem

Related to https://github.com/neondatabase/cloud/issues/26091 and https://github.com/neondatabase/cloud/issues/25840

Close https://github.com/neondatabase/neon/issues/11297

Discussion on Slack: https://neondb.slack.com/archives/C033RQ5SPDH/p1742320666313969

## Summary of changes

* When detaching, scan all aux files within `sparse_non_inherited_keyspace` in the ancestor timeline and create an image layer exactly at the ancestor LSN. All scanned keys will map to an empty value, which is a delete tombstone.
  - Note that end_lsn for rewritten delta layers = ancestor_lsn + 1, so the image layer will have image_end_lsn=end_lsn. With the current `select_layer` logic, the read path will always first read the image layer.
* Add a test case.