### PR TITLE
Mark min_readable_lsn as required in the pageserver API spec

### DIFF
--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -1079,6 +1079,7 @@ components:
         - last_record_lsn
         - disk_consistent_lsn
         - state
+        - min_readable_lsn
       properties:
         timeline_id:
           type: string


### PR DESCRIPTION
Fully applies the changes of https://github.com/neondatabase/cloud/pull/25233 to neon.git. The field is always present in the Rust struct definition, so it can be marked as required.

cc #10707