### PR TITLE
    feat(ci): add 'released' tag to container images from release runs

### DIFF
--- a/.github/scripts/generate_image_maps.py
+++ b/.github/scripts/generate_image_maps.py
@@ -41,7 +41,13 @@ registries = {
 
 outputs: dict[str, dict[str, list[str]]] = {}
 
-target_tags = [target_tag, "latest"] if branch == "main" else [target_tag]
+target_tags = (
+    [target_tag, "latest"]
+    if branch == "main"
+    else [target_tag, "released"]
+    if branch in ["release", "release-proxy", "release-compute"]
+    else [target_tag]
+)
 target_stages = (
     ["dev", "prod"] if branch in ["release", "release-proxy", "release-compute"] else ["dev"]
 )

--- a/.github/scripts/generate_image_maps.py
+++ b/.github/scripts/generate_image_maps.py
@@ -39,18 +39,18 @@ registries = {
     ],
 }
 
+release_branches = ["release", "release-proxy", "release-compute"]
+
 outputs: dict[str, dict[str, list[str]]] = {}
 
 target_tags = (
     [target_tag, "latest"]
     if branch == "main"
     else [target_tag, "released"]
-    if branch in ["release", "release-proxy", "release-compute"]
+    if branch in release_branches
     else [target_tag]
 )
-target_stages = (
-    ["dev", "prod"] if branch in ["release", "release-proxy", "release-compute"] else ["dev"]
-)
+target_stages = ["dev", "prod"] if branch in release_branches else ["dev"]
 
 for component_name, component_images in components.items():
     for stage in target_stages:


### PR DESCRIPTION
## Problem
We had a problem with https://github.com/neondatabase/neon/pull/11413 having e2e tests failing, because an e2e test (https://github.com/neondatabase/cloud/commit/8d271bed47498c83b35ff9ace9f7938e6e0f19f3) depended on an unreleased pageserver fix (https://github.com/neondatabase/neon/commit/0ee5bfa2fc01372737fe0e108ae40b3e6f5801a7). This came up because neon release CI runs against the most recent releases of the other components, but cloud e2e tests run against latest, which is tagged from main.

## Summary of changes
Add an additional `released` tag for released versions.

## Alternative to consider
We could (and maybe should) instead switch to `latest` being used for released versions and `main` being used where we use `latest` right now. That'd also mean we don't have to adjust the CI in the cloud repo.
