### PR TITLE
Fix PS connect attempt timeouts when facing interrupts

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -451,14 +451,13 @@ pageserver_connect(shardno_t shard_no, int elevel)
 		 */
 		while (us_since_last_attempt < shard->delay_us)
 		{
-			TimestampTz	current_time;
 			pg_usleep(shard->delay_us - us_since_last_attempt);
 
 			/* At least we should handle cancellations here */
 			CHECK_FOR_INTERRUPTS();
 
-			current_time = GetCurrentTimestamp();
-			us_since_last_attempt = (int64) (current_time - shard->last_reconnect_time);
+			now = GetCurrentTimestamp();
+			us_since_last_attempt = (int64) (now - shard->last_reconnect_time);
 		}
 
 		/* update the delay metric */


### PR DESCRIPTION
With the 50ms timeouts of pumping state in connector.c, we need to correctly handle these timeouts that also wake up pg_usleep.

This new approach makes the connection attempts re-start the wait whenever it gets woken up early; and CHECK_FOR_INTERRUPTS() is called to make sure we don't miss query cancellations.

## Problem

https://neondb.slack.com/archives/C04DGM6SMTM/p1746794528680269

## Summary of changes

Make sure we start sleeping again if pg_usleep got woken up ahead of time.