### PR TITLE
Automated release for Computes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1426,7 +1426,8 @@ jobs:
               -f dockerTag=${{needs.meta.outputs.build-tag}}
             ;;
           compute-release)
-            gh workflow --repo neondatabase/infra run deploy-compute-dev.yml --ref main -f dockerTag=${{needs.meta.outputs.build-tag}}
+            gh workflow --repo neondatabase/infra run deploy-compute.yml --ref main -f dockerTag=${{needs.meta.outputs.build-tag}} -f env=dev
+            gh workflow --repo neondatabase/infra run deploy-compute.yml --ref main -f dockerTag=${{needs.meta.outputs.build-tag}} -f env=prod
             ;;
           *)
             echo "RUN_KIND (value '${RUN_KIND}') is not set to either 'push-main', 'storage-release', 'proxy-release' or 'compute-release'"


### PR DESCRIPTION
## Problem
This PR makes changes that will enable automatically deploying new compute releases to prod, instead of the manual approval process that we have now.

Related to:
https://github.com/neondatabase/cloud/issues/27787
[Compute release automation RFC](https://github.com/neondatabase/neon/blob/main/docs/rfcs/038-independent-compute-release.md)

## Summary of changes

1. Added an argument to `deploy-compute.yml` that specifies whether the release must happen in `dev` or `prod`.