### PR TITLE
Add neon.safekeeper_connstrings GUC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ walproposer-lib: neon-pg-ext-v17
 		-f $(ROOT_PROJECT_DIR)/pgxn/neon/Makefile walproposer-lib
 	cp $(POSTGRES_INSTALL_DIR)/v17/lib/libpgport.a $(POSTGRES_INSTALL_DIR)/build/walproposer-lib
 	cp $(POSTGRES_INSTALL_DIR)/v17/lib/libpgcommon.a $(POSTGRES_INSTALL_DIR)/build/walproposer-lib
+	cp $(POSTGRES_INSTALL_DIR)/v17/lib/libpq.so $(POSTGRES_INSTALL_DIR)/build/walproposer-lib
 	$(AR) d $(POSTGRES_INSTALL_DIR)/build/walproposer-lib/libpgport.a \
 		pg_strong_random.o
 	$(AR) d $(POSTGRES_INSTALL_DIR)/build/walproposer-lib/libpgcommon.a \

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -218,7 +218,9 @@ impl TryFrom<ComputeSpec> for ParsedSpec {
             if matches!(spec.mode, ComputeMode::Primary) {
                 spec.cluster
                     .settings
-                    .find("neon.safekeepers")
+                    .find("neon.safekeeper_connstrings")
+                    // TODO(tristan957): Remove the compatibility code here.
+                    .or(spec.cluster.settings.find("neon.safekeepers"))
                     .ok_or("safekeeper connstrings should be provided")?
                     .split(',')
                     .map(|str| str.to_string())

--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -75,7 +75,7 @@ pub fn write_postgres_conf(
         neon_safekeepers_value.push_str(&spec.safekeeper_connstrings.join(","));
         writeln!(
             file,
-            "neon.safekeepers={}",
+            "neon.safekeeper_connstrings={}",
             escape_conf_value(&neon_safekeepers_value)
         )?;
     }

--- a/compute_tools/tests/pg_helpers_tests.rs
+++ b/compute_tools/tests/pg_helpers_tests.rs
@@ -30,7 +30,7 @@ mod pg_helpers_tests {
             r#"fsync = off
 wal_level = logical
 hot_standby = on
-neon.safekeepers = '127.0.0.1:6502,127.0.0.1:6503,127.0.0.1:6501'
+neon.safekeeper_connstrings = 'host=127.0.0.1 port=6502,host=127.0.0.1 port=6503,host=127.0.0.1 port=6501'
 wal_log_hints = on
 log_connections = on
 shared_buffers = 32768

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -632,7 +632,7 @@ struct EndpointStartCmdArgs {
 
     #[clap(
         long,
-        help = "Safekeepers membership generation to prefix neon.safekeepers with. Normally neon_local sets it on its own, but this option allows to override. Non zero value forces endpoint to use membership configurations."
+        help = "Safekeepers membership generation to prefix neon.safekeeper_connstrings with. Normally neon_local sets it on its own, but this option allows to override. Non zero value forces endpoint to use membership configurations."
     )]
     safekeepers_generation: Option<u32>,
     #[clap(

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -454,10 +454,10 @@ impl Endpoint {
                         .env
                         .safekeepers
                         .iter()
-                        .map(|sk| format!("localhost:{}", sk.get_compute_port()))
+                        .map(|sk| format!("host=localhost port={}", sk.get_compute_port()))
                         .collect::<Vec<String>>()
                         .join(",");
-                    conf.append("neon.safekeepers", &safekeepers);
+                    conf.append("neon.safekeeper_connstrings", &safekeepers);
                 } else {
                     // We only use setup without safekeepers for tests,
                     // and don't care about data durability on pageserver,
@@ -623,7 +623,8 @@ impl Endpoint {
                     .iter()
                     .find(|node| node.id == sk_id)
                     .ok_or_else(|| anyhow!("safekeeper {sk_id} does not exist"))?;
-                safekeeper_connstrings.push(format!("127.0.0.1:{}", sk.get_compute_port()));
+                safekeeper_connstrings
+                    .push(format!("host=127.0.0.1 port={}", sk.get_compute_port()));
             }
         }
         Ok(safekeeper_connstrings)

--- a/docker-compose/compute_wrapper/var/db/postgres/configs/config.json
+++ b/docker-compose/compute_wrapper/var/db/postgres/configs/config.json
@@ -105,6 +105,11 @@
                     "vartype": "string"
                 },
                 {
+                    "name": "neon.safekeeper_connstrings",
+                    "value": "host=safekeeper1 port=5454,host=safekeeper2 port=5454,host=safekeeper3 port=5454",
+                    "vartype": "string"
+                },
+                {
                     "name": "neon.timeline_id",
                     "value": "TIMELINE_ID",
                     "vartype": "string"

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -24,7 +24,7 @@ because configs may be parsed and dumped into logs.
 #### Tokens generation and validation
 JWT tokens are signed using a private key.
 Compute/pageserver/safekeeper use the private key's public counterpart to validate JWT tokens.
-These components should not have access to the private key and may only get tokens from their configuration or external clients. 
+These components should not have access to the private key and may only get tokens from their configuration or external clients.
 
 The key pair is generated once for an installation of compute/pageserver/safekeeper, e.g. by `neon_local init`.
 There is currently no way to rotate the key without bringing down all components.
@@ -117,8 +117,8 @@ pageserver uses JWT tokens for authentication, so the password is really a
 token.)
 
 Compute connects to Safekeepers to write and commit data. The list of safekeeper
-addresses is given in the `neon.safekeepers` GUC. The connections to the
-safekeepers take the password from the `$NEON_AUTH_TOKEN` environment
+addresses is given in the `neon.safekeeper_connstrings` GUC. The connections to
+the safekeepers take the password from the `$NEON_AUTH_TOKEN` environment
 variable, if set.
 
 The `compute_ctl` binary that runs before the PostgreSQL server, and launches

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -111,7 +111,7 @@ pub struct ComputeSpec {
     pub endpoint_id: Option<String>,
 
     /// Safekeeper membership config generation. It is put in
-    /// neon.safekeepers GUC and serves two purposes:
+    /// neon.safekeeper_connstrings GUC and serves two purposes:
     /// 1) Non zero value forces walproposer to use membership configurations.
     /// 2) If walproposer wants to update list of safekeepers to connect to
     ///    taking them from some safekeeper mconf, it should check what value

--- a/libs/compute_api/tests/cluster_spec.json
+++ b/libs/compute_api/tests/cluster_spec.json
@@ -85,8 +85,8 @@
                 "vartype": "bool"
             },
             {
-                "name": "neon.safekeepers",
-                "value": "127.0.0.1:6502,127.0.0.1:6503,127.0.0.1:6501",
+                "name": "neon.safekeeper_connstrings",
+                "value": "host=127.0.0.1 port=6502,host=127.0.0.1 port=6503,host=127.0.0.1 port=6501",
                 "vartype": "string"
             },
             {

--- a/libs/walproposer/build.rs
+++ b/libs/walproposer/build.rs
@@ -35,6 +35,7 @@ fn main() -> anyhow::Result<()> {
     println!("cargo:rustc-link-lib=static=walproposer");
     println!("cargo:rustc-link-lib=static=pgport");
     println!("cargo:rustc-link-lib=static=pgcommon");
+    println!("cargo:rustc-link-lib=pq");
     println!("cargo:rustc-link-search={walproposer_lib_search_str}");
 
     // Rebuild crate when libwalproposer.a changes

--- a/pgxn/neon/libpqwalproposer.h
+++ b/pgxn/neon/libpqwalproposer.h
@@ -86,7 +86,7 @@ typedef struct WalProposerConn
 								 * walprop_async_read */
 } WalProposerConn;
 
-extern WalProposerConn *libpqwp_connect_start(char *conninfo);
+extern WalProposerConn *libpqwp_connect_start(const char *conninfo);
 extern bool libpqwp_send_query(WalProposerConn *conn, char *query);
 extern WalProposerExecStatusType libpqwp_get_query_result(WalProposerConn *conn);
 extern PGAsyncReadResult libpqwp_async_read(WalProposerConn *conn, char **buf, int *amount);

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -707,12 +707,11 @@ typedef struct WalProposerConfig
 	char	   *neon_timeline;
 
 	/*
-	 * Comma-separated list of safekeepers, in the following format:
-	 * host1:port1,host2:port2,host3:port3
+	 * Comma-separated list of safekeeper connection strings
 	 *
 	 * This cstr should be editable.
 	 */
-	char	   *safekeepers_list;
+	char	   *safekeeper_connstrings;
 
 	/*
 	 * WalProposer reconnects to offline safekeepers once in this interval.
@@ -788,14 +787,15 @@ typedef struct WalProposer
 	/*
 	 * Generation of the membership conf of which safekeepers[] are presumably
 	 * members. To make cplane life a bit easier and have more control in
-	 * tests with which sks walproposer gets connected neon.safekeepers GUC
-	 * doesn't provide full mconf, only the list of endpoints to connect to.
-	 * We still would like to know generation associated with it because 1) we
-	 * need some handle to enforce using generations in walproposer, and
-	 * non-zero value of this serves the purpose; 2) currently we don't do
-	 * that, but in theory walproposer can update list of safekeepers to
-	 * connect to upon receiving mconf from safekeepers, and generation number
-	 * must be checked to see which list is newer.
+	 * tests with which sks walproposer gets connected
+	 * neon.safekeeper_connstrings GUC doesn't provide full mconf, only the list
+	 * of endpoints to connect to. We still would like to know generation
+	 * associated with it because 1) we need some handle to enforce using
+	 * generations in walproposer, and non-zero value of this serves the
+	 * purpose; 2) currently we don't do that, but in theory walproposer can
+	 * update list of safekeepers to connect to upon receiving mconf from
+	 * safekeepers, and generation number must be checked to see which list is
+	 * newer.
 	 */
 	Generation	safekeepers_generation;
 	/* Number of occupied slots in safekeepers[] */

--- a/safekeeper/tests/walproposer_sim/simulation.rs
+++ b/safekeeper/tests/walproposer_sim/simulation.rs
@@ -86,7 +86,7 @@ impl WalProposer {
 
         let config = Config {
             ttid,
-            safekeepers_list: addrs,
+            safekeeper_connstrings: addrs,
             safekeeper_reconnect_timeout: 1000,
             safekeeper_connection_timeout: 5000,
             sync_safekeepers,

--- a/safekeeper/tests/walproposer_sim/walproposer_api.rs
+++ b/safekeeper/tests/walproposer_sim/walproposer_api.rs
@@ -207,7 +207,7 @@ impl SimulationApi {
         // initialize connection state for each safekeeper
         let sk_conns = args
             .config
-            .safekeepers_list
+            .safekeeper_connstrings
             .iter()
             .map(|s| {
                 SafekeeperConn::new(

--- a/test_runner/regress/test_config.py
+++ b/test_runner/regress/test_config.py
@@ -49,9 +49,9 @@ def test_safekeepers_reconfigure_reorder(
     old_sks = ""
     with closing(endpoint.connect()) as conn:
         with conn.cursor() as cur:
-            cur.execute("SHOW neon.safekeepers")
+            cur.execute("SHOW neon.safekeeper_connstrings")
             res = cur.fetchone()
-            assert res is not None, "neon.safekeepers GUC is set"
+            assert res is not None, "neon.safekeeper_connstrings GUC is set"
             old_sks = res[0]
 
     # Reorder safekeepers
@@ -62,9 +62,9 @@ def test_safekeepers_reconfigure_reorder(
 
     with closing(endpoint.connect()) as conn:
         with conn.cursor() as cur:
-            cur.execute("SHOW neon.safekeepers")
+            cur.execute("SHOW neon.safekeeper_connstrings")
             res = cur.fetchone()
-            assert res is not None, "neon.safekeepers GUC is set"
+            assert res is not None, "neon.safekeeper_connstrings GUC is set"
             new_sks = res[0]
 
             assert new_sks != old_sks, "GUC changes were applied"

--- a/test_runner/regress/test_wal_acceptor_async.py
+++ b/test_runner/regress/test_wal_acceptor_async.py
@@ -711,10 +711,10 @@ async def run_quorum_sanity(env: NeonEnv):
     await quorum_sanity_single(env, [2, 3, 4], [1, 2, 3], [2, 3, 4], [2], False)
 
 
-# Test various combinations of membership configurations / neon.safekeepers
-# (list of safekeepers endpoint connects to) values / up & down safekeepers and
-# check that endpont can start and write data when we have quorum and can't when
-# we don't.
+# Test various combinations of membership configurations /
+# neon.safekeeper_connstrings (list of safekeeper connection strings) values /
+# up & down safekeepers and check that endpont can start and write data when we
+# have quorum and can't when we don't.
 def test_quorum_sanity(neon_env_builder: NeonEnvBuilder):
     neon_env_builder.num_safekeepers = 4
     env = neon_env_builder.init_start()


### PR DESCRIPTION
This GUC is very similar to neon.safekeepers, but instead of being formatted as host:port, it is a Postgres connection string. The purpose for changing how we connect to safekeepers is so that we can pass various libpq SSL keyword parameters in the connection string.

A future PR will remove the `neon.safekeepers` GUC.
