### PR TITLE
feat(compute_ctl): allow to change audit_log_level for existing

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -848,6 +848,7 @@ impl ComputeNode {
         let mut state = self.state.lock().unwrap();
         state.audit_log_level = audit_log_level;
     }
+    
     pub fn get_audit_log_level(&self) -> ComputeAudit {
         self.state.lock().unwrap().audit_log_level
     }

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -1561,7 +1561,7 @@ impl ComputeNode {
 
         if spec.audit_log_level == ComputeAudit::Hipaa && audit_log_level != spec.audit_log_level {
             info!(
-                "audit_log_level changed from {:?} to {:?}. Configuring audit logging",
+                "Configuring audit logging because audit_log_level changed from {:?} to {:?}",
                 audit_log_level, spec.audit_log_level
             );
 

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -192,16 +192,20 @@ pub fn write_postgres_conf(
             }
             writeln!(file, "# Managed by compute_ctl base audit settings: end")?;
         }
-        ComputeAudit::Hipaa => {
+        ComputeAudit::Hipaa | ComputeAudit::Full | ComputeAudit::FullWithParameters => {
             writeln!(
                 file,
                 "# Managed by compute_ctl compliance audit settings: begin"
             )?;
             // This log level is very verbose
             // but this is necessary for HIPAA compliance.
-            // Exclude 'misc' category, because it doesn't contain anythig relevant.
+            // Exclude 'misc' category, because it doesn't contain anything relevant.
             writeln!(file, "pgaudit.log='all, -misc'")?;
-            writeln!(file, "pgaudit.log_parameter=on")?;
+
+            if ComputeAudit::FullWithParameters == spec.audit_log_level {
+                // Log parameters for all queries
+                writeln!(file, "pgaudit.log_parameter=on")?;
+            }
             // Disable logging of catalog queries
             // The catalog doesn't contain sensitive data, so we don't need to audit it.
             writeln!(file, "pgaudit.log_catalog=off")?;

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -192,7 +192,7 @@ pub fn write_postgres_conf(
             }
             writeln!(file, "# Managed by compute_ctl base audit settings: end")?;
         }
-        ComputeAudit::Hipaa | ComputeAudit::Full | ComputeAudit::FullWithParameters => {
+        ComputeAudit::Hipaa => {
             writeln!(
                 file,
                 "# Managed by compute_ctl compliance audit settings: begin"
@@ -201,11 +201,8 @@ pub fn write_postgres_conf(
             // but this is necessary for HIPAA compliance.
             // Exclude 'misc' category, because it doesn't contain anything relevant.
             writeln!(file, "pgaudit.log='all, -misc'")?;
-
-            if ComputeAudit::FullWithParameters == spec.audit_log_level {
-                // Log parameters for all queries
-                writeln!(file, "pgaudit.log_parameter=on")?;
-            }
+            // Log parameters for all queries
+            writeln!(file, "pgaudit.log_parameter=on")?;
             // Disable logging of catalog queries
             // The catalog doesn't contain sensitive data, so we don't need to audit it.
             writeln!(file, "pgaudit.log_catalog=off")?;

--- a/compute_tools/src/rsyslog.rs
+++ b/compute_tools/src/rsyslog.rs
@@ -48,12 +48,12 @@ fn restart_rsyslog() -> Result<()> {
     Ok(())
 }
 
-// Return true if config was updated, false if it was already up-to-date.
-pub fn configure_audit_rsyslog(
-    log_directory: String,
-    tag: &str,
-    remote_endpoint: &str,
-) -> Result<()> {
+pub fn configure_audit_rsyslog(log_directory: String, tag: &str) -> Result<()> {
+    let remote_endpoint = std::env::var("AUDIT_LOGGING_ENDPOINT")?;
+    if remote_endpoint.is_empty() {
+        return Err(anyhow!("AUDIT_LOGGING_ENDPOINT is not set"));
+    }
+
     let rsyslog_conf_path = "/etc/rsyslog.d/compute_audit_rsyslog.conf";
 
     let old_config_content = match std::fs::read_to_string(rsyslog_conf_path) {

--- a/compute_tools/src/spec_apply.rs
+++ b/compute_tools/src/spec_apply.rs
@@ -281,7 +281,7 @@ impl ComputeNode {
             // so that all config operations are audit logged.
             match spec.audit_log_level
             {
-                ComputeAudit::Hipaa | ComputeAudit::Full | ComputeAudit::FullWithParameters => {
+                ComputeAudit::Hipaa => {
                     phases.push(CreatePgauditExtension);
                     phases.push(CreatePgauditlogtofileExtension);
                     phases.push(DisablePostgresDBPgAudit);

--- a/compute_tools/src/spec_apply.rs
+++ b/compute_tools/src/spec_apply.rs
@@ -281,7 +281,7 @@ impl ComputeNode {
             // so that all config operations are audit logged.
             match spec.audit_log_level
             {
-                ComputeAudit::Hipaa => {
+                ComputeAudit::Hipaa | ComputeAudit::Full | ComputeAudit::FullWithParameters => {
                     phases.push(CreatePgauditExtension);
                     phases.push(CreatePgauditlogtofileExtension);
                     phases.push(DisablePostgresDBPgAudit);

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -281,6 +281,16 @@ pub enum ComputeAudit {
     Hipaa,
 }
 
+impl ComputeAudit {
+    pub fn as_str(&self) -> &str {
+        match self {
+            ComputeAudit::Disabled => "disabled",
+            ComputeAudit::Log => "log",
+            ComputeAudit::Hipaa => "hipaa",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Cluster {
     pub cluster_id: Option<String>,

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -289,6 +289,7 @@ pub enum ComputeAudit {
     /// log query parameters
     FullWithParameters,
 }
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Cluster {
     pub cluster_id: Option<String>,

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -275,19 +275,10 @@ pub enum ComputeAudit {
     #[default]
     /// no audit logging. This is the default.
     Disabled,
-    ///  write masked audit log statements to the postgres log using pgaudit extension
+    /// write masked audit log statements to the postgres log using pgaudit extension
     Log,
-    /// Deprecated.
-    /// Has the same logic as Full.
-    /// TODO: remove when cplane is updated to use new name
+    /// log unmasked statements to the file using pgaudit and pgauditlogtofile extensions
     Hipaa,
-    /// write unmasked audit log statements to the AUDIT_LOGGING_ENDPOINT
-    /// using pgaudit and pgauditlogtofile extension
-    Full,
-    /// write unmasked audit log statements to the AUDIT_LOGGING_ENDPOINT
-    /// using pgaudit and pgauditlogtofile extensions.
-    /// log query parameters
-    FullWithParameters,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -160,12 +160,6 @@ pub struct ComputeSpec {
     pub drop_subscriptions_before_start: bool,
 
     /// Log level for audit logging:
-    ///
-    /// Disabled - no audit logging. This is the default.
-    /// log - log masked statements to the postgres log using pgaudit extension
-    /// hipaa - log unmasked statements to the file using pgaudit and pgauditlogtofile extension
-    ///
-    /// Extensions should be present in shared_preload_libraries
     #[serde(default)]
     pub audit_log_level: ComputeAudit,
 }
@@ -276,16 +270,25 @@ pub enum ComputeMode {
 }
 
 /// Log level for audit logging
-/// Disabled, log, hipaa
-/// Default is Disabled
-#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub enum ComputeAudit {
     #[default]
+    /// no audit logging. This is the default.
     Disabled,
+    ///  write masked audit log statements to the postgres log using pgaudit extension
     Log,
+    /// Deprecated.
+    /// Has the same logic as Full.
+    /// TODO: remove when cplane is updated to use new name
     Hipaa,
+    /// write unmasked audit log statements to the AUDIT_LOGGING_ENDPOINT
+    /// using pgaudit and pgauditlogtofile extension
+    Full,
+    /// write unmasked audit log statements to the AUDIT_LOGGING_ENDPOINT
+    /// using pgaudit and pgauditlogtofile extensions.
+    /// log query parameters
+    FullWithParameters,
 }
-
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Cluster {
     pub cluster_id: Option<String>,


### PR DESCRIPTION
 projects.

Preserve the information about the current audit log level in compute state, so that we don't relaunch rsyslog on every spec change

https://github.com/neondatabase/cloud/issues/25349