### PR TITLE
fix(test): allow stale generation warnings in storcon

### DIFF
--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -390,7 +390,8 @@ def test_create_churn_during_restart(neon_env_builder: NeonEnvBuilder):
     # Tenant creation requests which arrive out of order will generate complaints about
     # generation nubmers out of order.
     env.pageserver.allowed_errors.append(".*Generation .+ is less than existing .+")
-    env.pageserver.allowed_errors.append(".*due to stale generation.+")
+    env.pageserver.allowed_errors.append(".*due to stale generation.*")
+    env.storage_controller.allowed_errors.append(".*due to stale generation.*")
 
     # Timeline::flush_and_shutdown cannot tell if it is hitting a failure because of
     # an incomplete attach, or some other problem.  In the field this should be rare,

--- a/test_runner/regress/test_tenants.py
+++ b/test_runner/regress/test_tenants.py
@@ -390,7 +390,6 @@ def test_create_churn_during_restart(neon_env_builder: NeonEnvBuilder):
     # Tenant creation requests which arrive out of order will generate complaints about
     # generation nubmers out of order.
     env.pageserver.allowed_errors.append(".*Generation .+ is less than existing .+")
-    env.pageserver.allowed_errors.append(".*due to stale generation.*")
     env.storage_controller.allowed_errors.append(".*due to stale generation.*")
 
     # Timeline::flush_and_shutdown cannot tell if it is hitting a failure because of


### PR DESCRIPTION
## Problem

https://github.com/neondatabase/neon/pull/11531 did not fully fix the problem because the warning is part of the storcon instead of pageserver.

## Summary of changes

Allow stale generation error in storcon.