### PR TITLE
fix(pageserver): do not increase basebackup err counter when reconnect

### DIFF
--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -2235,7 +2235,9 @@ impl BasebackupQueryTimeOngoingRecording<'_> {
         let metric = match res {
             Ok(_) => &self.parent.ok,
             Err(QueryError::Shutdown) | Err(QueryError::Reconnect) => {
-                // Do not observe ok/err for shutdown/reconnect
+                // Do not observe ok/err for shutdown/reconnect.
+                // Reconnect error might be raised when the operation is waiting for LSN and the tenant shutdown interrupts
+                // the operation. A reconnect error will be issued and the client will retry.
                 return;
             }
             Err(QueryError::Disconnected(ConnectionError::Io(io_error)))

--- a/pageserver/src/metrics.rs
+++ b/pageserver/src/metrics.rs
@@ -2234,8 +2234,8 @@ impl BasebackupQueryTimeOngoingRecording<'_> {
         // If you want to change categorize of a specific error, also change it in `log_query_error`.
         let metric = match res {
             Ok(_) => &self.parent.ok,
-            Err(QueryError::Shutdown) => {
-                // Do not observe ok/err for shutdown
+            Err(QueryError::Shutdown) | Err(QueryError::Reconnect) => {
+                // Do not observe ok/err for shutdown/reconnect
                 return;
             }
             Err(QueryError::Disconnected(ConnectionError::Io(io_error)))


### PR DESCRIPTION
## Problem

We see unexpected basebackup error alerts in the alert channel.

https://github.com/neondatabase/neon/pull/11778 only fixed the alerts for shutdown errors. However, another path is that tenant shutting down while waiting LSN -> WaitLsnError::BadState -> QueryError::Reconnect. Therefore, the reconnect error should also be discarded from the ok/error counter.

## Summary of changes

Do not increase ok/err counter for reconnect errors.