### PR TITLE
pageserver: implement gRPC base backups

### DIFF
--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -950,6 +950,18 @@ pub(crate) enum WaitLsnError {
     Timeout(String),
 }
 
+impl From<WaitLsnError> for tonic::Status {
+    fn from(err: WaitLsnError) -> Self {
+        use tonic::Code;
+        let code = match &err {
+            WaitLsnError::Timeout(_) => Code::Internal,
+            WaitLsnError::BadState(_) => Code::Internal,
+            WaitLsnError::Shutdown => Code::Unavailable,
+        };
+        tonic::Status::new(code, format!("{err}"))
+    }
+}
+
 // The impls below achieve cancellation mapping for errors.
 // Perhaps there's a way of achieving this with less cruft.
 


### PR DESCRIPTION
## Problem

The gRPC page service should support base backups.

Touches https://github.com/neondatabase/neon/issues/11728.
Requires https://github.com/neondatabase/neon/pull/12046.

## Summary of changes

This patch implements base backups over gRPC. Unlike other requests, it does not dispatch to the `PageServerHandler` implementation, since it is mostly concerned with libpq-specifics.

Like the page service, this is a bare-bones implementation that will be improved in follow-up PRs.