### PR TITLE
CI(run-python-test-set): upload data compatibility snapshots from main

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -219,7 +219,7 @@ runs:
 
     - name: Upload compatibility snapshot
       # Note, that we use `github.base_ref` which is a target branch for a PR
-      if: github.event_name == 'pull_request' && github.base_ref == 'release'
+      if: (github.event_name == 'pull_request' && github.base_ref == 'release') || github.ref_name == 'main'
       uses: ./.github/actions/upload
       with:
         name: compatibility-snapshot-${{ runner.arch }}-${{ inputs.build_type }}-pg${{ inputs.pg_version }}


### PR DESCRIPTION
## Problem

There's no trivial way to add a data snapshot to `test_historic_storage_formats` test before release.

Ref: https://neondb.slack.com/archives/C059ZC138NR/p1744120836389149

## Summary of changes
- Upload data snapshot from main

