### PR TITLE
Support audit syslog over TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,7 @@ dependencies = [
  "fail",
  "flate2",
  "futures",
+ "hostname-validator",
  "http 1.1.0",
  "indexmap 2.9.0",
  "itertools 0.10.5",
@@ -2770,6 +2771,12 @@ dependencies = [
  "libc",
  "windows",
 ]
+
+[[package]]
+name = "hostname-validator"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "http"

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1983,8 +1983,7 @@ RUN apt update && \
         locales \
         lsof \
         procps \
-        rsyslog \
-        rsyslog-openssl \
+        rsyslog-gnutls \
         screen \
         tcpdump \
         $VERSION_INSTALLS && \

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -1984,6 +1984,7 @@ RUN apt update && \
         lsof \
         procps \
         rsyslog \
+        rsyslog-openssl \
         screen \
         tcpdump \
         $VERSION_INSTALLS && \

--- a/compute_tools/Cargo.toml
+++ b/compute_tools/Cargo.toml
@@ -27,6 +27,7 @@ fail.workspace = true
 flate2.workspace = true
 futures.workspace = true
 http.workspace = true
+hostname-validator = "1.1"
 indexmap.workspace = true
 itertools.workspace = true
 jsonwebtoken.workspace = true

--- a/compute_tools/src/config_template/compute_audit_rsyslog_template.conf
+++ b/compute_tools/src/config_template/compute_audit_rsyslog_template.conf
@@ -31,9 +31,11 @@ if ( $syslogtag == 'pgaudit_log') then {{
     queue.type="linkedList"
     queue.size="1000"
     action.ResumeRetryCount="10"
-    StreamDriver="ossl"
+    StreamDriver="gtls"
     StreamDriverMode="1"
     StreamDriverAuthMode="x509/name"
     StreamDriverPermittedPeers="{remote_syslog_host}"
+    StreamDriver.CheckExtendedKeyPurpose="on"
+    StreamDriver.PermitExpiredCerts="off"
   )
 }}

--- a/compute_tools/src/config_template/compute_audit_rsyslog_template.conf
+++ b/compute_tools/src/config_template/compute_audit_rsyslog_template.conf
@@ -10,7 +10,10 @@ input(type="imfile" File="{log_directory}/*.log"
   startmsg.regex="^[[:digit:]]{{4}}-[[:digit:]]{{2}}-[[:digit:]]{{2}} [[:digit:]]{{2}}:[[:digit:]]{{2}}:[[:digit:]]{{2}}.[[:digit:]]{{3}} GMT,")
 
 # the directory to store rsyslog state files
-global(workDirectory="/var/log/rsyslog")
+global(
+  workDirectory="/var/log/rsyslog"
+  DefaultNetstreamDriverCAFile="/etc/ssl/certs/ca-certificates.crt"
+)
 
 # Construct json, endpoint_id and project_id as additional metadata
 set $.json_log!endpoint_id = "{endpoint_id}";
@@ -21,5 +24,16 @@ set $.json_log!msg = $msg;
 template(name="PgAuditLog" type="string"
     string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% - - - - %$.json_log%")
 
-# Forward to remote syslog receiver (@@<hostname>:<port>;format
-local5.info @@{remote_endpoint};PgAuditLog
+# Forward to remote syslog receiver (over TLS)
+if ( $syslogtag == 'pgaudit_log') then {{
+  action(type="omfwd" target="{remote_syslog_host}" port="{remote_syslog_port}" protocol="tcp"
+    template="PgAuditLog"
+    queue.type="linkedList"
+    queue.size="1000"
+    action.ResumeRetryCount="10"
+    StreamDriver="ossl"
+    StreamDriverMode="1"
+    StreamDriverAuthMode="x509/name"
+    StreamDriverPermittedPeers="{remote_syslog_host}"
+  )
+}}

--- a/compute_tools/src/config_template/compute_audit_rsyslog_template.conf
+++ b/compute_tools/src/config_template/compute_audit_rsyslog_template.conf
@@ -15,6 +15,9 @@ global(
   DefaultNetstreamDriverCAFile="/etc/ssl/certs/ca-certificates.crt"
 )
 
+# Whether the remote syslog receiver uses tls
+set $.remote_syslog_tls = "{remote_syslog_tls}";
+
 # Construct json, endpoint_id and project_id as additional metadata
 set $.json_log!endpoint_id = "{endpoint_id}";
 set $.json_log!project_id = "{project_id}";
@@ -25,17 +28,28 @@ template(name="PgAuditLog" type="string"
     string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% - - - - %$.json_log%")
 
 # Forward to remote syslog receiver (over TLS)
-if ( $syslogtag == 'pgaudit_log') then {{
-  action(type="omfwd" target="{remote_syslog_host}" port="{remote_syslog_port}" protocol="tcp"
-    template="PgAuditLog"
-    queue.type="linkedList"
-    queue.size="1000"
-    action.ResumeRetryCount="10"
-    StreamDriver="gtls"
-    StreamDriverMode="1"
-    StreamDriverAuthMode="x509/name"
-    StreamDriverPermittedPeers="{remote_syslog_host}"
-    StreamDriver.CheckExtendedKeyPurpose="on"
-    StreamDriver.PermitExpiredCerts="off"
-  )
+if ( $syslogtag == 'pgaudit_log' ) then {{
+  if ( $.remote_syslog_tls == 'true' ) then {{
+    action(type="omfwd" target="{remote_syslog_host}" port="{remote_syslog_port}" protocol="tcp"
+      template="PgAuditLog"
+      queue.type="linkedList"
+      queue.size="1000"
+      action.ResumeRetryCount="10"
+      StreamDriver="gtls"
+      StreamDriverMode="1"
+      StreamDriverAuthMode="x509/name"
+      StreamDriverPermittedPeers="{remote_syslog_host}"
+      StreamDriver.CheckExtendedKeyPurpose="on"
+      StreamDriver.PermitExpiredCerts="off"
+    )
+    stop
+  }} else {{
+    action(type="omfwd" target="{remote_syslog_host}" port="{remote_syslog_port}" protocol="tcp"
+      template="PgAuditLog"
+      queue.type="linkedList"
+      queue.size="1000"
+      action.ResumeRetryCount="10"
+    )
+    stop
+  }}
 }}

--- a/compute_tools/src/rsyslog.rs
+++ b/compute_tools/src/rsyslog.rs
@@ -97,9 +97,10 @@ fn parse_audit_syslog_address(
         remote_plain_endpoint
     };
     // Urlify the remote_endpoint, so parsing can be done with url::Url.
-    let url_str = format!("http://{}", remote_endpoint);
-    let url = Url::parse(&url_str)
-        .map_err(|_| anyhow!("Error parsing {remote_endpoint}, expected host:port"))?;
+    let url_str = format!("http://{remote_endpoint}");
+    let url = Url::parse(&url_str).map_err(|err| {
+        anyhow!("Error parsing {remote_endpoint}, expected host:port, got {err:?}")
+    })?;
 
     let is_valid = url.scheme() == "http"
         && url.path() == "/"


### PR DESCRIPTION
Add support to transport syslogs over TLS. Since TLS params essentially require passing host and port separately, add a boolean flag to the configuration template and also use the same `action` format for plaintext logs. This allows seamless transition.

The plaintext host:port is picked from `AUDIT_LOGGING_ENDPOINT` (as earlier) and from `AUDIT_LOGGING_TLS_ENDPOINT`. The TLS host:port is used when defined and non-empty.

`remote_endpoint` is split separately to hostname and port as required by `omfwd` module.

Also the address parsing and config content generation are split to more testable functions with basic tests added.
