### PR TITLE
pgxn: support generations in safekeepers_cmp

### DIFF
--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -3012,11 +3012,11 @@ char *walprop_split_off_safekeepers_generation(char *safekeepers_list, uint32 *g
 		*generation = strtoul(safekeepers_list + 2, &endptr, 10);
 		if (errno != 0)
 		{
-			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
+			wpg_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
 		}
 		if (*endptr != ':')
 		{
-			wp_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
+			wpg_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
 		}
 		return endptr + 1;
 	}

--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -109,7 +109,7 @@ WalProposerCreate(WalProposerConfig *config, walproposer_api api)
 	 * If safekeepers list starts with g# parse generation number followed by
 	 * :
 	 */
-	host = walprop_pg_split_off_safekeepers_generation(wp->config->safekeepers_list, wp.safekeepers_generation);
+	host = walprop_pg_split_off_safekeepers_generation(wp->config->safekeepers_list, &wp->safekeepers_generation);
 	wp_log(LOG, "safekeepers_generation=%u", wp->safekeepers_generation);
 
 	for (; host != NULL && *host != '\0'; host = sep)

--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -109,28 +109,7 @@ WalProposerCreate(WalProposerConfig *config, walproposer_api api)
 	 * If safekeepers list starts with g# parse generation number followed by
 	 * :
 	 */
-	if (strncmp(wp->config->safekeepers_list, "g#", 2) == 0)
-	{
-		char	   *endptr;
-
-		errno = 0;
-		wp->safekeepers_generation = strtoul(wp->config->safekeepers_list + 2, &endptr, 10);
-		if (errno != 0)
-		{
-			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
-		}
-		if (*endptr != ':')
-		{
-			wp_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
-		}
-		/* Skip past : to the first hostname. */
-		host = endptr + 1;
-	}
-	else
-	{
-		wp->safekeepers_generation = INVALID_GENERATION;
-		host = wp->config->safekeepers_list;
-	}
+	host = walprop_pg_split_off_safekeepers_generation(wp->config->safekeepers_list, wp.safekeepers_generation);
 	wp_log(LOG, "safekeepers_generation=%u", wp->safekeepers_generation);
 
 	for (; host != NULL && *host != '\0'; host = sep)

--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -119,6 +119,10 @@ WalProposerCreate(WalProposerConfig *config, walproposer_api api)
 		{
 			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
 		}
+		if (*endptr != ':')
+		{
+			wp_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
+		}
 		/* Skip past : to the first hostname. */
 		host = endptr + 1;
 	}

--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -109,28 +109,7 @@ WalProposerCreate(WalProposerConfig *config, walproposer_api api)
 	 * If safekeepers list starts with g# parse generation number followed by
 	 * :
 	 */
-	if (strncmp(wp->config->safekeepers_list, "g#", 2) == 0)
-	{
-		char	   *endptr;
-
-		errno = 0;
-		wp->safekeepers_generation = strtoul(wp->config->safekeepers_list + 2, &endptr, 10);
-		if (errno != 0)
-		{
-			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
-		}
-		if (*endptr != ':')
-		{
-			wp_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
-		}
-		/* Skip past : to the first hostname. */
-		host = endptr + 1;
-	}
-	else
-	{
-		wp->safekeepers_generation = INVALID_GENERATION;
-		host = wp->config->safekeepers_list;
-	}
+	host = walprop_pg_split_off_safekeepers_generation(wp->config->safekeepers_list, &wp->safekeepers_generation);
 	wp_log(LOG, "safekeepers_generation=%u", wp->safekeepers_generation);
 
 	for (; host != NULL && *host != '\0'; host = sep)

--- a/pgxn/neon/walproposer.c
+++ b/pgxn/neon/walproposer.c
@@ -109,7 +109,28 @@ WalProposerCreate(WalProposerConfig *config, walproposer_api api)
 	 * If safekeepers list starts with g# parse generation number followed by
 	 * :
 	 */
-	host = walprop_split_off_safekeepers_generation(wp->config->safekeepers_list, &wp->safekeepers_generation);
+	if (strncmp(wp->config->safekeepers_list, "g#", 2) == 0)
+	{
+		char	   *endptr;
+
+		errno = 0;
+		wp->safekeepers_generation = strtoul(wp->config->safekeepers_list + 2, &endptr, 10);
+		if (errno != 0)
+		{
+			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
+		}
+		if (*endptr != ':')
+		{
+			wp_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
+		}
+		/* Skip past : to the first hostname. */
+		host = endptr + 1;
+	}
+	else
+	{
+		wp->safekeepers_generation = INVALID_GENERATION;
+		host = wp->config->safekeepers_list;
+	}
 	wp_log(LOG, "safekeepers_generation=%u", wp->safekeepers_generation);
 
 	for (; host != NULL && *host != '\0'; host = sep)
@@ -2996,29 +3017,3 @@ MembershipConfigurationFree(MembershipConfiguration *mconf)
 		pfree(mconf->new_members.m);
 	mconf->new_members.m = NULL;
 }
-
-char *walprop_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation)
-{
-	char	   *endptr;
-
-	if (strncmp(safekeepers_list, "g#", 2) != 0)
-	{
-		*generation = INVALID_GENERATION;
-		return safekeepers_list;
-	}
-	else
-	{
-		errno = 0;
-		*generation = strtoul(safekeepers_list + 2, &endptr, 10);
-		if (errno != 0)
-		{
-			wpg_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
-		}
-		if (*endptr != ':')
-		{
-			wpg_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
-		}
-		return endptr + 1;
-	}
-}
-

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -875,7 +875,6 @@ extern WalproposerShmemState *GetWalpropShmemState(void);
 extern void SafekeeperStateDesiredEvents(Safekeeper *sk, uint32 *sk_events, uint32 *nwr_events);
 extern TimeLineID walprop_pg_get_timeline_id(void);
 
-extern char *walprop_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation);
 
 #define WPEVENT		1337		/* special log level for walproposer internal
 								 * events */

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -875,7 +875,7 @@ extern WalproposerShmemState *GetWalpropShmemState(void);
 extern void SafekeeperStateDesiredEvents(Safekeeper *sk, uint32 *sk_events, uint32 *nwr_events);
 extern TimeLineID walprop_pg_get_timeline_id(void);
 
-extern char *walprop_pg_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation);
+extern char *walprop_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation);
 
 #define WPEVENT		1337		/* special log level for walproposer internal
 								 * events */

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -875,7 +875,6 @@ extern WalproposerShmemState *GetWalpropShmemState(void);
 extern void SafekeeperStateDesiredEvents(Safekeeper *sk, uint32 *sk_events, uint32 *nwr_events);
 extern TimeLineID walprop_pg_get_timeline_id(void);
 
-extern char *walprop_pg_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation);
 
 #define WPEVENT		1337		/* special log level for walproposer internal
 								 * events */

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -875,6 +875,7 @@ extern WalproposerShmemState *GetWalpropShmemState(void);
 extern void SafekeeperStateDesiredEvents(Safekeeper *sk, uint32 *sk_events, uint32 *nwr_events);
 extern TimeLineID walprop_pg_get_timeline_id(void);
 
+extern char *walprop_pg_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation);
 
 #define WPEVENT		1337		/* special log level for walproposer internal
 								 * events */

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -288,6 +288,10 @@ static char *split_off_safekeepers_generation(char *safekeepers_list, uint32 *ge
 		{
 			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
 		}
+		if (*endptr != ':')
+		{
+			wp_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
+		}
 		return endptr + 1;
 	}
 }

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -272,31 +272,6 @@ split_safekeepers_list(char *safekeepers_list, char *safekeepers[])
 	return n_safekeepers;
 }
 
-char *walprop_pg_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation)
-{
-	char	   *endptr;
-
-	if (strncmp(safekeepers_list, "g#", 2) != 0)
-	{
-		*generation = INVALID_GENERATION;
-		return safekeepers_list;
-	}
-	else
-	{
-		errno = 0;
-		*generation = strtoul(safekeepers_list + 2, &endptr, 10);
-		if (errno != 0)
-		{
-			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
-		}
-		if (*endptr != ':')
-		{
-			wp_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
-		}
-		return endptr + 1;
-	}
-}
-
 /*
  * Accept two coma-separated strings with list of safekeeper host:port addresses.
  * Split them into arrays and return false if two sets do not match, ignoring the order.
@@ -311,8 +286,8 @@ safekeepers_cmp(char *old, char *new)
 	uint32		gen_old = INVALID_GENERATION;
 	uint32		gen_new = INVALID_GENERATION;
 
-	old = walprop_pg_split_off_safekeepers_generation(old, &gen_old);
-	new = walprop_pg_split_off_safekeepers_generation(new, &gen_new);
+	old = walprop_split_off_safekeepers_generation(old, &gen_old);
+	new = walprop_split_off_safekeepers_generation(new, &gen_new);
 
 	if (gen_old != gen_new)
 	{

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -272,6 +272,30 @@ split_safekeepers_list(char *safekeepers_list, char *safekeepers[])
 	return n_safekeepers;
 }
 
+static char *split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation)
+{
+	char	   *endptr;
+
+	if (strncmp(safekeepers_list, "g#", 2) != 0)
+	{
+		return safekeepers_list;
+	}
+	else
+	{
+		errno = 0;
+		*generation = strtoul(safekeepers_list + 2, &endptr, 10);
+		if (errno != 0)
+		{
+			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
+		}
+		if (*endptr != ':')
+		{
+			wp_log(FATAL, "failed to parse neon.safekeepers: no colon after generation");
+		}
+		return endptr + 1;
+	}
+}
+
 /*
  * Accept two coma-separated strings with list of safekeeper host:port addresses.
  * Split them into arrays and return false if two sets do not match, ignoring the order.
@@ -286,8 +310,8 @@ safekeepers_cmp(char *old, char *new)
 	uint32		gen_old = INVALID_GENERATION;
 	uint32		gen_new = INVALID_GENERATION;
 
-	old = walprop_split_off_safekeepers_generation(old, &gen_old);
-	new = walprop_split_off_safekeepers_generation(new, &gen_new);
+	old = split_off_safekeepers_generation(old, &gen_old);
+	new = split_off_safekeepers_generation(new, &gen_new);
 
 	if (gen_old != gen_new)
 	{

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -272,13 +272,12 @@ split_safekeepers_list(char *safekeepers_list, char *safekeepers[])
 	return n_safekeepers;
 }
 
-char *walprop_pg_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation)
+static char *split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation)
 {
 	char	   *endptr;
 
 	if (strncmp(safekeepers_list, "g#", 2) != 0)
 	{
-		*generation = INVALID_GENERATION;
 		return safekeepers_list;
 	}
 	else
@@ -311,8 +310,8 @@ safekeepers_cmp(char *old, char *new)
 	uint32		gen_old = INVALID_GENERATION;
 	uint32		gen_new = INVALID_GENERATION;
 
-	old = walprop_pg_split_off_safekeepers_generation(old, &gen_old);
-	new = walprop_pg_split_off_safekeepers_generation(new, &gen_new);
+	old = split_off_safekeepers_generation(old, &gen_old);
+	new = split_off_safekeepers_generation(new, &gen_new);
 
 	if (gen_old != gen_new)
 	{

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -272,6 +272,26 @@ split_safekeepers_list(char *safekeepers_list, char *safekeepers[])
 	return n_safekeepers;
 }
 
+static char *split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation)
+{
+	char	   *endptr;
+
+	if (strncmp(safekeepers_list, "g#", 2) != 0)
+	{
+		return safekeepers_list;
+	}
+	else
+	{
+		errno = 0;
+		*generation = strtoul(safekeepers_list + 2, &endptr, 10);
+		if (errno != 0)
+		{
+			wp_log(FATAL, "failed to parse neon.safekeepers generation number: %m");
+		}
+		return endptr + 1;
+	}
+}
+
 /*
  * Accept two coma-separated strings with list of safekeeper host:port addresses.
  * Split them into arrays and return false if two sets do not match, ignoring the order.
@@ -283,6 +303,16 @@ safekeepers_cmp(char *old, char *new)
 	char	   *safekeepers_new[MAX_SAFEKEEPERS];
 	int			len_old = 0;
 	int			len_new = 0;
+	uint32		gen_old = INVALID_GENERATION;
+	uint32		gen_new = INVALID_GENERATION;
+
+	old = split_off_safekeepers_generation(old, &gen_old);
+	new = split_off_safekeepers_generation(new, &gen_new);
+
+	if (gen_old != gen_new)
+	{
+		return false;
+	}
 
 	len_old = split_safekeepers_list(old, safekeepers_old);
 	len_new = split_safekeepers_list(new, safekeepers_new);

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -272,12 +272,13 @@ split_safekeepers_list(char *safekeepers_list, char *safekeepers[])
 	return n_safekeepers;
 }
 
-static char *split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation)
+char *walprop_pg_split_off_safekeepers_generation(char *safekeepers_list, uint32 *generation)
 {
 	char	   *endptr;
 
 	if (strncmp(safekeepers_list, "g#", 2) != 0)
 	{
+		*generation = INVALID_GENERATION;
 		return safekeepers_list;
 	}
 	else
@@ -310,8 +311,8 @@ safekeepers_cmp(char *old, char *new)
 	uint32		gen_old = INVALID_GENERATION;
 	uint32		gen_new = INVALID_GENERATION;
 
-	old = split_off_safekeepers_generation(old, &gen_old);
-	new = split_off_safekeepers_generation(new, &gen_new);
+	old = walprop_pg_split_off_safekeepers_generation(old, &gen_old);
+	new = walprop_pg_split_off_safekeepers_generation(new, &gen_new);
 
 	if (gen_old != gen_new)
 	{


### PR DESCRIPTION
`safekeepers_cmp` was added by #8840 to make changes of the safekeeper set order independent: a `sk1,sk2,sk3` specifier changed to `sk3,sk1,sk2` should not cause a walproposer restart. However, this check didn't support generations, in the sense that it would see the `g#123:` as part of the first safekeeper in the list, and if the first safekeeper changes, it would also restart the walproposer.

Therefore, parse the generation properly and make it not be a part of the generation.

This PR doesn't add a specific test, but I have confirmed locally that `test_safekeepers_reconfigure_reorder` is fixed with the changes of PR #11712 applied thanks to this PR.

Part of https://github.com/neondatabase/neon/issues/11670