### PR TITLE
Always do wait in pageserver_try_receive loop

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -1152,15 +1152,12 @@ pageserver_try_receive(shardno_t shard_no)
 
 	while (true)
 	{
-		if (PQisBusy(shard->conn))
+		WaitEvent	event;
+		if (WaitEventSetWait(shard->wes_read, 0, &event, 1,
+							 WAIT_EVENT_NEON_PS_READ) != 1
+			|| (event.events & WL_SOCKET_READABLE) == 0)
 		{
-			WaitEvent	event;
-			if (WaitEventSetWait(shard->wes_read, 0, &event, 1,
-								 WAIT_EVENT_NEON_PS_READ) != 1
-				|| (event.events & WL_SOCKET_READABLE) == 0)
-			{
-				return NULL;
-			}
+			return NULL;
 		}
 		rc = PQgetCopyData(shard->conn, &resp_buff.data, 1 /* async */);
 		if (rc == 0)

--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -1152,16 +1152,16 @@ pageserver_try_receive(shardno_t shard_no)
 
 	while (true)
 	{
-		WaitEvent	event;
-		if (WaitEventSetWait(shard->wes_read, 0, &event, 1,
-							 WAIT_EVENT_NEON_PS_READ) != 1
-			|| (event.events & WL_SOCKET_READABLE) == 0)
-		{
-			return NULL;
-		}
 		rc = PQgetCopyData(shard->conn, &resp_buff.data, 1 /* async */);
 		if (rc == 0)
 		{
+			WaitEvent	event;
+			if (WaitEventSetWait(shard->wes_read, 0, &event, 1,
+								 WAIT_EVENT_NEON_PS_READ) != 1
+				|| (event.events & WL_SOCKET_READABLE) == 0)
+			{
+				return NULL;
+			}
 			if (!PQconsumeInput(shard->conn))
 			{
 				return NULL;


### PR DESCRIPTION
## Problem

40% slowdown in test_bulk_update update-with-prefetch benchmark

`PQconsumeInput` never returns error if there is not data

## Summary of changes

Always poll socket before calling `PQconsumeInput`
