### PR TITLE
pageseserver: rename cplane api to storage controller api

### DIFF
--- a/libs/pageserver_api/src/upcall_api.rs
+++ b/libs/pageserver_api/src/upcall_api.rs
@@ -1,4 +1,4 @@
-//! Types in this file are for pageserver's upward-facing API calls to the control plane,
+//! Types in this file are for pageserver's upward-facing API calls to the storage controller,
 //! required for acquiring and validating tenant generation numbers.
 //!
 //! See docs/rfcs/025-generation-numbers.md

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -16,7 +16,7 @@ use metrics::launch_timestamp::{LaunchTimestamp, set_launch_timestamp_metric};
 use metrics::set_build_info_metric;
 use nix::sys::socket::{setsockopt, sockopt};
 use pageserver::config::{PageServerConf, PageserverIdentity};
-use pageserver::controller_upcall_client::ControllerUpcallClient;
+use pageserver::controller_upcall_client::StorageControllerUpcallClient;
 use pageserver::deletion_queue::DeletionQueue;
 use pageserver::disk_usage_eviction_task::{self, launch_disk_usage_global_eviction_task};
 use pageserver::metrics::{STARTUP_DURATION, STARTUP_IS_LOADING};
@@ -427,7 +427,7 @@ fn start_pageserver(
     // Set up deletion queue
     let (deletion_queue, deletion_workers) = DeletionQueue::new(
         remote_storage.clone(),
-        ControllerUpcallClient::new(conf, &shutdown_pageserver),
+        StorageControllerUpcallClient::new(conf, &shutdown_pageserver),
         conf,
     );
     deletion_workers.spawn_with(BACKGROUND_RUNTIME.handle());

--- a/pageserver/src/controller_upcall_client.rs
+++ b/pageserver/src/controller_upcall_client.rs
@@ -21,10 +21,7 @@ use crate::virtual_file::on_fatal_io_error;
 
 /// The Pageserver's client for using the storage controller upcall API: this is a small API
 /// for dealing with generations (see docs/rfcs/025-generation-numbers.md).
-///
-/// The server presenting this API may either be the storage controller or some other
-/// service (such as the Neon control plane) providing a store of generation numbers.
-pub struct ControllerUpcallClient {
+pub struct StorageControllerUpcallClient {
     http_client: reqwest::Client,
     base_url: Url,
     node_id: NodeId,
@@ -37,7 +34,7 @@ pub enum RetryForeverError {
     ShuttingDown,
 }
 
-pub trait ControlPlaneGenerationsApi {
+pub trait StorageControllerUpcallApi {
     fn re_attach(
         &self,
         conf: &PageServerConf,
@@ -50,7 +47,7 @@ pub trait ControlPlaneGenerationsApi {
     ) -> impl Future<Output = Result<HashMap<TenantShardId, bool>, RetryForeverError>> + Send;
 }
 
-impl ControllerUpcallClient {
+impl StorageControllerUpcallClient {
     /// A None return value indicates that the input `conf` object does not have control
     /// plane API enabled.
     pub fn new(conf: &'static PageServerConf, cancel: &CancellationToken) -> Option<Self> {
@@ -124,7 +121,7 @@ impl ControllerUpcallClient {
     }
 }
 
-impl ControlPlaneGenerationsApi for ControllerUpcallClient {
+impl StorageControllerUpcallApi for StorageControllerUpcallClient {
     /// Block until we get a successful response, or error out if we are shut down
     #[tracing::instrument(skip_all)] // so that warning logs from retry_http_forever have context
     async fn re_attach(

--- a/pageserver/src/deletion_queue/validator.rs
+++ b/pageserver/src/deletion_queue/validator.rs
@@ -25,7 +25,7 @@ use tracing::{debug, info, warn};
 use super::deleter::DeleterMessage;
 use super::{DeletionHeader, DeletionList, DeletionQueueError, FlushOp, VisibleLsnUpdates};
 use crate::config::PageServerConf;
-use crate::controller_upcall_client::{ControlPlaneGenerationsApi, RetryForeverError};
+use crate::controller_upcall_client::{RetryForeverError, StorageControllerUpcallApi};
 use crate::metrics;
 use crate::virtual_file::MaybeFatalIo;
 
@@ -46,7 +46,7 @@ pub(super) enum ValidatorQueueMessage {
 }
 pub(super) struct Validator<C>
 where
-    C: ControlPlaneGenerationsApi,
+    C: StorageControllerUpcallApi,
 {
     conf: &'static PageServerConf,
     rx: tokio::sync::mpsc::Receiver<ValidatorQueueMessage>,
@@ -80,7 +80,7 @@ where
 
 impl<C> Validator<C>
 where
-    C: ControlPlaneGenerationsApi,
+    C: StorageControllerUpcallApi,
 {
     pub(super) fn new(
         conf: &'static PageServerConf,

--- a/pageserver/src/tenant/mgr.rs
+++ b/pageserver/src/tenant/mgr.rs
@@ -40,7 +40,7 @@ use super::{GlobalShutDown, TenantSharedResources};
 use crate::config::PageServerConf;
 use crate::context::{DownloadBehavior, RequestContext};
 use crate::controller_upcall_client::{
-    ControlPlaneGenerationsApi, ControllerUpcallClient, RetryForeverError,
+    RetryForeverError, StorageControllerUpcallApi, StorageControllerUpcallClient,
 };
 use crate::deletion_queue::DeletionQueueClient;
 use crate::http::routes::ACTIVE_TENANT_TIMEOUT;
@@ -344,7 +344,7 @@ async fn init_load_generations(
             "Emergency mode!  Tenants will be attached unsafely using their last known generation"
         );
         emergency_generations(tenant_confs)
-    } else if let Some(client) = ControllerUpcallClient::new(conf, cancel) {
+    } else if let Some(client) = StorageControllerUpcallClient::new(conf, cancel) {
         info!("Calling {} API to re-attach tenants", client.base_url());
         // If we are configured to use the control plane API, then it is the source of truth for what tenants to load.
         match client.re_attach(conf).await {


### PR DESCRIPTION
## Problem

The pageserver upcall api was designed to work with control plane or the storage controller.
We have completed the transition period and now the upcall api only targets the storage controller.

## Summary of changes

Rename types accordingly and tweak some comments.