### PR TITLE
Increase the timeout for extensions upgrade tests (on schedule).

### DIFF
--- a/.github/workflows/force-test-extensions-upgrade.yml
+++ b/.github/workflows/force-test-extensions-upgrade.yml
@@ -55,7 +55,7 @@ jobs:
           echo tag=${tag} >> ${GITHUB_OUTPUT}
 
       - name: Test extension upgrade
-        timeout-minutes: 20
+        timeout-minutes: 60
         env:
           NEW_COMPUTE_TAG: latest
           OLD_COMPUTE_TAG: ${{ steps.get-last-compute-release-tag.outputs.tag }}


### PR DESCRIPTION
## Problem
Sometimes the forced extension upgrade test fails (on schedule) due to a timeout.
## Summary of changes
The timeout is increased to 60 mins.