### PR TITLE
pgxn: Include local port in no-response log messages

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -15,6 +15,7 @@
 #include "postgres.h"
 
 #include <math.h>
+#include <sys/socket.h>
 
 #include "libpq-int.h"
 
@@ -42,7 +43,6 @@
 
 #ifdef __linux__
 #include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <linux/sockios.h>
 #endif
 
@@ -729,7 +729,6 @@ get_socket_stats(int socketfd, int *sndbuf, int *recvbuf)
 static void
 get_local_port(int socketfd, int *port)
 {
-#ifdef __linux__
 	struct sockaddr_in addr;
 	socklen_t addr_len = sizeof(addr);
 
@@ -737,10 +736,9 @@ get_local_port(int socketfd, int *port)
 	if (getsockname(socketfd, (struct sockaddr*) &addr, &addr_len) == 0)
 	{
 		*port = ntohs(addr.sin_port);
-		return;
+	} else {
+		*port = -1;
 	}
-#endif
-	*port = -1;
 }
 
 /*

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -729,17 +729,18 @@ get_socket_stats(int socketfd, int *sndbuf, int *recvbuf)
 static void
 get_local_port(int socketfd, int *port)
 {
-	*port = -1;
-
 #ifdef __linux__
 	struct sockaddr_in addr;
+	socklen_t addr_len = sizeof(addr);
 
-	memset(&addr, 0, sizeof(addr));
-	if (getsockname(socketfd, (struct sockaddr*) &addr, sizeof(addr)) == 0)
+	memset(&addr, 0, addr_len);
+	if (getsockname(socketfd, (struct sockaddr*) &addr, &addr_len) == 0)
 	{
 		*port = ntohs(addr.sin_port);
+		return;
 	}
 #endif
+	*port = -1;
 }
 
 /*


### PR DESCRIPTION
## Problem

Now that stuck connections are quickly terminated it's not easy to quickly find the right port from the pid to correlate the connection with the one seen on pageserver side.

## Summary of changes

Call getsockname() and include the local port number in the no-response-from-pageserver log messages.
