### PR TITLE
fix(pageserver): allow sibling archived branch for detaching

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -502,8 +502,6 @@ pub struct OffloadedTimeline {
     pub timeline_id: TimelineId,
     pub ancestor_timeline_id: Option<TimelineId>,
     /// Whether to retain the branch lsn at the ancestor or not
-    /// TODO: this field is not utilized yet. It should be either an `Option<bool>` which indicates
-    /// if the branch is flattened, or an `Option<Vec<Lsn>>` to indicate all accessible branch LSNs.
     pub ancestor_retain_lsn: Option<Lsn>,
 
     /// When the timeline was archived.

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -502,6 +502,8 @@ pub struct OffloadedTimeline {
     pub timeline_id: TimelineId,
     pub ancestor_timeline_id: Option<TimelineId>,
     /// Whether to retain the branch lsn at the ancestor or not
+    /// TODO: this field is not utilized yet. It should be either an `Option<bool>` which indicates
+    /// if the branch is flattened, or an `Option<Vec<Lsn>>` to indicate all accessible branch LSNs.
     pub ancestor_retain_lsn: Option<Lsn>,
 
     /// When the timeline was archived.

--- a/test_runner/regress/test_timeline_detach_ancestor.py
+++ b/test_runner/regress/test_timeline_detach_ancestor.py
@@ -343,7 +343,8 @@ def test_ancestor_detach_reparents_earlier(neon_env_builder: NeonEnvBuilder):
     wait_timeline_detail_404(client, env.initial_tenant, env.initial_timeline)
 
 
-def test_ancestor_detach_behavior_v2(neon_env_builder: NeonEnvBuilder):
+@pytest.mark.parametrize("snapshots_archived", ["archived", "normal"])
+def test_ancestor_detach_behavior_v2(neon_env_builder: NeonEnvBuilder, snapshots_archived: str):
     """
     Test the v2 behavior of ancestor detach.
 
@@ -385,6 +386,11 @@ def test_ancestor_detach_behavior_v2(neon_env_builder: NeonEnvBuilder):
 
         ep.safe_psql("INSERT INTO foo SELECT i::bigint FROM generate_series(0, 8191) g(i);")
 
+        branchpoint_y = wait_for_last_flush_lsn(env, ep, env.initial_tenant, env.initial_timeline)
+        client.timeline_checkpoint(env.initial_tenant, env.initial_timeline)
+
+        ep.safe_psql("INSERT INTO foo SELECT i::bigint FROM generate_series(0, 8191) g(i);")
+
         branchpoint_x = wait_for_last_flush_lsn(env, ep, env.initial_tenant, env.initial_timeline)
         client.timeline_checkpoint(env.initial_tenant, env.initial_timeline)
 
@@ -393,6 +399,10 @@ def test_ancestor_detach_behavior_v2(neon_env_builder: NeonEnvBuilder):
 
     earlier = env.create_branch(
         "earlier", ancestor_branch_name="main", ancestor_start_lsn=branchpoint_pipe
+    )
+
+    snapshot_branchpoint_old = env.create_branch(
+        "snapshot_branchpoint_old", ancestor_branch_name="main", ancestor_start_lsn=branchpoint_y
     )
 
     snapshot_branchpoint = env.create_branch(
@@ -407,19 +417,32 @@ def test_ancestor_detach_behavior_v2(neon_env_builder: NeonEnvBuilder):
 
     after = env.create_branch("after", ancestor_branch_name="main", ancestor_start_lsn=None)
 
+    if snapshots_archived == "archived":
+        # archive the previous snapshot branchpoint
+        client.timeline_archival_config(
+            env.initial_tenant, snapshot_branchpoint_old, TimelineArchivalState.ARCHIVED
+        )
+
     all_reparented = client.detach_ancestor(
         env.initial_tenant, branch_to_detach, detach_behavior="v2"
     )
     assert set(all_reparented) == set()
 
+    if snapshots_archived == "archived":
+        # restore the branchpoint so that we can query from the endpoint
+        client.timeline_archival_config(
+            env.initial_tenant, snapshot_branchpoint_old, TimelineArchivalState.UNARCHIVED
+        )
+
     env.pageserver.quiesce_tenants()
 
     # checking the ancestor after is much faster than waiting for the endpoint not start
     expected_result = [
-        ("main", env.initial_timeline, None, 16384, 1),
-        ("after", after, env.initial_timeline, 16384, 1),
-        ("snapshot_branchpoint", snapshot_branchpoint, env.initial_timeline, 8192, 1),
-        ("branch_to_detach", branch_to_detach, None, 8192, 1),
+        ("main", env.initial_timeline, None, 24576, 1),
+        ("after", after, env.initial_timeline, 24576, 1),
+        ("snapshot_branchpoint_old", snapshot_branchpoint_old, env.initial_timeline, 8192, 1),
+        ("snapshot_branchpoint", snapshot_branchpoint, env.initial_timeline, 16384, 1),
+        ("branch_to_detach", branch_to_detach, None, 16384, 1),
         ("earlier", earlier, env.initial_timeline, 0, 1),
     ]
 


### PR DESCRIPTION
## Problem

close https://github.com/neondatabase/neon/issues/11379

## Summary of changes

Remove checks around archived branches for detach v2. I also updated the comments `ancestor_retain_lsn`.