### PR TITLE
fix(compute): Enforce cloud_admin role in compute_ctl connections

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -340,6 +340,9 @@ impl ComputeNode {
         //
         //   - role=some_other_role
         //   - default_transaction_read_only=on
+        //   - search_path=non_public_schema, this should be actually safe because
+        //     we don't call any functions in user databases, but better to always reset
+        //     it to public.
         //
         // that can affect `compute_ctl` and prevent it from properly configuring the database schema.
         // Unset them via connection string options before connecting to the database.
@@ -349,7 +352,8 @@ impl ComputeNode {
         // as well. After rolling out this code, we can remove this parameter from control plane.
         // In the meantime, double-passing is fine, the last value is applied.
         // See: <https://github.com/neondatabase/cloud/blob/133dd8c4dbbba40edfbad475bf6a45073ca63faf/goapp/controlplane/internal/pkg/compute/provisioner/provisioner_common.go#L70>
-        const EXTRA_OPTIONS: &str = "-c role=cloud_admin -c default_transaction_read_only=off";
+        const EXTRA_OPTIONS: &str =
+            "-c role=cloud_admin -c default_transaction_read_only=off -c search_path=public";
         let options = match conn_conf.get_options() {
             Some(options) => format!("{} {}", options, EXTRA_OPTIONS),
             None => EXTRA_OPTIONS.to_string(),
@@ -1483,8 +1487,7 @@ impl ComputeNode {
 
                     // It doesn't matter what were the options before, here we just want
                     // to connect and create a new superuser role.
-                    const ZENITH_OPTIONS: &str =
-                        "-c role=zenith_admin -c default_transaction_read_only=off";
+                    const ZENITH_OPTIONS: &str = "-c role=zenith_admin -c default_transaction_read_only=off -c search_path=public";
                     zenith_admin_conf.options(ZENITH_OPTIONS);
 
                     let mut client =

--- a/test_runner/regress/test_compute_catalog.py
+++ b/test_runner/regress/test_compute_catalog.py
@@ -549,7 +549,8 @@ def test_drop_role_with_table_privileges_from_non_neon_superuser(neon_simple_env
 def test_db_with_custom_settings(neon_simple_env: NeonEnv):
     """
     Test that compute_ctl can work with databases that have some custom settings.
-    For example, role=some_other_role and default_transaction_read_only=on.
+    For example, role=some_other_role, default_transaction_read_only=on,
+    search_path=non_public_schema, statement_timeout=1 (1ms).
     """
     env = neon_simple_env
 
@@ -587,6 +588,7 @@ def test_db_with_custom_settings(neon_simple_env: NeonEnv):
         cursor.execute(f"ALTER DATABASE {TEST_DB} SET role = {TEST_ROLE}")
         cursor.execute(f"ALTER DATABASE {TEST_DB} SET default_transaction_read_only = on")
         cursor.execute(f"ALTER DATABASE {TEST_DB} SET search_path = {TEST_SCHEMA}")
+        cursor.execute(f"ALTER DATABASE {TEST_DB} SET statement_timeout = 1")
 
     with endpoint.cursor(dbname=TEST_DB) as cursor:
         cursor.execute("SELECT current_role")
@@ -603,5 +605,8 @@ def test_db_with_custom_settings(neon_simple_env: NeonEnv):
         search_path = cursor.fetchone()
         assert search_path is not None
         assert search_path[0] == TEST_SCHEMA
+
+        # Do not check statement_timeout, because we force it to 2min
+        # in `endpoint.cursor()` fixture.
 
     endpoint.reconfigure()


### PR DESCRIPTION
## Problem

Users can override some configuration parameters on the DB level with `ALTER DATABASE ... SET ...`. Some of these overrides, like `role` or `default_transaction_read_only`, affect `compute_ctl`'s ability to configure the DB schema properly.

## Summary of changes

Enforce `role=cloud_admin`, `statement_timeout=0`, and move `default_transaction_read_only=off` override from control plane [1] to `compute_ctl`. Also, enforce `search_path=public` just in case, although we do not call any functions in user databases.

[1]: https://github.com/neondatabase/cloud/blob/133dd8c4dbbba40edfbad475bf6a45073ca63faf/goapp/controlplane/internal/pkg/compute/provisioner/provisioner_common.go#L70

Fixes https://github.com/neondatabase/cloud/issues/28532
