### PR TITLE
fix(pageserver): do not bail out if image compaction is below GC cutoff

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -165,6 +165,7 @@ pub enum LastImageLayerCreationStatus {
         /// attempt.
         last_key: Key,
     },
+    NeedRepartition,
     Complete,
     #[default]
     Initial,


### PR DESCRIPTION
## Problem

https://github.com/neondatabase/neon/pull/11872

## Summary of changes

We saw a lot of logs of "skipping repartitioning due to image compaction LSN being below GC cutoff" in staging and it seems that we do rely on this behavior. So instead of skipping the image compaction entirely, we can try it until we hit the read error. If we hit the read error, then we do a force repartition the next time.