### PR TITLE
pageserver: Add tracing endpoint correctness check in config validation

### DIFF
--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -690,7 +690,7 @@ mod tests {
             denominator = 10
 
             [tracing.export_config]
-            endpoint = "localhost:4000"
+            endpoint = "localhost:4317"
             protocol = "http-binary"
             timeout = "1ms"
         "#;

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -544,6 +544,15 @@ impl PageServerConf {
                     ratio.numerator, ratio.denominator
                 )
             );
+
+            Url::parse(&tracing_config.export_config.endpoint)
+                .map_err(anyhow::Error::msg)
+                .with_context(|| {
+                    format!(
+                        "tracing endpoint URL is invalid : {}",
+                        tracing_config.export_config.endpoint
+                    )
+                })?;
         }
 
         IndexEntry::validate_checkpoint_distance(conf.default_tenant_conf.checkpoint_distance)

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -685,9 +685,7 @@ mod tests {
 
             [tracing]
 
-            [tracing.sampling_ratio]
-            numerator = 1
-            denominator = 10
+            sampling_ratio = { numerator = 1, denominator = 0 }
 
             [tracing.export_config]
             endpoint = "localhost:4317"
@@ -698,6 +696,6 @@ mod tests {
             .expect("config has valid fields");
         let workdir = Utf8PathBuf::from("/nonexistent");
         PageServerConf::parse_and_validate(NodeId(0), config_toml, &workdir)
-            .expect_err("parse_and_validate shall not pass for invalid tracing endpoint");
+            .expect_err("parse_and_validate should fail for endpoint without scheme");
     }
 }


### PR DESCRIPTION
## Problem

When using an incorrect endpoint string - `"localhost:4317"`, it's a runtime error, but it can be a config error
- Closes: https://github.com/neondatabase/neon/issues/11394

## Summary of changes

Add config parse time check via `request::Url::parse` validation.
