### PR TITLE
Remove XLogWaitForReplayOf at replica to avoid deadlock

### DIFF
--- a/pgxn/neon/communicator.c
+++ b/pgxn/neon/communicator.c
@@ -2059,9 +2059,6 @@ communicator_read_at_lsnv(NRelFileInfo rinfo, ForkNumber forkNum, BlockNumber ba
 
 		start_ts = GetCurrentTimestamp();
 
-		if (RecoveryInProgress() && MyBackendType != B_STARTUP)
-			XLogWaitForReplayOf(reqlsns->request_lsn);
-
 		/*
 		 * Try to find prefetched page in the list of received pages.
 		 */


### PR DESCRIPTION
## Problem

See https://github.com/neondatabase/neon/issues/9955

Waiting for replay can cause deadlock because waiting thread is holding lock on the buffer and doesn't allow redo to proceed.

## Summary of changes

Remove call of XLogWaitForReplayOf