### PR TITLE
Reserve in file descriptor pool sockets used for connections to page servers

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -339,7 +339,7 @@ load_shard_map(shardno_t shard_no, char *connstr_p, shardno_t *num_shards_p)
 		}
 		pagestore_local_counter = end_update_counter;
 
-		/* Reserver fiel descriptorts for sockets */
+        /* Reserve file descriptors for sockets */
 		while (max_sockets < num_shards)
 		{
 			max_sockets += 1;


### PR DESCRIPTION
## Problem

See https://github.com/neondatabase/neon/issues/11790

The neon extension opens extensions to the pageservers, which consumes file descriptors. Postgres has a mechanism to count how many FDs are in use, but it doesn't know about those FDs. We should call ReserveExternalFD() or AcquireExternalFD() to account for them.

## Summary of changes

Call `ReserveExternalFD()` for each shard