### PR TITLE
feat(compute): Introduce Postgres downtime metrics

### DIFF
--- a/compute_tools/src/metrics.rs
+++ b/compute_tools/src/metrics.rs
@@ -81,9 +81,9 @@ pub(crate) static COMPUTE_CTL_UP: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("failed to define a metric")
 });
 
-pub(crate) static PG_DOWNTIME_MS: Lazy<GenericGauge<AtomicF64>> = Lazy::new(|| {
+pub(crate) static PG_CURR_DOWNTIME_MS: Lazy<GenericGauge<AtomicF64>> = Lazy::new(|| {
     register_gauge!(
-        "compute_pg_downtime_ms",
+        "compute_pg_current_downtime_ms",
         "Non-cumulative duration of Postgres downtime in ms; resets after successful check",
     )
     .expect("failed to define a metric")
@@ -104,7 +104,7 @@ pub fn collect() -> Vec<MetricFamily> {
     metrics.extend(REMOTE_EXT_REQUESTS_TOTAL.collect());
     metrics.extend(DB_MIGRATION_FAILED.collect());
     metrics.extend(AUDIT_LOG_DIR_SIZE.collect());
-    metrics.extend(PG_DOWNTIME_MS.collect());
+    metrics.extend(PG_CURR_DOWNTIME_MS.collect());
     metrics.extend(PG_TOTAL_DOWNTIME_MS.collect());
     metrics
 }

--- a/compute_tools/src/metrics.rs
+++ b/compute_tools/src/metrics.rs
@@ -81,6 +81,14 @@ pub(crate) static COMPUTE_CTL_UP: Lazy<IntGaugeVec> = Lazy::new(|| {
     .expect("failed to define a metric")
 });
 
+pub(crate) static PG_DOWNTIME_MS: Lazy<GenericGauge<AtomicF64>> = Lazy::new(|| {
+    register_gauge!(
+        "compute_pg_downtime_ms",
+        "Non-cumulative duration of Postgres downtime in ms; resets after successful check",
+    )
+    .expect("failed to define a metric")
+});
+
 pub fn collect() -> Vec<MetricFamily> {
     let mut metrics = COMPUTE_CTL_UP.collect();
     metrics.extend(INSTALLED_EXTENSIONS.collect());
@@ -88,5 +96,6 @@ pub fn collect() -> Vec<MetricFamily> {
     metrics.extend(REMOTE_EXT_REQUESTS_TOTAL.collect());
     metrics.extend(DB_MIGRATION_FAILED.collect());
     metrics.extend(AUDIT_LOG_DIR_SIZE.collect());
+    metrics.extend(PG_DOWNTIME_MS.collect());
     metrics
 }

--- a/compute_tools/src/metrics.rs
+++ b/compute_tools/src/metrics.rs
@@ -1,8 +1,8 @@
-use metrics::core::{AtomicF64, Collector, GenericGauge};
+use metrics::core::{AtomicF64, AtomicU64, Collector, GenericCounter, GenericGauge};
 use metrics::proto::MetricFamily;
 use metrics::{
-    IntCounterVec, IntGaugeVec, UIntGaugeVec, register_gauge, register_int_counter_vec,
-    register_int_gauge_vec, register_uint_gauge_vec,
+    IntCounterVec, IntGaugeVec, UIntGaugeVec, register_gauge, register_int_counter,
+    register_int_counter_vec, register_int_gauge_vec, register_uint_gauge_vec,
 };
 use once_cell::sync::Lazy;
 
@@ -89,6 +89,14 @@ pub(crate) static PG_DOWNTIME_MS: Lazy<GenericGauge<AtomicF64>> = Lazy::new(|| {
     .expect("failed to define a metric")
 });
 
+pub(crate) static PG_TOTAL_DOWNTIME_MS: Lazy<GenericCounter<AtomicU64>> = Lazy::new(|| {
+    register_int_counter!(
+        "compute_pg_downtime_ms_total",
+        "Cumulative duration of Postgres downtime in ms",
+    )
+    .expect("failed to define a metric")
+});
+
 pub fn collect() -> Vec<MetricFamily> {
     let mut metrics = COMPUTE_CTL_UP.collect();
     metrics.extend(INSTALLED_EXTENSIONS.collect());
@@ -97,5 +105,6 @@ pub fn collect() -> Vec<MetricFamily> {
     metrics.extend(DB_MIGRATION_FAILED.collect());
     metrics.extend(AUDIT_LOG_DIR_SIZE.collect());
     metrics.extend(PG_DOWNTIME_MS.collect());
+    metrics.extend(PG_TOTAL_DOWNTIME_MS.collect());
     metrics
 }

--- a/compute_tools/src/monitor.rs
+++ b/compute_tools/src/monitor.rs
@@ -111,7 +111,7 @@ impl ComputeMonitor {
                                 self.compute.update_last_active(self.last_active);
                             }
                             Err(e) => {
-                                // Although we have many places where we can return errors in `refresh()`,
+                                // Although we have many places where we can return errors in `check()`,
                                 // normally it shouldn't happen. I.e., we will likely return error if
                                 // connection got broken, query timed out, Postgres returned invalid data, etc.
                                 // In all such cases it's suspicious, so let's report this as downtime.

--- a/test_runner/regress/test_compute_monitor.py
+++ b/test_runner/regress/test_compute_monitor.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
-import time
+from typing import TYPE_CHECKING
 
 from fixtures.metrics import parse_metrics
-from fixtures.neon_fixtures import NeonEnv
 from fixtures.utils import wait_until
+
+if TYPE_CHECKING:
+    from fixtures.neon_fixtures import NeonEnv
 
 
 def test_compute_monitor(neon_simple_env: NeonEnv):
     """
-    Test that we can change postgresql.conf settings even if
-    skip_pg_catalog_updates=True is set.
+    Test that compute_ctl can detect Postgres going down (unresponsive) and
+    reconnect when it comes back online. Also check that the downtime metrics
+    are properly emitted.
     """
     TEST_DB = "test_compute_monitor"
 
@@ -19,7 +22,7 @@ def test_compute_monitor(neon_simple_env: NeonEnv):
 
     # Check that default postgres database is present
     with endpoint.cursor() as cursor:
-        cursor.execute("SELECT datname FROM pg_database WHERE datname = %s", ("postgres",))
+        cursor.execute("SELECT datname FROM pg_database WHERE datname = 'postgres'")
         catalog_db = cursor.fetchone()
         assert catalog_db is not None
         assert len(catalog_db) == 1
@@ -34,21 +37,19 @@ def test_compute_monitor(neon_simple_env: NeonEnv):
 
     client = endpoint.http_client()
 
-    time.sleep(2)
-
     def check_metrics_down():
         raw_metrics = client.metrics()
         metrics = parse_metrics(raw_metrics)
-        compute_pg_downtime_ms = metrics.query_all("compute_pg_downtime_ms")
-        assert len(compute_pg_downtime_ms) == 1
-        assert compute_pg_downtime_ms[0].value > 0
+        compute_pg_current_downtime_ms = metrics.query_all("compute_pg_current_downtime_ms")
+        assert len(compute_pg_current_downtime_ms) == 1
+        assert compute_pg_current_downtime_ms[0].value > 0
         compute_pg_downtime_ms_total = metrics.query_all("compute_pg_downtime_ms_total")
         assert len(compute_pg_downtime_ms_total) == 1
         assert compute_pg_downtime_ms_total[0].value > 0
 
     wait_until(check_metrics_down)
 
-    # Create postgres database back
+    # Recreate postgres database
     with endpoint.cursor(dbname=TEST_DB) as cursor:
         cursor.execute("CREATE DATABASE postgres")
 
@@ -56,9 +57,9 @@ def test_compute_monitor(neon_simple_env: NeonEnv):
     def check_metrics_up():
         raw_metrics = client.metrics()
         metrics = parse_metrics(raw_metrics)
-        compute_pg_downtime_ms = metrics.query_all("compute_pg_downtime_ms")
-        assert len(compute_pg_downtime_ms) == 1
-        assert compute_pg_downtime_ms[0].value == 0
+        compute_pg_current_downtime_ms = metrics.query_all("compute_pg_current_downtime_ms")
+        assert len(compute_pg_current_downtime_ms) == 1
+        assert compute_pg_current_downtime_ms[0].value == 0
         compute_pg_downtime_ms_total = metrics.query_all("compute_pg_downtime_ms_total")
         assert len(compute_pg_downtime_ms_total) == 1
         assert compute_pg_downtime_ms_total[0].value > 0

--- a/test_runner/regress/test_compute_monitor.py
+++ b/test_runner/regress/test_compute_monitor.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import time
+
+from fixtures.metrics import parse_metrics
+from fixtures.neon_fixtures import NeonEnv
+from fixtures.utils import wait_until
+
+
+def test_compute_monitor(neon_simple_env: NeonEnv):
+    """
+    Test that we can change postgresql.conf settings even if
+    skip_pg_catalog_updates=True is set.
+    """
+    TEST_DB = "test_compute_monitor"
+
+    env = neon_simple_env
+    endpoint = env.endpoints.create_start("main")
+
+    # Check that default postgres database is present
+    with endpoint.cursor() as cursor:
+        cursor.execute("SELECT datname FROM pg_database WHERE datname = %s", ("postgres",))
+        catalog_db = cursor.fetchone()
+        assert catalog_db is not None
+        assert len(catalog_db) == 1
+
+        # Create a new database
+        cursor.execute(f"CREATE DATABASE {TEST_DB}")
+
+    # Drop database 'postgres'
+    with endpoint.cursor(dbname=TEST_DB) as cursor:
+        # Use FORCE to terminate all connections to the database
+        cursor.execute("DROP DATABASE postgres WITH (FORCE)")
+
+    client = endpoint.http_client()
+
+    time.sleep(2)
+
+    def check_metrics_down():
+        raw_metrics = client.metrics()
+        metrics = parse_metrics(raw_metrics)
+        compute_pg_downtime_ms = metrics.query_all("compute_pg_downtime_ms")
+        assert len(compute_pg_downtime_ms) == 1
+        assert compute_pg_downtime_ms[0].value > 0
+        compute_pg_downtime_ms_total = metrics.query_all("compute_pg_downtime_ms_total")
+        assert len(compute_pg_downtime_ms_total) == 1
+        assert compute_pg_downtime_ms_total[0].value > 0
+
+    wait_until(check_metrics_down)
+
+    # Create postgres database back
+    with endpoint.cursor(dbname=TEST_DB) as cursor:
+        cursor.execute("CREATE DATABASE postgres")
+
+    # Current downtime should reset to 0, but not total downtime
+    def check_metrics_up():
+        raw_metrics = client.metrics()
+        metrics = parse_metrics(raw_metrics)
+        compute_pg_downtime_ms = metrics.query_all("compute_pg_downtime_ms")
+        assert len(compute_pg_downtime_ms) == 1
+        assert compute_pg_downtime_ms[0].value == 0
+        compute_pg_downtime_ms_total = metrics.query_all("compute_pg_downtime_ms_total")
+        assert len(compute_pg_downtime_ms_total) == 1
+        assert compute_pg_downtime_ms_total[0].value > 0
+
+    wait_until(check_metrics_up)
+
+    # Just a sanity check that we log the downtime info
+    endpoint.log_contains("downtime_info")


### PR DESCRIPTION
## Problem

Currently, we only report the timestamp of the last moment we think Postgres was active. The problem is that if Postgres gets completely unresponsive, we still report some old timestamp, and it's impossible to distinguish situations 'Postgres is effectively down' and 'Postgres is running, but no client activity'.

## Summary of changes

Refactor the `compute_ctl`'s compute monitor so that it was easier to track the connection errors and failed activity checks, and report
- `now() - last_successful_check` as current downtime on any failure
- cumulative Postgres downtime during the whole compute lifetime

After adding a test, I also noticed that the compute monitor may not reconnect even though queries fail with `connection closed` or `error communicating with the server: Connection reset by peer (os error 54)`, but for some reason we do not catch it with `client.is_closed()`, so I added an explicit reconnect in case of any failures.

Discussion: https://neondb.slack.com/archives/C03TN5G758R/p1742489426966639
