### PR TITLE
compute: Set log_parameter=off for audit logging.

### DIFF
--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -202,7 +202,10 @@ pub fn write_postgres_conf(
             // but this is necessary for HIPAA compliance.
             // Exclude 'misc' category, because it doesn't contain anythig relevant.
             writeln!(file, "pgaudit.log='all, -misc'")?;
-            writeln!(file, "pgaudit.log_parameter=on")?;
+            // Disable logging of parameters.
+            // This is verbose and not strictly necessary for compliance.
+            // We may want to enable it in the future as a different audit_log_level.
+            writeln!(file, "pgaudit.log_parameter=off")?;
             // Disable logging of catalog queries
             // The catalog doesn't contain sensitive data, so we don't need to audit it.
             writeln!(file, "pgaudit.log_catalog=off")?;

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -198,16 +198,14 @@ pub fn write_postgres_conf(
                 file,
                 "# Managed by compute_ctl compliance audit settings: begin"
             )?;
-            // This log level is very verbose
-            // but this is necessary for compliance.
-            // Exclude 'misc' category, because it doesn't contain anything relevant.
-            writeln!(file, "pgaudit.log='all, -misc'")?;
             // Enable logging of parameters.
             // This is very verbose and may contain sensitive data.
             if spec.audit_log_level == ComputeAudit::Full {
                 writeln!(file, "pgaudit.log_parameter=on")?;
+                writeln!(file, "pgaudit.log='all'")?;
             } else {
                 writeln!(file, "pgaudit.log_parameter=off")?;
+                writeln!(file, "pgaudit.log='all, -misc'")?;
             }
             // Disable logging of catalog queries
             // The catalog doesn't contain sensitive data, so we don't need to audit it.

--- a/compute_tools/src/spec_apply.rs
+++ b/compute_tools/src/spec_apply.rs
@@ -278,12 +278,12 @@ impl ComputeNode {
             // so that all config operations are audit logged.
             match spec.audit_log_level
             {
-                ComputeAudit::Hipaa => {
+                ComputeAudit::Hipaa | ComputeAudit::Extended | ComputeAudit::Full => {
                     phases.push(CreatePgauditExtension);
                     phases.push(CreatePgauditlogtofileExtension);
                     phases.push(DisablePostgresDBPgAudit);
                 }
-                ComputeAudit::Log => {
+                ComputeAudit::Log | ComputeAudit::Base => {
                     phases.push(CreatePgauditExtension);
                     phases.push(DisablePostgresDBPgAudit);
                 }

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -289,16 +289,16 @@ pub enum ComputeAudit {
     Disabled,
     // Deprecated, use Base instead
     Log,
-    // (log = 'ddl', log_parameter='off')
+    // (pgaudit.log = 'ddl', pgaudit.log_parameter='off')
     // logged to the standard postgresql log stream
     Base,
     // Deprecated, use Full or Extended instead
     Hipaa,
-    // (log = 'all, -misc', log_parameter='off')
+    // (pgaudit.log = 'all, -misc', pgaudit.log_parameter='off')
     // logged to separate files collected by rsyslog
     // into dedicated log storage with strict access
     Extended,
-    // (log='all', log_parameter='on'),
+    // (pgaudit.log='all', pgaudit.log_parameter='on'),
     // logged to separate files collected by rsyslog
     // into dedicated log storage with strict access.
     Full,

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -159,13 +159,7 @@ pub struct ComputeSpec {
     #[serde(default)] // Default false
     pub drop_subscriptions_before_start: bool,
 
-    /// Log level for audit logging:
-    ///
-    /// Disabled - no audit logging. This is the default.
-    /// log - log masked statements to the postgres log using pgaudit extension
-    /// hipaa - log unmasked statements to the file using pgaudit and pgauditlogtofile extension
-    ///
-    /// Extensions should be present in shared_preload_libraries
+    /// Log level for compute audit logging
     #[serde(default)]
     pub audit_log_level: ComputeAudit,
 
@@ -289,14 +283,25 @@ impl ComputeMode {
 }
 
 /// Log level for audit logging
-/// Disabled, log, hipaa
-/// Default is Disabled
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub enum ComputeAudit {
     #[default]
     Disabled,
+    // Deprecated, use Base instead
     Log,
+    // (log = 'ddl', log_parameter='off')
+    // logged to the standard postgresql log stream
+    Base,
+    // Deprecated, use Full or Extended instead
     Hipaa,
+    // (log = 'all, -misc', log_parameter='off')
+    // logged to separate files collected by rsyslog
+    // into dedicated log storage with strict access
+    Extended,
+    // (log='all', log_parameter='on'),
+    // logged to separate files collected by rsyslog
+    // into dedicated log storage with strict access.
+    Full,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]


### PR DESCRIPTION
Log -> Base,
pgaudit.log = 'ddl', pgaudit.log_parameter='off'

Hipaa -> Extended.
pgaudit.log = 'all, -misc', pgaudit.log_parameter='off'
    
add new level Full:
pgaudit.log='all', pgaudit.log_parameter='on'

Keep old parameter names for compatibility,
until cplane side changes are implemented and released.

closes https://github.com/neondatabase/cloud/issues/27202
