### PR TITLE
proxy: Monitor passthrough tokio tasks and export metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,6 +5268,7 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
+ "tokio-metrics",
  "tokio-postgres",
  "tokio-postgres2",
  "tokio-rustls 0.26.2",
@@ -7324,6 +7325,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7817b32d36c9b94744d7aa3f8fc13526aa0f5112009d7045f3c659413a6e44ac"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 tokio = { version = "1.43.1", features = ["macros"] }
 tokio-epoll-uring = { git = "https://github.com/neondatabase/tokio-epoll-uring.git" , branch = "main" }
 tokio-io-timeout = "1.2.0"
+tokio-metrics = "0.4"
 tokio-postgres-rustls = "0.12.0"
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["tls12", "ring"]}
 tokio-stream = "0.1"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -89,6 +89,7 @@ tokio-postgres = { workspace = true, optional = true }
 tokio-rustls.workspace = true
 tokio-util.workspace = true
 tokio = { workspace = true, features = ["signal"] }
+tokio-metrics.workspace = true
 tracing-subscriber.workspace = true
 tracing-utils.workspace = true
 tracing.workspace = true

--- a/proxy/src/binary/local_proxy.rs
+++ b/proxy/src/binary/local_proxy.rs
@@ -14,7 +14,6 @@ use thiserror::Error;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 use tokio::task::JoinSet;
-use tokio_metrics::TaskMonitor;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use utils::sentry_init::init_sentry;
@@ -284,7 +283,7 @@ fn build_config(args: &LocalProxyCliArgs) -> anyhow::Result<&'static ProxyConfig
         wake_compute_retry_config: RetryConfig::parse(RetryConfig::WAKE_COMPUTE_DEFAULT_VALUES)?,
         connect_compute_locks,
         connect_to_compute: compute_config,
-        passthrough_task_monitor: TaskMonitor::new(),
+        passthrough_task_monitor: None,
     })))
 }
 

--- a/proxy/src/binary/local_proxy.rs
+++ b/proxy/src/binary/local_proxy.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 use tokio::task::JoinSet;
+use tokio_metrics::TaskMonitor;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use utils::sentry_init::init_sentry;
@@ -112,7 +113,7 @@ pub async fn run() -> anyhow::Result<()> {
     let _panic_hook_guard = utils::logging::replace_panic_hook_with_tracing_panic_hook();
     let _sentry_guard = init_sentry(Some(GIT_VERSION.into()), &[]);
 
-    Metrics::install(Arc::new(ThreadPoolMetrics::new(0)));
+    Metrics::install(Arc::new(ThreadPoolMetrics::new(0)), vec![]);
 
     // TODO: refactor these to use labels
     debug!("Version: {GIT_VERSION}");
@@ -283,6 +284,7 @@ fn build_config(args: &LocalProxyCliArgs) -> anyhow::Result<&'static ProxyConfig
         wake_compute_retry_config: RetryConfig::parse(RetryConfig::WAKE_COMPUTE_DEFAULT_VALUES)?,
         connect_compute_locks,
         connect_to_compute: compute_config,
+        passthrough_task_monitor: TaskMonitor::new(),
     })))
 }
 

--- a/proxy/src/binary/pg_sni_router.rs
+++ b/proxy/src/binary/pg_sni_router.rs
@@ -79,7 +79,7 @@ pub async fn run() -> anyhow::Result<()> {
     let _panic_hook_guard = utils::logging::replace_panic_hook_with_tracing_panic_hook();
     let _sentry_guard = init_sentry(Some(GIT_VERSION.into()), &[]);
 
-    Metrics::install(Arc::new(ThreadPoolMetrics::new(0)));
+    Metrics::install(Arc::new(ThreadPoolMetrics::new(0)), vec![]);
 
     let args = cli().get_matches();
     let destination: String = args

--- a/proxy/src/binary/proxy.rs
+++ b/proxy/src/binary/proxy.rs
@@ -234,7 +234,7 @@ struct ProxyCliArgs {
     pg_sni_router: PgSniRouterArgs,
 
     /// Collect performance stats of passthrough tasks and export metrics.
-    #[clap(long, default_value_t = false, value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
+    #[clap(long, default_value_t = tracing::level_enabled!(tracing::Level::DEBUG), value_parser = clap::builder::BoolishValueParser::new(), action = clap::ArgAction::Set)]
     enable_passthrough_task_metrics: bool,
 }
 

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -28,7 +28,7 @@ pub struct ProxyConfig {
     pub wake_compute_retry_config: RetryConfig,
     pub connect_compute_locks: ApiLocks<Host>,
     pub connect_to_compute: ComputeConfig,
-    pub passthrough_task_monitor: TaskMonitor,
+    pub passthrough_task_monitor: Option<TaskMonitor>,
 }
 
 pub struct ComputeConfig {

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Ok, bail, ensure};
 use arc_swap::ArcSwapOption;
 use clap::ValueEnum;
 use remote_storage::RemoteStorageConfig;
+use tokio_metrics::TaskMonitor;
 
 use crate::auth::backend::jwt::JwkCache;
 use crate::control_plane::locks::ApiLocks;
@@ -27,6 +28,7 @@ pub struct ProxyConfig {
     pub wake_compute_retry_config: RetryConfig,
     pub connect_compute_locks: ApiLocks<Host>,
     pub connect_to_compute: ComputeConfig,
+    pub passthrough_task_monitor: TaskMonitor,
 }
 
 pub struct ComputeConfig {

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -734,32 +734,33 @@ where
             .iter()
             .map(|(name, monitor)| (TokioTaskMonitorName(name), monitor.cumulative()))
             .collect::<Vec<_>>();
+        let snapshots = snapshots.as_slice();
 
         // instrumented/dropped
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The number of tasks instrumented.",
-            getter: |metrics| metrics.instrumented_count,
+            get_value: |m| m.instrumented_count,
         }
         .collect_family_into(MetricName::from_str("instrumented_count"), enc)?;
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The number of tasks dropped.",
-            getter: |metrics| metrics.dropped_count,
+            get_value: |m| m.dropped_count,
         }
         .collect_family_into(MetricName::from_str("dropped_count"), enc)?;
 
         // first_poll
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The number of tasks polled for the first time.",
-            getter: |metrics| metrics.first_poll_count,
+            get_value: |m| m.first_poll_count,
         }
         .collect_family_into(MetricName::from_str("first_poll_count"), enc)?;
         TokioTaskFloatGaugeMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total duration elapsed between the instant tasks are instrumented, and the instant they are first polled.",
-            getter: |metrics| metrics.total_first_poll_delay.as_secs_f64(),
+            get_value: |m| m.total_first_poll_delay.as_secs_f64(),
         }
         .collect_family_into(
             MetricName::from_str("total_first_poll_delay"),
@@ -768,102 +769,102 @@ where
 
         // idle
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total number of times that tasks idled, waiting to be awoken.",
-            getter: |metrics| metrics.total_idled_count,
+            get_value: |m| m.total_idled_count,
         }
         .collect_family_into(MetricName::from_str("total_idled_count"), enc)?;
         TokioTaskFloatGaugeMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total duration that tasks idled.",
-            getter: |metrics| metrics.total_idle_duration.as_secs_f64(),
+            get_value: |m| m.total_idle_duration.as_secs_f64(),
         }
         .collect_family_into(MetricName::from_str("total_idle_duration"), enc)?;
 
         // poll
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total number of times that tasks were polled.",
-            getter: |metrics| metrics.total_poll_count,
+            get_value: |m| m.total_poll_count,
         }
         .collect_family_into(MetricName::from_str("total_poll_count"), enc)?;
         TokioTaskFloatGaugeMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total duration elapsed during polls.",
-            getter: |metrics| metrics.total_poll_duration.as_secs_f64(),
+            get_value: |m| m.total_poll_duration.as_secs_f64(),
         }
         .collect_family_into(MetricName::from_str("total_poll_duration"), enc)?;
 
         // scheduled
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help:  "The total number of times that tasks were awoken (and then, presumably, scheduled for execution).",
-            getter: |metrics| metrics.total_scheduled_count,
+            get_value: |m| m.total_scheduled_count,
         }
         .collect_family_into(
             MetricName::from_str("total_scheduled_count"),
             enc,
         )?;
         TokioTaskFloatGaugeMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total duration that tasks spent waiting to be polled after awakening.",
-            getter: |metrics| metrics.total_scheduled_duration.as_secs_f64(),
+            get_value: |m| m.total_scheduled_duration.as_secs_f64(),
         }
         .collect_family_into(MetricName::from_str("total_scheduled_duration"), enc)?;
 
         // fast_poll
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total number of times that polling tasks completed swiftly.",
-            getter: |metrics| metrics.total_fast_poll_count,
+            get_value: |m| m.total_fast_poll_count,
         }
         .collect_family_into(MetricName::from_str("total_fast_poll_count"), enc)?;
         TokioTaskFloatGaugeMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total duration of fast polls.",
-            getter: |metrics| metrics.total_fast_poll_duration.as_secs_f64(),
+            get_value: |m| m.total_fast_poll_duration.as_secs_f64(),
         }
         .collect_family_into(MetricName::from_str("total_fast_poll_duration"), enc)?;
 
         // slow_poll
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total number of times that polling tasks completed slowly.",
-            getter: |metrics| metrics.total_slow_poll_count,
+            get_value: |m| m.total_slow_poll_count,
         }
         .collect_family_into(MetricName::from_str("total_slow_poll_count"), enc)?;
         TokioTaskFloatGaugeMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total duration of slow polls.",
-            getter: |metrics| metrics.total_slow_poll_duration.as_secs_f64(),
+            get_value: |m| m.total_slow_poll_duration.as_secs_f64(),
         }
         .collect_family_into(MetricName::from_str("total_slow_poll_duration"), enc)?;
 
         // short_delay
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total count of tasks with short scheduling delays.",
-            getter: |metrics| metrics.total_short_delay_count,
+            get_value: |m| m.total_short_delay_count,
         }
         .collect_family_into(MetricName::from_str("total_short_delay_count"), enc)?;
         TokioTaskFloatGaugeMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total duration of tasks with short scheduling delays.",
-            getter: |metrics| metrics.total_short_delay_duration.as_secs_f64(),
+            get_value: |m| m.total_short_delay_duration.as_secs_f64(),
         }
         .collect_family_into(MetricName::from_str("total_short_delay_duration"), enc)?;
 
         // long_delay
         TokioTaskCounterMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total count of tasks with long scheduling delays.",
-            getter: |metrics| metrics.total_long_delay_count,
+            get_value: |m| m.total_long_delay_count,
         }
         .collect_family_into(MetricName::from_str("total_long_delay_count"), enc)?;
         TokioTaskFloatGaugeMetric {
-            snapshots: snapshots.as_slice(),
+            snapshots,
             help: "The total number of times that a task had a long scheduling duration.",
-            getter: |metrics| metrics.total_long_delay_duration.as_secs_f64(),
+            get_value: |m| m.total_long_delay_duration.as_secs_f64(),
         }
         .collect_family_into(MetricName::from_str("total_long_delay_duration"), enc)?;
 
@@ -891,7 +892,7 @@ where
 {
     snapshots: &'a [(TokioTaskMonitorName<'a>, tokio_metrics::TaskMetrics)],
     help: &'a str,
-    getter: F,
+    get_value: F,
 }
 
 impl<E: Encoding, F> MetricFamilyEncoding<E> for TokioTaskCounterMetric<'_, F>
@@ -909,7 +910,7 @@ where
         CounterState::write_type(metric_name, enc)?;
 
         for (monitor_name, snapshot) in self.snapshots {
-            let value = (self.getter)(snapshot);
+            let value = (self.get_value)(snapshot);
             CounterState {
                 count: AtomicU64::new(value),
             }
@@ -925,7 +926,7 @@ where
 {
     snapshots: &'a [(TokioTaskMonitorName<'a>, tokio_metrics::TaskMetrics)],
     help: &'a str,
-    getter: F,
+    get_value: F,
 }
 
 impl<E: Encoding, F> MetricFamilyEncoding<E> for TokioTaskFloatGaugeMetric<'_, F>
@@ -943,7 +944,7 @@ where
         FloatGaugeState::write_type(metric_name, enc)?;
 
         for (monitor_name, snapshot) in self.snapshots {
-            let value = (self.getter)(snapshot);
+            let value = (self.get_value)(snapshot);
             FloatGaugeState {
                 count: AtomicF64::new(value),
             }

--- a/proxy/src/proxy/mod.rs
+++ b/proxy/src/proxy/mod.rs
@@ -167,7 +167,12 @@ pub async fn task_main(
                 Ok(Some(p)) => {
                     ctx.set_success();
                     let _disconnect = ctx.log_connect();
-                    match p.proxy_pass(&config.connect_to_compute).await {
+                    match tokio_metrics::TaskMonitor::instrument(
+                        &config.passthrough_task_monitor,
+                        p.proxy_pass(&config.connect_to_compute),
+                    )
+                    .await
+                    {
                         Ok(()) => {}
                         Err(ErrorSource::Client(e)) => {
                             warn!(


### PR DESCRIPTION
## Problem

We have no insight into how well tokio tasks are doing in the passthrough path.

## Summary of changes

Add a TaskMonitor for the passthrough tasks and export metrics. Gated by flag, disabled by default.