### PR TITLE
remove auth_endpoint password from log and command line for local proxy mode

### DIFF
--- a/proxy/src/auth/backend/mod.rs
+++ b/proxy/src/auth/backend/mod.rs
@@ -86,9 +86,14 @@ impl std::fmt::Display for Backend<'_, ()> {
                         Ok(mut url) => {
                             let _ = url.set_password(None);
                             let url = url.as_str();
-                            fmt.debug_tuple("ControlPlane::PostgresMock").field(&url).finish()
+                            fmt.debug_tuple("ControlPlane::PostgresMock")
+                                .field(&url)
+                                .finish()
                         }
-                        Err(_) => fmt.debug_tuple("ControlPlane::PostgresMock").field(&url).finish(),
+                        Err(_) => fmt
+                            .debug_tuple("ControlPlane::PostgresMock")
+                            .field(&url)
+                            .finish(),
                     }
                 }
                 #[cfg(test)]

--- a/proxy/src/auth/backend/mod.rs
+++ b/proxy/src/auth/backend/mod.rs
@@ -84,7 +84,7 @@ impl std::fmt::Display for Backend<'_, ()> {
                     let url = endpoint.url();
                     match url::Url::parse(url) {
                         Ok(mut url) => {
-                            let _ = url.set_password(None);
+                            let _ = url.set_password(Some("_redacted_"));
                             let url = url.as_str();
                             fmt.debug_tuple("ControlPlane::PostgresMock")
                                 .field(&url)

--- a/proxy/src/auth/backend/mod.rs
+++ b/proxy/src/auth/backend/mod.rs
@@ -80,10 +80,17 @@ impl std::fmt::Display for Backend<'_, ()> {
                     .field(&endpoint.url())
                     .finish(),
                 #[cfg(any(test, feature = "testing"))]
-                ControlPlaneClient::PostgresMock(endpoint) => fmt
-                    .debug_tuple("ControlPlane::PostgresMock")
-                    .field(&endpoint.url())
-                    .finish(),
+                ControlPlaneClient::PostgresMock(endpoint) => {
+                    let url = endpoint.url();
+                    match url::Url::parse(url) {
+                        Ok(mut url) => {
+                            let _ = url.set_password(None);
+                            let url = url.as_str();
+                            fmt.debug_tuple("ControlPlane::PostgresMock").field(&url).finish()
+                        }
+                        Err(_) => fmt.debug_tuple("ControlPlane::PostgresMock").field(&url).finish(),
+                    }
+                }
                 #[cfg(test)]
                 ControlPlaneClient::Test(_) => fmt.debug_tuple("ControlPlane::Test").finish(),
             },

--- a/proxy/src/binary/proxy.rs
+++ b/proxy/src/binary/proxy.rs
@@ -4,9 +4,9 @@ use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, ensure};
 #[cfg(any(test, feature = "testing"))]
 use anyhow::Context;
+use anyhow::{bail, ensure};
 use arc_swap::ArcSwapOption;
 use futures::future::Either;
 use remote_storage::RemoteStorageConfig;
@@ -780,10 +780,12 @@ fn build_auth_backend(
         AuthBackendType::Postgres => {
             let mut url: ApiUrl = args.auth_endpoint.parse()?;
             if args.auth_endpoint_password_from_env {
-                let password = args.pgpassword
+                let password = args
+                    .pgpassword
                     .as_ref()
                     .with_context(|| "Environment variable `PGPASSWORD` is not set")?;
-                url.set_password(Some(password)).expect("Failed to set password");
+                url.set_password(Some(password))
+                    .expect("Failed to set password");
             }
             let api = control_plane::client::mock::MockControlPlane::new(
                 url,

--- a/proxy/src/url.rs
+++ b/proxy/src/url.rs
@@ -34,18 +34,18 @@ impl std::str::FromStr for ApiUrl {
     }
 }
 
-impl std::ops::DerefMut for ApiUrl {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 /// This instance is safe because it doesn't allow us to modify the object.
 impl std::ops::Deref for ApiUrl {
     type Target = url::Url;
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl std::ops::DerefMut for ApiUrl {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/proxy/src/url.rs
+++ b/proxy/src/url.rs
@@ -34,6 +34,12 @@ impl std::str::FromStr for ApiUrl {
     }
 }
 
+impl std::ops::DerefMut for ApiUrl {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 /// This instance is safe because it doesn't allow us to modify the object.
 impl std::ops::Deref for ApiUrl {
     type Target = url::Url;


### PR DESCRIPTION
## Problem

When testing local proxy the auth-endpoint password shows up in command line and log

```bash
RUST_LOG=proxy LOGFMT=text cargo run --release --package proxy --bin proxy --features testing -- \
  --auth-backend postgres \
  --auth-endpoint 'postgresql://postgres:secret_password@127.0.0.1:5432/postgres' \
  --tls-cert server.crt \
  --tls-key server.key \
  --wss 0.0.0.0:4444
```

## Summary of changes

- Allow to set env variable PGPASSWORD
- fall back to use PGPASSWORD env variable when auth-endpoint does not contain password
- remove auth-endpoint password from logs in `--features testing` mode

Example

```bash
export PGPASSWORD=secret_password

RUST_LOG=proxy LOGFMT=text cargo run --package proxy --bin proxy --features testing -- \
  --auth-backend postgres \
  --auth-endpoint 'postgresql://postgres@127.0.0.1:5432/postgres' \
  --tls-cert server.crt \
  --tls-key server.key \
  --wss 0.0.0.0:4444 
```
