### PR TITLE
chore: expose detach_v2

### DIFF
--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -674,7 +674,7 @@ paths:
           in: query
           required: false
           schema:
-            # values: "v1", "v2"
+            description: Currently valid values are `v1`, `v2`
             type: string
       responses:
         "200":

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -669,6 +669,13 @@ paths:
         Detach a timeline from its ancestor and reparent all ancestors timelines with lower `ancestor_lsn`.
         Current implementation might not be retryable across failure cases, but will be enhanced in future.
         Detaching should be expected to be expensive operation. Timeouts should be retried.
+      parameters:
+        - name: detach_behavior
+          in: query
+          required: false
+          schema:
+            # values: "v1", "v2"
+            type: string
       responses:
         "200":
           description: |


### PR DESCRIPTION
we need this exposed in the spec to use it in cplane. extracted from https://github.com/neondatabase/cloud/pull/26167

## Problem

## Summary of changes
