### PR TITLE
feat(ci): lint gha with zizmor using the pedantic persona

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -54,3 +54,14 @@ jobs:
             done
             exit 1
           fi
+
+      - name: Lint with zizmor
+        run: zizmor --persona pedantic --format sarif . > zizmor.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload zizmor results
+        uses: github/codeql-action/upload-sarif@fc7e4a0fa01c3cca5fd6a1fddec5c0740c977aa2  # v3.28.14
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/build-tools.Dockerfile
+++ b/build-tools.Dockerfile
@@ -302,6 +302,7 @@ ARG CARGO_HACK_VERSION=0.6.33
 ARG CARGO_NEXTEST_VERSION=0.9.85
 ARG CARGO_CHEF_VERSION=0.1.71
 ARG CARGO_DIESEL_CLI_VERSION=2.2.6
+ARG ZIZMOR_VERSION=1.5.2
 RUN curl -sSO https://static.rust-lang.org/rustup/dist/$(uname -m)-unknown-linux-gnu/rustup-init && whoami && \
 	chmod +x rustup-init && \
 	./rustup-init -y --default-toolchain ${RUSTC_VERSION} && \
@@ -316,6 +317,7 @@ RUN curl -sSO https://static.rust-lang.org/rustup/dist/$(uname -m)-unknown-linux
     cargo install cargo-hack          --version ${CARGO_HACK_VERSION} && \
     cargo install cargo-nextest       --version ${CARGO_NEXTEST_VERSION} && \
     cargo install cargo-chef --locked --version ${CARGO_CHEF_VERSION} && \
+    cargo install zizmor --locked     --version ${ZIZMOR_VERSION} && \
     cargo install diesel_cli          --version ${CARGO_DIESEL_CLI_VERSION} \
                                       --features postgres-bundled --no-default-features && \
     rm -rf /home/nonroot/.cargo/registry && \


### PR DESCRIPTION
## Problem
We want to use zizmor to catch issues like [unpinned-uses](https://woodruffw.github.io/zizmor/audits/#unpinned-uses). Right now, zizmor will not fail on anything (yet), this just uploads sarif outputs to show issues in the diff view. Actually failing CI based on zizmor is blocked by fixing existing linting issues and determining what audit rules are hard failures for us.

## Summary of changes
Run zizmor and upload reports.
