### PR TITLE
walproposer: make it aware of membership

### DIFF
--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -1883,7 +1883,7 @@ CalculateMinFlushLsn(WalProposer *wp)
 	return lsn;
 }
 
-/* 
+/*
  * GetAcknowledgedByQuorumWALPosition for a single member set `mset`.
  *
  * `msk` is the member -> safekeeper mapping for mset, i.e. members_safekeepers
@@ -1904,11 +1904,11 @@ GetCommittedMset(WalProposer *wp, MemberSet *mset, Safekeeper **msk)
 
 		/*
 		 * Like in Raft, we aren't allowed to commit entries from previous
-		 * terms, so ignore reported LSN until it gets to epochStartLsn.
+		 * terms, so ignore reported LSN until it gets to propTermStartLsn.
 		 *
-		 * Note: we ignore sk state, which is ok: before first ack flushLsn
-		 * is 0, and later we just preserve value across reconnections. It
-		 * would be ok to check for SS_ACTIVE as well.
+		 * Note: we ignore sk state, which is ok: before first ack flushLsn is
+		 * 0, and later we just preserve value across reconnections. It would
+		 * be ok to check for SS_ACTIVE as well.
 		 */
 		if (sk != NULL && sk->appendResponse.flushLsn >= wp->propTermStartLsn)
 		{
@@ -1922,11 +1922,11 @@ GetCommittedMset(WalProposer *wp, MemberSet *mset, Safekeeper **msk)
 	qsort(responses, mset->len, sizeof(XLogRecPtr), CompareLsn);
 
 	/*
-	* And get value committed by the quorum. A way to view this: to get the
-	* highest value committed on the quorum, in the ordered array we skip n -
-	* n_quorum elements to get to the first (lowest) value present on all sks of
-	* the highest quorum.
-	*/
+	 * And get value committed by the quorum. A way to view this: to get the
+	 * highest value committed on the quorum, in the ordered array we skip n -
+	 * n_quorum elements to get to the first (lowest) value present on all sks
+	 * of the highest quorum.
+	 */
 	return responses[mset->len - MsetQuorum(mset)];
 }
 
@@ -1940,7 +1940,7 @@ GetCommittedMset(WalProposer *wp, MemberSet *mset, Safekeeper **msk)
 static XLogRecPtr
 GetAcknowledgedByQuorumWALPosition(WalProposer *wp)
 {
-	XLogRecPtr committed;
+	XLogRecPtr	committed;
 
 	/* legacy: generations disabled */
 	if (!WalProposerGenerationsEnabled(wp) && wp->mconf.generation == INVALID_GENERATION)
@@ -1948,25 +1948,25 @@ GetAcknowledgedByQuorumWALPosition(WalProposer *wp)
 		XLogRecPtr	responses[MAX_SAFEKEEPERS];
 
 		/*
-		* Sort acknowledged LSNs
-		*/
+		 * Sort acknowledged LSNs
+		 */
 		for (int i = 0; i < wp->n_safekeepers; i++)
 		{
 			/*
 			 * Like in Raft, we aren't allowed to commit entries from previous
-			 * terms, so ignore reported LSN until it gets to epochStartLsn.
+			 * terms, so ignore reported LSN until it gets to propTermStartLsn.
 			 *
-			 * Note: we ignore sk state, which is ok: before first ack flushLsn
-			 * is 0, and later we just preserve value across reconnections. It
-			 * would be ok to check for SS_ACTIVE as well.
+			 * Note: we ignore sk state, which is ok: before first ack
+			 * flushLsn is 0, and later we just preserve value across
+			 * reconnections. It would be ok to check for SS_ACTIVE as well.
 			 */
 			responses[i] = wp->safekeeper[i].appendResponse.flushLsn >= wp->propTermStartLsn ? wp->safekeeper[i].appendResponse.flushLsn : 0;
 		}
 		qsort(responses, wp->n_safekeepers, sizeof(XLogRecPtr), CompareLsn);
 
 		/*
-		* Get the smallest LSN committed by quorum
-		*/
+		 * Get the smallest LSN committed by quorum
+		 */
 		return responses[wp->n_safekeepers - wp->quorum];
 	}
 

--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -930,10 +930,12 @@ RecvAcceptorGreeting(Safekeeper *sk)
 		{
 			wp_log(FATAL, "mconf %u has zero members", sk->greetResponse.mconf.generation);
 		}
+
 		/*
-		 * If we at least started campaign, restart wp to get elected in the new
-		 * mconf. Note: in principle once wp is already elected re-election is
-		 * not required, but being conservative here is not bad.
+		 * If we at least started campaign, restart wp to get elected in the
+		 * new mconf. Note: in principle once wp is already elected
+		 * re-election is not required, but being conservative here is not
+		 * bad.
 		 *
 		 * TODO: put mconf to shmem to immediately pick it up on start,
 		 * otherwise if some safekeeper(s) misses latest mconf and gets
@@ -1971,7 +1973,8 @@ GetAcknowledgedByQuorumWALPosition(WalProposer *wp)
 		{
 			/*
 			 * Like in Raft, we aren't allowed to commit entries from previous
-			 * terms, so ignore reported LSN until it gets to propTermStartLsn.
+			 * terms, so ignore reported LSN until it gets to
+			 * propTermStartLsn.
 			 *
 			 * Note: we ignore sk state, which is ok: before first ack
 			 * flushLsn is 0, and later we just preserve value across
@@ -2093,13 +2096,13 @@ HandleSafekeeperResponse(WalProposer *wp, Safekeeper *fromsk)
 	}
 
 	/*
-	 * Generally sync is done when majority reached propTermStartLsn so we committed
-	 * it and made the majority aware of it, ensuring they are
-	 * ready to give all WAL to pageserver. It would mean whichever majority
-	 * is alive, there will be at least one safekeeper who is able to stream
-	 * WAL to pageserver to make basebackup possible. However, since at the
-	 * moment we don't have any good mechanism of defining the healthy and
-	 * most advanced safekeeper who should push the wal into pageserver and
+	 * Generally sync is done when majority reached propTermStartLsn so we
+	 * committed it and made the majority aware of it, ensuring they are ready
+	 * to give all WAL to pageserver. It would mean whichever majority is
+	 * alive, there will be at least one safekeeper who is able to stream WAL
+	 * to pageserver to make basebackup possible. However, since at the moment
+	 * we don't have any good mechanism of defining the healthy and most
+	 * advanced safekeeper who should push the wal into pageserver and
 	 * basically the random one gets connected, to prevent hanging basebackup
 	 * (due to pageserver connecting to not-synced-safekeeper) we currently
 	 * wait for all seemingly alive safekeepers to get synced.

--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -173,7 +173,7 @@ WalProposerCreate(WalProposerConfig *config, walproposer_api api)
 
 	if (wp->config->proto_version != 2 && wp->config->proto_version != 3)
 		wp_log(FATAL, "unsupported safekeeper protocol version %d", wp->config->proto_version);
-	if (wp->safekeepers_generation > 0 && wp->config->proto_version < 3)
+	if (wp->safekeepers_generation > INVALID_GENERATION && wp->config->proto_version < 3)
 		wp_log(FATAL, "enabling generations requires protocol version 3");
 	wp_log(LOG, "using safekeeper protocol version %d", wp->config->proto_version);
 

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -771,6 +771,15 @@ typedef struct WalProposer
 	WalProposerState state;
 	/* Current walproposer membership configuration */
 	MembershipConfiguration mconf;
+	/*
+	 * Parallels mconf.members with pointers to the member's slot in safekeepers
+	 * array of connections, or NULL if such member is not connected. Helps to
+	 * avoid looking slot per id through all .safekeepers[] when doing quorum
+	 * checks.
+	 */
+	Safekeeper* members_safekeepers[MAX_SAFEKEEPERS];
+	/* As above, but for new_members. */
+	Safekeeper* new_members_safekeepers[MAX_SAFEKEEPERS];
 
 	/* (n_safekeepers / 2) + 1 */
 	int			quorum;

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -771,17 +771,18 @@ typedef struct WalProposer
 	WalProposerState state;
 	/* Current walproposer membership configuration */
 	MembershipConfiguration mconf;
-	/*
-	 * Parallels mconf.members with pointers to the member's slot in safekeepers
-	 * array of connections, or NULL if such member is not connected. Helps to
-	 * avoid looking slot per id through all .safekeepers[] when doing quorum
-	 * checks.
-	 */
-	Safekeeper* members_safekeepers[MAX_SAFEKEEPERS];
-	/* As above, but for new_members. */
-	Safekeeper* new_members_safekeepers[MAX_SAFEKEEPERS];
 
-	/* (n_safekeepers / 2) + 1 */
+	/*
+	 * Parallels mconf.members with pointers to the member's slot in
+	 * safekeepers array of connections, or NULL if such member is not
+	 * connected. Helps to avoid looking slot per id through all
+	 * .safekeepers[] when doing quorum checks.
+	 */
+	Safekeeper *members_safekeepers[MAX_SAFEKEEPERS];
+	/* As above, but for new_members. */
+	Safekeeper *new_members_safekeepers[MAX_SAFEKEEPERS];
+
+	/* (n_safekeepers / 2) + 1. Used for static pre-generations quorum checks. */
 	int			quorum;
 
 	/*
@@ -839,7 +840,7 @@ typedef struct WalProposer
 	term_t		donorLastLogTerm;
 
 	/* Most advanced acceptor */
-	int			donor;
+	Safekeeper *donor;
 
 	/* timeline globally starts at this LSN */
 	XLogRecPtr	timelineStartLsn;

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -145,6 +145,7 @@ typedef uint64 NNodeId;
  * This and following structs pair ones in membership.rs.
  */
 typedef uint32 Generation;
+#define INVALID_GENERATION 0
 
 typedef struct SafekeeperId
 {

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -79,7 +79,12 @@ from fixtures.remote_storage import (
     default_remote_storage,
     remote_storage_to_toml_dict,
 )
-from fixtures.safekeeper.http import SafekeeperHttpClient
+from fixtures.safekeeper.http import (
+    MembershipConfiguration,
+    SafekeeperHttpClient,
+    SafekeeperId,
+    TimelineCreateRequest,
+)
 from fixtures.safekeeper.utils import wait_walreceivers_absent
 from fixtures.utils import (
     ATTACHMENT_NAME_REGEX,
@@ -4838,6 +4843,52 @@ class Safekeeper(LogUtils):
             self.assert_log_contains(msg)
 
         wait_until(paused)
+
+    @staticmethod
+    def sks_to_safekeeper_ids(sks: list[Safekeeper]) -> list[SafekeeperId]:
+        return [SafekeeperId(sk.id, "localhost", sk.port.pg_tenant_only) for sk in sks]
+
+    @staticmethod
+    def mconf_sks(env: NeonEnv, mconf: MembershipConfiguration) -> list[Safekeeper]:
+        """
+        List of Safekeepers which are members in `mconf`.
+        """
+        members_ids = [m.id for m in mconf.members]
+        new_members_ids = [m.id for m in mconf.new_members] if mconf.new_members is not None else []
+        return [sk for sk in env.safekeepers if sk.id in members_ids or sk.id in new_members_ids]
+
+    @staticmethod
+    def create_timeline(
+        tenant_id: TenantId,
+        timeline_id: TimelineId,
+        ps: NeonPageserver,
+        mconf: MembershipConfiguration,
+        sks: list[Safekeeper],
+    ):
+        """
+        Manually create timeline on safekeepers with given (presumably inital)
+        mconf: figure out LSN from pageserver, bake request and execute it on
+        given safekeepers.
+
+        Normally done by storcon, but some tests want to do it manually so far.
+        """
+        ps_http_cli = ps.http_client()
+        # figure out initial LSN.
+        ps_timeline_detail = ps_http_cli.timeline_detail(tenant_id, timeline_id)
+        init_lsn = ps_timeline_detail["last_record_lsn"]
+        log.info(f"initial LSN: {init_lsn}")
+        # sk timeline creation request expects minor version
+        pg_version = ps_timeline_detail["pg_version"] * 10000
+        # create inital mconf
+        sk_ids = [SafekeeperId(sk.id, "localhost", sk.port.pg_tenant_only) for sk in sks]
+        mconf = MembershipConfiguration(generation=1, members=sk_ids, new_members=None)
+        create_r = TimelineCreateRequest(
+            tenant_id, timeline_id, mconf, pg_version, Lsn(init_lsn), commit_lsn=None
+        )
+        log.info(f"sending timeline create: {create_r.to_json()}")
+
+        for sk in sks:
+            sk.http_client().timeline_create(create_r)
 
 
 class NeonBroker(LogUtils):

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -4863,7 +4863,7 @@ class Safekeeper(LogUtils):
         timeline_id: TimelineId,
         ps: NeonPageserver,
         mconf: MembershipConfiguration,
-        sks: list[Safekeeper],
+        members_sks: list[Safekeeper],
     ):
         """
         Manually create timeline on safekeepers with given (presumably inital)
@@ -4880,14 +4880,12 @@ class Safekeeper(LogUtils):
         # sk timeline creation request expects minor version
         pg_version = ps_timeline_detail["pg_version"] * 10000
         # create inital mconf
-        sk_ids = [SafekeeperId(sk.id, "localhost", sk.port.pg_tenant_only) for sk in sks]
-        mconf = MembershipConfiguration(generation=1, members=sk_ids, new_members=None)
         create_r = TimelineCreateRequest(
             tenant_id, timeline_id, mconf, pg_version, Lsn(init_lsn), commit_lsn=None
         )
         log.info(f"sending timeline create: {create_r.to_json()}")
 
-        for sk in sks:
+        for sk in members_sks:
             sk.http_client().timeline_create(create_r)
 
 

--- a/test_runner/regress/test_wal_acceptor_async.py
+++ b/test_runner/regress/test_wal_acceptor_async.py
@@ -609,7 +609,9 @@ async def quorum_sanity_single(
     from 1 and sequentially assigned to env.safekeepers.
     """
     members_sks = [env.safekeepers[i - 1] for i in members_sks_ids]
-    new_members_sks = [env.safekeepers[i - 1] for i in new_members_sks_ids] if new_members_sks_ids else None
+    new_members_sks = (
+        [env.safekeepers[i - 1] for i in new_members_sks_ids] if new_members_sks_ids else None
+    )
     sks_to_stop = [env.safekeepers[i - 1] for i in sks_to_stop_ids]
 
     mconf = MembershipConfiguration(

--- a/test_runner/regress/test_wal_acceptor_async.py
+++ b/test_runner/regress/test_wal_acceptor_async.py
@@ -621,7 +621,7 @@ async def quorum_sanity_single(
     )
     sks_to_stop_ids_str = "-".join([str(sk.id) for sk in sks_to_stop])
     log.info(
-        f"running quorum_sanity_single with compute_sks={compute_sks_ids_str}, members_sks={members_sks_ids_str}, new_members_sks={new_members_sks}, sks_to_stop={sks_to_stop_ids_str}, should_work_when_stopped={should_work_when_stopped}"
+        f"running quorum_sanity_single with compute_sks={compute_sks_ids_str}, members_sks={members_sks_ids_str}, new_members_sks={new_members_sks_ids_str}, sks_to_stop={sks_to_stop_ids_str}, should_work_when_stopped={should_work_when_stopped}"
     )
     branch_name = f"test_quorum_single_c{compute_sks_ids_str}_m{members_sks_ids_str}_{new_members_sks_ids_str}_s{sks_to_stop_ids_str}"
     timeline_id = env.create_branch(branch_name)
@@ -671,6 +671,13 @@ async def run_quorum_sanity(env: NeonEnv):
     await quorum_sanity_single(env, sks[1:4], sks[:3], None, [], True)
     # 3 members, 2/3 up, could work but wp talks to different 3s, so it shouldn't
     await quorum_sanity_single(env, sks[1:4], sks[:3], None, sks[2:3], False)
+
+    # joint conf of 1-2-3 and 2-3-4, all up, should work
+    await quorum_sanity_single(env, sks[:], sks[:3], sks[1:4], [], True)
+    # joint conf of 1-2-3 and 4, all up, should work
+    await quorum_sanity_single(env, sks[:], sks[:3], sks[3:4], [], True)
+    # joint conf of 1-2-3 and 4, 4 down, shouldn't work
+    await quorum_sanity_single(env, sks[:], sks[:3], sks[3:4], sks[3:4], False)
 
 
 # Test various combinations of membership configurations / neon.safekeepers


### PR DESCRIPTION
## Problem

Walproposer should get elected and commit WAL on safekeepers specified by the membership configuration.

## Summary of changes

- Add to wp `members_safekeepers` and `new_members_safekeepers` arrays mapping configuration members to connection slots. Establish this mapping (by node id) when safekeeper sends greeting, giving its id and when mconf becomes known / changes.
- Add to TermsCollected, VotesCollected, GetAcknowledgedByQuorumWALPosition membership aware logic. Currently it partially duplicates existing one, but we'll drop the latter eventually.
- In python, rename Configuration to MembershipConfiguration for clarity.
- Add test_quorum_sanity testing new logic.

ref https://github.com/neondatabase/neon/issues/10851