### PR TITLE
gitignore: add `/artifact_cache`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/artifact_cache
 /pg_install
 /target
 /tmp_check


### PR DESCRIPTION
## Problem

This is generated e.g. by `test_historic_storage_formats`, and causes VSCode to list all the contained files as new.

## Summary of changes

Add `/artifact_cache` to `.gitignore`.