### PR TITLE
Track last_active_query and activity kind in ComputeStatusResponse

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -11,7 +11,7 @@ use std::{env, fs};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use compute_api::privilege::Privilege;
-use compute_api::responses::{ComputeCtlConfig, ComputeMetrics, ComputeStatus};
+use compute_api::responses::{ActivityKind, ComputeCtlConfig, ComputeMetrics, ComputeStatus};
 use compute_api::spec::{
     ComputeAudit, ComputeFeature, ComputeMode, ComputeSpec, ExtVersion, PgIdent,
 };
@@ -132,6 +132,10 @@ pub struct ComputeState {
     /// Timestamp of the last Postgres activity. It could be `None` if
     /// compute wasn't used since start.
     pub last_active: Option<DateTime<Utc>>,
+    /// Timestamp of the last client's activity. Unlike `last_time` it doesn't take in account
+    /// baclkground activity: autovacuum, LR,...
+    pub last_active_query: Option<DateTime<Utc>>,
+    pub last_activity_kind: Option<ActivityKind>,
     pub error: Option<String>,
 
     /// Compute spec. This can be received from the CLI or - more likely -
@@ -159,6 +163,8 @@ impl ComputeState {
             start_time: Utc::now(),
             status: ComputeStatus::Empty,
             last_active: None,
+            last_active_query: None,
+            last_activity_kind: None,
             error: None,
             pspec: None,
             startup_span: None,
@@ -1692,13 +1698,22 @@ impl ComputeNode {
     }
 
     /// Update the `last_active` in the shared state, but ensure that it's a more recent one.
-    pub fn update_last_active(&self, last_active: Option<DateTime<Utc>>) {
+    pub fn update_last_active(
+        &self,
+        last_active: Option<DateTime<Utc>>,
+        activity_kind: ActivityKind,
+    ) {
         let mut state = self.state.lock().unwrap();
         // NB: `Some(<DateTime>)` is always greater than `None`.
         if last_active > state.last_active {
             state.last_active = last_active;
             debug!("set the last compute activity time to: {:?}", last_active);
         }
+        if activity_kind == ActivityKind::Query && last_active > state.last_active_query {
+            state.last_active_query = last_active;
+            debug!("set the last user's activity time to: {:?}", last_active);
+        }
+        state.last_activity_kind = Some(activity_kind);
     }
 
     // Look for core dumps and collect backtraces.

--- a/compute_tools/src/http/routes/mod.rs
+++ b/compute_tools/src/http/routes/mod.rs
@@ -30,6 +30,8 @@ impl From<&ComputeState> for ComputeStatusResponse {
                 .map(|pspec| pspec.timeline_id.to_string()),
             status: state.status,
             last_active: state.last_active,
+            last_active_query: state.last_active_query,
+            last_activity_kind: state.last_activity_kind,
             error: state.error.clone(),
         }
     }

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -30,7 +30,20 @@ pub struct ComputeStatusResponse {
     pub status: ComputeStatus,
     #[serde(serialize_with = "rfc3339_serialize")]
     pub last_active: Option<DateTime<Utc>>,
+    pub last_active_query: Option<DateTime<Utc>>,
+    pub last_activity_kind: Option<ActivityKind>,
     pub error: Option<String>,
+}
+
+#[derive(Serialize, Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityKind {
+    // Client's query is executed
+    Query,
+    // Logical replication  is active (subscription or publication)
+    LogicalReplication,
+    // Autovacuum is active
+    Autovacuum,
 }
 
 #[derive(Serialize, Clone, Copy, Debug, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Problem

With enabled persistence of pgstat file we want have metric to monitor how it may affect number of active computes which suspension is prevented because of active autovacuum.
Decision to suspend is made by control plane based on `last_activity` in `ComputeStatusResponse`.
monitor.cs is updating `last_activity` when LR or autovacuum are active.

## Summary of changes

Extend `ComputeStatusResponse` by adding two new fields to it: `last_active_query` and `last_activity_kind`.
`ActivityKind` can be `Query`, `LogicalRepliction` or `Autovacuum`
So based in this information control plane can determine when node suspension is pended because or LR or autovacuum activity.