### PR TITLE
Add grpc pagebench for communicator grpc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "pageserver/compaction",
     "pageserver/ctl",
     "pageserver/client",
+    "pageserver/client_grpc",
     "pageserver/pagebench",
     "pageserver/page_api",
     "proxy",
@@ -199,7 +200,7 @@ tokio-tar = "0.3"
 tokio-util = { version = "0.7.10", features = ["io", "rt"] }
 toml = "0.8"
 toml_edit = "0.22"
-tonic = { version = "0.13.1", default-features = false, features = ["channel", "codegen", "prost", "router", "server", "tls-ring", "tls-native-roots"] }
+tonic = { version = "0.13.1", default-features = false, features = ["gzip", "channel", "codegen", "prost", "router", "server", "tls-ring", "tls-native-roots"] }
 tonic-reflection = { version = "0.13.1", features = ["server"] }
 tower = { version = "0.5.2", default-features = false }
 tower-http = { version = "0.6.2", features = ["auth", "request-id", "trace"] }
@@ -254,6 +255,7 @@ metrics = { version = "0.1", path = "./libs/metrics/" }
 pageserver = { path = "./pageserver" }
 pageserver_api = { version = "0.1", path = "./libs/pageserver_api/" }
 pageserver_client = { path = "./pageserver/client" }
+pageserver_client_grpc = { path = "./pageserver/client_grpc" }
 pageserver_compaction = { version = "0.1", path = "./pageserver/compaction/" }
 pageserver_page_api = { path = "./pageserver/page_api" }
 postgres_backend = { version = "0.1", path = "./libs/postgres_backend/" }

--- a/pageserver/page_api/src/lib.rs
+++ b/pageserver/page_api/src/lib.rs
@@ -18,6 +18,6 @@ pub mod proto {
     pub use page_service_server::{PageService, PageServiceServer};
 }
 
-mod model;
+pub mod model;
 
 pub use model::*;

--- a/pageserver/page_api/src/model.rs
+++ b/pageserver/page_api/src/model.rs
@@ -102,6 +102,15 @@ impl TryFrom<ReadLsn> for proto::ReadLsn {
     }
 }
 
+impl From<&ReadLsn> for proto::ReadLsn {
+    fn from(value: &ReadLsn) -> proto::ReadLsn {
+        proto::ReadLsn {
+            request_lsn: value.request_lsn.into(),
+            not_modified_since_lsn: value.not_modified_since_lsn.unwrap_or_default().0,
+        }
+    }
+}
+
 // RelTag is defined in pageserver_api::reltag.
 pub type RelTag = pageserver_api::reltag::RelTag;
 
@@ -132,6 +141,16 @@ impl From<RelTag> for proto::RelTag {
     }
 }
 
+impl From<&RelTag> for proto::RelTag {
+    fn from(value: &RelTag) -> proto::RelTag {
+        proto::RelTag {
+            spc_oid: value.spcnode,
+            db_oid: value.dbnode,
+            rel_number: value.relnode,
+            fork_number: value.forknum as u32,
+        }
+    }
+}
 /// Checks whether a relation exists, at the given LSN. Only valid on shard 0, other shards error.
 #[derive(Clone, Copy, Debug)]
 pub struct CheckRelExistsRequest {
@@ -153,6 +172,14 @@ impl TryFrom<proto::CheckRelExistsRequest> for CheckRelExistsRequest {
     }
 }
 
+impl From<&CheckRelExistsRequest> for proto::CheckRelExistsRequest {
+    fn from(value: &CheckRelExistsRequest) -> proto::CheckRelExistsRequest {
+        proto::CheckRelExistsRequest {
+            read_lsn: Some((&value.read_lsn).into()),
+            rel: Some((&value.rel).into()),
+        }
+    }
+}
 pub type CheckRelExistsResponse = bool;
 
 impl From<proto::CheckRelExistsResponse> for CheckRelExistsResponse {
@@ -187,6 +214,15 @@ impl TryFrom<proto::GetBaseBackupRequest> for GetBaseBackupRequest {
                 .try_into()?,
             replica: pb.replica,
         })
+    }
+}
+
+impl From<&GetBaseBackupRequest> for proto::GetBaseBackupRequest {
+    fn from(value: &GetBaseBackupRequest) -> proto::GetBaseBackupRequest {
+        proto::GetBaseBackupRequest {
+            read_lsn: Some((&value.read_lsn).into()),
+            replica: value.replica,
+        }
     }
 }
 
@@ -246,6 +282,14 @@ impl TryFrom<proto::GetDbSizeRequest> for GetDbSizeRequest {
     }
 }
 
+impl From<&GetDbSizeRequest> for proto::GetDbSizeRequest {
+    fn from(value: &GetDbSizeRequest) -> proto::GetDbSizeRequest {
+        proto::GetDbSizeRequest {
+            read_lsn: Some((&value.read_lsn).into()),
+            db_oid: value.db_oid,
+        }
+    }
+}
 impl TryFrom<GetDbSizeRequest> for proto::GetDbSizeRequest {
     type Error = ProtocolError;
 
@@ -311,6 +355,17 @@ impl TryFrom<proto::GetPageRequest> for GetPageRequest {
     }
 }
 
+impl From<&GetPageRequest> for proto::GetPageRequest {
+    fn from(request: &GetPageRequest) -> proto::GetPageRequest {
+        proto::GetPageRequest {
+            request_id: request.request_id,
+            request_class: request.request_class.into(),
+            read_lsn: Some(request.read_lsn.try_into().unwrap()),
+            rel: Some(request.rel.into()),
+            block_number: request.block_numbers.clone().into_vec(),
+        }
+    }
+}
 impl TryFrom<GetPageRequest> for proto::GetPageRequest {
     type Error = ProtocolError;
 
@@ -505,6 +560,14 @@ impl TryFrom<proto::GetRelSizeRequest> for GetRelSizeRequest {
     }
 }
 
+impl From<&GetRelSizeRequest> for proto::GetRelSizeRequest {
+    fn from(value: &GetRelSizeRequest) -> proto::GetRelSizeRequest {
+        proto::GetRelSizeRequest {
+            read_lsn: Some((&value.read_lsn).into()),
+            rel: Some((&value.rel).into()),
+        }
+    }
+}
 impl TryFrom<GetRelSizeRequest> for proto::GetRelSizeRequest {
     type Error = ProtocolError;
 

--- a/pageserver/pagebench/Cargo.toml
+++ b/pageserver/pagebench/Cargo.toml
@@ -10,12 +10,14 @@ license.workspace = true
 anyhow.workspace = true
 camino.workspace = true
 clap.workspace = true
+thiserror.workspace = true
 futures.workspace = true
 hdrhistogram.workspace = true
 humantime.workspace = true
 humantime-serde.workspace = true
 rand.workspace = true
 reqwest.workspace=true
+bytes.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
@@ -23,6 +25,8 @@ tokio.workspace = true
 tokio-util.workspace = true
 
 pageserver_client.workspace = true
+pageserver_client_grpc.workspace = true
 pageserver_api.workspace = true
+pageserver_page_api.workspace = true
 utils = { path = "../../libs/utils/" }
 workspace_hack = { version = "0.1", path = "../../workspace_hack" }


### PR DESCRIPTION
## Problem
 Communicator development needs a way to test grpc and connection-related code.

## Summary of changes
Adds a client grpc layer for the new communicator grpc, and connects it to pagebench for testing.

Note: the pagebench code uses only the "get_page" call from grpc.

the "lib.rs" function was taken from the communicator-rewrite branch.
