### PR TITLE
pageserver: support import schema evolution

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -342,7 +342,12 @@ pub enum ShardImportStatus {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct ShardImportProgress {
+pub enum ShardImportProgress {
+    V1(ShardImportProgressV1),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ShardImportProgressV1 {
     /// Total number of jobs in the import plan
     pub jobs: usize,
     /// Number of jobs completed

--- a/pageserver/src/deletion_queue.rs
+++ b/pageserver/src/deletion_queue.rs
@@ -804,7 +804,7 @@ mod test {
             _tenant_shard_id: TenantShardId,
             _timeline_id: TimelineId,
             _generation: Generation,
-        ) -> Result<Option<ShardImportStatus>, RetryForeverError> {
+        ) -> Result<ShardImportStatus, RetryForeverError> {
             unimplemented!()
         }
     }

--- a/pageserver/src/tenant/timeline/import_pgdata.rs
+++ b/pageserver/src/tenant/timeline/import_pgdata.rs
@@ -58,7 +58,7 @@ pub async fn doit(
         .map_err(|_err| anyhow::anyhow!("Shut down while getting timeline import status"))?;
 
     info!(?shard_status, "peeking shard status");
-    match shard_status.unwrap_or(ShardImportStatus::InProgress(None)) {
+    match shard_status {
         ShardImportStatus::InProgress(maybe_progress) => {
             let storage =
                 importbucket_client::new(timeline.conf, &location, cancel.clone()).await?;


### PR DESCRIPTION
## Problem

Imports don't support schema evolution nicely. If we want to change the stuff we keep in storcon,
we'd have to carry the old cruft around.

## Summary of changes

Version import progress. Note that the import progress version determines the version of the import
job split and execution. This means that we can also use it as a mechanism for deploying new import
implementations in the future.