### PR TITLE
proxy: cache for password hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5519,6 +5519,7 @@ dependencies = [
  "workspace_hack",
  "x509-cert",
  "zerocopy 0.8.24",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,9 +234,10 @@ uuid = { version = "1.6.1", features = ["v4", "v7", "serde"] }
 walkdir = "2.3.2"
 rustls-native-certs = "0.8"
 whoami = "1.5.1"
-zerocopy = { version = "0.8", features = ["derive", "simd"] }
 json-structural-diff = { version = "0.2.0" }
 x509-cert = { version = "0.2.5" }
+zerocopy = { version = "0.8", features = ["derive", "simd"] }
+zeroize = "1.8"
 
 ## TODO replace this with tracing
 env_logger = "0.11"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -107,6 +107,7 @@ uuid.workspace = true
 x509-cert.workspace = true
 redis.workspace = true
 zerocopy.workspace = true
+zeroize.workspace = true
 # uncomment this to use the real subzero-core crate
 # subzero-core = { git = "https://github.com/neondatabase/subzero", rev = "396264617e78e8be428682f87469bb25429af88a", features = ["postgresql"], optional = true }
 # this is a stub for the subzero-core crate

--- a/proxy/src/auth/backend/hacks.rs
+++ b/proxy/src/auth/backend/hacks.rs
@@ -6,7 +6,7 @@ use crate::auth::{self, AuthFlow};
 use crate::config::AuthenticationConfig;
 use crate::context::RequestContext;
 use crate::control_plane::AuthSecret;
-use crate::intern::EndpointIdInt;
+use crate::intern::{EndpointIdInt, RoleNameInt};
 use crate::sasl;
 use crate::stream::{self, Stream};
 
@@ -25,12 +25,14 @@ pub(crate) async fn authenticate_cleartext(
     ctx.set_auth_method(crate::context::AuthMethod::Cleartext);
 
     let ep = EndpointIdInt::from(&info.endpoint);
+    let role = RoleNameInt::from(&info.user);
 
     let auth_flow = AuthFlow::new(
         client,
         auth::CleartextPassword {
             secret,
             endpoint: ep,
+            role,
             pool: config.thread_pool.clone(),
         },
     );

--- a/proxy/src/auth/backend/hacks.rs
+++ b/proxy/src/auth/backend/hacks.rs
@@ -33,7 +33,7 @@ pub(crate) async fn authenticate_cleartext(
             secret,
             endpoint: ep,
             role,
-            pool: config.thread_pool.clone(),
+            pool: config.scram_thread_pool.clone(),
         },
     );
     let auth_outcome = {

--- a/proxy/src/auth/backend/mod.rs
+++ b/proxy/src/auth/backend/mod.rs
@@ -25,7 +25,7 @@ use crate::control_plane::messages::EndpointRateLimitConfig;
 use crate::control_plane::{
     self, AccessBlockerFlags, AuthSecret, ControlPlaneApi, EndpointAccessControl, RoleAccessControl,
 };
-use crate::intern::EndpointIdInt;
+use crate::intern::{EndpointIdInt, RoleNameInt};
 use crate::pqproto::BeMessage;
 use crate::proxy::NeonOptions;
 use crate::proxy::wake_compute::WakeComputeBackend;
@@ -273,9 +273,11 @@ async fn authenticate_with_secret(
 ) -> auth::Result<ComputeCredentials> {
     if let Some(password) = unauthenticated_password {
         let ep = EndpointIdInt::from(&info.endpoint);
+        let role = RoleNameInt::from(&info.user);
 
         let auth_outcome =
-            validate_password_and_exchange(&config.thread_pool, ep, &password, secret).await?;
+            validate_password_and_exchange(&config.thread_pool, ep, role, &password, secret)
+                .await?;
         let keys = match auth_outcome {
             crate::sasl::Outcome::Success(key) => key,
             crate::sasl::Outcome::Failure(reason) => {

--- a/proxy/src/auth/backend/mod.rs
+++ b/proxy/src/auth/backend/mod.rs
@@ -276,7 +276,7 @@ async fn authenticate_with_secret(
         let role = RoleNameInt::from(&info.user);
 
         let auth_outcome =
-            validate_password_and_exchange(&config.thread_pool, ep, role, &password, secret)
+            validate_password_and_exchange(&config.scram_thread_pool, ep, role, &password, secret)
                 .await?;
         let keys = match auth_outcome {
             crate::sasl::Outcome::Success(key) => key,
@@ -501,7 +501,7 @@ mod tests {
 
     static CONFIG: Lazy<AuthenticationConfig> = Lazy::new(|| AuthenticationConfig {
         jwks_cache: JwkCache::default(),
-        thread_pool: ThreadPool::new(1),
+        scram_thread_pool: ThreadPool::new(1),
         scram_protocol_timeout: std::time::Duration::from_secs(5),
         ip_allowlist_check_enabled: true,
         is_vpc_acccess_proxy: false,

--- a/proxy/src/binary/local_proxy.rs
+++ b/proxy/src/binary/local_proxy.rs
@@ -29,7 +29,7 @@ use crate::config::{
 };
 use crate::control_plane::locks::ApiLocks;
 use crate::http::health_server::AppMetrics;
-use crate::metrics::{Metrics, ServiceInfo, ThreadPoolMetrics};
+use crate::metrics::{Metrics, ServiceInfo};
 use crate::rate_limiter::{EndpointRateLimiter, LeakyBucketConfig, RateBucketInfo};
 use crate::scram::threadpool::ThreadPool;
 use crate::serverless::cancel_set::CancelSet;
@@ -113,8 +113,6 @@ pub async fn run() -> anyhow::Result<()> {
     let _logging_guard = crate::logging::init_local_proxy()?;
     let _panic_hook_guard = utils::logging::replace_panic_hook_with_tracing_panic_hook();
     let _sentry_guard = init_sentry(Some(GIT_VERSION.into()), &[]);
-
-    Metrics::install(Arc::new(ThreadPoolMetrics::new(0)));
 
     // TODO: refactor these to use labels
     debug!("Version: {GIT_VERSION}");

--- a/proxy/src/binary/local_proxy.rs
+++ b/proxy/src/binary/local_proxy.rs
@@ -284,7 +284,7 @@ fn build_config(args: &LocalProxyCliArgs) -> anyhow::Result<&'static ProxyConfig
         http_config,
         authentication_config: AuthenticationConfig {
             jwks_cache: JwkCache::default(),
-            thread_pool: ThreadPool::new(0),
+            scram_thread_pool: ThreadPool::new(0),
             scram_protocol_timeout: Duration::from_secs(10),
             ip_allowlist_check_enabled: true,
             is_vpc_acccess_proxy: false,

--- a/proxy/src/binary/pg_sni_router.rs
+++ b/proxy/src/binary/pg_sni_router.rs
@@ -26,7 +26,7 @@ use utils::project_git_version;
 use utils::sentry_init::init_sentry;
 
 use crate::context::RequestContext;
-use crate::metrics::{Metrics, ServiceInfo, ThreadPoolMetrics};
+use crate::metrics::{Metrics, ServiceInfo};
 use crate::pglb::TlsRequired;
 use crate::pqproto::FeStartupPacket;
 use crate::protocol2::ConnectionInfo;
@@ -79,8 +79,6 @@ pub async fn run() -> anyhow::Result<()> {
     let _logging_guard = crate::logging::init()?;
     let _panic_hook_guard = utils::logging::replace_panic_hook_with_tracing_panic_hook();
     let _sentry_guard = init_sentry(Some(GIT_VERSION.into()), &[]);
-
-    Metrics::install(Arc::new(ThreadPoolMetrics::new(0)));
 
     let args = cli().get_matches();
     let destination: String = args

--- a/proxy/src/binary/proxy.rs
+++ b/proxy/src/binary/proxy.rs
@@ -617,7 +617,12 @@ pub async fn run() -> anyhow::Result<()> {
 /// ProxyConfig is created at proxy startup, and lives forever.
 fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
     let thread_pool = ThreadPool::new(args.scram_thread_pool_size);
-    Metrics::install(thread_pool.metrics.clone());
+    Metrics::get()
+        .proxy
+        .scram_pool
+        .0
+        .set(thread_pool.metrics.clone())
+        .ok();
 
     let tls_config = match (&args.tls_key, &args.tls_cert) {
         (Some(key_path), Some(cert_path)) => Some(config::configure_tls(

--- a/proxy/src/binary/proxy.rs
+++ b/proxy/src/binary/proxy.rs
@@ -690,7 +690,7 @@ fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
     };
     let authentication_config = AuthenticationConfig {
         jwks_cache: JwkCache::default(),
-        thread_pool,
+        scram_thread_pool: thread_pool,
         scram_protocol_timeout: args.scram_protocol_timeout,
         ip_allowlist_check_enabled: !args.is_private_access_proxy,
         is_vpc_acccess_proxy: args.is_private_access_proxy,

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -19,7 +19,7 @@ use crate::control_plane::messages::{EndpointJwksResponse, JwksSettings};
 use crate::ext::TaskExt;
 use crate::intern::RoleNameInt;
 use crate::rate_limiter::{RateLimitAlgorithm, RateLimiterConfig};
-use crate::scram::threadpool::ThreadPool;
+use crate::scram;
 use crate::serverless::GlobalConnPoolOptions;
 use crate::serverless::cancel_set::CancelSet;
 #[cfg(feature = "rest_broker")]
@@ -75,7 +75,7 @@ pub struct HttpConfig {
 }
 
 pub struct AuthenticationConfig {
-    pub thread_pool: Arc<ThreadPool>,
+    pub scram_thread_pool: Arc<scram::threadpool::ThreadPool>,
     pub scram_protocol_timeout: tokio::time::Duration,
     pub ip_allowlist_check_enabled: bool,
     pub is_vpc_acccess_proxy: bool,

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -5,6 +5,7 @@ use measured::label::{
     FixedCardinalitySet, LabelGroupSet, LabelGroupVisitor, LabelName, LabelSet, LabelValue,
     StaticLabelSet,
 };
+use measured::metric::group::Encoding;
 use measured::metric::histogram::Thresholds;
 use measured::metric::name::MetricName;
 use measured::{
@@ -18,10 +19,10 @@ use crate::control_plane::messages::ColdStartInfo;
 use crate::error::ErrorKind;
 
 #[derive(MetricGroup)]
-#[metric(new(thread_pool: Arc<ThreadPoolMetrics>))]
+#[metric(new())]
 pub struct Metrics {
     #[metric(namespace = "proxy")]
-    #[metric(init = ProxyMetrics::new(thread_pool))]
+    #[metric(init = ProxyMetrics::new())]
     pub proxy: ProxyMetrics,
 
     #[metric(namespace = "wake_compute_lock")]
@@ -34,34 +35,27 @@ pub struct Metrics {
     pub cache: CacheMetrics,
 }
 
-static SELF: OnceLock<Metrics> = OnceLock::new();
 impl Metrics {
-    pub fn install(thread_pool: Arc<ThreadPoolMetrics>) {
-        let mut metrics = Metrics::new(thread_pool);
-
-        metrics.proxy.errors_total.init_all_dense();
-        metrics.proxy.redis_errors_total.init_all_dense();
-        metrics.proxy.redis_events_count.init_all_dense();
-        metrics.proxy.retries_metric.init_all_dense();
-        metrics.proxy.connection_failures_total.init_all_dense();
-
-        SELF.set(metrics)
-            .ok()
-            .expect("proxy metrics must not be installed more than once");
-    }
-
+    #[track_caller]
     pub fn get() -> &'static Self {
-        #[cfg(test)]
-        return SELF.get_or_init(|| Metrics::new(Arc::new(ThreadPoolMetrics::new(0))));
+        static SELF: OnceLock<Metrics> = OnceLock::new();
 
-        #[cfg(not(test))]
-        SELF.get()
-            .expect("proxy metrics must be installed by the main() function")
+        SELF.get_or_init(|| {
+            let mut metrics = Metrics::new();
+
+            metrics.proxy.errors_total.init_all_dense();
+            metrics.proxy.redis_errors_total.init_all_dense();
+            metrics.proxy.redis_events_count.init_all_dense();
+            metrics.proxy.retries_metric.init_all_dense();
+            metrics.proxy.connection_failures_total.init_all_dense();
+
+            metrics
+        })
     }
 }
 
 #[derive(MetricGroup)]
-#[metric(new(thread_pool: Arc<ThreadPoolMetrics>))]
+#[metric(new())]
 pub struct ProxyMetrics {
     #[metric(flatten)]
     pub db_connections: CounterPairVec<NumDbConnectionsGauge>,
@@ -154,8 +148,25 @@ pub struct ProxyMetrics {
     pub connect_compute_lock: ApiLockMetrics,
 
     #[metric(namespace = "scram_pool")]
-    #[metric(init = thread_pool)]
-    pub scram_pool: Arc<ThreadPoolMetrics>,
+    pub scram_pool: OnceLockWrapper<Arc<ThreadPoolMetrics>>,
+}
+
+/// A Wrapper over [`OnceLock`] to implement [`MetricGroup`].
+pub struct OnceLockWrapper<T>(pub OnceLock<T>);
+
+impl<T> Default for OnceLockWrapper<T> {
+    fn default() -> Self {
+        Self(OnceLock::new())
+    }
+}
+
+impl<Enc: Encoding, T: MetricGroup<Enc>> MetricGroup<Enc> for OnceLockWrapper<T> {
+    fn collect_group_into(&self, enc: &mut Enc) -> Result<(), Enc::Err> {
+        if let Some(inner) = self.0.get() {
+            inner.collect_group_into(enc)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(MetricGroup)]

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -730,6 +730,7 @@ pub enum CacheKind {
     ProjectInfoEndpoints,
     ProjectInfoRoles,
     Schema,
+    Pbkdf2,
 }
 
 #[derive(FixedCardinalityLabel, Clone, Copy, Debug)]

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -134,6 +134,9 @@ pub struct ProxyMetrics {
     /// Number of TLS handshake failures
     pub tls_handshake_failures: Counter,
 
+    /// Number of SHA 256 rounds executed.
+    pub sha_rounds: Counter,
+
     /// HLL approximate cardinality of endpoints that are connecting
     pub connecting_endpoints: HyperLogLogVec<StaticLabelSet<Protocol>, 32>,
 

--- a/proxy/src/scram/cache.rs
+++ b/proxy/src/scram/cache.rs
@@ -1,5 +1,5 @@
 use tokio::time::Instant;
-use x509_cert::der::zeroize::Zeroize as _;
+use zeroize::Zeroize as _;
 
 use super::pbkdf2;
 use crate::cache::Cached;

--- a/proxy/src/scram/cache.rs
+++ b/proxy/src/scram/cache.rs
@@ -1,0 +1,77 @@
+use tokio::time::Instant;
+use x509_cert::der::zeroize::Zeroize;
+
+use super::pbkdf2;
+use crate::cache::Cached;
+use crate::cache::common::{Cache, count_cache_insert, count_cache_outcome, eviction_listener};
+use crate::intern::{EndpointIdInt, RoleNameInt};
+use crate::metrics::{CacheKind, Metrics};
+
+pub(crate) struct Pbkdf2Cache(moka::sync::Cache<(EndpointIdInt, RoleNameInt), Pbkdf2CacheEntry>);
+pub(crate) type CachedPbkdf2<'a> = Cached<&'a Pbkdf2Cache>;
+
+impl Cache for Pbkdf2Cache {
+    type Key = (EndpointIdInt, RoleNameInt);
+    type Value = Pbkdf2CacheEntry;
+
+    fn invalidate(&self, info: &(EndpointIdInt, RoleNameInt)) {
+        self.0.invalidate(info);
+    }
+}
+
+/// To speed up password hashing for more active customers, we store the tail results of the
+/// PBKDF2 algorithm. If the output of PBKDF2 is U1 ^ U2 ^ ⋯ ^ Uc, then we store
+/// suffix = U17 ^ U18 ^ ⋯ ^ Uc. We only need to calculate U1 ^ U2 ^ ⋯ ^ U15 ^ U16
+/// to determine the final result.
+///
+/// The suffix alone isn't enough to crack the password. The stored_key is still required.
+/// While both are cached in memory, given they're in different locations is makes it much
+/// harder to exploit, even if any such memory exploit exists in proxy.
+#[derive(Clone)]
+pub struct Pbkdf2CacheEntry {
+    /// corresponds to [`ServerSecret::cached_at`]
+    pub(super) cached_from: Instant,
+    pub(super) suffix: pbkdf2::Block,
+}
+
+impl Drop for Pbkdf2CacheEntry {
+    fn drop(&mut self) {
+        self.suffix.zeroize();
+    }
+}
+
+impl Pbkdf2Cache {
+    pub fn new() -> Self {
+        let builder = moka::sync::Cache::builder()
+            .name("pbkdf2")
+            .max_capacity(100)
+            .time_to_idle(std::time::Duration::from_secs(60));
+
+        Metrics::get().cache.capacity.set(CacheKind::Pbkdf2, 10);
+
+        let builder =
+            builder.eviction_listener(|_k, _v, cause| eviction_listener(CacheKind::Pbkdf2, cause));
+
+        Self(builder.build())
+    }
+
+    pub fn insert(&self, endpoint: EndpointIdInt, role: RoleNameInt, value: Pbkdf2CacheEntry) {
+        count_cache_insert(CacheKind::Pbkdf2);
+        self.0.insert((endpoint, role), value);
+    }
+
+    fn get(&self, endpoint: EndpointIdInt, role: RoleNameInt) -> Option<Pbkdf2CacheEntry> {
+        count_cache_outcome(CacheKind::Pbkdf2, self.0.get(&(endpoint, role)))
+    }
+
+    pub fn get_entry(
+        &self,
+        endpoint: EndpointIdInt,
+        role: RoleNameInt,
+    ) -> Option<CachedPbkdf2<'_>> {
+        self.get(endpoint, role).map(|value| Cached {
+            token: Some((self, (endpoint, role))),
+            value,
+        })
+    }
+}

--- a/proxy/src/scram/cache.rs
+++ b/proxy/src/scram/cache.rs
@@ -29,7 +29,7 @@ impl Cache for Pbkdf2Cache {
 /// harder to exploit, even if any such memory exploit exists in proxy.
 #[derive(Clone)]
 pub struct Pbkdf2CacheEntry {
-    /// corresponds to [`ServerSecret::cached_at`]
+    /// corresponds to [`super::ServerSecret::cached_at`]
     pub(super) cached_from: Instant,
     pub(super) suffix: pbkdf2::Block,
 }

--- a/proxy/src/scram/cache.rs
+++ b/proxy/src/scram/cache.rs
@@ -48,7 +48,8 @@ impl Pbkdf2Cache {
         let builder = moka::sync::Cache::builder()
             .name("pbkdf2")
             .max_capacity(SIZE)
-            .time_to_idle(TTL);
+            // We use time_to_live so we don't refresh the lifetime for an invalid password attempt.
+            .time_to_live(TTL);
 
         Metrics::get()
             .cache

--- a/proxy/src/scram/cache.rs
+++ b/proxy/src/scram/cache.rs
@@ -1,5 +1,5 @@
 use tokio::time::Instant;
-use x509_cert::der::zeroize::Zeroize;
+use x509_cert::der::zeroize::Zeroize as _;
 
 use super::pbkdf2;
 use crate::cache::Cached;

--- a/proxy/src/scram/cache.rs
+++ b/proxy/src/scram/cache.rs
@@ -42,12 +42,18 @@ impl Drop for Pbkdf2CacheEntry {
 
 impl Pbkdf2Cache {
     pub fn new() -> Self {
+        const SIZE: u64 = 100;
+        const TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
         let builder = moka::sync::Cache::builder()
             .name("pbkdf2")
-            .max_capacity(100)
-            .time_to_idle(std::time::Duration::from_secs(60));
+            .max_capacity(SIZE)
+            .time_to_idle(TTL);
 
-        Metrics::get().cache.capacity.set(CacheKind::Pbkdf2, 10);
+        Metrics::get()
+            .cache
+            .capacity
+            .set(CacheKind::Pbkdf2, SIZE as i64);
 
         let builder =
             builder.eviction_listener(|_k, _v, cause| eviction_listener(CacheKind::Pbkdf2, cause));

--- a/proxy/src/scram/exchange.rs
+++ b/proxy/src/scram/exchange.rs
@@ -132,7 +132,7 @@ async fn exchange_with_cache(
         if secret.cached_at == entry.cached_from {
             // cache is valid. compute the full hash by adding the prefix to the suffix.
             let mut hash = prefix;
-            pbkdf2::xor(&mut hash, &entry.suffix);
+            pbkdf2::xor_assign(&mut hash, &entry.suffix);
             let outcome = validate_pbkdf2(secret, &hash);
 
             if matches!(outcome, sasl::Outcome::Success(_)) {
@@ -160,7 +160,7 @@ async fn exchange_with_cache(
 
     // time to cache, compute the suffix by subtracting the prefix from the hash.
     let mut suffix = hash;
-    pbkdf2::xor(&mut suffix, &prefix);
+    pbkdf2::xor_assign(&mut suffix, &prefix);
 
     pool.cache.insert(
         (endpoint, role),

--- a/proxy/src/scram/exchange.rs
+++ b/proxy/src/scram/exchange.rs
@@ -1,15 +1,13 @@
 //! Implementation of the SCRAM authentication algorithm.
 
 use std::convert::Infallible;
+use std::time::Instant;
 
 use base64::Engine as _;
 use base64::prelude::BASE64_STANDARD;
-use hmac::Mac;
-use rand::RngCore;
 use tracing::{debug, trace};
 use x509_cert::der::zeroize::Zeroize;
 
-use super::ScramKey;
 use super::messages::{
     ClientFinalMessage, ClientFirstMessage, OwnedServerFirstMessage, SCRAM_RAW_NONCE_LEN,
 };
@@ -17,6 +15,7 @@ use super::pbkdf2::Pbkdf2;
 use super::secret::ServerSecret;
 use super::signature::SignatureBuilder;
 use super::threadpool::ThreadPool;
+use super::{ScramKey, pbkdf2};
 use crate::intern::{EndpointIdInt, RoleNameInt};
 use crate::sasl::{self, ChannelBinding, Error as SaslError};
 
@@ -85,11 +84,14 @@ async fn derive_client_key(
     password: &[u8],
     salt: &[u8],
     iterations: u32,
-) -> ScramKey {
+) -> pbkdf2::Block {
     pool.spawn_job(endpoint, Pbkdf2::start(password, salt, iterations))
         .await
 }
 
+/// For cleartext flow, we need to derive the client key to
+/// 1. authenticate the client.
+/// 2. authenticate with compute.
 pub(crate) async fn exchange(
     pool: &ThreadPool,
     endpoint: EndpointIdInt,
@@ -97,73 +99,109 @@ pub(crate) async fn exchange(
     secret: &ServerSecret,
     password: &[u8],
 ) -> sasl::Result<sasl::Outcome<super::ScramKey>> {
-    // hot path: let's check the threadpool cache
-    if let Some(entry) = pool.cache.get(&(endpoint, role)) {
-        // cached key is no longer valid.
-        if secret.is_password_invalid(&entry.client_key).into() {
-            debug!("invalidating cached password");
-            pool.cache.invalidate(&(endpoint, role));
-        } else if let Ok(client_key) = entry.verify(password) {
-            trace!("password validated from cache");
-            return Ok(sasl::Outcome::Success(client_key));
-        }
-    }
-
-    // slow path: full password verify.
-    let salt = BASE64_STANDARD.decode(&*secret.salt_base64)?;
-    let client_key = derive_client_key(pool, endpoint, password, &salt, secret.iterations).await;
-
-    if secret.is_password_invalid(&client_key).into() {
-        Ok(sasl::Outcome::Failure("password doesn't match"))
+    if secret.iterations > CACHED_ROUNDS {
+        exchange_with_cache(pool, endpoint, role, secret, password).await
     } else {
-        trace!("storing cached password");
-        pool.cache.insert(
-            (endpoint, role),
-            ClientSecretEntry::new(password, client_key.clone()),
-        );
-
-        Ok(sasl::Outcome::Success(client_key))
+        let salt = BASE64_STANDARD.decode(&*secret.salt_base64)?;
+        let hash = derive_client_key(pool, endpoint, password, &salt, secret.iterations).await;
+        Ok(validate_pbkdf2(secret, &hash))
     }
 }
 
-#[derive(Clone)]
-pub struct ClientSecretEntry {
-    salt: [u8; 64],
-    hash: [u8; 64],
-    client_key: ScramKey,
-}
+/// Compute the client key using a cache. We cache the suffix of the pbkdf2 result only,
+/// which is not enough by itself to perform an offline brute force.
+async fn exchange_with_cache(
+    pool: &ThreadPool,
+    endpoint: EndpointIdInt,
+    role: RoleNameInt,
+    secret: &ServerSecret,
+    password: &[u8],
+) -> sasl::Result<sasl::Outcome<super::ScramKey>> {
+    let salt = BASE64_STANDARD.decode(&*secret.salt_base64)?;
 
-impl Drop for ClientSecretEntry {
-    fn drop(&mut self) {
-        self.salt.zeroize();
-        self.hash.zeroize();
-    }
-}
+    debug_assert!(
+        secret.iterations > CACHED_ROUNDS,
+        "we should not cache password data if there isn't enough rounds needed"
+    );
 
-impl ClientSecretEntry {
-    fn new(password: &[u8], client_key: ScramKey) -> Self {
-        let mut salt = [0; 64];
-        rand::rng().fill_bytes(&mut salt);
+    // compute the prefix of the pbkdf2 output.
+    let prefix = derive_client_key(pool, endpoint, password, &salt, CACHED_ROUNDS).await;
 
-        let mut hmac = hmac::Hmac::<sha2::Sha512>::new_from_slice(password)
-            .expect("HMAC is able to accept all key sizes");
-        hmac.update(&salt);
-        let hash = hmac.finalize().into_bytes().into();
+    if let Some(entry) = pool.cache.get(&(endpoint, role)) {
+        // hot path: let's check the threadpool cache
+        if secret.cached_at == entry.cached_from {
+            // cache is valid. compute the full hash by adding the prefix to the suffix.
+            let mut hash = prefix;
+            pbkdf2::xor(&mut hash, &entry.suffix);
+            let outcome = validate_pbkdf2(secret, &hash);
 
-        Self {
-            salt,
-            hash,
-            client_key,
+            if matches!(outcome, sasl::Outcome::Success(_)) {
+                trace!("password validated from cache");
+            }
+
+            return Ok(outcome);
         }
+
+        // cached key is no longer valid.
+        debug!("invalidating cached password");
+        pool.cache.invalidate(&(endpoint, role));
     }
 
-    fn verify(&self, password: &[u8]) -> Result<ScramKey, hmac::digest::MacError> {
-        let mut hmac = hmac::Hmac::<sha2::Sha512>::new_from_slice(password)
-            .expect("HMAC is able to accept all key sizes");
-        hmac.update(&self.salt);
+    // slow path: full password hash.
+    let hash = derive_client_key(pool, endpoint, password, &salt, secret.iterations).await;
+    let outcome = validate_pbkdf2(secret, &hash);
 
-        hmac.verify_slice(&self.hash)
-            .map(|()| self.client_key.clone())
+    let client_key = match outcome {
+        sasl::Outcome::Success(client_key) => client_key,
+        sasl::Outcome::Failure(_) => return Ok(outcome),
+    };
+
+    trace!("storing cached password");
+
+    // time to cache, compute the suffix by subtracting the prefix from the hash.
+    let mut suffix = hash;
+    pbkdf2::xor(&mut suffix, &prefix);
+
+    pool.cache.insert(
+        (endpoint, role),
+        Pbkdf2CacheEntry {
+            cached_from: secret.cached_at,
+            suffix,
+        },
+    );
+
+    Ok(sasl::Outcome::Success(client_key))
+}
+
+fn validate_pbkdf2(secret: &ServerSecret, hash: &pbkdf2::Block) -> sasl::Outcome<ScramKey> {
+    let client_key = super::ScramKey::client_key(&(*hash).into());
+    if secret.is_password_invalid(&client_key).into() {
+        sasl::Outcome::Failure("password doesn't match")
+    } else {
+        sasl::Outcome::Success(client_key)
+    }
+}
+
+const CACHED_ROUNDS: u32 = 16;
+
+/// To speed up password hashing for more active customers, we store the tail results of the
+/// PBKDF2 algorithm. If the output of PBKDF2 is U1 ^ U2 ^ ⋯ ^ Uc, then we store
+/// suffix = U17 ^ U18 ^ ⋯ ^ Uc. We only need to calculate U1 ^ U2 ^ ⋯ ^ U15 ^ U16
+/// to determine the final result.
+///
+/// The suffix alone isn't enough to crack the password. The stored_key is still required.
+/// While both are cached in memory, given they're in different locations is makes it much
+/// harder to exploit, even if any such memory exploit exists in proxy.
+#[derive(Clone)]
+pub struct Pbkdf2CacheEntry {
+    /// corresponds to [`ServerSecret::cached_at`]
+    cached_from: Instant,
+    suffix: pbkdf2::Block,
+}
+
+impl Drop for Pbkdf2CacheEntry {
+    fn drop(&mut self) {
+        self.suffix.zeroize();
     }
 }
 

--- a/proxy/src/scram/exchange.rs
+++ b/proxy/src/scram/exchange.rs
@@ -5,7 +5,10 @@ use std::convert::Infallible;
 use base64::Engine as _;
 use base64::prelude::BASE64_STANDARD;
 use hmac::{Hmac, Mac};
+use rand::RngCore;
 use sha2::Sha256;
+use tracing::debug;
+use x509_cert::der::zeroize::Zeroize;
 
 use super::ScramKey;
 use super::messages::{
@@ -15,7 +18,7 @@ use super::pbkdf2::Pbkdf2;
 use super::secret::ServerSecret;
 use super::signature::SignatureBuilder;
 use super::threadpool::ThreadPool;
-use crate::intern::EndpointIdInt;
+use crate::intern::{EndpointIdInt, RoleNameInt};
 use crate::sasl::{self, ChannelBinding, Error as SaslError};
 
 /// The only channel binding mode we currently support.
@@ -89,31 +92,79 @@ async fn derive_client_key(
         .spawn_job(endpoint, Pbkdf2::start(password, salt, iterations))
         .await;
 
-    let make_key = |name| {
-        let key = Hmac::<Sha256>::new_from_slice(&salted_password)
-            .expect("HMAC is able to accept all key sizes")
-            .chain_update(name)
-            .finalize();
+    let mut hmac = Hmac::<Sha256>::new_from_slice(&salted_password)
+        .expect("HMAC is able to accept all key sizes");
+    hmac.update(b"Client Key");
 
-        <[u8; 32]>::from(key.into_bytes())
-    };
-
-    make_key(b"Client Key").into()
+    ScramKey::from(<[u8; 32]>::from(hmac.finalize().into_bytes()))
 }
 
 pub(crate) async fn exchange(
     pool: &ThreadPool,
     endpoint: EndpointIdInt,
+    role: RoleNameInt,
     secret: &ServerSecret,
     password: &[u8],
 ) -> sasl::Result<sasl::Outcome<super::ScramKey>> {
+    // hot path: let's check the threadpool cache
+    if let Some((entry, keys)) = pool.cache.get(&(endpoint, role)) {
+        // cached key is no longer valid.
+        if secret.is_password_invalid(&keys).into() {
+            debug!("invalidating cached password");
+            pool.cache.invalidate(&(endpoint, role));
+        } else if entry.verify(password) {
+            return Ok(sasl::Outcome::Success(keys));
+        }
+    }
+
+    // slow path: full password verify.
     let salt = BASE64_STANDARD.decode(&*secret.salt_base64)?;
     let client_key = derive_client_key(pool, endpoint, password, &salt, secret.iterations).await;
 
     if secret.is_password_invalid(&client_key).into() {
         Ok(sasl::Outcome::Failure("password doesn't match"))
     } else {
+        pool.cache.insert(
+            (endpoint, role),
+            (ClientSecretEntry::new(password), client_key.clone()),
+        );
+
         Ok(sasl::Outcome::Success(client_key))
+    }
+}
+
+#[derive(Clone)]
+pub struct ClientSecretEntry {
+    salt: [u8; 64],
+    hash: [u8; 64],
+}
+
+impl Drop for ClientSecretEntry {
+    fn drop(&mut self) {
+        self.salt.zeroize();
+        self.hash.zeroize();
+    }
+}
+
+impl ClientSecretEntry {
+    fn new(password: &[u8]) -> Self {
+        let mut salt = [0; 64];
+        rand::rng().fill_bytes(&mut salt);
+
+        let mut hmac = hmac::Hmac::<sha2::Sha512>::new_from_slice(password)
+            .expect("HMAC is able to accept all key sizes");
+        hmac.update(&salt);
+        let hash = hmac.finalize().into_bytes().into();
+
+        Self { salt, hash }
+    }
+
+    fn verify(&self, password: &[u8]) -> bool {
+        let mut hmac = hmac::Hmac::<sha2::Sha512>::new_from_slice(password)
+            .expect("HMAC is able to accept all key sizes");
+        hmac.update(&self.salt);
+
+        hmac.verify_slice(&self.hash).is_ok()
     }
 }
 

--- a/proxy/src/scram/key.rs
+++ b/proxy/src/scram/key.rs
@@ -1,5 +1,6 @@
 //! Tools for client/server/stored key management.
 
+use hmac::Mac;
 use subtle::ConstantTimeEq;
 use x509_cert::der::zeroize::Zeroize;
 
@@ -40,6 +41,14 @@ impl ScramKey {
 
     pub(crate) fn as_bytes(&self) -> [u8; SCRAM_KEY_LEN] {
         self.bytes
+    }
+
+    pub(crate) fn client_key(b: &[u8; 32]) -> Self {
+        let mut hmac = hmac::Hmac::<sha2::Sha256>::new_from_slice(b)
+            .expect("HMAC is able to accept all key sizes");
+        hmac.update(b"Client Key");
+        let client_key: [u8; 32] = hmac.finalize().into_bytes().into();
+        client_key.into()
     }
 }
 

--- a/proxy/src/scram/key.rs
+++ b/proxy/src/scram/key.rs
@@ -1,6 +1,7 @@
 //! Tools for client/server/stored key management.
 
 use subtle::ConstantTimeEq;
+use x509_cert::der::zeroize::Zeroize;
 
 /// Faithfully taken from PostgreSQL.
 pub(crate) const SCRAM_KEY_LEN: usize = 32;
@@ -12,6 +13,12 @@ pub(crate) const SCRAM_KEY_LEN: usize = 32;
 #[repr(transparent)]
 pub(crate) struct ScramKey {
     bytes: [u8; SCRAM_KEY_LEN],
+}
+
+impl Drop for ScramKey {
+    fn drop(&mut self) {
+        self.bytes.zeroize();
+    }
 }
 
 impl PartialEq for ScramKey {

--- a/proxy/src/scram/key.rs
+++ b/proxy/src/scram/key.rs
@@ -1,11 +1,12 @@
 //! Tools for client/server/stored key management.
 
-use hmac::Mac;
-use sha2::Digest;
+use hmac::Mac as _;
+use sha2::Digest as _;
 use subtle::ConstantTimeEq;
 use x509_cert::der::zeroize::Zeroize;
 
 use crate::metrics::Metrics;
+use crate::scram::pbkdf2::Prf;
 
 /// Faithfully taken from PostgreSQL.
 pub(crate) const SCRAM_KEY_LEN: usize = 32;
@@ -50,14 +51,13 @@ impl ScramKey {
     }
 
     pub(crate) fn client_key(b: &[u8; 32]) -> Self {
-        // Hmac::new_from_slice will run 2 sha256 rounds.
+        // Prf::new_from_slice will run 2 sha256 rounds.
         // Update + Finalize run 2 sha256 rounds.
         Metrics::get().proxy.sha_rounds.inc_by(4);
 
-        let mut hmac = hmac::Hmac::<sha2::Sha256>::new_from_slice(b)
-            .expect("HMAC is able to accept all key sizes");
-        hmac.update(b"Client Key");
-        let client_key: [u8; 32] = hmac.finalize().into_bytes().into();
+        let mut prf = Prf::new_from_slice(b).expect("HMAC is able to accept all key sizes");
+        prf.update(b"Client Key");
+        let client_key: [u8; 32] = prf.finalize().into_bytes().into();
         client_key.into()
     }
 }

--- a/proxy/src/scram/key.rs
+++ b/proxy/src/scram/key.rs
@@ -3,7 +3,7 @@
 use hmac::Mac as _;
 use sha2::Digest as _;
 use subtle::ConstantTimeEq;
-use x509_cert::der::zeroize::Zeroize;
+use zeroize::Zeroize as _;
 
 use crate::metrics::Metrics;
 use crate::scram::pbkdf2::Prf;

--- a/proxy/src/scram/mod.rs
+++ b/proxy/src/scram/mod.rs
@@ -114,23 +114,32 @@ mod tests {
         );
     }
 
-    async fn run_round_trip_test(server_password: &str, client_password: &str) {
-        let pool = ThreadPool::new(1);
-
+    async fn check(
+        pool: &ThreadPool,
+        scram_secret: &ServerSecret,
+        password: &[u8],
+    ) -> Result<(), &'static str> {
         let ep = EndpointId::from("foo");
         let ep = EndpointIdInt::from(ep);
         let role = RoleName::from("user");
         let role = RoleNameInt::from(&role);
 
-        let scram_secret = ServerSecret::build(server_password).await.unwrap();
-        let outcome = super::exchange(&pool, ep, role, &scram_secret, client_password.as_bytes())
+        let outcome = super::exchange(pool, ep, role, scram_secret, password)
             .await
             .unwrap();
 
         match outcome {
-            crate::sasl::Outcome::Success(_) => {}
-            crate::sasl::Outcome::Failure(r) => panic!("{r}"),
+            crate::sasl::Outcome::Success(_) => Ok(()),
+            crate::sasl::Outcome::Failure(r) => Err(r),
         }
+    }
+
+    async fn run_round_trip_test(server_password: &str, client_password: &str) {
+        let pool = ThreadPool::new(1);
+        let scram_secret = ServerSecret::build(server_password).await.unwrap();
+        check(&pool, &scram_secret, client_password.as_bytes())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -142,5 +151,28 @@ mod tests {
     #[should_panic(expected = "password doesn't match")]
     async fn failure() {
         run_round_trip_test("pencil", "eraser").await;
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn password_cache() {
+        let pool = ThreadPool::new(1);
+        let scram_secret = ServerSecret::build("password").await.unwrap();
+
+        // wrong passwords are not added to cache
+        check(&pool, &scram_secret, b"wrong").await.unwrap_err();
+        assert!(!logs_contain("storing cached password"));
+
+        // correct passwords get cached
+        check(&pool, &scram_secret, b"password").await.unwrap();
+        assert!(logs_contain("storing cached password"));
+
+        // wrong passwords do not match the cache
+        check(&pool, &scram_secret, b"wrong").await.unwrap_err();
+        assert!(!logs_contain("password validated from cache"));
+
+        // correct passwords match the cache
+        check(&pool, &scram_secret, b"password").await.unwrap();
+        assert!(logs_contain("password validated from cache"));
     }
 }

--- a/proxy/src/scram/mod.rs
+++ b/proxy/src/scram/mod.rs
@@ -18,10 +18,8 @@ pub mod threadpool;
 use base64::Engine as _;
 use base64::prelude::BASE64_STANDARD;
 pub(crate) use exchange::{Exchange, exchange};
-use hmac::{Hmac, Mac};
 pub(crate) use key::ScramKey;
 pub(crate) use secret::ServerSecret;
-use sha2::{Digest, Sha256};
 
 const SCRAM_SHA_256: &str = "SCRAM-SHA-256";
 const SCRAM_SHA_256_PLUS: &str = "SCRAM-SHA-256-PLUS";
@@ -40,22 +38,6 @@ fn base64_decode_array<const N: usize>(input: impl AsRef<[u8]>) -> Option<[u8; N
     }
 
     Some(bytes)
-}
-
-/// This function essentially is `Hmac(sha256, key, input)`.
-/// Further reading: <https://datatracker.ietf.org/doc/html/rfc2104>.
-fn hmac_sha256<'a>(key: &[u8], parts: impl IntoIterator<Item = &'a [u8]>) -> [u8; 32] {
-    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("bad key size");
-    parts.into_iter().for_each(|s| mac.update(s));
-
-    mac.finalize().into_bytes().into()
-}
-
-fn sha256<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    parts.into_iter().for_each(|s| hasher.update(s));
-
-    hasher.finalize().into()
 }
 
 #[cfg(test)]

--- a/proxy/src/scram/mod.rs
+++ b/proxy/src/scram/mod.rs
@@ -62,9 +62,9 @@ fn sha256<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> [u8; 32] {
 mod tests {
     use super::threadpool::ThreadPool;
     use super::{Exchange, ServerSecret};
-    use crate::intern::EndpointIdInt;
+    use crate::intern::{EndpointIdInt, RoleNameInt};
     use crate::sasl::{Mechanism, Step};
-    use crate::types::EndpointId;
+    use crate::types::{EndpointId, RoleName};
 
     #[test]
     fn snapshot() {
@@ -119,9 +119,11 @@ mod tests {
 
         let ep = EndpointId::from("foo");
         let ep = EndpointIdInt::from(ep);
+        let role = RoleName::from("user");
+        let role = RoleNameInt::from(&role);
 
         let scram_secret = ServerSecret::build(server_password).await.unwrap();
-        let outcome = super::exchange(&pool, ep, &scram_secret, client_password.as_bytes())
+        let outcome = super::exchange(&pool, ep, role, &scram_secret, client_password.as_bytes())
             .await
             .unwrap();
 

--- a/proxy/src/scram/mod.rs
+++ b/proxy/src/scram/mod.rs
@@ -6,6 +6,7 @@
 //! * <https://github.com/postgres/postgres/blob/94226d4506e66d6e7cbf4b391f1e7393c1962841/src/backend/libpq/auth-scram.c>
 //! * <https://github.com/postgres/postgres/blob/94226d4506e66d6e7cbf4b391f1e7393c1962841/src/interfaces/libpq/fe-auth-scram.c>
 
+mod cache;
 mod countmin;
 mod exchange;
 mod key;

--- a/proxy/src/scram/pbkdf2.rs
+++ b/proxy/src/scram/pbkdf2.rs
@@ -10,6 +10,8 @@ pub(crate) struct Pbkdf2 {
     iterations: u32,
 }
 
+pub type Pbkdf2Output = [u8; 32];
+
 // inspired from <https://github.com/neondatabase/rust-postgres/blob/20031d7a9ee1addeae6e0968e3899ae6bf01cee2/postgres-protocol/src/authentication/sasl.rs#L36-L61>
 impl Pbkdf2 {
     pub(crate) fn start(str: &[u8], salt: &[u8], iterations: u32) -> Self {
@@ -33,7 +35,7 @@ impl Pbkdf2 {
         (self.iterations).clamp(0, 4096)
     }
 
-    pub(crate) fn turn(&mut self) -> std::task::Poll<[u8; 32]> {
+    pub(crate) fn turn(&mut self) -> std::task::Poll<Pbkdf2Output> {
         let Self {
             hmac,
             prev,

--- a/proxy/src/scram/pbkdf2.rs
+++ b/proxy/src/scram/pbkdf2.rs
@@ -1,15 +1,22 @@
+//! For postgres password authentication, we need to perform a PBKDF2 using
+//! PRF=HMAC-SHA2-256, producing only 1 block (32 bytes) of output key.
+
 use hmac::digest::consts::U32;
 use hmac::digest::generic_array::GenericArray;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use x509_cert::der::zeroize::Zeroize;
 
-use super::ScramKey;
+type Prf = Hmac<Sha256>;
+pub(crate) type Block = GenericArray<u8, U32>;
 
 pub(crate) struct Pbkdf2 {
     hmac: Hmac<Sha256>,
-    prev: GenericArray<u8, U32>,
-    hi: GenericArray<u8, U32>,
+    /// U{r-1} for whatever iteration r we are currently on.
+    prev: Block,
+    /// the output of `fold(xor, U{1}..U{r})` for whatever iteration r we are currently on.
+    hi: Block,
+    /// number of iterations left
     iterations: u32,
 }
 
@@ -22,10 +29,12 @@ impl Drop for Pbkdf2 {
 
 // inspired from <https://github.com/neondatabase/rust-postgres/blob/20031d7a9ee1addeae6e0968e3899ae6bf01cee2/postgres-protocol/src/authentication/sasl.rs#L36-L61>
 impl Pbkdf2 {
-    pub(crate) fn start(str: &[u8], salt: &[u8], iterations: u32) -> Self {
+    pub(crate) fn start(pw: &[u8], salt: &[u8], iterations: u32) -> Self {
         // key the HMAC and derive the first block in-place
-        let mut hmac =
-            Hmac::<Sha256>::new_from_slice(str).expect("HMAC is able to accept all key sizes");
+        let mut hmac = Prf::new_from_slice(pw).expect("HMAC is able to accept all key sizes");
+
+        // U1 = PRF(Password, Salt + INT_32_BE(i))
+        // i = 1 since we only need 1 block of output.
         hmac.update(salt);
         hmac.update(&1u32.to_be_bytes());
         let init_block = hmac.finalize_reset().into_bytes();
@@ -43,7 +52,9 @@ impl Pbkdf2 {
         (self.iterations).clamp(0, 4096)
     }
 
-    pub(crate) fn turn(&mut self) -> std::task::Poll<ScramKey> {
+    /// For "fairness", we implement PBKDF2 with cooperative yielding, which is why we use this `turn`
+    /// function that only executes a fixed number of iterations before continuing.
+    pub(crate) fn turn(&mut self) -> std::task::Poll<Block> {
         let Self {
             hmac,
             prev,
@@ -54,31 +65,38 @@ impl Pbkdf2 {
         // only do up to 4096 iterations per turn for fairness
         let n = (*iterations).clamp(0, 4096);
         for _ in 0..n {
-            hmac.update(prev);
-            let block = hmac.finalize_reset().into_bytes();
-
-            for (hi_byte, &b) in hi.iter_mut().zip(block.iter()) {
-                *hi_byte ^= b;
-            }
-
-            *prev = block;
+            let next = single_round(hmac, prev);
+            xor(hi, &next);
+            *prev = next;
         }
 
         *iterations -= n;
         if *iterations == 0 {
-            std::task::Poll::Ready(ScramKey::client_key(&(*hi).into()))
+            std::task::Poll::Ready(*hi)
         } else {
             std::task::Poll::Pending
         }
     }
 }
 
+#[inline(always)]
+pub fn xor(x: &mut Block, y: &Block) {
+    for (x, &y) in std::iter::zip(x, y) {
+        *x ^= y;
+    }
+}
+
+#[inline(always)]
+fn single_round(prf: &mut Prf, ui: &Block) -> Block {
+    // Ui = PRF(Password, Ui-1)
+    prf.update(ui);
+    prf.finalize_reset().into_bytes()
+}
+
 #[cfg(test)]
 mod tests {
     use pbkdf2::pbkdf2_hmac_array;
     use sha2::Sha256;
-
-    use crate::scram::ScramKey;
 
     use super::Pbkdf2;
 
@@ -88,14 +106,14 @@ mod tests {
         let pass = b"Ne0n_!5_50_C007";
 
         let mut job = Pbkdf2::start(pass, salt, 60000);
-        let hash = loop {
+        let hash: [u8; 32] = loop {
             let std::task::Poll::Ready(hash) = job.turn() else {
                 continue;
             };
-            break hash;
+            break hash.into();
         };
 
-        let expected = ScramKey::client_key(&pbkdf2_hmac_array::<Sha256, 32>(pass, salt, 60000));
-        assert_eq!(hash.as_bytes(), expected.as_bytes());
+        let expected = pbkdf2_hmac_array::<Sha256, 32>(pass, salt, 60000);
+        assert_eq!(hash, expected);
     }
 }

--- a/proxy/src/scram/pbkdf2.rs
+++ b/proxy/src/scram/pbkdf2.rs
@@ -72,7 +72,7 @@ impl Pbkdf2 {
         let n = (*iterations).clamp(0, 4096);
         for _ in 0..n {
             let next = single_round(hmac, prev);
-            xor(hi, &next);
+            xor_assign(hi, &next);
             *prev = next;
         }
 
@@ -89,7 +89,7 @@ impl Pbkdf2 {
 }
 
 #[inline(always)]
-pub fn xor(x: &mut Block, y: &Block) {
+pub fn xor_assign(x: &mut Block, y: &Block) {
     for (x, &y) in std::iter::zip(x, y) {
         *x ^= y;
     }

--- a/proxy/src/scram/pbkdf2.rs
+++ b/proxy/src/scram/pbkdf2.rs
@@ -4,7 +4,7 @@
 use hmac::Mac as _;
 use hmac::digest::consts::U32;
 use hmac::digest::generic_array::GenericArray;
-use x509_cert::der::zeroize::Zeroize as _;
+use zeroize::Zeroize as _;
 
 use crate::metrics::Metrics;
 

--- a/proxy/src/scram/secret.rs
+++ b/proxy/src/scram/secret.rs
@@ -1,5 +1,7 @@
 //! Tools for SCRAM server secret management.
 
+use std::time::Instant;
+
 use base64::Engine as _;
 use base64::prelude::BASE64_STANDARD;
 use subtle::{Choice, ConstantTimeEq};
@@ -11,6 +13,9 @@ use super::key::ScramKey;
 /// and is used throughout the authentication process.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub(crate) struct ServerSecret {
+    /// When this secret was cached.
+    pub(crate) cached_at: Instant,
+
     /// Number of iterations for `PBKDF2` function.
     pub(crate) iterations: u32,
     /// Salt used to hash user's password.
@@ -34,6 +39,7 @@ impl ServerSecret {
             params.split_once(':').zip(keys.split_once(':'))?;
 
         let secret = ServerSecret {
+            cached_at: Instant::now(),
             iterations: iterations.parse().ok()?,
             salt_base64: salt.into(),
             stored_key: base64_decode_array(stored_key)?.into(),
@@ -54,6 +60,7 @@ impl ServerSecret {
     /// See `auth-scram.c : mock_scram_secret` for details.
     pub(crate) fn mock(nonce: [u8; 32]) -> Self {
         Self {
+            cached_at: Instant::now(),
             // this doesn't reveal much information as we're going to use
             // iteration count 1 for our generated passwords going forward.
             // PG16 users can set iteration count=1 already today.

--- a/proxy/src/scram/secret.rs
+++ b/proxy/src/scram/secret.rs
@@ -1,10 +1,9 @@
 //! Tools for SCRAM server secret management.
 
-use std::time::Instant;
-
 use base64::Engine as _;
 use base64::prelude::BASE64_STANDARD;
 use subtle::{Choice, ConstantTimeEq};
+use tokio::time::Instant;
 
 use super::base64_decode_array;
 use super::key::ScramKey;

--- a/proxy/src/scram/signature.rs
+++ b/proxy/src/scram/signature.rs
@@ -1,6 +1,10 @@
 //! Tools for client/server signature management.
 
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
 use super::key::{SCRAM_KEY_LEN, ScramKey};
+use crate::metrics::Metrics;
 
 /// A collection of message parts needed to derive the client's signature.
 #[derive(Debug)]
@@ -12,15 +16,19 @@ pub(crate) struct SignatureBuilder<'a> {
 
 impl SignatureBuilder<'_> {
     pub(crate) fn build(&self, key: &ScramKey) -> Signature {
-        let parts = [
-            self.client_first_message_bare.as_bytes(),
-            b",",
-            self.server_first_message.as_bytes(),
-            b",",
-            self.client_final_message_without_proof.as_bytes(),
-        ];
+        // don't know exactly. this is a rough approx
+        Metrics::get().proxy.sha_rounds.inc_by(8);
 
-        super::hmac_sha256(key.as_ref(), parts).into()
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(key.as_ref()).expect("HMAC accepts all key sizes");
+        mac.update(self.client_first_message_bare.as_bytes());
+        mac.update(b",");
+        mac.update(self.server_first_message.as_bytes());
+        mac.update(b",");
+        mac.update(self.client_final_message_without_proof.as_bytes());
+        Signature {
+            bytes: mac.finalize().into_bytes().into(),
+        }
     }
 }
 

--- a/proxy/src/scram/signature.rs
+++ b/proxy/src/scram/signature.rs
@@ -1,10 +1,10 @@
 //! Tools for client/server signature management.
 
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
+use hmac::Mac as _;
 
 use super::key::{SCRAM_KEY_LEN, ScramKey};
 use crate::metrics::Metrics;
+use crate::scram::pbkdf2::Prf;
 
 /// A collection of message parts needed to derive the client's signature.
 #[derive(Debug)]
@@ -19,8 +19,7 @@ impl SignatureBuilder<'_> {
         // don't know exactly. this is a rough approx
         Metrics::get().proxy.sha_rounds.inc_by(8);
 
-        let mut mac =
-            Hmac::<Sha256>::new_from_slice(key.as_ref()).expect("HMAC accepts all key sizes");
+        let mut mac = Prf::new_from_slice(key.as_ref()).expect("HMAC accepts all key sizes");
         mac.update(self.client_first_message_bare.as_bytes());
         mac.update(b",");
         mac.update(self.server_first_message.as_bytes());

--- a/proxy/src/scram/threadpool.rs
+++ b/proxy/src/scram/threadpool.rs
@@ -28,9 +28,8 @@ pub struct ThreadPool {
     pub metrics: Arc<ThreadPoolMetrics>,
 
     // we hash a lot of passwords.
-    // we keep a cache with in memory unique salts.
-    pub(super) cache:
-        moka::sync::Cache<(EndpointIdInt, RoleNameInt), (ClientSecretEntry, ScramKey)>,
+    // we keep a cache of partial hashes for faster validation.
+    pub(super) cache: moka::sync::Cache<(EndpointIdInt, RoleNameInt), ClientSecretEntry>,
 }
 
 /// How often to reset the sketch values

--- a/proxy/src/scram/threadpool.rs
+++ b/proxy/src/scram/threadpool.rs
@@ -214,6 +214,6 @@ mod tests {
             10, 114, 73, 188, 140, 222, 196, 156, 214, 184, 79, 157, 119, 242, 16, 31, 53, 242,
             178, 43, 95, 8, 225, 182, 122, 40, 219, 21, 89, 147, 64, 140,
         ];
-        assert_eq!(actual.as_slice(), expected.as_slice());
+        assert_eq!(actual.as_slice(), expected);
     }
 }

--- a/proxy/src/scram/threadpool.rs
+++ b/proxy/src/scram/threadpool.rs
@@ -18,7 +18,7 @@ use rand::{Rng, SeedableRng};
 
 use super::ScramKey;
 use super::exchange::ClientSecretEntry;
-use super::pbkdf2::{Pbkdf2, Pbkdf2Output};
+use super::pbkdf2::Pbkdf2;
 use crate::intern::{EndpointIdInt, RoleNameInt};
 use crate::metrics::{ThreadPoolMetrics, ThreadPoolWorkerId};
 use crate::scram::countmin::CountMinSketch;
@@ -145,7 +145,7 @@ struct JobSpec {
 }
 
 impl Future for JobSpec {
-    type Output = [u8; 32];
+    type Output = ScramKey;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         STATE.with_borrow_mut(|state| {
@@ -181,10 +181,10 @@ impl Future for JobSpec {
     }
 }
 
-pub(crate) struct JobHandle(tokio::task::JoinHandle<Pbkdf2Output>);
+pub(crate) struct JobHandle(tokio::task::JoinHandle<ScramKey>);
 
 impl Future for JobHandle {
-    type Output = Pbkdf2Output;
+    type Output = ScramKey;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.0.poll_unpin(cx) {
@@ -218,10 +218,10 @@ mod tests {
             .spawn_job(ep, Pbkdf2::start(b"password", &salt, 4096))
             .await;
 
-        let expected = [
+        let expected = ScramKey::client_key(&[
             10, 114, 73, 188, 140, 222, 196, 156, 214, 184, 79, 157, 119, 242, 16, 31, 53, 242,
             178, 43, 95, 8, 225, 182, 122, 40, 219, 21, 89, 147, 64, 140,
-        ];
-        assert_eq!(actual, expected);
+        ]);
+        assert_eq!(actual.as_bytes(), expected.as_bytes());
     }
 }

--- a/proxy/src/scram/threadpool.rs
+++ b/proxy/src/scram/threadpool.rs
@@ -10,19 +10,27 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use futures::FutureExt;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
-use super::pbkdf2::Pbkdf2;
-use crate::intern::EndpointIdInt;
+use super::ScramKey;
+use super::exchange::ClientSecretEntry;
+use super::pbkdf2::{Pbkdf2, Pbkdf2Output};
+use crate::intern::{EndpointIdInt, RoleNameInt};
 use crate::metrics::{ThreadPoolMetrics, ThreadPoolWorkerId};
 use crate::scram::countmin::CountMinSketch;
 
 pub struct ThreadPool {
     runtime: Option<tokio::runtime::Runtime>,
     pub metrics: Arc<ThreadPoolMetrics>,
+
+    // we hash a lot of passwords.
+    // we keep a cache with in memory unique salts.
+    pub(super) cache:
+        moka::sync::Cache<(EndpointIdInt, RoleNameInt), (ClientSecretEntry, ScramKey)>,
 }
 
 /// How often to reset the sketch values
@@ -68,6 +76,13 @@ impl ThreadPool {
             Self {
                 runtime: Some(runtime),
                 metrics: Arc::new(ThreadPoolMetrics::new(n_workers as usize)),
+                // only store the most common client_keys for a very short period of time.
+                // only helps reduce the CPU load from the whales.
+                cache: moka::sync::Cache::builder()
+                    .name("pbkdf2")
+                    .max_capacity(100)
+                    .time_to_idle(Duration::from_secs(60))
+                    .build(),
             }
         })
     }
@@ -166,10 +181,10 @@ impl Future for JobSpec {
     }
 }
 
-pub(crate) struct JobHandle(tokio::task::JoinHandle<[u8; 32]>);
+pub(crate) struct JobHandle(tokio::task::JoinHandle<Pbkdf2Output>);
 
 impl Future for JobHandle {
-    type Output = [u8; 32];
+    type Output = Pbkdf2Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.0.poll_unpin(cx) {

--- a/proxy/src/scram/threadpool.rs
+++ b/proxy/src/scram/threadpool.rs
@@ -16,8 +16,8 @@ use futures::FutureExt;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
-use super::ScramKey;
-use super::exchange::ClientSecretEntry;
+use super::exchange::Pbkdf2CacheEntry;
+use super::pbkdf2;
 use super::pbkdf2::Pbkdf2;
 use crate::intern::{EndpointIdInt, RoleNameInt};
 use crate::metrics::{ThreadPoolMetrics, ThreadPoolWorkerId};
@@ -29,7 +29,7 @@ pub struct ThreadPool {
 
     // we hash a lot of passwords.
     // we keep a cache of partial hashes for faster validation.
-    pub(super) cache: moka::sync::Cache<(EndpointIdInt, RoleNameInt), ClientSecretEntry>,
+    pub(super) cache: moka::sync::Cache<(EndpointIdInt, RoleNameInt), Pbkdf2CacheEntry>,
 }
 
 /// How often to reset the sketch values
@@ -144,7 +144,7 @@ struct JobSpec {
 }
 
 impl Future for JobSpec {
-    type Output = ScramKey;
+    type Output = pbkdf2::Block;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         STATE.with_borrow_mut(|state| {
@@ -180,10 +180,10 @@ impl Future for JobSpec {
     }
 }
 
-pub(crate) struct JobHandle(tokio::task::JoinHandle<ScramKey>);
+pub(crate) struct JobHandle(tokio::task::JoinHandle<pbkdf2::Block>);
 
 impl Future for JobHandle {
-    type Output = ScramKey;
+    type Output = pbkdf2::Block;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.0.poll_unpin(cx) {
@@ -217,10 +217,10 @@ mod tests {
             .spawn_job(ep, Pbkdf2::start(b"password", &salt, 4096))
             .await;
 
-        let expected = ScramKey::client_key(&[
+        let expected = &[
             10, 114, 73, 188, 140, 222, 196, 156, 214, 184, 79, 157, 119, 242, 16, 31, 53, 242,
             178, 43, 95, 8, 225, 182, 122, 40, 219, 21, 89, 147, 64, 140,
-        ]);
-        assert_eq!(actual.as_bytes(), expected.as_bytes());
+        ];
+        assert_eq!(actual.as_slice(), expected.as_slice());
     }
 }

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -26,7 +26,7 @@ use crate::context::RequestContext;
 use crate::control_plane::client::ApiLockError;
 use crate::control_plane::errors::{GetAuthInfoError, WakeComputeError};
 use crate::error::{ErrorKind, ReportableError, UserFacingError};
-use crate::intern::EndpointIdInt;
+use crate::intern::{EndpointIdInt, RoleNameInt};
 use crate::pqproto::StartupMessageParams;
 use crate::proxy::{connect_auth, connect_compute};
 use crate::rate_limiter::EndpointRateLimiter;
@@ -76,9 +76,11 @@ impl PoolingBackend {
         };
 
         let ep = EndpointIdInt::from(&user_info.endpoint);
+        let role = RoleNameInt::from(&user_info.user);
         let auth_outcome = crate::auth::validate_password_and_exchange(
             &self.config.authentication_config.thread_pool,
             ep,
+            role,
             password,
             secret,
         )

--- a/proxy/src/serverless/backend.rs
+++ b/proxy/src/serverless/backend.rs
@@ -78,7 +78,7 @@ impl PoolingBackend {
         let ep = EndpointIdInt::from(&user_info.endpoint);
         let role = RoleNameInt::from(&user_info.user);
         let auth_outcome = crate::auth::validate_password_and_exchange(
-            &self.config.authentication_config.thread_pool,
+            &self.config.authentication_config.scram_thread_pool,
             ep,
             role,
             password,


### PR DESCRIPTION
## Problem

Password hashing for sql-over-http takes up a lot of CPU. Perhaps we can get away with temporarily caching some steps so we only need fewer rounds, which will save some CPU time.

## Summary of changes

The output of pbkdf2 is the XOR of the outputs of each iteration round, eg `U1 ^ U2 ^ ... U15 ^ U16 ^ U17 ^ ... ^ Un`. We cache the suffix of the expression `U16 ^ U17 ^ ... ^ Un`. To compute the result from the cached suffix, we only need to compute the prefix `U1 ^ U2 ^ ... U15`. The suffix by itself is useless, which prevent's its use in brute-force attacks should this cached memory leak.

We are also caching the full 4096 round hash in memory, which can be used for brute-force attacks, where this suffix could be used to speed it up. My hope/expectation is that since these will be in different allocations, it makes any such memory exploitation much much harder. Since the full hash cache might be invalidated while the suffix is cached, I'm storing the timestamp of the computation as a way to identity the match.

I also added `zeroize()` to clear the sensitive state from the stack/heap.

For the most security conscious customers, we hope to roll out OIDC soon, so they can disable passwords entirely.

---

The numbers for the threadpool were pretty random, but according to our busiest region for sql-over-http, we only see about 150 unique endpoints every minute. So storing ~100 of the most common endpoints for that minute should be the vast majority of requests.

1 minute was chosen so we don't keep data in memory for too long.