### PR TITLE
proxy: encode json as we parse rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,6 +5304,7 @@ dependencies = [
  "itoa",
  "jose-jwa",
  "jose-jwk",
+ "json",
  "lasso",
  "measured",
  "metrics",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -48,6 +48,7 @@ indexmap = { workspace = true, features = ["serde"] }
 ipnet.workspace = true
 itertools.workspace = true
 itoa.workspace = true
+json = { path = "../libs/proxy/json" }
 lasso = { workspace = true, features = ["multi-threaded"] }
 measured = { workspace = true, features = ["lasso"] }
 metrics.workspace = true

--- a/proxy/src/serverless/json.rs
+++ b/proxy/src/serverless/json.rs
@@ -431,17 +431,15 @@ mod tests {
     }
 
     fn pg_text_to_json(val: &str, pg_type: &Type) -> Value {
-        let output = json::value_to_vec!(|output| {
-            super::pg_text_to_json(output, val, pg_type).unwrap();
-        });
-        serde_json::from_slice(&output).unwrap()
+        let output = json::value_to_string!(|v| super::pg_text_to_json(v, val, pg_type).unwrap());
+        serde_json::from_str(&output).unwrap()
     }
 
     fn pg_array_parse(pg_array: &str, pg_type: &Type) -> Value {
-        let output = json::value_to_vec!(|list| json::value_as_list!(|list| {
-            super::pg_array_parse(list, pg_array, pg_type, ',').unwrap();
+        let output = json::value_to_string!(|v| json::value_as_list!(|v| {
+            super::pg_array_parse(v, pg_array, pg_type, ',').unwrap();
         }));
-        serde_json::from_slice(&output).unwrap()
+        serde_json::from_str(&output).unwrap()
     }
 
     #[test]

--- a/proxy/src/serverless/sql_over_http.rs
+++ b/proxy/src/serverless/sql_over_http.rs
@@ -881,110 +881,106 @@ async fn query_to_json<T: GenericClient>(
 ) -> Result<ReadyForQueryStatus, SqlOverHttpError> {
     let query_start = Instant::now();
 
-    let mut json_obj = output.object();
+    let ready = json::value_as_object!(|output| {
+        let array_mode = data.array_mode.unwrap_or(parsed_headers.default_array_mode);
+        let raw_output = parsed_headers.raw_output;
 
-    let array_mode = data.array_mode.unwrap_or(parsed_headers.default_array_mode);
-    let raw_output = parsed_headers.raw_output;
+        output.entry("rowAsArray", array_mode);
 
-    json_obj.entry("rowAsArray", array_mode);
+        let query_params = data.params;
+        let mut row_stream = client
+            .query_raw_txt(&data.query, query_params)
+            .await
+            .map_err(SqlOverHttpError::Postgres)?;
+        let query_acknowledged = Instant::now();
 
-    let query_params = data.params;
-    let mut row_stream = client
-        .query_raw_txt(&data.query, query_params)
-        .await
-        .map_err(SqlOverHttpError::Postgres)?;
-    let query_acknowledged = Instant::now();
-
-    let mut json_fields = json_obj.key("fields").list();
-
-    for c in row_stream.statement.columns() {
-        let mut json_field = json_fields.entry().object();
-
-        json_field.entry("name", c.name());
-        json_field.entry("dataTypeID", c.type_().oid());
-        json_field.entry("tableID", c.table_oid());
-        json_field.entry("columnID", c.column_id());
-        json_field.entry("dataTypeSize", c.type_size());
-        json_field.entry("dataTypeModifier", c.type_modifier());
-        json_field.entry("format", "text");
-
-        json_field.finish();
-    }
-
-    json_fields.finish();
-
-    // Manually drain the stream into a vector to leave row_stream hanging
-    // around to get a command tag. Also check that the response is not too big.
-    let mut json_rows = json_obj.key("rows").list();
-    let mut rows = 0;
-    while let Some(row) = row_stream.next().await {
-        let row = row.map_err(SqlOverHttpError::Postgres)?;
-
-        rows += 1;
-        let v = json_rows.entry();
-        pg_text_row_to_json(v, &row, raw_output, array_mode)?;
-
-        // we don't have a streaming response support yet so this is to prevent OOM
-        // from a malicious query (eg a cross join)
-        if json_rows.as_buffer().len() > config.max_response_size_bytes {
-            return Err(SqlOverHttpError::ResponseTooLarge(
-                config.max_response_size_bytes,
-            ));
-        }
-
-        // assumption: parsing pg text and converting to json takes CPU time.
-        // let's assume it is slightly expensive, so we should consume some cooperative budget.
-        // Especially considering that `RowStream::next` might be pulling from a batch
-        // of rows and never hit the tokio mpsc for a long time (although unlikely).
-        tokio::task::consume_budget().await;
-    }
-    json_rows.finish();
-
-    let query_resp_end = Instant::now();
-    let RowStream {
-        command_tag,
-        status: ready,
-        ..
-    } = row_stream;
-
-    let command_tag = command_tag.unwrap_or_default();
-
-    info!(
-        rows,
-        ?ready,
-        command_tag,
-        acknowledgement = ?(query_acknowledged - query_start),
-        response = ?(query_resp_end - query_start),
-        "finished executing query"
-    );
-
-    // grab the command tag and number of rows affected
-    let (command_tag_name, command_tag_rest) = command_tag
-        .split_once(' ')
-        .map_or((&*command_tag, None), |(a, b)| (a, Some(b)));
-
-    json_obj.entry("command", command_tag_name);
-
-    let command_tag_count = command_tag_rest
-        .and_then(|rest| {
-            if command_tag_name == "INSERT" {
-                // INSERT returns OID first and then number of rows
-                let (_oid, count) = rest.split_once(' ')?;
-                Some(count)
-            } else {
-                // other commands return number of rows (if any)
-                Some(rest)
+        let json_fields = output.key("fields");
+        json::value_as_list!(|json_fields| {
+            for c in row_stream.statement.columns() {
+                let json_field = json_fields.entry();
+                json::value_as_object!(|json_field| {
+                    json_field.entry("name", c.name());
+                    json_field.entry("dataTypeID", c.type_().oid());
+                    json_field.entry("tableID", c.table_oid());
+                    json_field.entry("columnID", c.column_id());
+                    json_field.entry("dataTypeSize", c.type_size());
+                    json_field.entry("dataTypeModifier", c.type_modifier());
+                    json_field.entry("format", "text");
+                });
             }
-        })
-        .and_then(|count| count.parse::<i64>().ok());
+        });
 
-    if let Some(command_tag_count) = command_tag_count {
-        json_obj.entry("rowCount", command_tag_count);
-    } else {
-        json_obj.entry("rowCount", json::Null);
-    }
+        // Manually drain the stream into a vector to leave row_stream hanging
+        // around to get a command tag. Also check that the response is not too big.
+        let json_rows = output.key("rows");
+        let rows = json::value_as_list!(|json_rows| {
+            let mut rows = 0;
+            while let Some(row) = row_stream.next().await {
+                let row = row.map_err(SqlOverHttpError::Postgres)?;
 
-    json_obj.finish();
+                rows += 1;
+                let v = json_rows.entry();
+                pg_text_row_to_json(v, &row, raw_output, array_mode)?;
+
+                // we don't have a streaming response support yet so this is to prevent OOM
+                // from a malicious query (eg a cross join)
+                if json_rows.as_buffer().len() > config.max_response_size_bytes {
+                    return Err(SqlOverHttpError::ResponseTooLarge(
+                        config.max_response_size_bytes,
+                    ));
+                }
+
+                // assumption: parsing pg text and converting to json takes CPU time.
+                // let's assume it is slightly expensive, so we should consume some cooperative budget.
+                // Especially considering that `RowStream::next` might be pulling from a batch
+                // of rows and never hit the tokio mpsc for a long time (although unlikely).
+                tokio::task::consume_budget().await;
+            }
+            rows
+        });
+
+        let query_resp_end = Instant::now();
+        let RowStream {
+            command_tag,
+            status: ready,
+            ..
+        } = row_stream;
+
+        let command_tag = command_tag.unwrap_or_default();
+
+        info!(
+            rows,
+            ?ready,
+            command_tag,
+            acknowledgement = ?(query_acknowledged - query_start),
+            response = ?(query_resp_end - query_start),
+            "finished executing query"
+        );
+
+        // grab the command tag and number of rows affected
+        let (command_tag_name, command_tag_rest) = command_tag
+            .split_once(' ')
+            .map_or((&*command_tag, None), |(a, b)| (a, Some(b)));
+
+        output.entry("command", command_tag_name);
+
+        let command_tag_count = command_tag_rest
+            .and_then(|rest| {
+                if command_tag_name == "INSERT" {
+                    // INSERT returns OID first and then number of rows
+                    let (_oid, count) = rest.split_once(' ')?;
+                    Some(count)
+                } else {
+                    // other commands return number of rows (if any)
+                    Some(rest)
+                }
+            })
+            .and_then(|count| count.parse::<i64>().ok());
+
+        output.entry("rowCount", command_tag_count);
+
+        ready
+    });
 
     Ok(ready)
 }


### PR DESCRIPTION
Serialize query row responses directly into JSON. Some of this code should be using the `json::value_as_object/list` macros, but I've avoided it for now to minimize the size of the diff.