### PR TITLE
Do not check relsize cache in getpage and do not update it in get_rel_size

### DIFF
--- a/libs/pageserver_api/src/key.rs
+++ b/libs/pageserver_api/src/key.rs
@@ -562,6 +562,21 @@ pub fn rel_block_to_key(rel: RelTag, blknum: BlockNumber) -> Key {
 }
 
 #[inline(always)]
+pub fn key_to_rel_tag(key: Key) -> RelTag {
+    RelTag {
+        spcnode: key.field2,
+        dbnode: key.field3,
+        relnode: key.field4,
+        forknum: key.field5,
+    }
+}
+
+#[inline(always)]
+pub fn key_to_blknum(key: Key) -> BlockNumber {
+    key.field6
+}
+
+#[inline(always)]
 pub fn rel_size_to_key(rel: RelTag) -> Key {
     Key {
         field1: 0x00,

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -199,11 +199,8 @@ pub struct TimelineResources {
 
 /// The relation size cache caches relation sizes at the end of the timeline. It speeds up WAL
 /// ingestion considerably, because WAL ingestion needs to check on most records if the record
-/// implicitly extends the relation.  At startup, `complete_as_of` is initialized to the current end
-/// of the timeline (disk_consistent_lsn).  It's used on reads of relation sizes to check if the
-/// value can be used to also update the cache, see [`Timeline::update_cached_rel_size`].
+/// implicitly extends the relation.
 pub(crate) struct RelSizeCache {
-    pub(crate) complete_as_of: Lsn,
     pub(crate) map: HashMap<RelTag, (Lsn, BlockNumber)>,
 }
 
@@ -2970,7 +2967,6 @@ impl Timeline {
 
                 last_received_wal: Mutex::new(None),
                 rel_size_cache: RwLock::new(RelSizeCache {
-                    complete_as_of: disk_consistent_lsn,
                     map: HashMap::new(),
                 }),
 


### PR DESCRIPTION
## Problem

See https://neondb.slack.com/archives/C033RQ5SPDH/p1746645666075799

Relation size cache is not correctly updated at PS in case of replicas.

## Summary of changes

Do not update rel_size_cache in `get_rel_size`, update it only in walreceiver.
To avoid degrade of performance do not check that block is within relation boundaries inn`getpage` assuming that Postgres should never access block beyond end of the relation. 