### PR TITLE
compute-ctl: add spec for enable_tls, separate from compute-ctl config

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -213,7 +213,6 @@ pub struct ParsedSpec {
     pub storage_auth_token: Option<String>,
     pub endpoint_storage_addr: Option<SocketAddr>,
     pub endpoint_storage_token: Option<String>,
-    pub enable_tls: bool,
 }
 
 impl TryFrom<ComputeSpec> for ParsedSpec {
@@ -279,8 +278,6 @@ impl TryFrom<ComputeSpec> for ParsedSpec {
             .clone()
             .or_else(|| spec.cluster.settings.find("neon.endpoint_storage_token"));
 
-        let enable_tls = spec.enable_tls;
-
         Ok(ParsedSpec {
             spec,
             pageserver_connstr,
@@ -290,7 +287,6 @@ impl TryFrom<ComputeSpec> for ParsedSpec {
             timeline_id,
             endpoint_storage_addr,
             endpoint_storage_token,
-            enable_tls,
         })
     }
 }

--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -603,9 +603,13 @@ impl ComputeNode {
             });
         }
 
-        let mut tls_config = self.compute_ctl_config.tls.clone();
-        if !pspec.spec.enable_tls {
-            tls_config = None;
+        let mut tls_config = None;
+        if pspec
+            .spec
+            .features
+            .contains(&ComputeFeature::TlsExperimental)
+        {
+            tls_config = self.compute_ctl_config.tls.clone();
         }
 
         // If there are any remote extensions in shared_preload_libraries, start downloading them
@@ -1213,9 +1217,13 @@ impl ComputeNode {
         let spec = &pspec.spec;
         let pgdata_path = Path::new(&self.params.pgdata);
 
-        let mut tls_config = self.compute_ctl_config.tls.clone();
-        if !spec.enable_tls {
-            tls_config = None;
+        let mut tls_config = None;
+        if pspec
+            .spec
+            .features
+            .contains(&ComputeFeature::TlsExperimental)
+        {
+            tls_config = self.compute_ctl_config.tls.clone();
         }
 
         // Remove/create an empty pgdata directory and put configuration there.
@@ -1549,9 +1557,9 @@ impl ComputeNode {
                 .clone(),
         );
 
-        let mut tls_config = self.compute_ctl_config.tls.clone();
-        if !spec.enable_tls {
-            tls_config = None;
+        let mut tls_config = None;
+        if spec.features.contains(&ComputeFeature::TlsExperimental) {
+            tls_config = self.compute_ctl_config.tls.clone();
         }
 
         let max_concurrent_connections = self.max_service_connections(compute_state, &spec);
@@ -1615,9 +1623,10 @@ impl ComputeNode {
     #[instrument(skip_all)]
     pub fn reconfigure(&self) -> Result<()> {
         let spec = self.state.lock().unwrap().pspec.clone().unwrap().spec;
-        let mut tls_config = self.compute_ctl_config.tls.clone();
-        if !spec.enable_tls {
-            tls_config = None;
+
+        let mut tls_config = None;
+        if spec.features.contains(&ComputeFeature::TlsExperimental) {
+            tls_config = self.compute_ctl_config.tls.clone();
         }
 
         if let Some(ref pgbouncer_settings) = spec.pgbouncer_settings {

--- a/compute_tools/src/http/routes/configure.rs
+++ b/compute_tools/src/http/routes/configure.rs
@@ -22,7 +22,7 @@ pub(in crate::http) async fn configure(
     State(compute): State<Arc<ComputeNode>>,
     request: Json<ConfigurationRequest>,
 ) -> Response {
-    let pspec = match ParsedSpec::try_from(request.spec.clone()) {
+    let pspec = match ParsedSpec::try_from(request.0.spec) {
         Ok(p) => p,
         Err(e) => return JsonResponse::error(StatusCode::BAD_REQUEST, e),
     };

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -748,7 +748,6 @@ impl Endpoint {
                 endpoint_storage_addr: Some(endpoint_storage_addr),
                 endpoint_storage_token: Some(endpoint_storage_token),
                 autoprewarm: false,
-                enable_tls: false,
             };
 
             // this strange code is needed to support respec() in tests

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -748,6 +748,7 @@ impl Endpoint {
                 endpoint_storage_addr: Some(endpoint_storage_addr),
                 endpoint_storage_token: Some(endpoint_storage_token),
                 autoprewarm: false,
+                enable_tls: false,
             };
 
             // this strange code is needed to support respec() in tests

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -181,6 +181,10 @@ pub struct ComputeSpec {
     /// Download LFC state from endpoint_storage and pass it to Postgres on startup
     #[serde(default)]
     pub autoprewarm: bool,
+
+    /// Whether postgres should use TLS
+    #[serde(default)]
+    pub enable_tls: bool,
 }
 
 /// Feature flag to signal `compute_ctl` to enable certain experimental functionality.

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -181,10 +181,6 @@ pub struct ComputeSpec {
     /// Download LFC state from endpoint_storage and pass it to Postgres on startup
     #[serde(default)]
     pub autoprewarm: bool,
-
-    /// Whether postgres should use TLS
-    #[serde(default)]
-    pub enable_tls: bool,
 }
 
 /// Feature flag to signal `compute_ctl` to enable certain experimental functionality.
@@ -195,6 +191,9 @@ pub enum ComputeFeature {
     /// Enable the experimental activity monitor logic, which uses `pg_stat_database` to
     /// track short-lived connections as user activity.
     ActivityMonitorExperimental,
+
+    /// Enable TLS functionality.
+    TlsExperimental,
 
     /// This is a special feature flag that is used to represent unknown feature flags.
     /// Basically all unknown to enum flags are represented as this one. See unit test


### PR DESCRIPTION
## Problem

Inbetween adding the TLS config for compute-ctl, and adding the TLS config in controlplane, we switched from using a provision flag to a bind flag. This happened to work in all of my testing in preview regions as they have no VM pool, so each bind was also a provision. However, in staging I found that the TLS config is still only processed during provision, even though it's only sent on bind.

## Summary of changes

* Add a new feature flag value, `tls_experimental`, which tells postgres/pgbouncer/local_proxy to use the TLS certificates on bind.
* compute_ctl on provision will be told where the certificates are, instead of being told on bind.
