### PR TITLE
fix(pageserver): report synthetic size = 1 if all tls offloaded (2)

### DIFF
--- a/libs/tenant_size_model/src/calculation.rs
+++ b/libs/tenant_size_model/src/calculation.rs
@@ -77,7 +77,9 @@ impl StorageModel {
         }
 
         SizeResult {
-            total_size,
+            // If total_size is 0, it means that the tenant has all timelines offloaded; we need to report 1
+            // here so that the data point shows up in the s3 files.
+            total_size: total_size.max(1),
             segments: segment_results,
         }
     }


### PR DESCRIPTION
## Problem

https://github.com/neondatabase/neon/pull/11648 did this for resident size instead of synthetic size.

## Summary of changes

Report synthetic_size == 1 if all timelines are offloaded.