### PR TITLE
One more fix for unlogged build support in DEBUG_COMPARE_LOCAL

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -3575,7 +3575,7 @@ neon_readv(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		for (int i = 0; i < nblocks; i++)
 		{
 			BlockNumber blkno = blocknum + i;
-			if (!BITMAP_ISSET(read, i))
+			if (!BITMAP_ISSET(read_pages, i))
 				continue;
 
 #if PG_MAJORVERSION_NUM >= 17
@@ -3698,6 +3698,9 @@ neon_write(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, const vo
 #ifndef DEBUG_COMPARE_LOCAL
 			/* This is a bit tricky. Check if the relation exists locally */
 			if (mdexists(reln, forknum))
+#else
+			if (mdexists(reln, INIT_FORKNUM))
+#endif
 			{
 				/* It exists locally. Guess it's unlogged then. */
 #if PG_MAJORVERSION_NUM >= 17
@@ -3714,7 +3717,6 @@ neon_write(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, const vo
 				 */
 				return;
 			}
-#endif
 			break;
 
 		case RELPERSISTENCE_PERMANENT:
@@ -3771,6 +3773,9 @@ neon_writev(SMgrRelation reln, ForkNumber forknum, BlockNumber blkno,
 #ifndef DEBUG_COMPARE_LOCAL
 			/* This is a bit tricky. Check if the relation exists locally */
 			if (mdexists(reln, forknum))
+#else
+			if (mdexists(reln, INIT_FORKNUM))
+#endif
 			{
 				/* It exists locally. Guess it's unlogged then. */
 				mdwritev(reln, forknum, blkno, buffers, nblocks, skipFsync);
@@ -3784,7 +3789,6 @@ neon_writev(SMgrRelation reln, ForkNumber forknum, BlockNumber blkno,
 				 */
 				return;
 			}
-#endif
 			break;
 
 		case RELPERSISTENCE_PERMANENT:
@@ -4198,6 +4202,8 @@ neon_start_unlogged_build(SMgrRelation reln)
 #ifndef DEBUG_COMPARE_LOCAL
  	if (!IsParallelWorker())
 		mdcreate(reln, MAIN_FORKNUM, false);
+#else
+	mdcreate(reln, INIT_FORKNUM, false);
 #endif
 }
 
@@ -4276,6 +4282,8 @@ neon_end_unlogged_build(SMgrRelation reln)
 #ifndef DEBUG_COMPARE_LOCAL
 			/* use isRedo == true, so that we drop it immediately */
 			mdunlink(rinfob, forknum, true);
+#else
+			mdunlink(rinfob, INIT_FORKNUM, true);
 #endif
 		}
 	}


### PR DESCRIPTION
## Problem

Support of unlogged build in DEBUG_COMPARE_LOCAL.
Neon SMGR treats present of local file as indicator of unlogged relations.
But it doesn't work in  DEBUG_COMPARE_LOCAL mode.

## Summary of changes

Use INIT_FORKNUM as indicator of unlogged file and create this file while unlogged index build.