### PR TITLE
pageserver: set `Stopping` state on attach cancellation

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1371,7 +1371,7 @@ impl Tenant {
                         // Mark the tenant as broken.
                         TenantState::Attaching | TenantState::Stopping { .. } => {
                             error!("attach failed, setting tenant state to Broken: {err:?}");
-                            *state = TenantState::broken_from_reason(err.to_string()) 
+                            *state = TenantState::broken_from_reason(err.to_string())
                         }
                         // The attach task owns the tenant state until activated.
                         state => panic!("invalid tenant state {state} during attach: {err:?}"),


### PR DESCRIPTION
## Problem

If a tenant is cancelled (e.g. due to Pageserver shutdown) during attach, it is set to `Broken`. This results both in error log spam and 500 responses for clients -- shutdown is supposed to return 503 responses which can be retried.

This becomes more likely to happen with #11328, where we perform tenant manifest downloads/uploads during attach.

## Summary of changes

Set tenant state to `Stopping` when attach fails and the tenant is cancelled, downgrading the log messages to INFO. This introduces two variants of `Stopping` -- with and without a caller barrier -- where the latter is used to signal attach cancellation.