### PR TITLE
CI(test-images): increase timeout from 20m to 60m

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -963,7 +963,7 @@ jobs:
           fi
 
       - name: Verify docker-compose example and test extensions
-        timeout-minutes: 20
+        timeout-minutes: 60
         env:
           TAG: >-
             ${{


### PR DESCRIPTION
## Problem

For some reason (unknown yet) 20m timeout is not enough for `test-images` job on arm runners.
Ref: https://github.com/neondatabase/neon/actions/runs/15075321681/job/42387530399?pr=11953

## Summary of changes
- Increase the timeout from 20m to 1h
