### PR TITLE
pageserver: keep tombstone in relation size cache on relation drop

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -204,7 +204,13 @@ pub struct TimelineResources {
 /// value can be used to also update the cache, see [`Timeline::update_cached_rel_size`].
 pub(crate) struct RelSizeCache {
     pub(crate) complete_as_of: Lsn,
-    pub(crate) map: HashMap<RelTag, (Lsn, BlockNumber)>,
+    pub(crate) map: HashMap<RelTag, (Lsn, RelSizeCacheEntry)>,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum RelSizeCacheEntry {
+    Present(BlockNumber),
+    Truncated,
 }
 
 pub struct Timeline {
@@ -690,15 +696,15 @@ impl std::fmt::Display for ReadPath {
 
 #[derive(thiserror::Error)]
 pub struct MissingKeyError {
-    keyspace: KeySpace,
-    shard: ShardNumber,
-    query: Option<VersionedKeySpaceQuery>,
+    pub keyspace: KeySpace,
+    pub shard: ShardNumber,
+    pub query: Option<VersionedKeySpaceQuery>,
     // This is largest request LSN from the get page request batch
-    original_hwm_lsn: Lsn,
-    ancestor_lsn: Option<Lsn>,
+    pub original_hwm_lsn: Lsn,
+    pub ancestor_lsn: Option<Lsn>,
     /// Debug information about the read path if there's an error
-    read_path: Option<ReadPath>,
-    backtrace: Option<std::backtrace::Backtrace>,
+    pub read_path: Option<ReadPath>,
+    pub backtrace: Option<std::backtrace::Backtrace>,
 }
 
 impl MissingKeyError {


### PR DESCRIPTION
## Problem

Relation size cache should always contain the latest values as of the last ingested record.
This means that requests from a replica operating at a past LSN should not update the cache.

This was not the case if the relation was dropped from the primary. The entry was removed
from the cache and any replica at an LSN above the start-up disk consistent LSN of the pageserver
could update the relation size cache. This leads to the primary using wrong cached values.

## Summary of changes

Instead of erasing from the relation size cache, add a tombstone entry. This prevents replicas
from clobbering it. Tombstones are not preserved across start-ups. This is not needed because
all entries in the relation size cache must be above the start-up disk consistent LSN.