### PR TITLE
pageserver: remove backtrace in info level log

### DIFF
--- a/pageserver/src/tenant/timeline/import_pgdata.rs
+++ b/pageserver/src/tenant/timeline/import_pgdata.rs
@@ -201,8 +201,8 @@ async fn prepare_import(
         .await;
         match res {
             Ok(_) => break,
-            Err(err) => {
-                info!(?err, "indefinitely waiting for pgdata to finish");
+            Err(_err) => {
+                info!("indefinitely waiting for pgdata to finish");
                 if tokio::time::timeout(std::time::Duration::from_secs(10), cancel.cancelled())
                     .await
                     .is_ok()


### PR DESCRIPTION
## Problem

We print a backtrace in an info level log every 10 seconds while waiting for the import data to land in the bucket.

## Summary of changes

The backtrace is not useful. Remove it.