### PR TITLE
fix(test): wait for shard split complete for test_lsn_lease_storcon

### DIFF
--- a/test_runner/regress/test_tenant_size.py
+++ b/test_runner/regress/test_tenant_size.py
@@ -776,6 +776,7 @@ def test_lsn_lease_storcon(neon_env_builder: NeonEnvBuilder):
         env.initial_tenant, env.initial_timeline, last_flush_lsn
     )
     env.storage_controller.tenant_shard_split(env.initial_tenant, 8)
+    env.storage_controller.reconcile_until_idle(timeout_secs=120)
     # TODO: do we preserve LSN leases across shard splits?
     env.storage_controller.pageserver_api().timeline_lsn_lease(
         env.initial_tenant, env.initial_timeline, last_flush_lsn


### PR DESCRIPTION
## Problem

close https://github.com/neondatabase/neon/issues/11397
ref https://github.com/neondatabase/cloud/issues/23667

## Summary of changes

We need to wait until the shard split is complete, otherwise it will print warning like waiting for shard split exclusive lock for 30s.

