### PR TITLE
tests: remove config tweak allowing old versions to start with a batching config

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1322,10 +1322,6 @@ class NeonEnv:
                 log.info("test may use old binaries, ignoring warnings about unknown config items")
                 ps.allowed_errors.append(".*ignoring unknown configuration item.*")
 
-                # Allow old software to start until https://github.com/neondatabase/neon/pull/11275
-                # lands in the compatiblity snapshot.
-                ps_cfg["page_service_pipelining"].pop("batching")
-
             self.pageservers.append(ps)
             cfg["pageservers"].append(ps_cfg)
 


### PR DESCRIPTION
## Problem

Pageservers now ignore unknown config fields, so this config tweaking is no longer needed. 

## Summary of changes

Get rid of the hack.

Closes https://github.com/neondatabase/neon/issues/11524
