### PR TITLE
Remove dead spec parameters

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -210,24 +210,20 @@ impl TryFrom<ComputeSpec> for ParsedSpec {
         // may be empty. In that case, we need to dig them from the GUCs in the
         // cluster.settings field.
         let pageserver_connstr = spec
-            .pageserver_connstring
-            .clone()
-            .or_else(|| spec.cluster.settings.find("neon.pageserver_connstring"))
-            .ok_or("pageserver connstr should be provided")?;
-        let safekeeper_connstrings = if spec.safekeeper_connstrings.is_empty() {
-            if matches!(spec.mode, ComputeMode::Primary) {
-                spec.cluster
-                    .settings
-                    .find("neon.safekeepers")
-                    .ok_or("safekeeper connstrings should be provided")?
-                    .split(',')
-                    .map(|str| str.to_string())
-                    .collect()
-            } else {
-                vec![]
-            }
+            .cluster
+            .settings
+            .find("neon.pageserver_connstring")
+            .expect("pageserver connstr should be provided");
+        let safekeeper_connstrings = if matches!(spec.mode, ComputeMode::Primary) {
+            spec.cluster
+                .settings
+                .find("neon.safekeepers")
+                .ok_or("safekeeper connstrings should be provided")?
+                .split(',')
+                .map(|str| str.to_string())
+                .collect()
         } else {
-            spec.safekeeper_connstrings.clone()
+            vec![]
         };
         let storage_auth_token = spec.storage_auth_token.clone();
         let tenant_id: TenantId = if let Some(tenant_id) = spec.tenant_id {

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -90,19 +90,17 @@ pub struct ComputeSpec {
 
     // Information needed to connect to the storage layer.
     //
-    // `tenant_id`, `timeline_id` and `pageserver_connstring` are always needed.
+    // `tenant_id` and `timeline_id` are always needed.
     //
     // Depending on `mode`, this can be a primary read-write node, a read-only
     // replica, or a read-only node pinned at an older LSN.
-    // `safekeeper_connstrings` must be set for a primary.
     //
-    // For backwards compatibility, the control plane may leave out all of
+    // For backwards compatibility, the control plane may leave out both of
     // these, and instead set the "neon.tenant_id", "neon.timeline_id",
     // etc. GUCs in cluster.settings. TODO: Once the control plane has been
     // updated to fill these fields, we can make these non optional.
     pub tenant_id: Option<TenantId>,
     pub timeline_id: Option<TimelineId>,
-    pub pageserver_connstring: Option<String>,
 
     // More neon ids that we expose to the compute_ctl
     // and to postgres as neon extension GUCs.
@@ -121,8 +119,6 @@ pub struct ComputeSpec {
     /// compute_ctl with postgres_ffi.
     #[serde(default)]
     pub safekeepers_generation: Option<u32>,
-    #[serde(default)]
-    pub safekeeper_connstrings: Vec<String>,
 
     #[serde(default)]
     pub mode: ComputeMode,


### PR DESCRIPTION
Pageserver and safekeeper connection strings are passed as Postgres GUCs by the production control plane, so remove the dead spec parameters and teach neon_local to behave like the production control plane.
