### PR TITLE
Fix: add the 17 version

### DIFF
--- a/control_plane/src/storage_controller.rs
+++ b/control_plane/src/storage_controller.rs
@@ -48,7 +48,7 @@ pub struct StorageController {
 
 const COMMAND: &str = "storage_controller";
 
-const STORAGE_CONTROLLER_POSTGRES_VERSION: u32 = 16;
+const STORAGE_CONTROLLER_POSTGRES_VERSION: u32 = 17;
 
 const DB_NAME: &str = "storage_controller";
 
@@ -184,7 +184,7 @@ impl StorageController {
     /// to other versions if that one isn't found.  Some automated tests create circumstances
     /// where only one version is available in pg_distrib_dir, such as `test_remote_extensions`.
     async fn get_pg_dir(&self, dir_name: &str) -> anyhow::Result<Utf8PathBuf> {
-        let prefer_versions = [STORAGE_CONTROLLER_POSTGRES_VERSION, 16, 15, 14];
+        let prefer_versions = [STORAGE_CONTROLLER_POSTGRES_VERSION, 17, 16, 15, 14];
 
         for v in prefer_versions {
             let path = Utf8PathBuf::from_path_buf(self.env.pg_dir(v, dir_name)?).unwrap();


### PR DESCRIPTION

## Problem

When only PostgreSQL version 17 is installed, `cargo neon start` fails to start. The `storage_controller` searches for compatible PostgreSQL versions, but its hardcoded search list did not include version 17.

This caused the system to fail to locate any valid PostgreSQL installation directory, leading to a panic when trying to access it. The following error was observed:

```
Starting neon broker at http://127.0.0.1:50051/Starting pageserver node 1 at '127.0.0.1:64000' in "/home/chorikim/neon/.neon/pageserver_1", retrying for 10sStarting safekeeper at '127.0.0.1:5454' in '/home/chorikim/neon/.neon/safekeepers/sk1', retrying for 10sStarting endpoint_storage at 127.0.0.1:9993
...
thread 'main' panicked at [masked_path]/neon/control_plane/src/storage_controller.rs:321:54:
called `Result::unwrap()` on an `Err` value: Postgres directory 'bin' not found in /home/chorikim/neon/pg_install
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'main' panicked at control_plane/src/bin/neon_local.rs:1924:29:
we don't panic or cancel the tasks: JoinError::Panic(Id(2), "called `Result::unwrap()` on an `Err` value: Postgres directory 'bin' not found in [masked_path]/neon/pg_install", ...)
SIGKILL & wait the started process
SIGKILL & wait the started process
SIGKILL & wait the started process
SIGKILL & wait the started process
```

## Summary of changes

This commit adds support for PostgreSQL 17 to the `storage_controller`, resolving the startup panic.

-   `STORAGE_CONTROLLER_POSTGRES_VERSION` constant is updated to `17`.
-   The `prefer_versions` array, which dictates the search order for PostgreSQL versions, is updated to include `17` as the highest priority. This ensures that a PostgreSQL 17 installation can be correctly located.
