### PR TITLE
tests: extend node offline allow list

### DIFF
--- a/test_runner/fixtures/pageserver/allowed_errors.py
+++ b/test_runner/fixtures/pageserver/allowed_errors.py
@@ -118,6 +118,7 @@ DEFAULT_STORAGE_CONTROLLER_ALLOWED_ERRORS = [
     # failing to connect to them.
     ".*Call to node.*management API.*failed.*receive body.*",
     ".*Call to node.*management API.*failed.*ReceiveBody.*",
+    ".*Call to node.*management API still failed after .+ retries, giving up.*",
     ".*Failed to update node .+ after heartbeat round.*error sending request for url.*",
     ".*background_reconcile: failed to fetch top tenants:.*client error \\(Connect\\).*",
     # Many tests will start up with a node offline


### PR DESCRIPTION
## Problem

`test_storage_controller_many_tenants` was failing on a log line:
```
WARN Call to node 1 (http://localhost:15392) management API still failed after 3 retries, giving up: Timeout("deadline has elapsed")\n
```

This is just a symptom of a pageserver being down, which is a normal part of this test.

## Summary of changes

- Extend the existing set of "node down" log errors to include this case, these are permitted in all tests.
