### PR TITLE
pageserver: add TLS support for gRPC server

### DIFF
--- a/libs/pageserver_api/src/config.rs
+++ b/libs/pageserver_api/src/config.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_HTTP_LISTEN_PORT: u16 = 9898;
 pub const DEFAULT_HTTP_LISTEN_ADDR: &str = formatcp!("127.0.0.1:{DEFAULT_HTTP_LISTEN_PORT}");
 // TODO: gRPC is disabled by default for now, but the port is used in neon_local.
 pub const DEFAULT_GRPC_LISTEN_PORT: u16 = 51051; // storage-broker already uses 50051
+pub const DEFAULT_GRPC_LISTEN_TLS: bool = false; // TODO: enable by default?
 
 use std::collections::HashMap;
 use std::num::{NonZeroU64, NonZeroUsize};
@@ -107,6 +108,7 @@ pub struct ConfigToml {
     pub listen_http_addr: String,
     pub listen_https_addr: Option<String>,
     pub listen_grpc_addr: Option<String>,
+    pub listen_grpc_tls: bool,
     pub ssl_key_file: Utf8PathBuf,
     pub ssl_cert_file: Utf8PathBuf,
     #[serde(with = "humantime_serde")]
@@ -593,6 +595,7 @@ impl Default for ConfigToml {
             listen_http_addr: (DEFAULT_HTTP_LISTEN_ADDR.to_string()),
             listen_https_addr: (None),
             listen_grpc_addr: None, // TODO: default to 127.0.0.1:51051
+            listen_grpc_tls: DEFAULT_GRPC_LISTEN_TLS,
             ssl_key_file: Utf8PathBuf::from(DEFAULT_SSL_KEY_FILE),
             ssl_cert_file: Utf8PathBuf::from(DEFAULT_SSL_CERT_FILE),
             ssl_cert_reload_period: Duration::from_secs(60),

--- a/pageserver/src/config.rs
+++ b/pageserver/src/config.rs
@@ -63,6 +63,8 @@ pub struct PageServerConf {
     ///
     /// EXPERIMENTAL: this protocol is unstable and under active development.
     pub listen_grpc_addr: Option<String>,
+    /// If true, enable TLS for the gRPC server, using ssl_key_file and ssl_cert_file.
+    pub listen_grpc_tls: bool,
 
     /// Path to a file with certificate's private key for https and gRPC API.
     /// Default: server.key
@@ -228,7 +230,7 @@ pub struct PageServerConf {
 
     pub tracing: Option<pageserver_api::config::Tracing>,
 
-    /// Enable TLS in page service API.
+    /// Enable TLS in the libpq page service API.
     /// Does not force TLS: the client negotiates TLS usage during the handshake.
     /// Uses key and certificate from ssl_key_file/ssl_cert_file.
     pub enable_tls_page_service_api: bool,
@@ -363,6 +365,7 @@ impl PageServerConf {
             listen_http_addr,
             listen_https_addr,
             listen_grpc_addr,
+            listen_grpc_tls,
             ssl_key_file,
             ssl_cert_file,
             ssl_cert_reload_period,
@@ -433,6 +436,7 @@ impl PageServerConf {
             listen_http_addr,
             listen_https_addr,
             listen_grpc_addr,
+            listen_grpc_tls,
             ssl_key_file,
             ssl_cert_file,
             ssl_cert_reload_period,


### PR DESCRIPTION
## Problem

The Pageserver gRPC server should support TLS.

Requires #11972.
Touches #11728.

## Summary of changes

Add a `listen_grpc_tls` setting to enable gRPC TLS support, using the Pageserver's standard SSL certificate and key with automatic reloading.

When enabled, inbound TLS connections are transparently decrypted before they're passed on to the Tonic server.