### PR TITLE
fix: remove duplicate pgrx14 build layer in compute image

### DIFF
--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1088,6 +1088,10 @@ USER root
 #
 # Layer "rust extensions pgrx14"
 #
+# Version 14 is now required by a few extensions.
+# This layer should be used as a base for new pgrx extensions,
+# and eventually get merged with `rust-extensions-build`
+
 #########################################################################################
 FROM pg-build-nonroot-with-cargo AS rust-extensions-build-pgrx14
 ARG PG_VERSION

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1096,22 +1096,6 @@ RUN cargo install --locked --version 0.14.1 cargo-pgrx && \
     /bin/bash -c 'cargo pgrx init --pg${PG_VERSION:1}=/usr/local/pgsql/bin/pg_config'
 
 USER root
-#########################################################################################
-#
-# Layer "rust extensions pgrx14"
-#
-# Version 14 is now required by a few 
-# This layer should be used as a base for new pgrx extensions,
-# and eventually get merged with `rust-extensions-build`
-#
-#########################################################################################
-FROM pg-build-nonroot-with-cargo AS rust-extensions-build-pgrx14
-ARG PG_VERSION
-
-RUN cargo install --locked --version 0.14.1 cargo-pgrx && \
-    /bin/bash -c 'cargo pgrx init --pg${PG_VERSION:1}=/usr/local/pgsql/bin/pg_config'
-
-USER root
 
 #########################################################################################
 #

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1091,7 +1091,7 @@ USER root
 # Version 14 is now required by a few extensions.
 # This layer should be used as a base for new pgrx extensions,
 # and eventually get merged with `rust-extensions-build`
-
+#
 #########################################################################################
 FROM pg-build-nonroot-with-cargo AS rust-extensions-build-pgrx14
 ARG PG_VERSION


### PR DESCRIPTION
## Problem

There were two `rust-extensions-build-pgrx14` layers in the compute image which resulted in warnings in the dockerfile.

## Summary of changes

Removed duplicate `rust-extensions-build-pgrx14` layer from compute image.