### PR TITLE
Add metadata to pgaudit log logline

### DIFF
--- a/compute_tools/src/config_template/compute_audit_rsyslog_template.conf
+++ b/compute_tools/src/config_template/compute_audit_rsyslog_template.conf
@@ -3,9 +3,10 @@ module(load="imfile")
 
 # Input configuration for log files in the specified directory
 # Replace {log_directory} with the directory containing the log files
-input(type="imfile" File="{log_directory}/*.log" Tag="{tag}" Severity="info" Facility="local0")
+input(type="imfile" File="{log_directory}/*.log" Tag="pgaudit_log" Severity="info" Facility="local5")
 # the directory to store rsyslog state files
 global(workDirectory="/var/log/rsyslog")
 
-# Forward logs to remote syslog server
-*.* @@{remote_endpoint}
+template(name="PgAuditLog" type="string" string="endpoint_id={endpont_id} project_id={project_id} msg=%msg%\n")
+
+local5.info @@{remote_endpoint};PgAuditLog


### PR DESCRIPTION
Previously we were using `project-id/endpoint-id` as SYSLOGTAG, which has a limit of 32 characters, so the endpoint-id got truncated. Instead, prepend these as key=value pairs to the log line, which is easy enough to parse, without a worry of hitting as strict limits.

TODO:
- [ ] pass endpoint_id and project_id in the templating
This requires we pass those as endpoint_id and project_id in the templating.