### PR TITLE
storage_controller: make address for peers mandatory

### DIFF
--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -1762,23 +1762,19 @@ async fn maybe_forward(req: Request<Body>) -> ForwardOutcome {
     };
 
     let cfg = state.service.get_config();
-    if let Some(ref self_addr) = cfg.address_for_peers {
-        let leader_addr = match Uri::from_str(leader.address.as_str()) {
-            Ok(uri) => uri,
-            Err(err) => {
-                return ForwardOutcome::Forwarded(Err(ApiError::InternalServerError(
-                    anyhow::anyhow!(
-                        "Failed to parse leader uri for forwarding while in stepped down state: {err}"
-                    ),
-                )));
-            }
-        };
-
-        if *self_addr == leader_addr {
-            return ForwardOutcome::Forwarded(Err(ApiError::ResourceUnavailable(
-                "Leader is stepped down instance".into(),
-            )));
+    let leader_addr = match Uri::from_str(leader.address.as_str()) {
+        Ok(uri) => uri,
+        Err(err) => {
+            return ForwardOutcome::Forwarded(Err(ApiError::InternalServerError(anyhow::anyhow!(
+                "Failed to parse leader uri for forwarding while in stepped down state: {err}"
+            ))));
         }
+    };
+
+    if cfg.address_for_peers == leader_addr {
+        return ForwardOutcome::Forwarded(Err(ApiError::ResourceUnavailable(
+            "Leader is stepped down instance".into(),
+        )));
     }
 
     tracing::info!("Forwarding {} to leader at {}", uri, leader.address);

--- a/storage_controller/src/leadership.rs
+++ b/storage_controller/src/leadership.rs
@@ -62,22 +62,15 @@ impl Leadership {
         &self,
         current_leader: Option<ControllerPersistence>,
     ) -> Result<()> {
-        if let Some(address_for_peers) = &self.config.address_for_peers {
-            // TODO: `address-for-peers` can become a mandatory cli arg
-            // after we update the k8s setup
-            let proposed_leader = ControllerPersistence {
-                address: address_for_peers.to_string(),
-                started_at: chrono::Utc::now(),
-            };
+        let proposed_leader = ControllerPersistence {
+            address: self.config.address_for_peers.to_string(),
+            started_at: chrono::Utc::now(),
+        };
 
-            self.persistence
-                .update_leader(current_leader, proposed_leader)
-                .await
-                .map_err(Error::Database)
-        } else {
-            tracing::info!("No address-for-peers provided. Skipping leader persistence.");
-            Ok(())
-        }
+        self.persistence
+            .update_leader(current_leader, proposed_leader)
+            .await
+            .map_err(Error::Database)
     }
 
     async fn current_leader(&self) -> DatabaseResult<Option<ControllerPersistence>> {

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -429,7 +429,7 @@ pub struct Config {
 
     pub heartbeat_interval: Duration,
 
-    pub address_for_peers: Option<Uri>,
+    pub address_for_peers: Uri,
 
     pub start_as_candidate: bool,
 


### PR DESCRIPTION
## Problem

`address-for-peers` is now used everywhere (TODO: apart from cplane set-up)).

## Summary of changes

Make the config mandatory