### PR TITLE
Fix the empty region if run on schedule

### DIFF
--- a/.github/workflows/cloud-extensions.yml
+++ b/.github/workflows/cloud-extensions.yml
@@ -68,7 +68,7 @@ jobs:
         id: create-neon-project
         uses: ./.github/actions/neon-project-create
         with:
-          region_id: ${{ inputs.region_id }}
+          region_id: ${{ inputs.region_id || 'aws-us-east-2' }}
           postgres_version: ${{ matrix.pg-version }}
           project_settings: ${{ steps.project-settings.outputs.settings }}
           # We need these settings to get the expected output results.


### PR DESCRIPTION
## Problem

When the workflow ran on a schedule, the `region_id` input was not set.  
As a result, an empty region value was used, which caused errors during execution.

## Summary of Changes

- Added fallback logic to set a default region (`aws-us-east-2`) when `region_id` is not provided.
- Ensures the workflow works correctly both when triggered manually (`workflow_dispatch`) and on schedule (`cron`).