### PR TITLE
libs: introduce SegmentSize type

### DIFF
--- a/libs/postgres_ffi/benches/waldecoder.rs
+++ b/libs/postgres_ffi/benches/waldecoder.rs
@@ -5,7 +5,7 @@ use postgres_ffi::v17::wal_generator::LogicalMessageGenerator;
 use postgres_ffi::v17::waldecoder_handler::WalStreamDecoderHandler;
 use postgres_ffi::waldecoder::WalStreamDecoder;
 use pprof::criterion::{Output, PProfProfiler};
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 const KB: usize = 1024;
 
@@ -21,23 +21,26 @@ criterion_main!(benches);
 fn bench_complete_record(c: &mut Criterion) {
     let mut g = c.benchmark_group("complete_record");
     for size in [64, KB, 8 * KB, 128 * KB] {
+        let value_size = size as SegmentSize;
         // Kind of weird to change the group throughput per benchmark, but it's the only way
         // to vary it per benchmark. It works.
-        g.throughput(criterion::Throughput::Bytes(size as u64));
-        g.bench_function(format!("size={size}"), |b| run_bench(b, size).unwrap());
+        g.throughput(criterion::Throughput::Bytes(value_size as u64));
+        g.bench_function(format!("size={size}"), |b| {
+            run_bench(b, value_size).unwrap()
+        });
     }
 
-    fn run_bench(b: &mut Bencher, size: usize) -> anyhow::Result<()> {
+    fn run_bench(b: &mut Bencher, size: SegmentSize) -> anyhow::Result<()> {
         const PREFIX: &CStr = c"";
         let value_size = LogicalMessageGenerator::make_value_size(size, PREFIX);
-        let value = vec![1; value_size];
+        let value = vec![1; value_size as usize];
 
         let mut decoder = WalStreamDecoder::new(Lsn(0), 170000);
         let msg = LogicalMessageGenerator::new(PREFIX, &value)
             .next()
             .unwrap()
             .encode(Lsn(0));
-        assert_eq!(msg.len(), size);
+        assert_eq!(msg.len(), size as usize);
 
         b.iter(|| {
             let msg = msg.clone(); // Bytes::clone() is cheap

--- a/libs/postgres_ffi/src/lib.rs
+++ b/libs/postgres_ffi/src/lib.rs
@@ -12,7 +12,7 @@
 
 use bytes::Bytes;
 use utils::bin_ser::SerializeError;
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 macro_rules! postgres_ffi {
     ($version:ident) => {
@@ -238,7 +238,7 @@ pub use v14::xlog_utils::{
 pub const BLCKSZ: u16 = 8192;
 pub const RELSEG_SIZE: u32 = 1024 * 1024 * 1024 / (BLCKSZ as u32);
 pub const XLOG_BLCKSZ: usize = 8192;
-pub const WAL_SEGMENT_SIZE: usize = 16 * 1024 * 1024;
+pub const WAL_SEGMENT_SIZE: SegmentSize = 16 * 1024 * 1024;
 
 pub const MAX_SEND_SIZE: usize = XLOG_BLCKSZ * 16;
 

--- a/libs/postgres_ffi/src/wal_generator.rs
+++ b/libs/postgres_ffi/src/wal_generator.rs
@@ -2,7 +2,7 @@ use std::ffi::{CStr, CString};
 
 use bytes::{Bytes, BytesMut};
 use crc32c::crc32c_append;
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 use super::bindings::{RmgrId, XLogLongPageHeaderData, XLogPageHeaderData, XLOG_PAGE_MAGIC};
 use super::xlog_utils::{
@@ -39,7 +39,7 @@ impl Record {
 
         // Construct the WAL record header.
         let mut header = XLogRecord {
-            xl_tot_len: (XLOG_SIZE_OF_XLOG_RECORD + data_header.len() + self.data.len()) as u32,
+            xl_tot_len: XLOG_SIZE_OF_XLOG_RECORD + data_header.len() as SegmentSize + self.data.len() as SegmentSize,
             xl_xid: 0,
             xl_prev: prev_lsn.into(),
             xl_info: self.info,
@@ -158,7 +158,7 @@ impl<R: RecordGenerator> WalGenerator<R> {
                     XLogLongPageHeaderData {
                         std: page_header,
                         xlp_sysid: Self::SYS_ID,
-                        xlp_seg_size: WAL_SEGMENT_SIZE as u32,
+                        xlp_seg_size: WAL_SEGMENT_SIZE,
                         xlp_xlog_blcksz: XLOG_BLCKSZ as u32,
                     }
                     .encode()
@@ -234,10 +234,10 @@ impl LogicalMessageGenerator {
 
     /// Computes how large a value must be to get a record of the given size. Convenience method to
     /// construct records of pre-determined size. Panics if the record size is too small.
-    pub fn make_value_size(record_size: usize, prefix: &CStr) -> usize {
+    pub fn make_value_size(record_size: SegmentSize, prefix: &CStr) -> SegmentSize {
         let xlog_header_size = XLOG_SIZE_OF_XLOG_RECORD;
-        let lm_header_size = size_of::<XlLogicalMessage>();
-        let prefix_size = prefix.to_bytes_with_nul().len();
+        let lm_header_size = size_of::<XlLogicalMessage>() as SegmentSize;
+        let prefix_size = prefix.to_bytes_with_nul().len() as SegmentSize;
         let data_header_size = match record_size - xlog_header_size - 2 {
             0..=255 => 2,
             256..=258 => panic!("impossible record_size {record_size}"),

--- a/libs/postgres_ffi/src/waldecoder_handler.rs
+++ b/libs/postgres_ffi/src/waldecoder_handler.rs
@@ -108,7 +108,7 @@ impl WalStreamDecoderHandler for WalStreamDecoder {
                     if self.lsn.segment_offset(WAL_SEGMENT_SIZE) == 0 {
                         // parse long header
 
-                        if self.inputbuf.remaining() < XLOG_SIZE_OF_XLOG_LONG_PHD {
+                        if self.inputbuf.remaining() < XLOG_SIZE_OF_XLOG_LONG_PHD as usize{
                             return Ok(None);
                         }
 
@@ -123,7 +123,7 @@ impl WalStreamDecoderHandler for WalStreamDecoder {
 
                         self.lsn += XLOG_SIZE_OF_XLOG_LONG_PHD as u64;
                     } else if self.lsn.block_offset() == 0 {
-                        if self.inputbuf.remaining() < XLOG_SIZE_OF_XLOG_SHORT_PHD {
+                        if self.inputbuf.remaining() < XLOG_SIZE_OF_XLOG_SHORT_PHD as usize{
                             return Ok(None);
                         }
 
@@ -153,7 +153,7 @@ impl WalStreamDecoderHandler for WalStreamDecoder {
                     // peek xl_tot_len at the beginning of the record.
                     // FIXME: assumes little-endian
                     let xl_tot_len = (&self.inputbuf[0..4]).get_u32_le();
-                    if (xl_tot_len as usize) < XLOG_SIZE_OF_XLOG_RECORD {
+                    if xl_tot_len < XLOG_SIZE_OF_XLOG_RECORD {
                         return Err(WalDecodeError {
                             msg: format!("invalid xl_tot_len {}", xl_tot_len),
                             lsn: self.lsn,
@@ -216,7 +216,7 @@ impl WalStreamDecoderHandler for WalStreamDecoder {
     fn complete_record(&mut self, recordbuf: Bytes) -> Result<(Lsn, Bytes), WalDecodeError> {
         // We now have a record in the 'recordbuf' local variable.
         let xlogrec =
-            XLogRecord::from_slice(&recordbuf[0..XLOG_SIZE_OF_XLOG_RECORD]).map_err(|e| {
+            XLogRecord::from_slice(&recordbuf[0..XLOG_SIZE_OF_XLOG_RECORD as usize]).map_err(|e| {
                 WalDecodeError {
                     msg: format!("xlog record deserialization failed {}", e),
                     lsn: self.lsn,

--- a/libs/postgres_ffi/src/walrecord.rs
+++ b/libs/postgres_ffi/src/walrecord.rs
@@ -269,7 +269,7 @@ pub fn decode_wal_record(
         xlogrec.xl_info
     );
 
-    let remaining: usize = xlogrec.xl_tot_len as usize - XLOG_SIZE_OF_XLOG_RECORD;
+    let remaining: usize = (xlogrec.xl_tot_len - XLOG_SIZE_OF_XLOG_RECORD) as usize;
 
     if buf.remaining() != remaining {
         //TODO error

--- a/libs/postgres_ffi/wal_craft/src/lib.rs
+++ b/libs/postgres_ffi/wal_craft/src/lib.rs
@@ -393,7 +393,7 @@ impl Crafter for LastWalRecordXlogSwitchEndsOnPageBoundary {
             let xlog_switch_record_end: PgLsn =
                 client.query_one("SELECT pg_switch_wal()", &[])?.get(0);
 
-            if u64::from(xlog_switch_record_end) as usize % XLOG_BLCKSZ
+            if (u64::from(xlog_switch_record_end) % XLOG_BLCKSZ as u64) as u32
                 != XLOG_SIZE_OF_XLOG_SHORT_PHD
             {
                 warn!(

--- a/libs/postgres_ffi/wal_craft/src/xlog_utils_test.rs
+++ b/libs/postgres_ffi/wal_craft/src/xlog_utils_test.rs
@@ -81,10 +81,10 @@ fn test_end_of_wal<C: crate::Crafter>(test_name: &str) {
                 continue;
             }
             let mut f = File::options().write(true).open(file.path()).unwrap();
-            static ZEROS: [u8; WAL_SEGMENT_SIZE] = [0u8; WAL_SEGMENT_SIZE];
+            static ZEROS: [u8; WAL_SEGMENT_SIZE as usize] = [0u8; WAL_SEGMENT_SIZE as usize];
             f.write_all(
                 &ZEROS[0..min(
-                    WAL_SEGMENT_SIZE,
+                    WAL_SEGMENT_SIZE as usize,
                     (u64::from(*start_lsn) - seg_start_lsn) as usize,
                 )],
             )

--- a/libs/wal_decoder/benches/bench_interpret_wal.rs
+++ b/libs/wal_decoder/benches/bench_interpret_wal.rs
@@ -226,9 +226,9 @@ fn decode_interpret_main(bench: &BenchmarkData, shards: &[ShardIdentity]) {
 
 fn decode_interpret(bench: &BenchmarkData, shard: &[ShardIdentity]) -> anyhow::Result<()> {
     let mut decoder = WalStreamDecoder::new(bench.meta.start_lsn, bench.meta.pg_version);
-    let xlogoff: usize = bench.meta.start_lsn.segment_offset(WAL_SEGMENT_SIZE);
+    let xlogoff = bench.meta.start_lsn.segment_offset(WAL_SEGMENT_SIZE);
 
-    for chunk in bench.wal[xlogoff..].chunks(MAX_SEND_SIZE) {
+    for chunk in bench.wal[xlogoff as usize..].chunks(MAX_SEND_SIZE) {
         decoder.feed_bytes(chunk);
         while let Some((lsn, recdata)) = decoder.poll_decode().unwrap() {
             assert!(lsn.is_aligned());

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -29,7 +29,7 @@ use tokio::io;
 use tokio::io::AsyncWrite;
 use tokio_tar::{Builder, EntryType, Header};
 use tracing::*;
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 use crate::context::RequestContext;
 use crate::pgdatadir_mapping::Version;
@@ -754,7 +754,7 @@ where
             self.lsn,
         )
         .map_err(|e| anyhow!(e).context("Failed generating wal segment"))?;
-        if wal_seg.len() != WAL_SEGMENT_SIZE {
+        if SegmentSize::try_from(wal_seg.len()) != Ok(WAL_SEGMENT_SIZE) {
             return Err(BasebackupError::Server(anyhow!(
                 "wal_seg.len() != WAL_SEGMENT_SIZE, wal_seg.len()={}",
                 wal_seg.len()

--- a/pageserver/src/import_datadir.rs
+++ b/pageserver/src/import_datadir.rs
@@ -301,7 +301,7 @@ async fn import_wal(
 
         use std::io::Read;
         let nread = file.read_to_end(&mut buf)?;
-        if nread != WAL_SEGMENT_SIZE - offset {
+        if nread != WAL_SEGMENT_SIZE as usize - offset as usize {
             // Maybe allow this for .partial files?
             error!("read only {} bytes from WAL file", nread);
         }
@@ -455,7 +455,7 @@ pub async fn import_wal_from_tar(
             }
         };
 
-        waldecoder.feed_bytes(&bytes[offset..]);
+        waldecoder.feed_bytes(&bytes[offset as usize..]);
 
         let mut modification = tline.begin_modification(last_lsn);
         while last_lsn <= end_lsn {

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -2377,17 +2377,17 @@ mod tests {
         let started_at = std::time::Instant::now();
 
         // Initialize walingest
-        let xlogoff: usize = startpoint.segment_offset(WAL_SEGMENT_SIZE);
+        let xlogoff = startpoint.segment_offset(WAL_SEGMENT_SIZE);
         let mut decoder = WalStreamDecoder::new(startpoint, pg_version);
         let mut walingest = WalIngest::new(tline.as_ref(), startpoint, &ctx)
             .await
             .unwrap();
         let mut modification = tline.begin_modification(startpoint);
-        println!("decoding {} bytes", bytes.len() - xlogoff);
+        println!("decoding {} bytes", bytes.len() - xlogoff as usize);
 
         // Decode and ingest wal. We process the wal in chunks because
         // that's what happens when we get bytes from safekeepers.
-        for chunk in bytes[xlogoff..].chunks(50) {
+        for chunk in bytes[xlogoff as usize..].chunks(50) {
             decoder.feed_bytes(chunk);
             while let Some((lsn, recdata)) = decoder.poll_decode().unwrap() {
                 let interpreted = InterpretedWalRecord::from_bytes_filtered(

--- a/safekeeper/src/copy_timeline.rs
+++ b/safekeeper/src/copy_timeline.rs
@@ -8,7 +8,7 @@ use tokio::fs::OpenOptions;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tracing::{info, warn};
 use utils::id::TenantTimelineId;
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 use crate::GlobalTimelines;
 use crate::control_file::FileStorage;
@@ -98,7 +98,7 @@ pub async fn handle_request(
         }
     }
 
-    let wal_seg_size = state.server.wal_seg_size as usize;
+    let wal_seg_size = state.server.wal_seg_size;
     if wal_seg_size == 0 {
         bail!("wal_seg_size is not set");
     }
@@ -168,7 +168,7 @@ pub async fn handle_request(
 
 async fn copy_disk_segments(
     tli: &WalResidentTimeline,
-    wal_seg_size: usize,
+    wal_seg_size: SegmentSize,
     start_lsn: Lsn,
     end_lsn: Lsn,
     tli_dir_path: &Utf8PathBuf,

--- a/safekeeper/src/http/routes.rs
+++ b/safekeeper/src/http/routes.rs
@@ -103,7 +103,7 @@ async fn timeline_create_handler(mut request: Request<Body>) -> Result<Response<
     let server_info = ServerInfo {
         pg_version: request_data.pg_version,
         system_id: request_data.system_id.unwrap_or(0),
-        wal_seg_size: request_data.wal_seg_size.unwrap_or(WAL_SEGMENT_SIZE as u32),
+        wal_seg_size: request_data.wal_seg_size.unwrap_or(WAL_SEGMENT_SIZE),
     };
     let global_timelines = get_global_timelines(&request);
     global_timelines

--- a/safekeeper/src/metrics.rs
+++ b/safekeeper/src/metrics.rs
@@ -831,7 +831,7 @@ impl Collector for TimelineCollector {
             if tli.last_removed_segno != 0 {
                 let segno_count = tli
                     .flush_lsn
-                    .segment_number(tli.persisted_state.server.wal_seg_size as usize)
+                    .segment_number(tli.persisted_state.server.wal_seg_size)
                     - tli.last_removed_segno;
                 let disk_usage_bytes = segno_count * tli.persisted_state.server.wal_seg_size as u64;
                 self.disk_usage

--- a/safekeeper/src/pull_timeline.rs
+++ b/safekeeper/src/pull_timeline.rs
@@ -25,7 +25,7 @@ use tracing::{error, info, instrument};
 use utils::crashsafe::fsync_async_opt;
 use utils::id::{NodeId, TenantTimelineId};
 use utils::logging::SecretString;
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 use utils::pausable_failpoint;
 
 use crate::control_file::CONTROL_FILE_NAME;
@@ -75,7 +75,7 @@ pub struct SnapshotContext {
     pub term: Term,
     pub last_log_term: Term,
     pub flush_lsn: Lsn,
-    pub wal_seg_size: usize,
+    pub wal_seg_size: SegmentSize,
     // used to remove WAL hold off in Drop.
     pub tli: WalResidentTimeline,
 }

--- a/safekeeper/src/safekeeper.rs
+++ b/safekeeper/src/safekeeper.rs
@@ -1439,7 +1439,7 @@ mod tests {
 
     fn test_sk_state() -> TimelinePersistentState {
         let mut state = TimelinePersistentState::empty();
-        state.server.wal_seg_size = WAL_SEGMENT_SIZE as u32;
+        state.server.wal_seg_size = WAL_SEGMENT_SIZE;
         state.tenant_id = TenantId::from([1u8; 16]);
         state.timeline_id = TimelineId::from([1u8; 16]);
         state

--- a/safekeeper/src/state.rs
+++ b/safekeeper/src/state.rs
@@ -151,7 +151,7 @@ impl TimelinePersistentState {
             ServerInfo {
                 pg_version: 170000, /* Postgres server version (major * 10000) */
                 system_id: 0,       /* Postgres system identifier */
-                wal_seg_size: WAL_SEGMENT_SIZE as u32,
+                wal_seg_size: WAL_SEGMENT_SIZE,
             },
             Lsn::INVALID,
             Lsn::INVALID,

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -23,7 +23,7 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::*;
 use utils::id::{NodeId, TenantId, TenantTimelineId};
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 use utils::sync::gate::Gate;
 
 use crate::metrics::{FullTimelineInfo, MISC_OPERATION_SECONDS, WalStorageMetrics};
@@ -337,8 +337,8 @@ impl SharedState {
         Ok(Self::new(sk))
     }
 
-    pub(crate) fn get_wal_seg_size(&self) -> usize {
-        self.sk.state().server.wal_seg_size as usize
+    pub(crate) fn get_wal_seg_size(&self) -> SegmentSize {
+        self.sk.state().server.wal_seg_size
     }
 
     fn get_safekeeper_info(
@@ -726,7 +726,7 @@ impl Timeline {
     }
 
     /// Returns wal_seg_size.
-    pub async fn get_wal_seg_size(&self) -> usize {
+    pub async fn get_wal_seg_size(&self) -> SegmentSize {
         self.read_shared_state().await.get_wal_seg_size()
     }
 

--- a/safekeeper/src/timeline_manager.rs
+++ b/safekeeper/src/timeline_manager.rs
@@ -20,7 +20,7 @@ use tokio::task::{JoinError, JoinHandle};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, info_span, instrument, warn};
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 use crate::SafeKeeperConf;
 use crate::control_file::{FileStorage, Storage};
@@ -198,7 +198,7 @@ pub(crate) struct Manager {
     // configuration & dependencies
     pub(crate) tli: ManagerTimeline,
     pub(crate) conf: SafeKeeperConf,
-    pub(crate) wal_seg_size: usize,
+    pub(crate) wal_seg_size: SegmentSize,
     pub(crate) walsenders: Arc<WalSenders>,
 
     // current state

--- a/safekeeper/src/wal_backup_partial.rs
+++ b/safekeeper/src/wal_backup_partial.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 use utils::id::NodeId;
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 use crate::SafeKeeperConf;
 use crate::metrics::{
@@ -149,7 +149,7 @@ impl State {
 }
 
 pub struct PartialBackup {
-    wal_seg_size: usize,
+    wal_seg_size: SegmentSize,
     tli: WalResidentTimeline,
     conf: SafeKeeperConf,
     local_prefix: Utf8PathBuf,

--- a/safekeeper/src/wal_storage.rs
+++ b/safekeeper/src/wal_storage.rs
@@ -26,7 +26,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tracing::*;
 use utils::crashsafe::durable_rename;
 use utils::id::TenantTimelineId;
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 use crate::metrics::{
     REMOVED_WAL_SEGMENTS, WAL_STORAGE_OPERATION_SECONDS, WalStorageMetrics, time_io_closure,
@@ -90,7 +90,7 @@ pub struct PhysicalStorage {
     no_sync: bool,
 
     /// Size of WAL segment in bytes.
-    wal_seg_size: usize,
+    wal_seg_size: SegmentSize,
     pg_version: u32,
     system_id: u64,
 
@@ -168,7 +168,7 @@ impl PhysicalStorage {
         state: &TimelinePersistentState,
         no_sync: bool,
     ) -> Result<PhysicalStorage> {
-        let wal_seg_size = state.server.wal_seg_size as usize;
+        let wal_seg_size = state.server.wal_seg_size;
 
         // Find out where stored WAL ends, starting at commit_lsn which is a
         // known recent record boundary (unless we don't have WAL at all).
@@ -310,7 +310,12 @@ impl PhysicalStorage {
 
     /// Write WAL bytes, which are known to be located in a single WAL segment. Returns true if the
     /// segment was completed, closed, and flushed to disk.
-    async fn write_in_segment(&mut self, segno: u64, xlogoff: usize, buf: &[u8]) -> Result<bool> {
+    async fn write_in_segment(
+        &mut self,
+        segno: u64,
+        xlogoff: SegmentSize,
+        buf: &[u8],
+    ) -> Result<bool> {
         let mut file = if let Some(file) = self.file.take() {
             file
         } else {
@@ -326,7 +331,7 @@ impl PhysicalStorage {
         // syscall, but needed in case of async). It does *not* fsyncs the file.
         file.flush().await?;
 
-        if xlogoff + buf.len() == self.wal_seg_size {
+        if xlogoff as usize + buf.len() == self.wal_seg_size as usize {
             // If we reached the end of a WAL segment, flush and close it.
             self.fdatasync_file(&file).await?;
 
@@ -367,8 +372,8 @@ impl PhysicalStorage {
             let segno = self.write_lsn.segment_number(self.wal_seg_size);
 
             // If crossing a WAL boundary, only write up until we reach wal segment size.
-            let bytes_write = if xlogoff + buf.len() > self.wal_seg_size {
-                self.wal_seg_size - xlogoff
+            let bytes_write = if xlogoff as usize + buf.len() > self.wal_seg_size as usize {
+                (self.wal_seg_size - xlogoff) as usize
             } else {
                 buf.len()
             };
@@ -599,7 +604,7 @@ impl Storage for PhysicalStorage {
 /// Remove all WAL segments in timeline_dir that match the given predicate.
 async fn remove_segments_from_disk(
     timeline_dir: &Utf8Path,
-    wal_seg_size: usize,
+    wal_seg_size: SegmentSize,
     remove_predicate: impl Fn(XLogSegNo) -> bool,
 ) -> Result<()> {
     let _timer = WAL_STORAGE_OPERATION_SECONDS
@@ -640,7 +645,7 @@ async fn remove_segments_from_disk(
 pub struct WalReader {
     remote_path: RemotePath,
     timeline_dir: Utf8PathBuf,
-    wal_seg_size: usize,
+    wal_seg_size: SegmentSize,
     pos: Lsn,
     wal_segment: Option<Pin<Box<dyn AsyncRead + Send + Sync>>>,
 
@@ -678,7 +683,7 @@ impl WalReader {
         if start_pos
             < state
                 .timeline_start_lsn
-                .segment_lsn(state.server.wal_seg_size as usize)
+                .segment_lsn(state.server.wal_seg_size)
         {
             bail!(
                 "Requested streaming from {}, which is before the start of the timeline {}, and also doesn't start at the first segment of that timeline",
@@ -690,7 +695,7 @@ impl WalReader {
         Ok(Self {
             remote_path: remote_timeline_path(ttid)?,
             timeline_dir,
-            wal_seg_size: state.server.wal_seg_size as usize,
+            wal_seg_size: state.server.wal_seg_size,
             pos: start_pos,
             wal_segment: None,
             enable_remote_read,
@@ -738,12 +743,14 @@ impl WalReader {
             // How many bytes may we consume in total?
             let tl_start_seg_offset = self.timeline_start_lsn.segment_offset(self.wal_seg_size);
 
-            debug_assert!(seg_bytes.len() > pos_seg_offset);
-            debug_assert!(seg_bytes.len() > tl_start_seg_offset);
+            debug_assert!(seg_bytes.len() > pos_seg_offset as usize);
+            debug_assert!(seg_bytes.len() > tl_start_seg_offset as usize);
 
             // Copy as many bytes as possible into the buffer
-            let len = (tl_start_seg_offset - pos_seg_offset).min(buf.len());
-            buf[0..len].copy_from_slice(&seg_bytes[pos_seg_offset..pos_seg_offset + len]);
+            let len = ((tl_start_seg_offset - pos_seg_offset) as usize).min(buf.len());
+            buf[0..len].copy_from_slice(
+                &seg_bytes[pos_seg_offset as usize..pos_seg_offset as usize + len],
+            );
 
             self.pos += len as u64;
 
@@ -765,7 +772,7 @@ impl WalReader {
         // How much to read and send in message? We cannot cross the WAL file
         // boundary, and we don't want send more than provided buffer.
         let xlogoff = self.pos.segment_offset(self.wal_seg_size);
-        let send_size = min(buf.len(), self.wal_seg_size - xlogoff);
+        let send_size = min(buf.len(), (self.wal_seg_size - xlogoff) as usize);
 
         // Read some data from the file.
         let buf = &mut buf[0..send_size];
@@ -826,7 +833,7 @@ impl WalReader {
 pub(crate) async fn open_wal_file(
     timeline_dir: &Utf8Path,
     segno: XLogSegNo,
-    wal_seg_size: usize,
+    wal_seg_size: SegmentSize,
 ) -> Result<(tokio::fs::File, bool)> {
     let (wal_file_path, wal_file_partial_path) = wal_file_paths(timeline_dir, segno, wal_seg_size);
 
@@ -853,7 +860,7 @@ pub(crate) async fn open_wal_file(
 pub fn wal_file_paths(
     timeline_dir: &Utf8Path,
     segno: XLogSegNo,
-    wal_seg_size: usize,
+    wal_seg_size: SegmentSize,
 ) -> (Utf8PathBuf, Utf8PathBuf) {
     let wal_file_name = XLogFileName(PG_TLI, segno, wal_seg_size);
     let wal_file_path = timeline_dir.join(wal_file_name.clone());

--- a/storage_scrubber/src/scan_safekeeper_metadata.rs
+++ b/storage_scrubber/src/scan_safekeeper_metadata.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use tokio_postgres::types::PgLsn;
 use tracing::{debug, error, info};
 use utils::id::{TenantId, TenantTimelineId, TimelineId};
-use utils::lsn::Lsn;
+use utils::lsn::{Lsn, SegmentSize};
 
 use crate::cloud_admin_api::CloudAdminApiClient;
 use crate::metadata_stream::stream_listing;
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// Generally we should ask safekeepers, but so far we use everywhere default 16MB.
-const WAL_SEGSIZE: usize = 16 * 1024 * 1024;
+const WAL_SEGSIZE: SegmentSize = 16 * 1024 * 1024;
 
 #[derive(Serialize)]
 pub struct MetadataSummary {


### PR DESCRIPTION
## Problem

Segment sizes, and the sizes of WAL records within those segments, are defined to be u32, and encoded as such in some places, but at runtime are often handled as `usize`.

Fixes: https://github.com/neondatabase/neon/issues/612

## Summary of changes

- Introduce a SegmentSize alias to u32
- Convert inappropriate `usize` variables storing segment sizes to use the new alias.