### PR TITLE
no merge: intentionally break benchmarks for verifying CI

### DIFF
--- a/pageserver/benches/bench_ingest.rs
+++ b/pageserver/benches/bench_ingest.rs
@@ -22,7 +22,7 @@ use wal_decoder::serialized_batch::SerializedValueBatch;
 // A very cheap hash for generating non-sequential keys.
 fn murmurhash32(mut h: u32) -> u32 {
     h ^= h >> 16;
-    h = h.wrapping_mul(0x85ebca6b);
+    h  h.wrapping_mul(0x85ebca6b);
     h ^= h >> 13;
     h = h.wrapping_mul(0xc2b2ae35);
     h ^= h >> 16;


### PR DESCRIPTION
`cargo clippy` still works with this change in, `cargo clippy --all-targets` does not. Our CI *should* run with `--all-targets`, but let's make sure