### PR TITLE
WIP: fallocate files before starting to write

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -1290,6 +1290,7 @@ pub(crate) enum StorageIoOperation {
     Fsync,
     Metadata,
     SetLen,
+    Fallocate,
 }
 
 impl StorageIoOperation {
@@ -1305,6 +1306,7 @@ impl StorageIoOperation {
             StorageIoOperation::Fsync => "fsync",
             StorageIoOperation::Metadata => "metadata",
             StorageIoOperation::SetLen => "set_len",
+            StorageIoOperation::Fallocate => "fallocate",
         }
     }
 }

--- a/pageserver/src/tenant/ephemeral_file.rs
+++ b/pageserver/src/tenant/ephemeral_file.rs
@@ -88,7 +88,7 @@ impl EphemeralFile {
             gate.enter()?,
         );
 
-        file.fallocate_keep_size(0, 1 * 1024 * 1024 * 1024, ctx)
+        file.fallocate(0, 1 * 1024 * 1024 * 1024, ctx)
             .await
             .unwrap();
 

--- a/pageserver/src/tenant/ephemeral_file.rs
+++ b/pageserver/src/tenant/ephemeral_file.rs
@@ -88,6 +88,10 @@ impl EphemeralFile {
             gate.enter()?,
         );
 
+        file.fallocate_keep_size(0, 1 * 1024 * 1024 * 1024, ctx)
+            .await
+            .unwrap();
+
         let page_cache_file_id = page_cache::next_file_id(); // XXX get rid, we're not page-caching anymore
 
         Ok(EphemeralFile {

--- a/pageserver/src/tenant/remote_timeline_client/download.rs
+++ b/pageserver/src/tenant/remote_timeline_client/download.rs
@@ -76,6 +76,8 @@ pub async fn download_layer_file<'a>(
         layer_metadata.generation,
     );
 
+    let expected = layer_metadata.file_size;
+
     let (bytes_amount, temp_file) = download_retry(
         || async {
             // TempVirtualFile requires us to never reuse a filename while an old
@@ -103,6 +105,16 @@ pub async fn download_layer_file<'a>(
                 .map_err(DownloadError::Other)?,
                 gate.enter().map_err(|_| DownloadError::Cancelled)?,
             );
+            if let Ok(file_size) = TryInto::<i64>::try_into(layer_metadata.file_size.next_multiple_of(
+64 * 1024 /* TODO this is the max roundtup size by the buffered writer set_len_then_truncate */
+
+            )) {
+                temp_file.fallocate_keep_size(
+                    0,
+                    file_size,
+                    ctx,
+                ).await.unwrap();
+            };
             download_object(storage, &remote_path, temp_file, gate, cancel, ctx).await
         },
         &format!("download {remote_path:?}"),
@@ -110,7 +122,6 @@ pub async fn download_layer_file<'a>(
     )
     .await?;
 
-    let expected = layer_metadata.file_size;
     if expected != bytes_amount {
         return Err(DownloadError::Other(anyhow!(
             "According to layer file metadata should have downloaded {expected} bytes but downloaded {bytes_amount} bytes into file {:?}",

--- a/pageserver/src/tenant/remote_timeline_client/download.rs
+++ b/pageserver/src/tenant/remote_timeline_client/download.rs
@@ -109,7 +109,7 @@ pub async fn download_layer_file<'a>(
 64 * 1024 /* TODO this is the max roundtup size by the buffered writer set_len_then_truncate */
 
             )) {
-                temp_file.fallocate_keep_size(
+                temp_file.fallocate(
                     0,
                     file_size,
                     ctx,

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -440,7 +440,7 @@ impl DeltaLayerWriterInner {
             gate.enter()?,
         );
 
-        file.fallocate_keep_size(0, 1 * 1024 * 1024 * 1024, ctx)
+        file.fallocate(0, 1 * 1024 * 1024 * 1024, ctx)
             .await
             .unwrap();
 

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -440,6 +440,10 @@ impl DeltaLayerWriterInner {
             gate.enter()?,
         );
 
+        file.fallocate_keep_size(0, 1 * 1024 * 1024 * 1024, ctx)
+            .await
+            .unwrap();
+
         // Start at PAGE_SZ, make room for the header block
         let blob_writer = BlobWriter::new(
             file,

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -806,7 +806,7 @@ impl ImageLayerWriterInner {
             gate.enter()?,
         );
 
-        file.fallocate_keep_size(0, 1 * 1024 * 1024 * 1024, ctx)
+        file.fallocate(0, 1 * 1024 * 1024 * 1024, ctx)
             .await
             .unwrap();
 

--- a/pageserver/src/tenant/storage_layer/image_layer.rs
+++ b/pageserver/src/tenant/storage_layer/image_layer.rs
@@ -806,6 +806,10 @@ impl ImageLayerWriterInner {
             gate.enter()?,
         );
 
+        file.fallocate_keep_size(0, 1 * 1024 * 1024 * 1024, ctx)
+            .await
+            .unwrap();
+
         // Start at `PAGE_SZ` to make room for the header block.
         let blob_writer = BlobWriter::new(
             file,

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -161,6 +161,15 @@ impl VirtualFile {
         self.inner.set_len(len, ctx).await
     }
 
+    pub async fn fallocate_keep_size(
+        &self,
+        offset: i64,
+        size: i64,
+        ctx: &RequestContext,
+    ) -> Result<(), Error> {
+        self.inner.fallocate_keep_size(offset, size, ctx).await
+    }
+
     pub async fn metadata(&self) -> Result<Metadata, Error> {
         self.inner.metadata().await
     }
@@ -635,6 +644,20 @@ impl VirtualFileInner {
         with_file!(self, StorageIoOperation::SetLen, |file_guard| {
             let (_file_guard, res) = io_engine::get().set_len(file_guard, len).await;
             res.maybe_fatal_err("set_len")
+        })
+    }
+
+    pub async fn fallocate_keep_size(
+        &self,
+        offset: i64,
+        size: i64,
+        _ctx: &RequestContext,
+    ) -> Result<(), Error> {
+        with_file!(self, StorageIoOperation::Fallocate, |file_guard| {
+            let (_file_guard, res) = io_engine::get()
+                .fallocate_keep_size(file_guard, offset, size)
+                .await;
+            res.maybe_fatal_err("fallocate") // TODO haven't thought about this
         })
     }
 

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -161,13 +161,13 @@ impl VirtualFile {
         self.inner.set_len(len, ctx).await
     }
 
-    pub async fn fallocate_keep_size(
+    pub async fn fallocate(
         &self,
         offset: i64,
         size: i64,
         ctx: &RequestContext,
     ) -> Result<(), Error> {
-        self.inner.fallocate_keep_size(offset, size, ctx).await
+        self.inner.fallocate(offset, size, ctx).await
     }
 
     pub async fn metadata(&self) -> Result<Metadata, Error> {
@@ -647,16 +647,14 @@ impl VirtualFileInner {
         })
     }
 
-    pub async fn fallocate_keep_size(
+    pub async fn fallocate(
         &self,
         offset: i64,
         size: i64,
         _ctx: &RequestContext,
     ) -> Result<(), Error> {
         with_file!(self, StorageIoOperation::Fallocate, |file_guard| {
-            let (_file_guard, res) = io_engine::get()
-                .fallocate_keep_size(file_guard, offset, size)
-                .await;
+            let (_file_guard, res) = io_engine::get().fallocate(file_guard, offset, size).await;
             res.maybe_fatal_err("fallocate") // TODO haven't thought about this
         })
     }


### PR DESCRIPTION
This avoids punting to io-uring async worker pool on newer kernel versions.

refs
- https://gist.github.com/problame/ed876bea40b915ba53267b8265e99352
- https://github.com/neondatabase/neon/issues/11446#issuecomment-2838464096