### PR TITLE
test_runner: only use last gen in `test_location_conf_churn`

### DIFF
--- a/test_runner/regress/test_pageserver_secondary.py
+++ b/test_runner/regress/test_pageserver_secondary.py
@@ -242,7 +242,11 @@ def test_location_conf_churn(neon_env_builder: NeonEnvBuilder, make_httpserver, 
             pageserver.tenant_location_configure(tenant_id, location_conf)
             last_state[pageserver.id] = (mode, generation)
 
-            if mode.startswith("Attached"):
+            # It's only valid to read from the last generation. Newer generations may yank layer
+            # files used in older generations.
+            last_generation = max(s[1] for s in last_state.values() if s[1] is not None)
+
+            if mode.startswith("Attached") and generation == last_generation:
                 # This is a basic test: we are validating that he endpoint works properly _between_
                 # configuration changes.  A stronger test would be to validate that clients see
                 # no errors while we are making the changes.


### PR DESCRIPTION
## Problem

`test_location_conf_churn` performs random location updates on Pageservers. While doing this, it could instruct the compute to connect to a stale generation and execute queries. This is invalid, and will fail if a newer generation has removed layer files used by the stale generation.

Resolves #11348.

## Summary of changes

Only connect to the latest generation when executing queries.