### PR TITLE
Make GcBlock::reasons a tokio Mutex

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -1220,7 +1220,7 @@ async fn tenant_status(
                     .generation()
                     .into()
                     .expect("Tenants are always attached with a generation"),
-                gc_blocking: tenant.gc_block.summary().map(|x| format!("{x:?}")),
+                gc_blocking: tenant.gc_block.summary().await.map(|x| format!("{x:?}")),
             },
             walredo: tenant.wal_redo_manager_status(),
             timelines: tenant.list_timeline_ids(),

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1810,7 +1810,7 @@ impl Tenant {
         // IndexPart is the source of truth.
         self.clean_up_timelines(&existent_timelines)?;
 
-        self.gc_block.set_scanned(gc_blocks);
+        self.gc_block.set_scanned(gc_blocks).await;
 
         fail::fail_point!("attach-before-activate", |_| {
             anyhow::bail!("attach-before-activate");

--- a/pageserver/src/tenant/timeline/delete.rs
+++ b/pageserver/src/tenant/timeline/delete.rs
@@ -207,7 +207,7 @@ impl DeleteTimelineFlow {
             timeline.shutdown(super::ShutdownMode::Hard).await;
         }
 
-        tenant.gc_block.before_delete(&timeline.timeline_id());
+        tenant.gc_block.before_delete(&timeline.timeline_id()).await;
 
         fail::fail_point!("timeline-delete-before-index-deleted-at", |_| {
             Err(anyhow::anyhow!(


### PR DESCRIPTION
It is better for the executor if mutexes are async ones. For example, if it is part of a deadlock involving the gc task, we can print stuff like "still running" now.

For #11351