### PR TITLE
tests: use endpoint http wrapper to get auth

### DIFF
--- a/test_runner/performance/test_compute_startup.py
+++ b/test_runner/performance/test_compute_startup.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-import requests
 from fixtures.benchmark_fixture import MetricReport, NeonBenchmarker
 
 if TYPE_CHECKING:
@@ -68,9 +67,7 @@ def test_compute_startup_simple(
             endpoint.safe_psql("select 1;")
 
         # Get metrics
-        metrics = requests.get(
-            f"http://localhost:{endpoint.external_http_port}/metrics.json"
-        ).json()
+        metrics = endpoint.http_client().metrics_json()
         durations = {
             "wait_for_spec_ms": f"{i}_wait_for_spec",
             "sync_safekeepers_ms": f"{i}_sync_safekeepers",
@@ -155,9 +152,7 @@ def test_compute_ondemand_slru_startup(
             assert sum == 1000000
 
         # Get metrics
-        metrics = requests.get(
-            f"http://localhost:{endpoint.external_http_port}/metrics.json"
-        ).json()
+        metrics = endpoint.http_client().metrics_json()
         durations = {
             "wait_for_spec_ms": f"{slru}_{i}_wait_for_spec",
             "sync_safekeepers_ms": f"{slru}_{i}_sync_safekeepers",


### PR DESCRIPTION
## Problem

`test_compute_startup_simple` and `test_compute_ondemand_slru_startup` are failing.

This test implicitly asserts that the metrics.json endpoint succeeds and returns all expected metrics, but doesn't make it easy to see what went wrong if it doesn't (e.g. in this failure https://neon-github-public-dev.s3.amazonaws.com/reports/main/14513210240/index.html#suites/13d8e764c394daadbad415a08454c04e/b0f92a86b2ed309f/)

In this case, it was failing because of a missing auth token, because it was using `requests` directly instead of using the endpoint http client type.

## Summary of changes

- Use endpoint http wrapper to get raise_for_status & auth token

