### PR TITLE
storage_controller: enforce generations in import upcalls

### DIFF
--- a/libs/pageserver_api/src/upcall_api.rs
+++ b/libs/pageserver_api/src/upcall_api.rs
@@ -4,6 +4,7 @@
 //! See docs/rfcs/025-generation-numbers.md
 
 use serde::{Deserialize, Serialize};
+use utils::generation::Generation;
 use utils::id::{NodeId, TimelineId};
 
 use crate::controller_api::NodeRegisterRequest;
@@ -64,8 +65,16 @@ pub struct ValidateResponseTenant {
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct TimelineImportStatusRequest {
+    pub tenant_shard_id: TenantShardId,
+    pub timeline_id: TimelineId,
+    pub generation: Generation,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct PutTimelineImportStatusRequest {
     pub tenant_shard_id: TenantShardId,
     pub timeline_id: TimelineId,
     pub status: ShardImportStatus,
+    pub generation: Generation,
 }

--- a/pageserver/src/deletion_queue.rs
+++ b/pageserver/src/deletion_queue.rs
@@ -793,6 +793,7 @@ mod test {
             &self,
             _tenant_shard_id: TenantShardId,
             _timeline_id: TimelineId,
+            _generation: Generation,
             _status: pageserver_api::models::ShardImportStatus,
         ) -> Result<(), RetryForeverError> {
             unimplemented!()
@@ -802,6 +803,7 @@ mod test {
             &self,
             _tenant_shard_id: TenantShardId,
             _timeline_id: TimelineId,
+            _generation: Generation,
         ) -> Result<Option<ShardImportStatus>, RetryForeverError> {
             unimplemented!()
         }

--- a/pageserver/src/tenant/timeline/import_pgdata.rs
+++ b/pageserver/src/tenant/timeline/import_pgdata.rs
@@ -48,7 +48,11 @@ pub async fn doit(
     let storcon_client = StorageControllerUpcallClient::new(timeline.conf, &cancel);
 
     let shard_status = storcon_client
-        .get_timeline_import_status(timeline.tenant_shard_id, timeline.timeline_id)
+        .get_timeline_import_status(
+            timeline.tenant_shard_id,
+            timeline.timeline_id,
+            timeline.generation,
+        )
         .await
         .map_err(|_err| anyhow::anyhow!("Shut down while getting timeline import status"))?;
 
@@ -175,6 +179,7 @@ pub async fn doit(
                 .put_timeline_import_status(
                     timeline.tenant_shard_id,
                     timeline.timeline_id,
+                    timeline.generation,
                     // TODO(vlad): What about import errors?
                     ShardImportStatus::Done,
                 )

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -31,7 +31,7 @@ use pageserver_api::models::{
 };
 use pageserver_api::shard::TenantShardId;
 use pageserver_api::upcall_api::{
-    PutTimelineImportStatusRequest, ReAttachRequest, ValidateRequest,
+    PutTimelineImportStatusRequest, ReAttachRequest, TimelineImportStatusRequest, ValidateRequest,
 };
 use pageserver_client::{BlockUnblock, mgmt_api};
 use routerify::Middleware;
@@ -160,22 +160,22 @@ async fn handle_validate(req: Request<Body>) -> Result<Response<Body>, ApiError>
 async fn handle_get_timeline_import_status(req: Request<Body>) -> Result<Response<Body>, ApiError> {
     check_permissions(&req, Scope::GenerationsApi)?;
 
-    let tenant_shard_id: TenantShardId = parse_request_param(&req, "tenant_shard_id")?;
-    let timeline_id: TimelineId = parse_request_param(&req, "timeline_id")?;
-
-    let req = match maybe_forward(req).await {
+    let mut req = match maybe_forward(req).await {
         ForwardOutcome::Forwarded(res) => {
             return res;
         }
         ForwardOutcome::NotForwarded(req) => req,
     };
 
+    let get_req = json_request::<TimelineImportStatusRequest>(&mut req).await?;
+
     let state = get_state(&req);
+
     json_response(
         StatusCode::OK,
         state
             .service
-            .handle_timeline_shard_import_progress(tenant_shard_id, timeline_id)
+            .handle_timeline_shard_import_progress(get_req)
             .await?,
     )
 }

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -3982,7 +3982,7 @@ impl Service {
                     "Rejecting import progress update from stale generation"
                 );
 
-                return Err(ApiError::BadRequest(anyhow::anyhow!("Invalid generation")));
+                return Err(ApiError::PreconditionFailed("Invalid generation".into()));
             }
         }
 


### PR DESCRIPTION
## Problem

Import up-calls did not enforce the usage of the latest generation. The import might have finished in one previous generation, but not in the latest one. Hence, the controller might try to activate a timeline before it is ready. In theory, that would be fine, but it's tricky to reason about.

## Summary of Changes

Pageserver provides the current generation in the upcall to the storage controller and the later validates the generation. If the generation is stale, we return an error which stops progress of the import job. Note that the import job will retry the upcall until the stale location is detached.

I'll add some proper tests for this as part of the [checkpointing PR](https://github.com/neondatabase/neon/pull/11862). 

Closes https://github.com/neondatabase/neon/issues/11884
