### PR TITLE
proxy(passthrough): optimisations for copy_bidirectional

### DIFF
--- a/proxy/src/binary/pg_sni_router.rs
+++ b/proxy/src/binary/pg_sni_router.rs
@@ -383,8 +383,12 @@ async fn handle_client(
     info!("performing the proxy pass...");
 
     let res = match client {
-        Connection::Raw(mut c) => copy_bidirectional_client_compute(&mut tls_stream, &mut c).await,
-        Connection::Tls(mut c) => copy_bidirectional_client_compute(&mut tls_stream, &mut c).await,
+        Connection::Raw(mut c) => {
+            copy_bidirectional_client_compute(&mut tls_stream, &mut c, |_, _| {}).await
+        }
+        Connection::Tls(mut c) => {
+            copy_bidirectional_client_compute(&mut tls_stream, &mut c, |_, _| {}).await
+        }
     };
 
     match res {

--- a/proxy/src/binary/pg_sni_router.rs
+++ b/proxy/src/binary/pg_sni_router.rs
@@ -393,6 +393,9 @@ async fn handle_client(
 
     match res {
         Ok(_) => Ok(()),
+        Err(ErrorSource::Timeout(_)) => Err(anyhow!(
+            "timed out while gracefully shutting down the connection"
+        )),
         Err(ErrorSource::Client(err)) => Err(err).context("client"),
         Err(ErrorSource::Compute(err)) => Err(err).context("compute"),
     }

--- a/proxy/src/console_redirect_proxy.rs
+++ b/proxy/src/console_redirect_proxy.rs
@@ -129,6 +129,12 @@ pub async fn task_main(
                     let _disconnect = ctx.log_connect();
                     match p.proxy_pass(&config.connect_to_compute).await {
                         Ok(()) => {}
+                        Err(ErrorSource::Timeout(_)) => {
+                            info!(
+                                ?session_id,
+                                "per-client task timed out while gracefully shutting down the connection"
+                            );
+                        }
                         Err(ErrorSource::Client(e)) => {
                             error!(
                                 ?session_id,

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -200,8 +200,10 @@ pub enum HttpDirection {
 #[derive(FixedCardinalityLabel, Copy, Clone)]
 #[label(singleton = "direction")]
 pub enum Direction {
-    Tx,
-    Rx,
+    #[label(rename = "tx")]
+    ComputeToClient,
+    #[label(rename = "rx")]
+    ClientToCompute,
 }
 
 #[derive(FixedCardinalityLabel, Clone, Copy, Debug)]

--- a/proxy/src/proxy/copy_bidirectional.rs
+++ b/proxy/src/proxy/copy_bidirectional.rs
@@ -67,7 +67,6 @@ where
     }
 }
 
-#[tracing::instrument(skip_all)]
 pub async fn copy_bidirectional_client_compute<Client, Compute>(
     client: &mut Client,
     compute: &mut Compute,

--- a/proxy/src/proxy/copy_bidirectional.rs
+++ b/proxy/src/proxy/copy_bidirectional.rs
@@ -1,41 +1,16 @@
 use std::future::poll_fn;
 use std::io;
+use std::ops::Range;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
+use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tracing::info;
 
 use crate::metrics::Direction;
 
-enum TransferState {
-    Running(CopyBuffer),
-    ShuttingDown(Direction),
-    Done,
-}
-
-impl TransferState {
-    #[inline(always)]
-    fn shutdown(&mut self) {
-        let Self::Running(_) = self else { return };
-
-        // we go via this cold function to actually drop the buffer and write the log.
-        // this is quite a bit more efficient as this is not a hot function for the passthrough.
-        self.shutdown_cold();
-    }
-
-    /// Drop the running state, and write a log.
-    #[cold]
-    #[inline(never)]
-    fn shutdown_cold(&mut self) {
-        let Self::Running(buf) = self else { return };
-        match buf.dir {
-            Direction::ComputeToClient => info!("Client is done, terminate compute"),
-            Direction::ClientToCompute => info!("Compute is done, terminate client"),
-        }
-        *self = Self::ShuttingDown(buf.dir);
-    }
-}
+const DISCONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Mark a value as being unlikely.
 #[cold]
@@ -48,6 +23,7 @@ fn cold<I>(i: I) -> I {
 pub enum ErrorSource {
     Client(io::Error),
     Compute(io::Error),
+    Timeout(tokio::time::error::Elapsed),
 }
 
 impl ErrorSource {
@@ -66,36 +42,6 @@ impl ErrorSource {
     }
 }
 
-fn transfer_one_direction<A, B>(
-    cx: &mut Context<'_>,
-    state: &mut TransferState,
-    f: &mut impl for<'a> FnMut(Direction, &'a [u8]),
-    r: &mut A,
-    w: &mut B,
-) -> Poll<Result<(), ErrorSource>>
-where
-    A: AsyncRead + AsyncWrite + Unpin + ?Sized,
-    B: AsyncRead + AsyncWrite + Unpin + ?Sized,
-{
-    let mut r = Pin::new(r);
-    let mut w = Pin::new(w);
-    loop {
-        match state {
-            TransferState::Running(buf) => match buf.poll_copy(cx, f, r.as_mut(), w.as_mut()) {
-                Poll::Pending => break Poll::Pending,
-                Poll::Ready(Err(e)) => break Poll::Ready(Err(cold(e))),
-                Poll::Ready(Ok(())) => *state = TransferState::ShuttingDown(buf.dir),
-            },
-            TransferState::ShuttingDown(dir) => match w.as_mut().poll_shutdown(cx) {
-                Poll::Pending => break Poll::Pending,
-                Poll::Ready(Err(e)) => break Poll::Ready(Err(ErrorSource::write(*dir, cold(e)))),
-                Poll::Ready(Ok(())) => *state = TransferState::Done,
-            },
-            TransferState::Done => break Poll::Ready(Ok(())),
-        }
-    }
-}
-
 pub async fn copy_bidirectional_client_compute<Client, Compute>(
     client: &mut Client,
     compute: &mut Compute,
@@ -105,117 +51,183 @@ where
     Client: AsyncRead + AsyncWrite + Unpin + ?Sized,
     Compute: AsyncRead + AsyncWrite + Unpin + ?Sized,
 {
+    let mut client = Pin::new(client);
+    let mut compute = Pin::new(compute);
+
     let f = &mut f;
-    let client_to_compute =
-        &mut TransferState::Running(CopyBuffer::new(Direction::ClientToCompute));
-    let compute_to_client =
-        &mut TransferState::Running(CopyBuffer::new(Direction::ComputeToClient));
+    let mut client_to_compute = CopyBuffer::new(Direction::ClientToCompute);
+    let mut compute_to_client = CopyBuffer::new(Direction::ComputeToClient);
 
-    poll_fn(|cx| {
-        match transfer_one_direction(cx, client_to_compute, f, client, compute) {
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(cold(e))),
-            Poll::Ready(Ok(())) => {
-                compute_to_client.shutdown();
-                return transfer_one_direction(cx, compute_to_client, f, compute, client);
-            }
-            Poll::Pending => {}
+    // Initial copy hot path
+    poll_fn(|cx| -> Poll<Result<(), ErrorSource>> {
+        let copy1 = client_to_compute.poll_copy(cx, f, client.as_mut(), compute.as_mut())?;
+        let copy2 = compute_to_client.poll_copy(cx, f, compute.as_mut(), client.as_mut())?;
+
+        if copy1.is_pending() && copy2.is_pending() {
+            return Poll::Pending;
         }
 
-        match transfer_one_direction(cx, compute_to_client, f, compute, client) {
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(cold(e))),
-            Poll::Pending => return Poll::Pending,
-            Poll::Ready(Ok(())) => {}
+        if copy1.is_ready() {
+            info!("Compute is done, terminate client");
+
+            // we will never write anymore data to the compute.
+            client_to_compute.filled = 0..0;
+
+            // make sure to shutdown the compute conn.
+            client_to_compute.need_flush = true;
         }
 
-        client_to_compute.shutdown();
-        transfer_one_direction(cx, client_to_compute, f, client, compute)
+        if copy2.is_ready() {
+            info!("Client is done, terminate compute");
+
+            // we will never write anymore data to the client.
+            compute_to_client.filled = 0..0;
+
+            // make sure to shutdown the client conn.
+            compute_to_client.need_flush = true;
+        }
+
+        Poll::Ready(Ok(()))
     })
-    .await
+    .await?;
+
+    // Finish sending the rest of the data to client/compute before shutting it down.
+    //
+    // Edge case:
+    // * peer has filled the TCP buffers and is blocking on a `write()`,
+    // * proxy has filled the TCP buffers and is waiting on a `write()`.
+    // Since no side is reading from the buffers, no progress will be made.
+    let shutdown = poll_fn(|cx| {
+        let res1 = client_to_compute.poll_empty(cx, compute.as_mut())?;
+        let res2 = compute_to_client.poll_empty(cx, client.as_mut())?;
+
+        ready!(res1);
+        ready!(res2);
+        Poll::Ready(Ok(()))
+    });
+
+    // We assume most peers will have enough buffer space so this issue doesn't arise, but we apply
+    // a timeout just in case.
+    //
+    // We could also update `poll_empty` to try and read the data, but I think this is not an edge case
+    // worth overcomplicating.
+    let res = tokio::time::timeout(DISCONNECT_TIMEOUT, shutdown).await;
+
+    match res {
+        Ok(res) => res,
+        Err(timeout) => Err(ErrorSource::Timeout(timeout)),
+    }
 }
 
+const DEFAULT_BUF_SIZE: usize = 1024;
 pub(super) struct CopyBuffer {
     dir: Direction,
-    read_done: bool,
     need_flush: bool,
-    pos: usize,
-    cap: usize,
-    buf: Box<[u8]>,
+    filled: Range<usize>,
+    buf: [u8; DEFAULT_BUF_SIZE],
 }
-const DEFAULT_BUF_SIZE: usize = 1024;
 
 impl CopyBuffer {
-    pub(super) fn new(dir: Direction) -> Self {
+    pub(super) const fn new(dir: Direction) -> Self {
         Self {
             dir,
-            read_done: false,
             need_flush: false,
-            pos: 0,
-            cap: 0,
-            buf: vec![0; DEFAULT_BUF_SIZE].into_boxed_slice(),
+            filled: 0..0,
+            buf: [0; DEFAULT_BUF_SIZE],
         }
     }
 
-    fn poll_fill_buf<R>(
+    /// Returns Ready(Ok(())) when no more writes could progress, and the buffer has space to read.
+    #[inline(always)]
+    fn poll_write_loop<W>(
+        &mut self,
+        cx: &mut Context<'_>,
+        mut writer: Pin<&mut W>,
+    ) -> Poll<Result<(), ErrorSource>>
+    where
+        W: AsyncWrite + ?Sized,
+    {
+        debug_assert!(!self.filled.is_empty());
+
+        loop {
+            let filled_buf = &self.buf[self.filled.clone()];
+            match writer.as_mut().poll_write(cx, filled_buf) {
+                Poll::Ready(Err(err)) => {
+                    return Poll::Ready(Err(ErrorSource::write(self.dir, cold(err))));
+                }
+                Poll::Ready(Ok(0)) => {
+                    let err =
+                        io::Error::new(io::ErrorKind::WriteZero, "write zero byte into writer");
+                    return Poll::Ready(Err(ErrorSource::write(self.dir, cold(err))));
+                }
+                Poll::Ready(Ok(i)) => {
+                    // update the write head.
+                    self.filled.start += i;
+                    self.need_flush = true;
+
+                    // we wrote some data, but the filled buffer might not be fully empty yet.
+                    if !self.filled.is_empty() {
+                        continue;
+                    }
+
+                    // the buffer is definitely empty. reset positions.
+                    self.filled = 0..0;
+                    break;
+                }
+                // While we couldn't write, we might be able to read.
+                Poll::Pending if self.filled.end < self.buf.len() => break,
+                // We couldn't write, and have no space to read. Just exit.
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    /// Returns Ready(Ok((true))) when read returns EOF.
+    /// Returns Ready(Ok((false))) when read returns data.
+    #[inline(always)]
+    fn poll_read_once<R>(
         &mut self,
         cx: &mut Context<'_>,
         f: &mut impl for<'a> FnMut(Direction, &'a [u8]),
         reader: Pin<&mut R>,
-    ) -> Poll<Result<(), ErrorSource>>
+    ) -> Poll<Result<bool, ErrorSource>>
     where
         R: AsyncRead + ?Sized,
     {
-        let mut buf = ReadBuf::new(&mut self.buf);
-        buf.set_filled(self.cap);
+        debug_assert!(self.filled.end < self.buf.len());
+        let mut buf = ReadBuf::new(&mut self.buf[self.filled.end..]);
 
         match reader.poll_read(cx, &mut buf) {
             Poll::Ready(Ok(())) => {
-                f(self.dir, &buf.filled()[self.cap..]);
-                let filled_len = buf.filled().len();
-                self.read_done = self.cap == filled_len;
-                self.cap = filled_len;
+                let filled = buf.filled();
+                // no more data to read, switch to shutdown mode.
+                if filled.is_empty() {
+                    self.need_flush = true;
+                    return Poll::Ready(Ok(true));
+                }
 
-                Poll::Ready(Ok(()))
+                // run our inspection callback.
+                f(self.dir, filled);
+
+                // update the read head.
+                self.filled.end += filled.len();
+
+                // read more data
+                Poll::Ready(Ok(false))
             }
-            Poll::Ready(Err(e)) => Poll::Ready(Err(ErrorSource::read(self.dir, cold(e)))),
+            // cannot continue on error.
+            Poll::Ready(Err(e)) => {
+                return Poll::Ready(Err(ErrorSource::read(self.dir, cold(e))));
+            }
+            // No more data to read, and no more data to write.
             Poll::Pending => Poll::Pending,
         }
     }
 
-    fn poll_write_buf<R, W>(
-        &mut self,
-        cx: &mut Context<'_>,
-        f: &mut impl for<'a> FnMut(Direction, &'a [u8]),
-        reader: Pin<&mut R>,
-        writer: Pin<&mut W>,
-    ) -> Poll<Result<(), ErrorSource>>
-    where
-        R: AsyncRead + ?Sized,
-        W: AsyncWrite + ?Sized,
-    {
-        let me = &mut *self;
-        match writer.poll_write(cx, &me.buf[me.pos..me.cap]) {
-            Poll::Pending if !me.read_done || me.cap < me.buf.len() => {}
-            Poll::Pending => return Poll::Pending,
-            Poll::Ready(Ok(0)) => {
-                let err = io::Error::new(io::ErrorKind::WriteZero, "write zero byte into writer");
-                return Poll::Ready(Err(ErrorSource::write(self.dir, cold(err))));
-            }
-            Poll::Ready(Ok(i)) => {
-                self.pos += i;
-                self.need_flush = true;
-                return Poll::Ready(Ok(()));
-            }
-            Poll::Ready(Err(err)) => {
-                return Poll::Ready(Err(ErrorSource::write(me.dir, cold(err))));
-            }
-        }
-
-        // Top up the buffer towards full if we can read a bit more
-        // data - this should improve the chances of a large write
-        me.poll_fill_buf(cx, f, reader)
-    }
-
-    pub(super) fn poll_copy<R, W>(
+    /// Returns Ready(Ok(())) when read returns EOF.
+    fn poll_copy<R, W>(
         &mut self,
         cx: &mut Context<'_>,
         f: &mut impl for<'a> FnMut(Direction, &'a [u8]),
@@ -226,57 +238,64 @@ impl CopyBuffer {
         R: AsyncRead + ?Sized,
         W: AsyncWrite + ?Sized,
     {
+        // this register eliminates a branch in the hot loop.
+        let mut empty = self.filled.is_empty();
+
+        // write then read hot loop
         loop {
-            // If there is some space left in our buffer, then we try to read some
-            // data to continue, thus maximizing the chances of a large write.
-            if self.cap < self.buf.len() && !self.read_done {
-                match self.poll_fill_buf(cx, f, reader.as_mut()) {
-                    Poll::Ready(Ok(())) => (),
-                    Poll::Ready(Err(err)) => return Poll::Ready(Err(cold(err))),
-                    Poll::Pending => {
-                        // Ignore pending reads when our buffer is not empty, because
-                        // we can try to write data immediately.
-                        if self.pos == self.cap {
-                            // Try flushing when the reader has no progress to avoid deadlock
-                            // when the reader depends on buffered writer.
-                            if self.need_flush {
-                                ready!(writer.as_mut().poll_flush(cx))
-                                    .map_err(|e| ErrorSource::write(self.dir, cold(e)))?;
-                                self.need_flush = false;
-                            }
-
-                            return Poll::Pending;
-                        }
-                    }
-                }
+            if !empty {
+                ready!(self.poll_write_loop(cx, writer.as_mut())?);
             }
 
-            // If our buffer has some data, let's write it out!
-            while self.pos < self.cap {
-                ready!(self.poll_write_buf(cx, f, reader.as_mut(), writer.as_mut()))?;
-            }
-
-            // If pos larger than cap, this loop will never stop.
-            // In particular, user's wrong poll_write implementation returning
-            // incorrect written length may lead to thread blocking.
-            debug_assert!(
-                self.pos <= self.cap,
-                "writer returned length larger than input slice"
-            );
-
-            // All data has been written, the buffer can be considered empty again
-            self.pos = 0;
-            self.cap = 0;
-
-            // If we've written all the data and we've seen EOF, flush out the
-            // data and finish the transfer.
-            if self.read_done {
-                return writer
-                    .as_mut()
-                    .poll_flush(cx)
-                    .map_err(|e| ErrorSource::write(self.dir, e));
+            // If empty is true, there is guaranteed space to read.
+            // If empty is false, and the write loop returned ready, then we know there's space for more reads.
+            match self.poll_read_once(cx, f, reader.as_mut())? {
+                // EOF
+                Poll::Ready(true) => return Poll::Ready(Ok(())),
+                // Needs write.
+                Poll::Ready(false) => empty = false,
+                // Cannot read. The peer might not send us anything until
+                // they receive data from us, so let's switch to flushing.
+                Poll::Pending => break,
             }
         }
+
+        if self.need_flush {
+            let flush = writer.as_mut().poll_flush(cx);
+            ready!(flush.map_err(|e| ErrorSource::write(self.dir, e))?);
+            self.need_flush = false;
+        }
+
+        // there might be more data still to read.
+        Poll::Pending
+    }
+
+    /// Returns Ready(Ok(())) when the conn is fully shutdown.
+    pub(super) fn poll_empty<W>(
+        &mut self,
+        cx: &mut Context<'_>,
+        mut writer: Pin<&mut W>,
+    ) -> Poll<Result<(), ErrorSource>>
+    where
+        W: AsyncWrite + ?Sized,
+    {
+        if !self.filled.is_empty() {
+            ready!(self.poll_write_loop(cx, writer.as_mut())?);
+
+            if !self.filled.is_empty() {
+                // still some data to write
+                return Poll::Pending;
+            }
+        }
+
+        if self.need_flush {
+            let res = writer.poll_shutdown(cx);
+            ready!(res.map_err(|e| ErrorSource::write(self.dir, e))?);
+            self.need_flush = false;
+        }
+
+        // no data to read, no data to write.
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -288,61 +307,59 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_to_compute() {
-        let (mut client_client, mut client_proxy) = tokio::io::duplex(8); // Create a mock duplex stream
-        let (mut compute_proxy, mut compute_client) = tokio::io::duplex(32); // Create a mock duplex stream
+        let (mut client, mut client_proxy) = tokio::io::duplex(32); // Create a mock duplex stream
+        let (mut proxy_compute, mut compute) = tokio::io::duplex(16); // Create a mock duplex stream
 
-        // Simulate 'a' finishing while there's still data for 'b'
-        client_client.write_all(b"hello").await.unwrap();
-        client_client.shutdown().await.unwrap();
-        compute_client.write_all(b"Neon").await.unwrap();
-        compute_client.shutdown().await.unwrap();
+        client.write_all(b"Neon Serverless Postgres").await.unwrap();
+        compute.write_all(b"is amazing").await.unwrap();
 
-        copy_bidirectional_client_compute(&mut client_proxy, &mut compute_proxy, |_, _| {})
-            .await
-            .unwrap();
+        client.shutdown().await.unwrap();
 
-        drop(client_proxy);
-        drop(compute_proxy);
+        let copy = tokio::spawn(async move {
+            copy_bidirectional_client_compute(&mut client_proxy, &mut proxy_compute, |_, _| {})
+                .await
+                .unwrap();
+        });
 
         // Assert correct transferred amounts
-        let mut client_recv = vec![];
-        client_client.read_buf(&mut client_recv).await.unwrap();
+        let mut client_recv = String::new();
+        let mut compute_recv = String::new();
 
-        let mut compute_recv = vec![];
-        compute_client.read_buf(&mut compute_recv).await.unwrap();
+        client.read_to_string(&mut client_recv).await.unwrap();
+        compute.read_to_string(&mut compute_recv).await.unwrap();
 
-        assert_eq!(compute_recv, b"hello");
-        assert_eq!(client_recv, b"");
+        assert_eq!(compute_recv, "Neon Serverless Postgres");
+        assert_eq!(client_recv, "is amazing");
+
+        copy.await.unwrap();
     }
 
     #[tokio::test]
     async fn test_compute_to_client() {
-        let (mut client_client, mut client_proxy) = tokio::io::duplex(32); // Create a mock duplex stream
-        let (mut compute_proxy, mut compute_client) = tokio::io::duplex(8); // Create a mock duplex stream
+        let (mut client, mut client_proxy) = tokio::io::duplex(32); // Create a mock duplex stream
+        let (mut proxy_compute, mut compute) = tokio::io::duplex(16); // Create a mock duplex stream
 
-        // Simulate 'a' finishing while there's still data for 'b'
-        compute_client.write_all(b"hello").await.unwrap();
-        compute_client.shutdown().await.unwrap();
-        client_client
-            .write_all(b"Neon Serverless Postgres")
-            .await
-            .unwrap();
+        client.write_all(b"Neon Serverless Postgres").await.unwrap();
+        compute.write_all(b"is amazing").await.unwrap();
 
-        copy_bidirectional_client_compute(&mut client_proxy, &mut compute_proxy, |_, _| {})
-            .await
-            .unwrap();
+        compute.shutdown().await.unwrap();
 
-        drop(client_proxy);
-        drop(compute_proxy);
+        let copy = tokio::spawn(async move {
+            copy_bidirectional_client_compute(&mut client_proxy, &mut proxy_compute, |_, _| {})
+                .await
+                .unwrap();
+        });
 
         // Assert correct transferred amounts
-        let mut client_recv = vec![];
-        client_client.read_buf(&mut client_recv).await.unwrap();
+        let mut client_recv = String::new();
+        let mut compute_recv = String::new();
 
-        let mut compute_recv = vec![];
-        compute_client.read_buf(&mut compute_recv).await.unwrap();
+        client.read_to_string(&mut client_recv).await.unwrap();
+        compute.read_to_string(&mut compute_recv).await.unwrap();
 
-        assert_eq!(client_recv, b"hello");
-        assert_eq!(compute_recv, b"Neon Ser");
+        assert_eq!(compute_recv, "Neon Serverless ");
+        assert_eq!(client_recv, "is amazing");
+
+        copy.await.unwrap();
     }
 }

--- a/proxy/src/proxy/copy_bidirectional.rs
+++ b/proxy/src/proxy/copy_bidirectional.rs
@@ -9,30 +9,9 @@ use tracing::info;
 use crate::metrics::Direction;
 
 enum TransferState {
-    Running(CopyBuffer, Direction),
-    ShuttingDown,
+    Running(CopyBuffer),
+    ShuttingDown(Direction),
     Done,
-}
-
-#[derive(Debug)]
-pub(crate) enum ErrorDirection {
-    Read(io::Error),
-    Write(io::Error),
-}
-
-impl ErrorSource {
-    fn from_client(err: ErrorDirection) -> ErrorSource {
-        match err {
-            ErrorDirection::Read(client) => Self::Client(client),
-            ErrorDirection::Write(compute) => Self::Compute(compute),
-        }
-    }
-    fn from_compute(err: ErrorDirection) -> ErrorSource {
-        match err {
-            ErrorDirection::Write(client) => Self::Client(client),
-            ErrorDirection::Read(compute) => Self::Compute(compute),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -41,13 +20,29 @@ pub enum ErrorSource {
     Compute(io::Error),
 }
 
+impl ErrorSource {
+    fn read(dir: Direction, err: io::Error) -> Self {
+        match dir {
+            Direction::ComputeToClient => ErrorSource::Compute(err),
+            Direction::ClientToCompute => ErrorSource::Client(err),
+        }
+    }
+
+    fn write(dir: Direction, err: io::Error) -> Self {
+        match dir {
+            Direction::ComputeToClient => ErrorSource::Client(err),
+            Direction::ClientToCompute => ErrorSource::Compute(err),
+        }
+    }
+}
+
 fn transfer_one_direction<A, B>(
     cx: &mut Context<'_>,
     state: &mut TransferState,
     f: &mut impl for<'a> FnMut(Direction, &'a [u8]),
     r: &mut A,
     w: &mut B,
-) -> Poll<Result<(), ErrorDirection>>
+) -> Poll<Result<(), ErrorSource>>
 where
     A: AsyncRead + AsyncWrite + Unpin + ?Sized,
     B: AsyncRead + AsyncWrite + Unpin + ?Sized,
@@ -56,12 +51,12 @@ where
     let mut w = Pin::new(w);
     loop {
         match state {
-            TransferState::Running(buf, dir) => {
-                ready!(buf.poll_copy(cx, |b| f(*dir, b), r.as_mut(), w.as_mut()))?;
-                *state = TransferState::ShuttingDown;
+            TransferState::Running(buf) => {
+                ready!(buf.poll_copy(cx, f, r.as_mut(), w.as_mut()))?;
+                *state = TransferState::ShuttingDown(buf.dir);
             }
-            TransferState::ShuttingDown => {
-                ready!(w.as_mut().poll_shutdown(cx)).map_err(ErrorDirection::Write)?;
+            TransferState::ShuttingDown(dir) => {
+                ready!(w.as_mut().poll_shutdown(cx)).map_err(|e| ErrorSource::write(*dir, e))?;
                 *state = TransferState::Done;
             }
             TransferState::Done => return Poll::Ready(Ok(())),
@@ -78,42 +73,36 @@ where
     Client: AsyncRead + AsyncWrite + Unpin + ?Sized,
     Compute: AsyncRead + AsyncWrite + Unpin + ?Sized,
 {
-    let mut client_to_compute =
-        TransferState::Running(CopyBuffer::new(), Direction::ClientToCompute);
-    let mut compute_to_client =
-        TransferState::Running(CopyBuffer::new(), Direction::ComputeToClient);
+    let mut client_to_compute = TransferState::Running(CopyBuffer::new(Direction::ClientToCompute));
+    let mut compute_to_client = TransferState::Running(CopyBuffer::new(Direction::ComputeToClient));
 
     poll_fn(|cx| {
         let mut client_to_compute_result =
-            transfer_one_direction(cx, &mut client_to_compute, &mut f, client, compute)
-                .map_err(ErrorSource::from_client)?;
+            transfer_one_direction(cx, &mut client_to_compute, &mut f, client, compute)?;
         let mut compute_to_client_result =
-            transfer_one_direction(cx, &mut compute_to_client, &mut f, compute, client)
-                .map_err(ErrorSource::from_compute)?;
+            transfer_one_direction(cx, &mut compute_to_client, &mut f, compute, client)?;
 
         // TODO: 1 info log, with a enum label for close direction.
 
         // Early termination checks from compute to client.
         if let TransferState::Done = compute_to_client {
-            if let TransferState::Running(..) = &client_to_compute {
+            if let TransferState::Running(buf) = &client_to_compute {
                 info!("Compute is done, terminate client");
                 // Initiate shutdown
-                client_to_compute = TransferState::ShuttingDown;
+                client_to_compute = TransferState::ShuttingDown(buf.dir);
                 client_to_compute_result =
-                    transfer_one_direction(cx, &mut client_to_compute, &mut f, client, compute)
-                        .map_err(ErrorSource::from_client)?;
+                    transfer_one_direction(cx, &mut client_to_compute, &mut f, client, compute)?;
             }
         }
 
         // Early termination checks from client to compute.
         if let TransferState::Done = client_to_compute {
-            if let TransferState::Running(..) = &compute_to_client {
+            if let TransferState::Running(buf) = &compute_to_client {
                 info!("Client is done, terminate compute");
                 // Initiate shutdown
-                compute_to_client = TransferState::ShuttingDown;
+                compute_to_client = TransferState::ShuttingDown(buf.dir);
                 compute_to_client_result =
-                    transfer_one_direction(cx, &mut compute_to_client, &mut f, compute, client)
-                        .map_err(ErrorSource::from_compute)?;
+                    transfer_one_direction(cx, &mut compute_to_client, &mut f, compute, client)?;
             }
         }
 
@@ -125,8 +114,8 @@ where
     .await
 }
 
-#[derive(Debug)]
 pub(super) struct CopyBuffer {
+    dir: Direction,
     read_done: bool,
     need_flush: bool,
     pos: usize,
@@ -136,8 +125,9 @@ pub(super) struct CopyBuffer {
 const DEFAULT_BUF_SIZE: usize = 1024;
 
 impl CopyBuffer {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(dir: Direction) -> Self {
         Self {
+            dir,
             read_done: false,
             need_flush: false,
             pos: 0,
@@ -149,9 +139,9 @@ impl CopyBuffer {
     fn poll_fill_buf<R>(
         &mut self,
         cx: &mut Context<'_>,
-        f: &mut impl for<'a> FnMut(&'a [u8]),
+        f: &mut impl for<'a> FnMut(Direction, &'a [u8]),
         reader: Pin<&mut R>,
-    ) -> Poll<io::Result<()>>
+    ) -> Poll<Result<(), ErrorSource>>
     where
         R: AsyncRead + ?Sized,
     {
@@ -160,23 +150,23 @@ impl CopyBuffer {
         buf.set_filled(me.cap);
 
         let res = reader.poll_read(cx, &mut buf);
-        f(&buf.filled()[me.cap..]);
+        f(me.dir, &buf.filled()[me.cap..]);
 
         if let Poll::Ready(Ok(())) = res {
             let filled_len = buf.filled().len();
             me.read_done = me.cap == filled_len;
             me.cap = filled_len;
         }
-        res
+        res.map_err(|e| ErrorSource::read(me.dir, e))
     }
 
     fn poll_write_buf<R, W>(
         &mut self,
         cx: &mut Context<'_>,
-        f: &mut impl for<'a> FnMut(&'a [u8]),
+        f: &mut impl for<'a> FnMut(Direction, &'a [u8]),
         mut reader: Pin<&mut R>,
         mut writer: Pin<&mut W>,
-    ) -> Poll<Result<usize, ErrorDirection>>
+    ) -> Poll<Result<usize, ErrorSource>>
     where
         R: AsyncRead + ?Sized,
         W: AsyncWrite + ?Sized,
@@ -187,22 +177,21 @@ impl CopyBuffer {
                 // Top up the buffer towards full if we can read a bit more
                 // data - this should improve the chances of a large write
                 if !me.read_done && me.cap < me.buf.len() {
-                    ready!(me.poll_fill_buf(cx, f, reader.as_mut()))
-                        .map_err(ErrorDirection::Read)?;
+                    ready!(me.poll_fill_buf(cx, f, reader.as_mut()))?;
                 }
                 Poll::Pending
             }
-            res @ Poll::Ready(_) => res.map_err(ErrorDirection::Write),
+            res @ Poll::Ready(_) => res.map_err(|e| ErrorSource::write(me.dir, e)),
         }
     }
 
     pub(super) fn poll_copy<R, W>(
         &mut self,
         cx: &mut Context<'_>,
-        mut f: impl for<'a> FnMut(&'a [u8]),
+        f: &mut impl for<'a> FnMut(Direction, &'a [u8]),
         mut reader: Pin<&mut R>,
         mut writer: Pin<&mut W>,
-    ) -> Poll<Result<(), ErrorDirection>>
+    ) -> Poll<Result<(), ErrorSource>>
     where
         R: AsyncRead + ?Sized,
         W: AsyncWrite + ?Sized,
@@ -211,9 +200,9 @@ impl CopyBuffer {
             // If there is some space left in our buffer, then we try to read some
             // data to continue, thus maximizing the chances of a large write.
             if self.cap < self.buf.len() && !self.read_done {
-                match self.poll_fill_buf(cx, &mut f, reader.as_mut()) {
+                match self.poll_fill_buf(cx, f, reader.as_mut()) {
                     Poll::Ready(Ok(())) => (),
-                    Poll::Ready(Err(err)) => return Poll::Ready(Err(ErrorDirection::Read(err))),
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
                     Poll::Pending => {
                         // Ignore pending reads when our buffer is not empty, because
                         // we can try to write data immediately.
@@ -222,7 +211,7 @@ impl CopyBuffer {
                             // when the reader depends on buffered writer.
                             if self.need_flush {
                                 ready!(writer.as_mut().poll_flush(cx))
-                                    .map_err(ErrorDirection::Write)?;
+                                    .map_err(|e| ErrorSource::write(self.dir, e))?;
                                 self.need_flush = false;
                             }
 
@@ -234,12 +223,11 @@ impl CopyBuffer {
 
             // If our buffer has some data, let's write it out!
             while self.pos < self.cap {
-                let i = ready!(self.poll_write_buf(cx, &mut f, reader.as_mut(), writer.as_mut()))?;
+                let i = ready!(self.poll_write_buf(cx, f, reader.as_mut(), writer.as_mut()))?;
                 if i == 0 {
-                    return Poll::Ready(Err(ErrorDirection::Write(io::Error::new(
-                        io::ErrorKind::WriteZero,
-                        "write zero byte into writer",
-                    ))));
+                    let err =
+                        io::Error::new(io::ErrorKind::WriteZero, "write zero byte into writer");
+                    return Poll::Ready(Err(ErrorSource::write(self.dir, err)));
                 }
                 self.pos += i;
                 self.need_flush = true;
@@ -260,7 +248,8 @@ impl CopyBuffer {
             // If we've written all the data and we've seen EOF, flush out the
             // data and finish the transfer.
             if self.read_done {
-                ready!(writer.as_mut().poll_flush(cx)).map_err(ErrorDirection::Write)?;
+                ready!(writer.as_mut().poll_flush(cx))
+                    .map_err(|e| ErrorSource::write(self.dir, e))?;
                 return Poll::Ready(Ok(()));
             }
         }

--- a/proxy/src/proxy/mod.rs
+++ b/proxy/src/proxy/mod.rs
@@ -167,6 +167,12 @@ pub async fn task_main(
                     let _disconnect = ctx.log_connect();
                     match p.proxy_pass(&config.connect_to_compute).await {
                         Ok(()) => {}
+                        Err(ErrorSource::Timeout(_)) => {
+                            info!(
+                                ?session_id,
+                                "per-client task timed out while gracefully shutting down the connection"
+                            );
+                        }
                         Err(ErrorSource::Client(e)) => {
                             warn!(
                                 ?session_id,

--- a/proxy/src/proxy/passthrough.rs
+++ b/proxy/src/proxy/passthrough.rs
@@ -13,7 +13,7 @@ use crate::stream::Stream;
 use crate::usage_metrics::{Ids, MetricCounterRecorder, USAGE_METRICS};
 
 /// Forward bytes in both directions (client <-> compute).
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 pub(crate) async fn proxy_pass(
     client: impl AsyncRead + AsyncWrite + Unpin,
     compute: impl AsyncRead + AsyncWrite + Unpin,


### PR DESCRIPTION
Currently completely untested. I spent a long time in godbolt playing with assembly and moving branches around. I'm pretty confident that the implementation of copy_bidirectional is now _more_ correct. The hot-loop of an active connection (`poll_copy`) is now much smaller, so hopefully can be measured.

I need to find a suitable benchmark to properly measure it.

I think it's more correct, because the previous implementation would not correctly drain the remaining bytes to the peer before shutting down said peer. This new implementation tries to flush all remaining buffers. There is now a timeout on this case to prevent it getting stuck