### PR TITLE
communicator: address build/lint/rustfmt errors

### DIFF
--- a/pageserver/client_grpc/src/lib.rs
+++ b/pageserver/client_grpc/src/lib.rs
@@ -7,9 +7,7 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use bytes::Bytes;
-use http;
 use thiserror::Error;
-use tonic;
 use tonic::metadata::AsciiMetadataValue;
 use tonic::transport::Channel;
 
@@ -96,10 +94,7 @@ impl PageserverClient {
         Ok(response.get_ref().num_blocks)
     }
 
-    pub async fn get_page(
-        &self,
-        request: &GetPageRequest,
-    ) -> Result<Bytes, PageserverClientError> {
+    pub async fn get_page(&self, request: &GetPageRequest) -> Result<Bytes, PageserverClientError> {
         // FIXME: calculate the shard number correctly
         let shard_no = 0;
 
@@ -133,10 +128,9 @@ impl PageserverClient {
         request: &GetBaseBackupRequest,
         gzip: bool,
     ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<proto::GetBaseBackupResponseChunk>>,
-            PageserverClientError,
-        >
-    {
+        tonic::Response<tonic::codec::Streaming<proto::GetBaseBackupResponseChunk>>,
+        PageserverClientError,
+    > {
         // Current sharding model assumes that all metadata is present only at shard 0.
         let shard_no = 0;
 
@@ -155,7 +149,10 @@ impl PageserverClient {
     ///
     /// This implements very basic caching. If we already have a client for the given shard,
     /// reuse it. If not, create a new client and put it to the cache.
-    async fn get_client(&self, shard_no: u16) -> Result<MyPageServiceClient, PageserverClientError> {
+    async fn get_client(
+        &self,
+        shard_no: u16,
+    ) -> Result<MyPageServiceClient, PageserverClientError> {
         let reused_channel: Option<Channel> = {
             let channels = self.channels.read().unwrap();
 

--- a/pageserver/data_api/build.rs
+++ b/pageserver/data_api/build.rs
@@ -1,7 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate rust code from .proto protobuf.
     tonic_build::configure()
-        .bytes(&["."])
+        .bytes(["."])
         .compile_protos(&["proto/page_service.proto"], &["proto"])
         .unwrap_or_else(|e| panic!("failed to compile protos {:?}", e));
     Ok(())

--- a/pgxn/neon/communicator/build.rs
+++ b/pgxn/neon/communicator/build.rs
@@ -1,5 +1,3 @@
-use cbindgen;
-
 use std::env;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/pgxn/neon/communicator/src/backend_comms.rs
+++ b/pgxn/neon/communicator/src/backend_comms.rs
@@ -56,6 +56,7 @@ pub enum NeonIOHandleState {
 
 impl CommunicatorInitStruct {
     // safety:: fixme: it's possible to get two mutable referneces to same slot
+    #[allow(clippy::mut_from_ref)] // TODO: remove allow
     pub fn get_request_slot(&self, request_idx: u32) -> &mut NeonIOHandle {
         assert!(request_idx < self.num_neon_request_slots);
 
@@ -117,7 +118,7 @@ impl CommunicatorBackendStruct {
         slot.state
             .store(NeonIOHandleState::Submitted, Ordering::Release);
 
-        return idx as i32;
+        idx as i32
     }
 
     pub fn poll_request_completion(

--- a/pgxn/neon/communicator/src/backend_interface.rs
+++ b/pgxn/neon/communicator/src/backend_interface.rs
@@ -50,7 +50,7 @@ pub extern "C" fn bcomm_start_io_request(
     // Tell the communicator about it
     bs.submit_request(request_idx);
 
-    return request_idx;
+    request_idx
 }
 
 /// Check if a request has completed. Returns:

--- a/pgxn/neon/communicator/src/worker_process/logging.rs
+++ b/pgxn/neon/communicator/src/worker_process/logging.rs
@@ -117,7 +117,7 @@ struct EventBuilder<'a> {
     maker: &'a Maker,
 }
 
-impl<'a> std::io::Write for EventBuilder<'a> {
+impl std::io::Write for EventBuilder<'_> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.event.message.write(buf)
     }
@@ -127,7 +127,7 @@ impl<'a> std::io::Write for EventBuilder<'a> {
     }
 }
 
-impl<'a> Drop for EventBuilder<'a> {
+impl Drop for EventBuilder<'_> {
     fn drop(&mut self) {
         let maker = self.maker;
         let event = std::mem::take(&mut self.event);


### PR DESCRIPTION
This addresses or glosses over all current build/lint errors in the `communicator-rewrite` branch, and applies `rustfmt` formatting to touched files.