### PR TITLE
chore(ci): pin python base images to sha

### DIFF
--- a/test_runner/pg_clients/csharp/npgsql/Dockerfile
+++ b/test_runner/pg_clients/csharp/npgsql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:2d7f935b8c7fe032cd3d36b5ce9c82c24413881e6dad1b4fbdf36cf369e4244f AS build
 WORKDIR /source
 
 COPY *.csproj .
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY . .
 RUN dotnet publish -c release -o /app --no-restore
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0
+FROM mcr.microsoft.com/dotnet/runtime:8.0@sha256:a6fc92280fbf2149cd6846d39c5bf7b9b535184e470aa68ef2847b9a02f6b99e
 WORKDIR /app
 COPY --from=build /app .
 

--- a/test_runner/pg_clients/java/jdbc/Dockerfile
+++ b/test_runner/pg_clients/java/jdbc/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:22
+# use base image openjdk:22
+FROM openjdk:22@sha256:b7d44427f4622d3f6b9a60583e5218ecfa8b4e44f3e01dfd0d9b7d7abba31c9a
 WORKDIR /source
 
 COPY . .

--- a/test_runner/pg_clients/python/asyncpg/Dockerfile
+++ b/test_runner/pg_clients/python/asyncpg/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12
+# use base image python:3.12
+FROM python:3.12@sha256:4e7024df2f2099e87d0a41893c299230d2a974c3474e681b0996f141951f9817
 WORKDIR /source
 
 COPY . .

--- a/test_runner/pg_clients/python/pg8000/Dockerfile
+++ b/test_runner/pg_clients/python/pg8000/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12
+# use base image python:3.12
+FROM python:3.12@sha256:4e7024df2f2099e87d0a41893c299230d2a974c3474e681b0996f141951f9817
 WORKDIR /source
 
 COPY . .

--- a/test_runner/pg_clients/rust/tokio-postgres/Dockerfile
+++ b/test_runner/pg_clients/rust/tokio-postgres/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.79
+# use base image rust:1.79
+FROM rust:1.79@sha256:9b2689d6f99ff381f178fa4361db745c8c355faecde73aa5b18b0efa84f03e62
 WORKDIR /source
 
 COPY . .

--- a/test_runner/pg_clients/swift/PostgresClientKitExample/Dockerfile
+++ b/test_runner/pg_clients/swift/PostgresClientKitExample/Dockerfile
@@ -1,11 +1,13 @@
-FROM swift:5.10 AS build
+# use base image swift:5.10
+FROM swift:5.10@sha256:69828d795abc6aa3f7b7f7a02054ab308420f54dcc806fcbd89c54944e61a089 AS build
 RUN apt-get -q update && apt-get -q install -y libssl-dev
 WORKDIR /source
 
 COPY . .
 RUN swift build --configuration release
 
-FROM swift:5.10
+# use base image swift:5.10
+FROM swift:5.10@sha256:69828d795abc6aa3f7b7f7a02054ab308420f54dcc806fcbd89c54944e61a089
 WORKDIR /app
 COPY --from=build /source/.build/release .
 CMD ["/app/PostgresClientKitExample"]

--- a/test_runner/pg_clients/swift/PostgresNIOExample/Dockerfile
+++ b/test_runner/pg_clients/swift/PostgresNIOExample/Dockerfile
@@ -1,10 +1,12 @@
-FROM swift:5.10 AS build
+# use base image swift:5.10
+FROM swift:5.10@sha256:69828d795abc6aa3f7b7f7a02054ab308420f54dcc806fcbd89c54944e61a089 AS build
 WORKDIR /source
 
 COPY . .
 RUN swift build --configuration release
 
-FROM swift:5.10
+# use base image swift:5.10
+FROM swift:5.10@sha256:69828d795abc6aa3f7b7f7a02054ab308420f54dcc806fcbd89c54944e61a089
 WORKDIR /app
 COPY --from=build /source/.build/release .
 CMD ["/app/PostgresNIOExample"]

--- a/test_runner/pg_clients/typescript/postgresql-client/Dockerfile
+++ b/test_runner/pg_clients/typescript/postgresql-client/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:22
+# use base image node:22
+FROM node:22@sha256:c7fd844945a76eeaa83cb372e4d289b4a30b478a1c80e16c685b62c54156285b
 WORKDIR /source
 
 COPY . .

--- a/test_runner/pg_clients/typescript/serverless-driver/Dockerfile
+++ b/test_runner/pg_clients/typescript/serverless-driver/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:22
+# use base image node:22
+FROM node:22@sha256:c7fd844945a76eeaa83cb372e4d289b4a30b478a1c80e16c685b62c54156285b
 WORKDIR /source
 
 COPY . .


### PR DESCRIPTION
Similar to how we pin base `debian` images, also pin `python` base images, so we better cache them and have reproducible builds.