### PR TITLE
Make get_vectored perf span a child of get_page perf span

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -2236,9 +2236,10 @@ impl PageServerHandler {
 
         let ctx = match perf_instrument {
             true => RequestContextBuilder::from(ctx)
-                .root_perf_span(|| {
+                .perf_span(|get_page_span| {
                     info_span!(
                         target: PERF_TRACE_TARGET,
+                        parent: get_page_span,
                         "GET_VECTORED",
                         tenant_id = %timeline.tenant_shard_id.tenant_id,
                         timeline_id = %timeline.timeline_id,


### PR DESCRIPTION
## Problem
https://github.com/neondatabase/neon/issues/11913

## Summary of changes
Make `get_vectored` perf span a child of any of the sampled `get_page` perf spans. This seems fine since we have already ensured `perf_instrument = true` for any of the sampled `get_page` requests. 