### PR TITLE
metric to query installed extensions on a compute

### DIFF
--- a/compute/etc/neon_collector.jsonnet
+++ b/compute/etc/neon_collector.jsonnet
@@ -28,6 +28,7 @@
     import 'sql_exporter/getpage_wait_seconds_bucket.libsonnet',
     import 'sql_exporter/getpage_wait_seconds_count.libsonnet',
     import 'sql_exporter/getpage_wait_seconds_sum.libsonnet',
+    import 'sql_exporter/installed_extensions.libsonnet',
     import 'sql_exporter/lfc_approximate_working_set_size.libsonnet',
     import 'sql_exporter/lfc_approximate_working_set_size_windows.libsonnet',
     import 'sql_exporter/lfc_cache_size_limit.libsonnet',

--- a/compute/etc/sql_exporter/installed_extensions.libsonnet
+++ b/compute/etc/sql_exporter/installed_extensions.libsonnet
@@ -1,0 +1,11 @@
+{
+    metric_name: 'installed_extensions',
+    type: 'gauge',
+    help: 'List of installed extensions',
+    key_labels: ['extension_name'],
+    values: [
+        'extension_name',
+        'installed_version',
+    ],
+    query: importstr 'sql_exporter/installed_extensions.sql',
+}

--- a/compute/etc/sql_exporter/installed_extensions.libsonnet
+++ b/compute/etc/sql_exporter/installed_extensions.libsonnet
@@ -1,11 +1,11 @@
 {
-    metric_name: 'installed_extensions',
-    type: 'gauge',
-    help: 'List of installed extensions',
-    key_labels: ['extension_name'],
-    values: [
-        'extension_name',
-        'installed_version',
-    ],
-    query: importstr 'sql_exporter/installed_extensions.sql',
+  metric_name: 'installed_extensions',
+  type: 'gauge',
+  help: 'List of installed extensions',
+  key_labels: ['extension_name'],
+  values: [
+    'extension_name',
+    'installed_version',
+  ],
+  query: importstr 'sql_exporter/installed_extensions.sql',
 }

--- a/compute/etc/sql_exporter/installed_extensions.sql
+++ b/compute/etc/sql_exporter/installed_extensions.sql
@@ -1,0 +1,3 @@
+SELECT av_ext.name as extension_name, ext.extversion AS installed_version
+FROM pg_available_extensions av_ext
+JOIN pg_extension ext ON av_ext.name = ext.extname;


### PR DESCRIPTION
## Problem

Currently, we collect metrics of what extensions are installed on computes at start up time. We do not have a metric that does it during runtime.

## Summary of changes

Exposed a metric `installed_extensions` that queries the `pg_extension` table which records all the installed extensions. 