### PR TITLE
large tenant oltp benchmark: reindex with downtime (remove concurrently)

### DIFF
--- a/test_runner/performance/test_perf_oltp_large_tenant.py
+++ b/test_runner/performance/test_perf_oltp_large_tenant.py
@@ -145,11 +145,14 @@ def run_database_maintenance(env: PgCompare):
                 END $$;
                 """
             )
-
-            log.info("start REINDEX TABLE CONCURRENTLY transaction.transaction")
-            with env.zenbenchmark.record_duration("reindex concurrently"):
-                cur.execute("REINDEX TABLE CONCURRENTLY transaction.transaction;")
-            log.info("finished REINDEX TABLE CONCURRENTLY transaction.transaction")
+            # in production a customer would likely use reindex concurrently 
+            # but for our test we don't care about the downtime
+            # and it would just about double the time we report in the test
+            # because we need one more table scan for each index
+            log.info("start REINDEX TABLE transaction.transaction")
+            with env.zenbenchmark.record_duration("reindex"):
+                cur.execute("REINDEX TABLE transaction.transaction;")
+            log.info("finished REINDEX TABLE transaction.transaction")
 
 
 @pytest.mark.parametrize("custom_scripts", get_custom_scripts())

--- a/test_runner/performance/test_perf_oltp_large_tenant.py
+++ b/test_runner/performance/test_perf_oltp_large_tenant.py
@@ -145,7 +145,7 @@ def run_database_maintenance(env: PgCompare):
                 END $$;
                 """
             )
-            # in production a customer would likely use reindex concurrently 
+            # in production a customer would likely use reindex concurrently
             # but for our test we don't care about the downtime
             # and it would just about double the time we report in the test
             # because we need one more table scan for each index


### PR DESCRIPTION
## Problem

our large oltp benchmark runs very long - we want to remove the duration of the reindex step.
we don't run concurrent workload anyhow but added "concurrently" only to have a "prod-like" approach. But if it just doubles the time we report because it requires two instead of one full table scan we can remove it 

## Summary of changes

remove keyword concurrently from the reindex step