### PR TITLE
pageserver: add gRPC authentication

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -3378,18 +3378,12 @@ impl tonic::service::Interceptor for TenantAuthInterceptor {
             .expect("TenantMetadataInterceptor must run before TenantAuthInterceptor");
 
         // Fetch and decode the JWT token.
-        let authorization = req
+        let jwt = req
             .metadata()
             .get("authorization")
             .ok_or(tonic::Status::unauthenticated("no authorization header"))?
             .to_str()
-            .map_err(|_| tonic::Status::invalid_argument("invalid authorization header"))?;
-        if &authorization[0..7] != "Bearer " {
-            return Err(tonic::Status::invalid_argument(
-                "invalid authorization header",
-            ));
-        }
-        let jwt = authorization
+            .map_err(|_| tonic::Status::invalid_argument("invalid authorization header"))?
             .strip_prefix("Bearer")
             .ok_or_else(|| tonic::Status::invalid_argument("invalid authorization header"))?
             .trim();

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -3389,7 +3389,10 @@ impl tonic::service::Interceptor for TenantAuthInterceptor {
                 "invalid authorization header",
             ));
         }
-        let jwt = &authorization[7..].trim();
+        let jwt = authorization
+            .strip_prefix("Bearer")
+            .ok_or_else(|| tonic::Status::invalid_argument("invalid authorization header"))?
+            .trim();
         let jwtdata: TokenData<Claims> = auth
             .decode(jwt)
             .map_err(|err| tonic::Status::invalid_argument(format!("invalid JWT token: {err}")))?;

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -3351,8 +3351,7 @@ impl tonic::service::Interceptor for TenantMetadataInterceptor {
     }
 }
 
-/// Authenticates gRPC page service requests, and stores the JWT claims as a request extension. Must
-/// run after TenantMetadataInterceptor.
+/// Authenticates gRPC page service requests. Must run after TenantMetadataInterceptor.
 #[derive(Clone)]
 struct TenantAuthInterceptor {
     auth: Option<Arc<SwappableJwtAuth>>,
@@ -3381,7 +3380,7 @@ impl tonic::service::Interceptor for TenantAuthInterceptor {
         let jwt = req
             .metadata()
             .get("authorization")
-            .ok_or(tonic::Status::unauthenticated("no authorization header"))?
+            .ok_or_else(|| tonic::Status::unauthenticated("no authorization header"))?
             .to_str()
             .map_err(|_| tonic::Status::invalid_argument("invalid authorization header"))?
             .strip_prefix("Bearer ")

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -3316,7 +3316,7 @@ impl tonic::service::Interceptor for TenantMetadataInterceptor {
         let tenant_id = req
             .metadata()
             .get("neon-tenant-id")
-            .ok_or(tonic::Status::invalid_argument("missing neon-tenant-id"))?
+            .ok_or_else(|| tonic::Status::invalid_argument("missing neon-tenant-id"))?
             .to_str()
             .map_err(|_| tonic::Status::invalid_argument("invalid neon-tenant-id"))?;
         let tenant_id = TenantId::from_str(tenant_id)
@@ -3326,7 +3326,7 @@ impl tonic::service::Interceptor for TenantMetadataInterceptor {
         let timeline_id = req
             .metadata()
             .get("neon-timeline-id")
-            .ok_or(tonic::Status::invalid_argument("missing neon-timeline-id"))?
+            .ok_or_else(|| tonic::Status::invalid_argument("missing neon-timeline-id"))?
             .to_str()
             .map_err(|_| tonic::Status::invalid_argument("invalid neon-timeline-id"))?;
         let timeline_id = TimelineId::from_str(timeline_id)
@@ -3336,7 +3336,7 @@ impl tonic::service::Interceptor for TenantMetadataInterceptor {
         let shard_index = req
             .metadata()
             .get("neon-shard-id")
-            .ok_or(tonic::Status::invalid_argument("missing neon-shard-id"))?
+            .ok_or_else(|| tonic::Status::invalid_argument("missing neon-shard-id"))?
             .to_str()
             .map_err(|_| tonic::Status::invalid_argument("invalid neon-shard-id"))?;
         let shard_index = ShardIndex::from_str(shard_index)

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -3384,7 +3384,7 @@ impl tonic::service::Interceptor for TenantAuthInterceptor {
             .ok_or(tonic::Status::unauthenticated("no authorization header"))?
             .to_str()
             .map_err(|_| tonic::Status::invalid_argument("invalid authorization header"))?
-            .strip_prefix("Bearer")
+            .strip_prefix("Bearer ")
             .ok_or_else(|| tonic::Status::invalid_argument("invalid authorization header"))?
             .trim();
         let jwtdata: TokenData<Claims> = auth


### PR DESCRIPTION
## Problem

We need authentication for the gRPC server.

Requires #11972.
Touches #11728.

## Summary of changes

Add two request interceptors that decode the tenant/timeline/shard metadata and authenticate the JWT token against them.