### PR TITLE
tests: attach final metrics to allure report

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -947,8 +947,6 @@ class NeonEnvBuilder:
                     continue
                 if SMALL_DB_FILE_NAME_REGEX.fullmatch(test_file.name):
                     continue
-                if FINAL_METRICS_FILE_NAME == test_file.name:
-                    continue
                 log.debug(f"Removing large database {test_file} file")
                 test_file.unlink()
             elif test_entry.is_dir():
@@ -2989,7 +2987,7 @@ class NeonPageserver(PgProtocol, LogUtils):
             return
 
         metrics = self.http_client().get_metrics_str()
-        metrics_snapshot_path = self.workdir / FINAL_METRICS_FILE_NAME
+        metrics_snapshot_path = self.workdir / "final_metrics.txt"
 
         with open(metrics_snapshot_path, "w") as f:
             f.write(metrics)
@@ -5155,9 +5153,6 @@ def pytest_addoption(parser: Parser):
 SMALL_DB_FILE_NAME_REGEX: re.Pattern[str] = re.compile(
     r"config-v1|heatmap-v1|tenant-manifest|metadata|.+\.(?:toml|pid|json|sql|conf)"
 )
-
-FINAL_METRICS_FILE_NAME: str = "final_metrics.txt"
-
 
 SKIP_DIRS = frozenset(
     (

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -258,7 +258,7 @@ def get_scale_for_db(size_mb: int) -> int:
 
 
 ATTACHMENT_NAME_REGEX: re.Pattern[str] = re.compile(
-    r"regression\.(diffs|out)|.+\.(?:log|stderr|stdout|filediff|metrics|html|walredo)"
+    r"regression\.(diffs|out)|.+\.(?:log|stderr|stdout|filediff|metrics|html|walredo)|final_metrics.txt"
 )
 
 


### PR DESCRIPTION
## Problem

Metrics are saved in https://github.com/neondatabase/neon/pull/11559, but the file is not matched by the attachment regex.

## Summary of changes

Make attachment regex match the metrics file.
