### PR TITLE
Unlogged build debug compare local v2

### DIFF
--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -802,11 +802,6 @@ neon_create(SMgrRelation reln, ForkNumber forkNum, bool isRedo)
 
 		case RELPERSISTENCE_TEMP:
 		case RELPERSISTENCE_UNLOGGED:
-			neon_log(LOG, "Create %c relation %u/%u/%u.%u",
-					 reln->smgr_relpersistence,
-					 RelFileInfoFmt(InfoFromSMgrRel(reln)),
-					 forkNum);
-
 #ifdef DEBUG_COMPARE_LOCAL
 			mdcreate(reln, forkNum, forkNum == INIT_FORKNUM || isRedo);
 			if (forkNum == MAIN_FORKNUM)

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1959,8 +1959,6 @@ neon_start_unlogged_build(SMgrRelation reln)
 			(errmsg(NEON_TAG "starting unlogged build of relation %u/%u/%u",
 					RelFileInfoFmt(InfoFromSMgrRel(reln)))));
 
-	unlogged_build_delete_init_fork = false;
-
 	switch (reln->smgr_relpersistence)
 	{
 		case 0:

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -293,6 +293,7 @@ neon_wallog_pagev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 								blkno,
 								RelFileInfoFmt(InfoFromSMgrRel(reln)),
 								forknum)));
+				Assert(false);
 
 				lsn = GetXLogReplayRecPtr(NULL); /* in standby mode, soldier on */
 			}

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -290,7 +290,7 @@ neon_wallog_pagev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 				 * value in that case, which is the last replayed LSN.
 				 */
 				ereport(RecoveryInProgress() ? LOG : PANIC,
-						(errmsg(NEON_TAG "Page %u of relation %u/%u/%u.%u is evicted with zero LSN",
+						(errmsg(NEON_TAG "Page %u of relation %u/%u/%u.%u is evicted withxfxf zero LSN",
 								blkno,
 								RelFileInfoFmt(InfoFromSMgrRel(reln)),
 								forknum)));
@@ -2099,11 +2099,11 @@ neon_end_unlogged_build(SMgrRelation reln)
 			mdunlink(rinfob, forknum, true);
 #endif
 		}
-	}
 #ifdef DEBUG_COMPARE_LOCAL
-	if (unlogged_build_delete_init_fork)
-		mdunlink(rinfob, INIT_FORKNUM, true);
+		if (unlogged_build_delete_init_fork)
+			mdunlink(rinfob, INIT_FORKNUM, true);
 #endif
+	}
 	unlogged_build_rel = NULL;
 	unlogged_build_phase = UNLOGGED_BUILD_NOT_IN_PROGRESS;
 }

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -290,11 +290,10 @@ neon_wallog_pagev(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 				 * value in that case, which is the last replayed LSN.
 				 */
 				ereport(RecoveryInProgress() ? LOG : PANIC,
-						(errmsg(NEON_TAG "Page %u of relation %u/%u/%u.%u is evicted withxfxf zero LSN",
+						(errmsg(NEON_TAG "Page %u of relation %u/%u/%u.%u is evicted with zero LSN",
 								blkno,
 								RelFileInfoFmt(InfoFromSMgrRel(reln)),
 								forknum)));
-				Assert(false);
 
 				lsn = GetXLogReplayRecPtr(NULL); /* in standby mode, soldier on */
 			}

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -1961,7 +1961,7 @@ neon_start_unlogged_build(SMgrRelation reln)
 		neon_log(ERROR, "unlogged relation build is already in progress");
 	Assert(unlogged_build_rel == NULL);
 
-	ereport(LOG,
+	ereport(SmgrTrace,
 			(errmsg(NEON_TAG "starting unlogged build of relation %u/%u/%u",
 					RelFileInfoFmt(InfoFromSMgrRel(reln)))));
 
@@ -2064,7 +2064,7 @@ neon_end_unlogged_build(SMgrRelation reln)
 
 	Assert(unlogged_build_rel == reln);
 
-	ereport(LOG,
+	ereport(SmgrTrace,
 			(errmsg(NEON_TAG "ending unlogged build of relation %u/%u/%u",
 					RelFileInfoFmt(InfoFromNInfoB(rinfob)))));
 


### PR DESCRIPTION
## Problem

Init fork is used in DEBUG_COMPARE_LOCAL to determine unlogged relation or unlogged build.
But it is created only after the relation is initialized and so can be swapped out, producing `Page is evicted with zero LSN` error.

## Summary of changes

Create init fork together with main fork for unlogged relations in DEBUG_COMPARE_LOCAL  mode.