### PR TITLE
feat(direct IO): runtime validation of requirements & support config flag on macOS

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1843,10 +1843,8 @@ pub mod virtual_file {
         /// Uses buffered IO.
         Buffered,
         /// Uses direct IO for reads only.
-        #[cfg(target_os = "linux")]
         Direct,
         /// Use direct IO for reads and writes.
-        #[cfg(target_os = "linux")]
         DirectRw,
     }
 

--- a/pageserver/benches/bench_ingest.rs
+++ b/pageserver/benches/bench_ingest.rs
@@ -244,13 +244,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     ];
     let exploded_parameters = {
         let mut out = Vec::new();
-        for io_mode in [
-            IoMode::Buffered,
-            #[cfg(target_os = "linux")]
-            IoMode::Direct,
-            #[cfg(target_os = "linux")]
-            IoMode::DirectRw,
-        ] {
+        for io_mode in [IoMode::Buffered, IoMode::Direct, IoMode::DirectRw] {
             for param in expect.clone() {
                 let HandPickedParameters {
                     volume_mib,


### PR DESCRIPTION
This PR adds a runtime validation mode to check adherence to alignment and size-multiple requirements at the VirtualFile level.

This allows catching O_DIRECT bugs on systems that don't have O_DIRECT (macOS).
Consequently, we can now accept `virtual_file_io_mode={direct,direct-rw}` on macOS now.
This has the side benefit of removing some annoying conditional compilation around `IoMode`.

It can also help prevent alignment bugs from slipping into production because test systems may have more lax requirements than production. (This is not the case today, but it could change in the future).

Refs
- fixes https://github.com/neondatabase/neon/issues/11676
