### PR TITLE
feat(pageserver): use hostname as feature flag resolver property

### DIFF
--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -1022,6 +1022,7 @@ impl RemoteStorage for S3Bucket {
             let Version { key, .. } = &vd;
             let version_id = vd.version_id().map(|v| v.0.as_str());
             if version_id == Some("null") {
+                // TODO: check the behavior of using the SDK on a non-versioned container
                 return Err(TimeTravelError::Other(anyhow!(
                     "Received ListVersions response for key={key} with version_id='null', \
                     indicating either disabled versioning, or legacy objects with null version id values"

--- a/pageserver/src/feature_resolver.rs
+++ b/pageserver/src/feature_resolver.rs
@@ -86,7 +86,16 @@ impl FeatureResolver {
                         }
                     }
                 }
-                // TODO: add pageserver URL.
+                // TODO: move this to a background task so that we don't block startup in case of slow disk
+                if let Ok(hostname) = std::fs::read_to_string("/etc/hostname") {
+                    let hostname = hostname.trim().to_string();
+                    if hostname.ends_with(".neon.tech") || hostname.ends_with(".neon.build") {
+                        properties.insert(
+                            "pageserver_hostname".to_string(),
+                            PostHogFlagFilterPropertyValue::String(hostname),
+                        );
+                    }
+                }
                 Arc::new(properties)
             };
             let fake_tenants = {


### PR DESCRIPTION
## Problem

part of https://github.com/neondatabase/neon/issues/11813

## Summary of changes

Collect pageserver hostname property so that we can use it in the PostHog UI. Not sure if this is the best way to do that -- open to suggestions.