### PR TITLE
Fix codestyle for compute.sh for docker-compose

### DIFF
--- a/docker-compose/compute_wrapper/shell/compute.sh
+++ b/docker-compose/compute_wrapper/shell/compute.sh
@@ -71,7 +71,7 @@ else
         "http://pageserver:9898/v1/tenant/${tenant_id}/timeline/"
     )
     result=$(curl "${PARAMS[@]}")
-    echo "${result}" | jq .
+    printf '%s\n' "${result}" | jq .
   fi
 fi
 


### PR DESCRIPTION
## Problem
The script `compute.sh` had a non-consistent coding style and didn't follow best practices for modern bash scripts
## Summary of changes
The coding style was fixed to follow best practices.
