### PR TITLE
pageserver: refactor read path for multi LSN batching support

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -3981,12 +3981,6 @@ impl Timeline {
         cancel: &CancellationToken,
         ctx: &RequestContext,
     ) -> Result<TimelineVisitOutcome, GetVectoredError> {
-        let mut unmapped_keyspace = keyspace.clone();
-        let mut fringe = LayerFringe::new();
-
-        let mut completed_keyspace = KeySpace::default();
-        let mut image_covered_keyspace = KeySpaceRandomAccum::new();
-
         // Prevent GC from progressing while visiting the current timeline.
         // If we are GC-ing because a new image layer was added while traversing
         // the timeline, then it will remove layers that are required for fulfilling
@@ -3997,9 +3991,64 @@ impl Timeline {
         // See `compaction::compact_with_gc` for why we need this.
         let _guard = timeline.gc_compaction_layer_update_lock.read().await;
 
+        // Initialize the fringe
+        let mut fringe = {
+            let mut fringe = LayerFringe::new();
+
+            let guard = timeline.layers.read().await;
+            let layers = guard.layer_map()?;
+
+            for range in keyspace.ranges.iter() {
+                let results = layers.range_search(range.clone(), cont_lsn);
+
+                results
+                    .found
+                    .into_iter()
+                    .map(|(SearchResult { layer, lsn_floor }, keyspace_accum)| {
+                        (
+                            guard.upgrade(layer),
+                            keyspace_accum.to_keyspace(),
+                            lsn_floor..cont_lsn,
+                        )
+                    })
+                    .for_each(|(layer, keyspace, lsn_range)| {
+                        fringe.update(layer, keyspace, lsn_range)
+                    });
+            }
+
+            fringe
+        };
+
+        let mut completed_keyspace = KeySpace::default();
+        let mut image_covered_keyspace = KeySpaceRandomAccum::new();
+
         loop {
             if cancel.is_cancelled() {
                 return Err(GetVectoredError::Cancelled);
+            }
+
+            let mut unmapped_keyspace;
+
+            if let Some((layer_to_read, keyspace_to_read, lsn_range)) = fringe.next_layer() {
+                if let Some(ref mut read_path) = reconstruct_state.read_path {
+                    read_path.record_layer_visit(&layer_to_read, &keyspace_to_read, &lsn_range);
+                }
+                let next_cont_lsn = lsn_range.start;
+                layer_to_read
+                    .get_values_reconstruct_data(
+                        keyspace_to_read.clone(),
+                        lsn_range,
+                        reconstruct_state,
+                        ctx,
+                    )
+                    .await?;
+
+                unmapped_keyspace = keyspace_to_read;
+                cont_lsn = next_cont_lsn;
+
+                reconstruct_state.on_layer_visited(&layer_to_read);
+            } else {
+                break;
             }
 
             let (keys_done_last_step, keys_with_image_coverage) =
@@ -4049,28 +4098,6 @@ impl Timeline {
                 // range at *a particular point in time*. It is fine for the answer to be different
                 // at two different time points.
                 drop(guard);
-            }
-
-            if let Some((layer_to_read, keyspace_to_read, lsn_range)) = fringe.next_layer() {
-                if let Some(ref mut read_path) = reconstruct_state.read_path {
-                    read_path.record_layer_visit(&layer_to_read, &keyspace_to_read, &lsn_range);
-                }
-                let next_cont_lsn = lsn_range.start;
-                layer_to_read
-                    .get_values_reconstruct_data(
-                        keyspace_to_read.clone(),
-                        lsn_range,
-                        reconstruct_state,
-                        ctx,
-                    )
-                    .await?;
-
-                unmapped_keyspace = keyspace_to_read;
-                cont_lsn = next_cont_lsn;
-
-                reconstruct_state.on_layer_visited(&layer_to_read);
-            } else {
-                break;
             }
         }
 


### PR DESCRIPTION
## Problem

We wish to improve pageserver batching such that one batch can contain requests for
pages at different LSNs. The current shape of the code doesn't lend itself to the change.

## Summary of changes

Refactor the read path such that the fringe gets initialized upfront. This is where the multi LSN
change will plug in. A couple other small changes fell out of this.

There should be NO behaviour change here. If you smell one, shout!

I recommend reviewing commits individually (intentionally made them as small as possible).

Related: https://github.com/neondatabase/neon/issues/10765