### PR TITLE
[hackathon]: patched pgrx14 and updated anon

### DIFF
--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1357,6 +1357,7 @@ RUN wget https://gitlab.com/dalibo/postgresql_anonymizer/-/archive/2.1.0/postgre
     find /usr/local/pgsql -type f | sed 's|^/usr/local/pgsql/||' > /before.txt && \
     sed -i 's/pgrx = "0.14.1"/pgrx = { git = "https:\/\/github.com\/thesuhas\/pgrx.git", branch = "expose_guc_assign_hook", features = [ "unsafe-postgres" ] }/g' Cargo.toml && \
     sed -i 's/pgrx-tests = "0.14.1"/pgrx-tests = { git = "https:\/\/github.com\/thesuhas\/pgrx.git", branch = "expose_guc_assign_hook" }/g' Cargo.toml && \
+    sed -i '/\[dependencies\]/a libc = "0.2.172"' Cargo.toml && \
     patch -p1 < /ext-src/anon_v2.patch
 
 FROM rust-extensions-build-pgrx14 AS pg-anon-pg-build

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1097,7 +1097,7 @@ USER root
 FROM pg-build-nonroot-with-cargo AS rust-extensions-build-pgrx14
 ARG PG_VERSION
 
-RUN cargo install --locked --version 0.14.1 cargo-pgrx && \
+RUN cargo install --locked --git https://github.com/thesuhas/pgrx.git --branch expose_guc_assign_hook cargo-pgrx && \
     /bin/bash -c 'cargo pgrx init --pg${PG_VERSION:1}=/usr/local/pgsql/bin/pg_config'
 
 USER root

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1355,6 +1355,7 @@ RUN wget https://gitlab.com/dalibo/postgresql_anonymizer/-/archive/2.1.0/postgre
     echo "48e7f5ae2f1ca516df3da86c5c739d48dd780a4e885705704ccaad0faa89d6c0  pg_anon.tar.gz" | sha256sum --check && \
     mkdir pg_anon-src && cd pg_anon-src && tar xzf ../pg_anon.tar.gz --strip-components=1 -C . && \
     find /usr/local/pgsql -type f | sed 's|^/usr/local/pgsql/||' > /before.txt && \
+    sed -i 's/pgrx = "0.14.1"/pgrx = { git = "https:\/\/github.com\/thesuhas\/pgrx.git", branch = "expose_guc_assign_hook", features = [ "unsafe-postgres" ] }/g' Cargo.toml && \
     patch -p1 < /ext-src/anon_v2.patch
 
 FROM rust-extensions-build-pgrx14 AS pg-anon-pg-build

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1356,6 +1356,7 @@ RUN wget https://gitlab.com/dalibo/postgresql_anonymizer/-/archive/2.1.0/postgre
     mkdir pg_anon-src && cd pg_anon-src && tar xzf ../pg_anon.tar.gz --strip-components=1 -C . && \
     find /usr/local/pgsql -type f | sed 's|^/usr/local/pgsql/||' > /before.txt && \
     sed -i 's/pgrx = "0.14.1"/pgrx = { git = "https:\/\/github.com\/thesuhas\/pgrx.git", branch = "expose_guc_assign_hook", features = [ "unsafe-postgres" ] }/g' Cargo.toml && \
+    sed -i 's/pgrx-tests = "0.14.1"/pgrx-tests = { git = "https:\/\/github.com\/thesuhas\/pgrx.git", branch = "expose_guc_assign_hook" }/g' Cargo.toml && \
     patch -p1 < /ext-src/anon_v2.patch
 
 FROM rust-extensions-build-pgrx14 AS pg-anon-pg-build

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1355,7 +1355,6 @@ RUN wget https://gitlab.com/dalibo/postgresql_anonymizer/-/archive/2.1.0/postgre
     echo "48e7f5ae2f1ca516df3da86c5c739d48dd780a4e885705704ccaad0faa89d6c0  pg_anon.tar.gz" | sha256sum --check && \
     mkdir pg_anon-src && cd pg_anon-src && tar xzf ../pg_anon.tar.gz --strip-components=1 -C . && \
     find /usr/local/pgsql -type f | sed 's|^/usr/local/pgsql/||' > /before.txt && \
-    sed -i 's/pgrx = "0.14.1"/pgrx = { version = "=0.14.1", features = [ "unsafe-postgres" ] }/g' Cargo.toml && \
     patch -p1 < /ext-src/anon_v2.patch
 
 FROM rust-extensions-build-pgrx14 AS pg-anon-pg-build

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -1,8 +1,8 @@
 diff --git a/sql/anon.sql b/sql/anon.sql
-index 0cdc769..f6cc950 100644
+index 0cdc769..85a58a6 100644
 --- a/sql/anon.sql
 +++ b/sql/anon.sql
-@@ -1141,3 +1141,8 @@ $$
+@@ -1141,3 +1141,9 @@ $$
  -- TODO : https://en.wikipedia.org/wiki/L-diversity
  
  -- TODO : https://en.wikipedia.org/wiki/T-closeness
@@ -11,6 +11,7 @@ index 0cdc769..f6cc950 100644
 +
 +GRANT ALL ON SCHEMA anon to neon_superuser;
 +GRANT ALL ON ALL TABLES IN SCHEMA anon TO neon_superuser;
++-- GRANT SET ON PARAMETER anon.transparent_dynamic_masking TO neon_superuser;
 diff --git a/sql/init.sql b/sql/init.sql
 index 7da6553..7961984 100644
 --- a/sql/init.sql
@@ -151,7 +152,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..848c902 100644
+index 74d3822..696a505 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -163,7 +164,7 @@ index 74d3822..848c902 100644
  
  pub static ANON_DUMMY_LOCALE: GucSetting<Option<&'static CStr>> =
      GucSetting::<Option<&'static CStr>>::new(Some(unsafe {
-@@ -51,6 +51,43 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
+@@ -51,6 +51,45 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
          CStr::from_bytes_with_nul_unchecked(b"mask\0")
      }));
  
@@ -171,12 +172,13 @@ index 74d3822..848c902 100644
 +unsafe extern "C-unwind" fn check_bool_guc_hook(
 +   _newval: *mut bool,
 +   _extra: *mut *mut c_void,
-+   _source: u32
++   source: u32
 +) -> bool {
 +    unsafe {
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
++        pg_sys::info!("Source: {}", source);
 +        pg_sys::info!("user: {} trying to change boolean guc", user_str);
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +            return true;
@@ -189,12 +191,13 @@ index 74d3822..848c902 100644
 +unsafe extern "C-unwind" fn check_string_guc_hook(
 +_newval: *mut *mut libc::c_char,
 +_extra: *mut *mut c_void,
-+_source: u32
++source: u32
 +) -> bool {
 +    unsafe {
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
++        pg_sys::info!("Source: {}", source);
 +        pg_sys::info!("user: {} trying to change string guc", user_str);
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +            return true;
@@ -207,7 +210,7 @@ index 74d3822..848c902 100644
  // Register the GUC parameters for the extension
  //
  pub fn register_gucs() {
-@@ -61,6 +98,9 @@ pub fn register_gucs() {
+@@ -61,6 +100,9 @@ pub fn register_gucs() {
          &ANON_DUMMY_LOCALE,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -217,7 +220,7 @@ index 74d3822..848c902 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -70,6 +110,9 @@ pub fn register_gucs() {
+@@ -70,6 +112,9 @@ pub fn register_gucs() {
          &ANON_K_ANONYMITY_PROVIDER,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -227,7 +230,7 @@ index 74d3822..848c902 100644
      );
  
      //
-@@ -87,6 +130,9 @@ pub fn register_gucs() {
+@@ -87,6 +132,9 @@ pub fn register_gucs() {
          &ANON_MASKING_POLICIES,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY, /* | GucFlags::LIST_INPUT */
@@ -237,7 +240,7 @@ index 74d3822..848c902 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -94,16 +140,22 @@ pub fn register_gucs() {
+@@ -94,16 +142,22 @@ pub fn register_gucs() {
          "Mask all columns with NULL (or the default value for NOT NULL columns)",
          "",
          &ANON_PRIVACY_BY_DEFAULT,
@@ -262,7 +265,7 @@ index 74d3822..848c902 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -113,6 +165,9 @@ pub fn register_gucs() {
+@@ -113,6 +167,9 @@ pub fn register_gucs() {
          &ANON_RESTRICT_TO_TRUSTED_SCHEMAS,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -272,7 +275,7 @@ index 74d3822..848c902 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -120,8 +175,11 @@ pub fn register_gucs() {
+@@ -120,8 +177,11 @@ pub fn register_gucs() {
          "A masking rule cannot change a column data type, unless you disable this",
          "Disabling the mode is not recommended",
          &ANON_STRICT_MODE,
@@ -285,7 +288,7 @@ index 74d3822..848c902 100644
      );
  
      // The GUC vars below are not used in the Rust code
-@@ -134,6 +192,9 @@ pub fn register_gucs() {
+@@ -134,6 +194,9 @@ pub fn register_gucs() {
          &ANON_ALGORITHM,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -295,7 +298,7 @@ index 74d3822..848c902 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -141,8 +202,11 @@ pub fn register_gucs() {
+@@ -141,8 +204,11 @@ pub fn register_gucs() {
          "The schema where the dynamic masking views are stored",
          "",
          &ANON_MASK_SCHEMA,
@@ -308,7 +311,7 @@ index 74d3822..848c902 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -152,6 +216,9 @@ pub fn register_gucs() {
+@@ -152,6 +218,9 @@ pub fn register_gucs() {
          &ANON_SALT,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -318,7 +321,7 @@ index 74d3822..848c902 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -159,7 +226,10 @@ pub fn register_gucs() {
+@@ -159,7 +228,10 @@ pub fn register_gucs() {
          "The schema where the table are masked by the dynamic masking engine",
          "",
          &ANON_SOURCE_SCHEMA,

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -152,7 +152,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..8b500ce 100644
+index 74d3822..d4121ae 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -186,13 +186,13 @@ index 74d3822..8b500ce 100644
 +        // 2. PGC_S_TEST (12) -> ALTER ROLE/DATABASE
 +        // 3. PGC_S_SESSION (13) -> SET ...
 +        // TODO (thesuhas): Does PGC_S_GLOBAL need to be added to whitelisted sources?
++        pg_sys::info!("Source: {}", source);
 +        if source == 0 || source == 6 || source == 7 || source == 8 {
 +            return true;
 +        }
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
-+        pg_sys::info!("Source: {}", source);
 +        pg_sys::info!("user: {} trying to change boolean guc", user_str);
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +            return true;
@@ -218,13 +218,13 @@ index 74d3822..8b500ce 100644
 +        // 1. PGC_S_FILE (3) -> ALTER SYSTEM
 +        // 2. PGC_S_TEST (12) -> ALTER ROLE/DATABASE
 +        // 3. PGC_S_SESSION (13) -> SET ...
++        pg_sys::info!("Source: {}", source);
 +        if source == 0 || source == 6 || source == 7 || source == 8 {
 +            return true;
 +        }
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
-+        pg_sys::info!("Source: {}", source);
 +        pg_sys::info!("user: {} trying to change string guc", user_str);
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +            return true;

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -152,7 +152,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..cb31bb8 100644
+index 74d3822..8b500ce 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -164,7 +164,7 @@ index 74d3822..cb31bb8 100644
  
  pub static ANON_DUMMY_LOCALE: GucSetting<Option<&'static CStr>> =
      GucSetting::<Option<&'static CStr>>::new(Some(unsafe {
-@@ -51,6 +51,55 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
+@@ -51,25 +51,97 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
          CStr::from_bytes_with_nul_unchecked(b"mask\0")
      }));
  
@@ -175,9 +175,18 @@ index 74d3822..cb31bb8 100644
 +   source: u32
 +) -> bool {
 +    unsafe {
-+        // This is the default boot up source (PGC_S_DEFAULT), most likely a new session or server. Allow
-+        // user to load GUC
-+        if source == 0 {
++        // The sources that we allow are:
++        // 1. PGC_S_DEFAULT (0) -> for default boot up source, likely new session or server.
++        // 2. PGC_S_DATABASE (6) -> a GUC set for a particular database
++        // 3. PGC_S_USER (7) -> a GUC set for a particular role
++        // 4. PGC_S_DATABASE_USER (8) -> a GUC set for a particular role in a particular database
++        // This check only allows sources that load a variable, not ones that try to alter it.
++        // Sources that try to alter it are:
++        // 1. PGC_S_FILE (3) -> ALTER SYSTEM
++        // 2. PGC_S_TEST (12) -> ALTER ROLE/DATABASE
++        // 3. PGC_S_SESSION (13) -> SET ...
++        // TODO (thesuhas): Does PGC_S_GLOBAL need to be added to whitelisted sources?
++        if source == 0 || source == 6 || source == 7 || source == 8 {
 +            return true;
 +        }
 +        let oid = pg_sys::GetUserId();
@@ -199,9 +208,17 @@ index 74d3822..cb31bb8 100644
 +source: u32
 +) -> bool {
 +    unsafe {
-+        // This is the default boot up source (PGC_S_DEFAULT), most likely a new session or server. Allow
-+        // user to load GUC
-+        if source == 0 {
++        // The sources that we allow are:
++        // 1. PGC_S_DEFAULT (0) -> for default boot up source, likely new session or server.
++        // 2. PGC_S_DATABASE (6) -> a GUC set for a particular database
++        // 3. PGC_S_USER (7) -> a GUC set for a particular role
++        // 4. PGC_S_DATABASE_USER (8) -> a GUC set for a particular role in a particular database
++        // This check only allows sources that load a variable, not ones that try to alter it.
++        // Sources that try to alter it are:
++        // 1. PGC_S_FILE (3) -> ALTER SYSTEM
++        // 2. PGC_S_TEST (12) -> ALTER ROLE/DATABASE
++        // 3. PGC_S_SESSION (13) -> SET ...
++        if source == 0 || source == 6 || source == 7 || source == 8 {
 +            return true;
 +        }
 +        let oid = pg_sys::GetUserId();
@@ -220,7 +237,11 @@ index 74d3822..cb31bb8 100644
  // Register the GUC parameters for the extension
  //
  pub fn register_gucs() {
-@@ -61,6 +110,9 @@ pub fn register_gucs() {
+-    GucRegistry::define_string_guc(
++    GucRegistry::define_string_guc_with_hooks(
+         "anon.dummy_locale",
+         "The default locale for the dummy data functions",
+         "",
          &ANON_DUMMY_LOCALE,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -229,8 +250,11 @@ index 74d3822..cb31bb8 100644
 +        None,
      );
  
-     GucRegistry::define_string_guc(
-@@ -70,6 +122,9 @@ pub fn register_gucs() {
+-    GucRegistry::define_string_guc(
++    GucRegistry::define_string_guc_with_hooks(
+         "anon.k_anonymity_provider",
+         "The security label provider used for k-anonymity",
+         "",
          &ANON_K_ANONYMITY_PROVIDER,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -240,7 +264,15 @@ index 74d3822..cb31bb8 100644
      );
  
      //
-@@ -87,6 +142,9 @@ pub fn register_gucs() {
+@@ -80,86 +152,113 @@ pub fn register_gucs() {
+     //
+     // https://github.com/pgcentralfoundation/pgrx/commit/d096efe6fb2d86e87d117b520b9ccd2f90b2e0d1
+     //
+-    GucRegistry::define_string_guc(
++    GucRegistry::define_string_guc_with_hooks(
+         "anon.masking_policies",
+         "Define additional masking policies (the 'anon' policy is already defined)",
+         "",
          &ANON_MASKING_POLICIES,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY, /* | GucFlags::LIST_INPUT */
@@ -249,8 +281,9 @@ index 74d3822..cb31bb8 100644
 +        None,
      );
  
-     GucRegistry::define_bool_guc(
-@@ -94,16 +152,22 @@ pub fn register_gucs() {
+-    GucRegistry::define_bool_guc(
++    GucRegistry::define_bool_guc_with_hooks(
+         "anon.privacy_by_default",
          "Mask all columns with NULL (or the default value for NOT NULL columns)",
          "",
          &ANON_PRIVACY_BY_DEFAULT,
@@ -261,7 +294,8 @@ index 74d3822..cb31bb8 100644
 +        None,
 +        None,
      );
-     GucRegistry::define_bool_guc(
+-    GucRegistry::define_bool_guc(
++    GucRegistry::define_bool_guc_with_hooks(
          "anon.transparent_dynamic_masking",
          "New masking engine (EXPERIMENTAL)",
          "",
@@ -274,8 +308,11 @@ index 74d3822..cb31bb8 100644
 +        None,
      );
  
-     GucRegistry::define_bool_guc(
-@@ -113,6 +177,9 @@ pub fn register_gucs() {
+-    GucRegistry::define_bool_guc(
++    GucRegistry::define_bool_guc_with_hooks(
+         "anon.restrict_to_trusted_schemas",
+         "Masking filters must be in a trusted schema",
+         "Activate this option to prevent non-superuser from using their own masking filters",
          &ANON_RESTRICT_TO_TRUSTED_SCHEMAS,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -284,8 +321,9 @@ index 74d3822..cb31bb8 100644
 +        None,
      );
  
-     GucRegistry::define_bool_guc(
-@@ -120,8 +187,11 @@ pub fn register_gucs() {
+-    GucRegistry::define_bool_guc(
++    GucRegistry::define_bool_guc_with_hooks(
+         "anon.strict_mode",
          "A masking rule cannot change a column data type, unless you disable this",
          "Disabling the mode is not recommended",
          &ANON_STRICT_MODE,
@@ -298,7 +336,13 @@ index 74d3822..cb31bb8 100644
      );
  
      // The GUC vars below are not used in the Rust code
-@@ -134,6 +204,9 @@ pub fn register_gucs() {
+     // but they are used in the plpgsql code
+ 
+-    GucRegistry::define_string_guc(
++    GucRegistry::define_string_guc_with_hooks(
+         "anon.algorithm",
+         "The hash method used for pseudonymizing functions",
+         "",
          &ANON_ALGORITHM,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -307,8 +351,9 @@ index 74d3822..cb31bb8 100644
 +        None,
      );
  
-     GucRegistry::define_string_guc(
-@@ -141,8 +214,11 @@ pub fn register_gucs() {
+-    GucRegistry::define_string_guc(
++    GucRegistry::define_string_guc_with_hooks(
+         "anon.maskschema",
          "The schema where the dynamic masking views are stored",
          "",
          &ANON_MASK_SCHEMA,
@@ -320,8 +365,11 @@ index 74d3822..cb31bb8 100644
 +        None,
      );
  
-     GucRegistry::define_string_guc(
-@@ -152,6 +228,9 @@ pub fn register_gucs() {
+-    GucRegistry::define_string_guc(
++    GucRegistry::define_string_guc_with_hooks(
+         "anon.salt",
+         "The salt value used for the pseudonymizing functions",
+         "",
          &ANON_SALT,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -330,8 +378,9 @@ index 74d3822..cb31bb8 100644
 +        None,
      );
  
-     GucRegistry::define_string_guc(
-@@ -159,7 +238,10 @@ pub fn register_gucs() {
+-    GucRegistry::define_string_guc(
++    GucRegistry::define_string_guc_with_hooks(
+         "anon.sourceschema",
          "The schema where the table are masked by the dynamic masking engine",
          "",
          &ANON_SOURCE_SCHEMA,

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -152,7 +152,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..696a505 100644
+index 74d3822..cb31bb8 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -164,7 +164,7 @@ index 74d3822..696a505 100644
  
  pub static ANON_DUMMY_LOCALE: GucSetting<Option<&'static CStr>> =
      GucSetting::<Option<&'static CStr>>::new(Some(unsafe {
-@@ -51,6 +51,45 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
+@@ -51,6 +51,55 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
          CStr::from_bytes_with_nul_unchecked(b"mask\0")
      }));
  
@@ -175,6 +175,11 @@ index 74d3822..696a505 100644
 +   source: u32
 +) -> bool {
 +    unsafe {
++        // This is the default boot up source (PGC_S_DEFAULT), most likely a new session or server. Allow
++        // user to load GUC
++        if source == 0 {
++            return true;
++        }
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
@@ -194,6 +199,11 @@ index 74d3822..696a505 100644
 +source: u32
 +) -> bool {
 +    unsafe {
++        // This is the default boot up source (PGC_S_DEFAULT), most likely a new session or server. Allow
++        // user to load GUC
++        if source == 0 {
++            return true;
++        }
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
@@ -210,7 +220,7 @@ index 74d3822..696a505 100644
  // Register the GUC parameters for the extension
  //
  pub fn register_gucs() {
-@@ -61,6 +100,9 @@ pub fn register_gucs() {
+@@ -61,6 +110,9 @@ pub fn register_gucs() {
          &ANON_DUMMY_LOCALE,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -220,7 +230,7 @@ index 74d3822..696a505 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -70,6 +112,9 @@ pub fn register_gucs() {
+@@ -70,6 +122,9 @@ pub fn register_gucs() {
          &ANON_K_ANONYMITY_PROVIDER,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -230,7 +240,7 @@ index 74d3822..696a505 100644
      );
  
      //
-@@ -87,6 +132,9 @@ pub fn register_gucs() {
+@@ -87,6 +142,9 @@ pub fn register_gucs() {
          &ANON_MASKING_POLICIES,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY, /* | GucFlags::LIST_INPUT */
@@ -240,7 +250,7 @@ index 74d3822..696a505 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -94,16 +142,22 @@ pub fn register_gucs() {
+@@ -94,16 +152,22 @@ pub fn register_gucs() {
          "Mask all columns with NULL (or the default value for NOT NULL columns)",
          "",
          &ANON_PRIVACY_BY_DEFAULT,
@@ -265,7 +275,7 @@ index 74d3822..696a505 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -113,6 +167,9 @@ pub fn register_gucs() {
+@@ -113,6 +177,9 @@ pub fn register_gucs() {
          &ANON_RESTRICT_TO_TRUSTED_SCHEMAS,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -275,7 +285,7 @@ index 74d3822..696a505 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -120,8 +177,11 @@ pub fn register_gucs() {
+@@ -120,8 +187,11 @@ pub fn register_gucs() {
          "A masking rule cannot change a column data type, unless you disable this",
          "Disabling the mode is not recommended",
          &ANON_STRICT_MODE,
@@ -288,7 +298,7 @@ index 74d3822..696a505 100644
      );
  
      // The GUC vars below are not used in the Rust code
-@@ -134,6 +194,9 @@ pub fn register_gucs() {
+@@ -134,6 +204,9 @@ pub fn register_gucs() {
          &ANON_ALGORITHM,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -298,7 +308,7 @@ index 74d3822..696a505 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -141,8 +204,11 @@ pub fn register_gucs() {
+@@ -141,8 +214,11 @@ pub fn register_gucs() {
          "The schema where the dynamic masking views are stored",
          "",
          &ANON_MASK_SCHEMA,
@@ -311,7 +321,7 @@ index 74d3822..696a505 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -152,6 +218,9 @@ pub fn register_gucs() {
+@@ -152,6 +228,9 @@ pub fn register_gucs() {
          &ANON_SALT,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -321,7 +331,7 @@ index 74d3822..696a505 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -159,7 +228,10 @@ pub fn register_gucs() {
+@@ -159,7 +238,10 @@ pub fn register_gucs() {
          "The schema where the table are masked by the dynamic masking engine",
          "",
          &ANON_SOURCE_SCHEMA,

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -1,22 +1,3 @@
-diff --git a/Cargo.toml b/Cargo.toml
-index 1037705..9f2ffee 100644
---- a/Cargo.toml
-+++ b/Cargo.toml
-@@ -24,12 +24,12 @@ fake = { version = "4.3.0", features = ["bigdecimal", "chrono", "http", "rust_de
- image = "0.25.5"
- md-5 = "0.10.6"
- paste = "1.0"
--pgrx = "0.14.1"
-+pgrx = { git = "https://github.com/thesuhas/pgrx.git", branch = "expose_guc_assign_hook" }
- rand = "0.8.5"
- regex = "1.10.2"
- 
- [dev-dependencies]
--pgrx-tests = "0.14.1"
-+pgrx-tests = { git = "https://github.com/thesuhas/pgrx.git", branch = "expose_guc_assign_hook" }
- 
- [profile.dev]
- panic = "unwind"
 diff --git a/sql/anon.sql b/sql/anon.sql
 index 0cdc769..f6cc950 100644
 --- a/sql/anon.sql

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -151,7 +151,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..1680cc5 100644
+index 74d3822..95e9de8 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -177,7 +177,7 @@ index 74d3822..1680cc5 100644
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
-+        // postgres user OID
++        pg_sys::log!("user: {} trying to change boolean guc", user_str);
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +            return true;
 +        }
@@ -195,7 +195,7 @@ index 74d3822..1680cc5 100644
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
-+        // postgres user OID
++        pg_sys::log!("user: {} trying to change string guc", user_str);
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +        return true;
 +    }

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -151,7 +151,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..72e7f6b 100644
+index 74d3822..1680cc5 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -237,9 +237,12 @@ index 74d3822..72e7f6b 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -96,6 +142,9 @@ pub fn register_gucs() {
+@@ -94,16 +140,22 @@ pub fn register_gucs() {
+         "Mask all columns with NULL (or the default value for NOT NULL columns)",
+         "",
          &ANON_PRIVACY_BY_DEFAULT,
-         GucContext::Suset,
+-        GucContext::Suset,
++        GucContext::Userset,
          GucFlags::default(),
 +        Some(check_bool_guc_hook),
 +        None,
@@ -247,9 +250,11 @@ index 74d3822..72e7f6b 100644
      );
      GucRegistry::define_bool_guc(
          "anon.transparent_dynamic_masking",
-@@ -104,6 +153,9 @@ pub fn register_gucs() {
+         "New masking engine (EXPERIMENTAL)",
+         "",
          &ANON_TRANSPARENT_DYNAMIC_MASKING,
-         GucContext::Suset,
+-        GucContext::Suset,
++        GucContext::Userset,
          GucFlags::default(),
 +        Some(check_bool_guc_hook),
 +        None,
@@ -267,9 +272,12 @@ index 74d3822..72e7f6b 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -122,6 +177,9 @@ pub fn register_gucs() {
+@@ -120,8 +175,11 @@ pub fn register_gucs() {
+         "A masking rule cannot change a column data type, unless you disable this",
+         "Disabling the mode is not recommended",
          &ANON_STRICT_MODE,
-         GucContext::Suset,
+-        GucContext::Suset,
++        GucContext::Userset,
          GucFlags::default(),
 +        Some(check_bool_guc_hook),
 +        None,
@@ -287,9 +295,12 @@ index 74d3822..72e7f6b 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -143,6 +204,9 @@ pub fn register_gucs() {
+@@ -141,8 +202,11 @@ pub fn register_gucs() {
+         "The schema where the dynamic masking views are stored",
+         "",
          &ANON_MASK_SCHEMA,
-         GucContext::Suset,
+-        GucContext::Suset,
++        GucContext::Userset,
          GucFlags::default(),
 +        Some(check_string_guc_hook),
 +        None,
@@ -307,9 +318,12 @@ index 74d3822..72e7f6b 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -161,5 +228,8 @@ pub fn register_gucs() {
+@@ -159,7 +226,10 @@ pub fn register_gucs() {
+         "The schema where the table are masked by the dynamic masking engine",
+         "",
          &ANON_SOURCE_SCHEMA,
-         GucContext::Suset,
+-        GucContext::Suset,
++        GucContext::Userset,
          GucFlags::default(),
 +        Some(check_string_guc_hook),
 +        None,

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -151,7 +151,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..95e9de8 100644
+index 74d3822..49f58e8 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -181,7 +181,7 @@ index 74d3822..95e9de8 100644
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +            return true;
 +        }
-+        pg_sys::ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
++        pg_sys::ereport!(PgLogLevel::NOTICE, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
 +        false
 +    }
 +}
@@ -199,7 +199,7 @@ index 74d3822..95e9de8 100644
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +        return true;
 +    }
-+    pg_sys::ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
++    pg_sys::ereport!(PgLogLevel::NOTICE, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
 +    false
 +    }
 +}

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -151,7 +151,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..49f58e8 100644
+index 74d3822..848c902 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -177,11 +177,11 @@ index 74d3822..49f58e8 100644
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
-+        pg_sys::log!("user: {} trying to change boolean guc", user_str);
++        pg_sys::info!("user: {} trying to change boolean guc", user_str);
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
 +            return true;
 +        }
-+        pg_sys::ereport!(PgLogLevel::NOTICE, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
++        pg_sys::ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
 +        false
 +    }
 +}
@@ -195,12 +195,12 @@ index 74d3822..49f58e8 100644
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
 +        let user_str = user_name.to_str().unwrap();
-+        pg_sys::log!("user: {} trying to change string guc", user_str);
++        pg_sys::info!("user: {} trying to change string guc", user_str);
 +        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
-+        return true;
-+    }
-+    pg_sys::ereport!(PgLogLevel::NOTICE, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
-+    false
++            return true;
++        }
++        pg_sys::ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
++        false
 +    }
 +}
 +

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -151,7 +151,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..6dbd0bc 100644
+index 74d3822..7d57125 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -186,7 +186,7 @@ index 74d3822..6dbd0bc 100644
 +}
 +
 + unsafe extern "C-unwind" fn check_string_guc_hook(
-+    _newval: *mut *mut i8,
++    _newval: *mut *mut libc::c_char,
 +    _extra: *mut *mut c_void,
 +    _source: u32
 + ) -> bool {

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -151,7 +151,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..2cd52d3 100644
+index 74d3822..72e7f6b 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -251,7 +251,7 @@ index 74d3822..2cd52d3 100644
          &ANON_TRANSPARENT_DYNAMIC_MASKING,
          GucContext::Suset,
          GucFlags::default(),
-+        None,
++        Some(check_bool_guc_hook),
 +        None,
 +        None,
      );

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -1,3 +1,22 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 1037705..9f2ffee 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -24,12 +24,12 @@ fake = { version = "4.3.0", features = ["bigdecimal", "chrono", "http", "rust_de
+ image = "0.25.5"
+ md-5 = "0.10.6"
+ paste = "1.0"
+-pgrx = "0.14.1"
++pgrx = { git = "https://github.com/thesuhas/pgrx.git", branch = "expose_guc_assign_hook" }
+ rand = "0.8.5"
+ regex = "1.10.2"
+ 
+ [dev-dependencies]
+-pgrx-tests = "0.14.1"
++pgrx-tests = { git = "https://github.com/thesuhas/pgrx.git", branch = "expose_guc_assign_hook" }
+ 
+ [profile.dev]
+ panic = "unwind"
 diff --git a/sql/anon.sql b/sql/anon.sql
 index 0cdc769..f6cc950 100644
 --- a/sql/anon.sql
@@ -12,7 +31,7 @@ index 0cdc769..f6cc950 100644
 +GRANT ALL ON SCHEMA anon to neon_superuser;
 +GRANT ALL ON ALL TABLES IN SCHEMA anon TO neon_superuser;
 diff --git a/sql/init.sql b/sql/init.sql
-index 7da6553..9b6164b 100644
+index 7da6553..7961984 100644
 --- a/sql/init.sql
 +++ b/sql/init.sql
 @@ -74,50 +74,49 @@ $$
@@ -127,3 +146,190 @@ index 7da6553..9b6164b 100644
    VOLATILE
    PARALLEL UNSAFE -- because init is unsafe
    SECURITY INVOKER
+@@ -264,3 +263,22 @@ $$
+ ;
+ 
+ SECURITY LABEL FOR anon ON FUNCTION anon.unload IS 'UNTRUSTED';
++
++
++CREATE OR REPLACE FUNCTION anon.toggle_transparent_dynamic_masking(
++  dbname TEXT,
++  toggle BOOLEAN DEFAULT TRUE
++)
++RETURNS VOID AS
++$$
++BEGIN
++  EXECUTE format('ALTER DATABASE %I SET anon.transparent_dynamic_masking TO %s', dbname, toggle::TEXT);
++END;
++$$
++  LANGUAGE plpgsql
++  VOLATILE
++  SECURITY DEFINER
++  SET search_path=''
++;
++
++SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
+diff --git a/src/guc.rs b/src/guc.rs
+index 74d3822..6dbd0bc 100644
+--- a/src/guc.rs
++++ b/src/guc.rs
+@@ -3,7 +3,7 @@
+ //----------------------------------------------------------------------------
+ 
+ use pgrx::*;
+-use std::ffi::CStr;
++use std::ffi::{CStr, c_void};
+ 
+ pub static ANON_DUMMY_LOCALE: GucSetting<Option<&'static CStr>> =
+     GucSetting::<Option<&'static CStr>>::new(Some(unsafe {
+@@ -51,6 +51,41 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
+         CStr::from_bytes_with_nul_unchecked(b"mask\0")
+     }));
+ 
++
++unsafe extern "C-unwind" fn check_bool_guc_hook(
++   _newval: *mut bool,
++   _extra: *mut *mut c_void,
++   _source: u32
++) -> bool {
++    unsafe {
++        let oid = pg_sys::GetUserId();
++        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
++        // postgres user OID
++        if user_name.to_str().unwrap() != "neon_superuser" || !pg_sys::superuser() {
++            pg_sys::ereport!(PgLogLevel::NOTICE, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
++            return false;
++        }
++        return true;
++    }
++}
++
++ unsafe extern "C-unwind" fn check_string_guc_hook(
++    _newval: *mut *mut i8,
++    _extra: *mut *mut c_void,
++    _source: u32
++ ) -> bool {
++     unsafe {
++         let oid = pg_sys::GetUserId();
++         let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
++         // postgres user OID
++         if user_name.to_str().unwrap() != "neon_superuser" || !pg_sys::superuser() {
++             pg_sys::ereport!(PgLogLevel::NOTICE, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
++             return false;
++         }
++         return true;
++     }
++ }
++
+ // Register the GUC parameters for the extension
+ //
+ pub fn register_gucs() {
+@@ -61,6 +96,9 @@ pub fn register_gucs() {
+         &ANON_DUMMY_LOCALE,
+         GucContext::Suset,
+         GucFlags::SUPERUSER_ONLY,
++        Some(check_string_guc_hook),
++        None,
++        None,
+     );
+ 
+     GucRegistry::define_string_guc(
+@@ -70,6 +108,9 @@ pub fn register_gucs() {
+         &ANON_K_ANONYMITY_PROVIDER,
+         GucContext::Suset,
+         GucFlags::SUPERUSER_ONLY,
++        Some(check_string_guc_hook),
++        None,
++        None,
+     );
+ 
+     //
+@@ -87,6 +128,9 @@ pub fn register_gucs() {
+         &ANON_MASKING_POLICIES,
+         GucContext::Suset,
+         GucFlags::SUPERUSER_ONLY, /* | GucFlags::LIST_INPUT */
++        Some(check_string_guc_hook),
++        None,
++        None,
+     );
+ 
+     GucRegistry::define_bool_guc(
+@@ -96,6 +140,9 @@ pub fn register_gucs() {
+         &ANON_PRIVACY_BY_DEFAULT,
+         GucContext::Suset,
+         GucFlags::default(),
++        Some(check_bool_guc_hook),
++        None,
++        None,
+     );
+     GucRegistry::define_bool_guc(
+         "anon.transparent_dynamic_masking",
+@@ -104,6 +151,9 @@ pub fn register_gucs() {
+         &ANON_TRANSPARENT_DYNAMIC_MASKING,
+         GucContext::Suset,
+         GucFlags::default(),
++        None,
++        None,
++        None,
+     );
+ 
+     GucRegistry::define_bool_guc(
+@@ -113,6 +163,9 @@ pub fn register_gucs() {
+         &ANON_RESTRICT_TO_TRUSTED_SCHEMAS,
+         GucContext::Suset,
+         GucFlags::SUPERUSER_ONLY,
++        Some(check_bool_guc_hook),
++        None,
++        None,
+     );
+ 
+     GucRegistry::define_bool_guc(
+@@ -122,6 +175,9 @@ pub fn register_gucs() {
+         &ANON_STRICT_MODE,
+         GucContext::Suset,
+         GucFlags::default(),
++        Some(check_bool_guc_hook),
++        None,
++        None,
+     );
+ 
+     // The GUC vars below are not used in the Rust code
+@@ -134,6 +190,9 @@ pub fn register_gucs() {
+         &ANON_ALGORITHM,
+         GucContext::Suset,
+         GucFlags::SUPERUSER_ONLY,
++        Some(check_string_guc_hook),
++        None,
++        None,
+     );
+ 
+     GucRegistry::define_string_guc(
+@@ -143,6 +202,9 @@ pub fn register_gucs() {
+         &ANON_MASK_SCHEMA,
+         GucContext::Suset,
+         GucFlags::default(),
++        Some(check_string_guc_hook),
++        None,
++        None,
+     );
+ 
+     GucRegistry::define_string_guc(
+@@ -152,6 +214,9 @@ pub fn register_gucs() {
+         &ANON_SALT,
+         GucContext::Suset,
+         GucFlags::SUPERUSER_ONLY,
++        Some(check_string_guc_hook),
++        None,
++        None,
+     );
+ 
+     GucRegistry::define_string_guc(
+@@ -161,5 +226,8 @@ pub fn register_gucs() {
+         &ANON_SOURCE_SCHEMA,
+         GucContext::Suset,
+         GucFlags::default(),
++        Some(check_string_guc_hook),
++        None,
++        None,
+     );
+ }

--- a/compute/patches/anon_v2.patch
+++ b/compute/patches/anon_v2.patch
@@ -151,7 +151,7 @@ index 7da6553..7961984 100644
 +
 +SECURITY LABEL FOR anon ON FUNCTION anon.toggle_transparent_dynamic_masking IS 'UNTRUSTED';
 diff --git a/src/guc.rs b/src/guc.rs
-index 74d3822..7d57125 100644
+index 74d3822..2cd52d3 100644
 --- a/src/guc.rs
 +++ b/src/guc.rs
 @@ -3,7 +3,7 @@
@@ -163,7 +163,7 @@ index 74d3822..7d57125 100644
  
  pub static ANON_DUMMY_LOCALE: GucSetting<Option<&'static CStr>> =
      GucSetting::<Option<&'static CStr>>::new(Some(unsafe {
-@@ -51,6 +51,41 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
+@@ -51,6 +51,43 @@ static ANON_MASK_SCHEMA: GucSetting<Option<&'static CStr>> =
          CStr::from_bytes_with_nul_unchecked(b"mask\0")
      }));
  
@@ -176,36 +176,38 @@ index 74d3822..7d57125 100644
 +    unsafe {
 +        let oid = pg_sys::GetUserId();
 +        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
++        let user_str = user_name.to_str().unwrap();
 +        // postgres user OID
-+        if user_name.to_str().unwrap() != "neon_superuser" || !pg_sys::superuser() {
-+            pg_sys::ereport!(PgLogLevel::NOTICE, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
-+            return false;
++        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
++            return true;
 +        }
-+        return true;
++        pg_sys::ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
++        false
 +    }
 +}
 +
-+ unsafe extern "C-unwind" fn check_string_guc_hook(
-+    _newval: *mut *mut libc::c_char,
-+    _extra: *mut *mut c_void,
-+    _source: u32
-+ ) -> bool {
-+     unsafe {
-+         let oid = pg_sys::GetUserId();
-+         let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
-+         // postgres user OID
-+         if user_name.to_str().unwrap() != "neon_superuser" || !pg_sys::superuser() {
-+             pg_sys::ereport!(PgLogLevel::NOTICE, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
-+             return false;
-+         }
-+         return true;
-+     }
-+ }
++unsafe extern "C-unwind" fn check_string_guc_hook(
++_newval: *mut *mut libc::c_char,
++_extra: *mut *mut c_void,
++_source: u32
++) -> bool {
++    unsafe {
++        let oid = pg_sys::GetUserId();
++        let user_name = CStr::from_ptr(pg_sys::GetUserNameFromId(oid, true));
++        let user_str = user_name.to_str().unwrap();
++        // postgres user OID
++        if pg_sys::superuser() || user_str == "neon_superuser" || user_str == "neondb_owner" {
++        return true;
++    }
++    pg_sys::ereport!(PgLogLevel::ERROR, PgSqlErrorCode::ERRCODE_INSUFFICIENT_PRIVILEGE, "You are not authorized to change this GUC");
++    false
++    }
++}
 +
  // Register the GUC parameters for the extension
  //
  pub fn register_gucs() {
-@@ -61,6 +96,9 @@ pub fn register_gucs() {
+@@ -61,6 +98,9 @@ pub fn register_gucs() {
          &ANON_DUMMY_LOCALE,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -215,7 +217,7 @@ index 74d3822..7d57125 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -70,6 +108,9 @@ pub fn register_gucs() {
+@@ -70,6 +110,9 @@ pub fn register_gucs() {
          &ANON_K_ANONYMITY_PROVIDER,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -225,7 +227,7 @@ index 74d3822..7d57125 100644
      );
  
      //
-@@ -87,6 +128,9 @@ pub fn register_gucs() {
+@@ -87,6 +130,9 @@ pub fn register_gucs() {
          &ANON_MASKING_POLICIES,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY, /* | GucFlags::LIST_INPUT */
@@ -235,7 +237,7 @@ index 74d3822..7d57125 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -96,6 +140,9 @@ pub fn register_gucs() {
+@@ -96,6 +142,9 @@ pub fn register_gucs() {
          &ANON_PRIVACY_BY_DEFAULT,
          GucContext::Suset,
          GucFlags::default(),
@@ -245,7 +247,7 @@ index 74d3822..7d57125 100644
      );
      GucRegistry::define_bool_guc(
          "anon.transparent_dynamic_masking",
-@@ -104,6 +151,9 @@ pub fn register_gucs() {
+@@ -104,6 +153,9 @@ pub fn register_gucs() {
          &ANON_TRANSPARENT_DYNAMIC_MASKING,
          GucContext::Suset,
          GucFlags::default(),
@@ -255,7 +257,7 @@ index 74d3822..7d57125 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -113,6 +163,9 @@ pub fn register_gucs() {
+@@ -113,6 +165,9 @@ pub fn register_gucs() {
          &ANON_RESTRICT_TO_TRUSTED_SCHEMAS,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -265,7 +267,7 @@ index 74d3822..7d57125 100644
      );
  
      GucRegistry::define_bool_guc(
-@@ -122,6 +175,9 @@ pub fn register_gucs() {
+@@ -122,6 +177,9 @@ pub fn register_gucs() {
          &ANON_STRICT_MODE,
          GucContext::Suset,
          GucFlags::default(),
@@ -275,7 +277,7 @@ index 74d3822..7d57125 100644
      );
  
      // The GUC vars below are not used in the Rust code
-@@ -134,6 +190,9 @@ pub fn register_gucs() {
+@@ -134,6 +192,9 @@ pub fn register_gucs() {
          &ANON_ALGORITHM,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -285,7 +287,7 @@ index 74d3822..7d57125 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -143,6 +202,9 @@ pub fn register_gucs() {
+@@ -143,6 +204,9 @@ pub fn register_gucs() {
          &ANON_MASK_SCHEMA,
          GucContext::Suset,
          GucFlags::default(),
@@ -295,7 +297,7 @@ index 74d3822..7d57125 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -152,6 +214,9 @@ pub fn register_gucs() {
+@@ -152,6 +216,9 @@ pub fn register_gucs() {
          &ANON_SALT,
          GucContext::Suset,
          GucFlags::SUPERUSER_ONLY,
@@ -305,7 +307,7 @@ index 74d3822..7d57125 100644
      );
  
      GucRegistry::define_string_guc(
-@@ -161,5 +226,8 @@ pub fn register_gucs() {
+@@ -161,5 +228,8 @@ pub fn register_gucs() {
          &ANON_SOURCE_SCHEMA,
          GucContext::Suset,
          GucFlags::default(),


### PR DESCRIPTION
## Problem

Currently, PGRX does not have [hooks for GUC](https://doxygen.postgresql.org/guc_8h.html#a12bd84ed8c3a7bf952ed88ceaded10dc). This hackathon project aims to add that, and patch the `anon` extension to use these hooks to give users the ability to change `anon` GUCs without needing `cloud_admin` or `superuser` permissions.

## Summary of changes

Updated compute docker file to point to patched pgrx14 and patched `anon` to make use of pgrx14 changes.

Relevant PR: https://github.com/pgcentralfoundation/pgrx/pull/2075
Relevant Issue: https://github.com/neondatabase/cloud/issues/20456