### PR TITLE
fix(test): allow shutdown warning in preempt tests

### DIFF
--- a/test_runner/regress/test_compaction.py
+++ b/test_runner/regress/test_compaction.py
@@ -199,6 +199,8 @@ def test_pageserver_gc_compaction_preempt(
     conf = PREEMPT_GC_COMPACTION_TENANT_CONF.copy()
     env = neon_env_builder.init_start(initial_tenant_conf=conf)
 
+    env.pageserver.allowed_errors.append(".*The timeline or pageserver is shutting down.*")
+
     tenant_id = env.initial_tenant
     timeline_id = env.initial_timeline
 


### PR DESCRIPTION
## Problem

test_gc_compaction_preempt is still flaky

## Summary of changes

- allow shutdown warning logs