### PR TITLE
fix(tests): improve test_scrubber_tenant_snapshot stability

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7270,7 +7270,7 @@ impl Service {
             }
 
             // Eventual consistency: if an earlier reconcile job failed, and the shard is still
-            // dirty, spawn another rone
+            // dirty, spawn another one
             if self
                 .maybe_reconcile_shard(shard, &pageservers, ReconcilerPriority::Normal)
                 .is_some()

--- a/test_runner/regress/test_storage_scrubber.py
+++ b/test_runner/regress/test_storage_scrubber.py
@@ -134,7 +134,7 @@ def test_scrubber_tenant_snapshot(neon_env_builder: NeonEnvBuilder, shard_count:
     for pageserver in env.pageservers:
         pageserver.start()
 
-    # Turn shedulling back on.
+    # Turn scheduling back on.
     # We don't care about optimizations, so enable only essential scheduling
     env.storage_controller.tenant_policy_update(tenant_id, {"scheduling": "Essential"})
 


### PR DESCRIPTION
## Problem
`test_scrubber_tenant_snapshot` is flaky with `request was dropped` errors. More details are in the issue.
- Closes: https://github.com/neondatabase/neon/issues/11278

## Summary of changes
- Disable shard scheduling during pageservers restart
- Add `reconcile_until_idle` in the end of the test