### PR TITLE
Allow potential warning in test_storcon_create_delete_sk_down

### DIFF
--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -4109,6 +4109,7 @@ def test_storcon_create_delete_sk_down(neon_env_builder: NeonEnvBuilder, restart
     env.storage_controller.allowed_errors.extend(
         [
             ".*Call to safekeeper.* management API still failed after.*",
+            ".*Call to safekeeper.* management API failed, will retry.*",
             ".*reconcile_one.*tenant_id={tenant_id}.*Call to safekeeper.* management API still failed after.*",
         ]
     )


### PR DESCRIPTION
Since merging #11400 and addition of `test_storcon_create_delete_sk_down`, we've seen an error occur multiple times.

https://github.com/neondatabase/neon/pull/11400#issuecomment-2782528369