### PR TITLE
feat(posthog_client): support feature flag secure API

### DIFF
--- a/libs/posthog_client_lite/src/background_loop.rs
+++ b/libs/posthog_client_lite/src/background_loop.rs
@@ -62,7 +62,7 @@ impl FeatureResolverBackgroundLoop {
                             tracing::info!("Feature flag updated");
                         }
                         Err(e) => {
-                            tracing::warn!("Cannot get feature flags: {}", e);
+                            tracing::warn!("Cannot process feature flag spec: {}", e);
                         }
                     }
                 }

--- a/libs/posthog_client_lite/src/background_loop.rs
+++ b/libs/posthog_client_lite/src/background_loop.rs
@@ -55,9 +55,16 @@ impl FeatureResolverBackgroundLoop {
                             continue;
                         }
                     };
-                    let feature_store = FeatureStore::new_with_flags(resp.flags);
-                    this.feature_store.store(Arc::new(feature_store));
-                    tracing::info!("Feature flag updated");
+                    let project_id = this.posthog_client.config.project_id.parse::<u64>().ok();
+                    match FeatureStore::new_with_flags(resp.flags, project_id) {
+                        Ok(feature_store) => {
+                            this.feature_store.store(Arc::new(feature_store));
+                            tracing::info!("Feature flag updated");
+                        }
+                        Err(e) => {
+                            tracing::warn!("Cannot get feature flags: {}", e);
+                        }
+                    }
                 }
                 tracing::info!("PostHog feature resolver stopped");
             }

--- a/libs/posthog_client_lite/src/lib.rs
+++ b/libs/posthog_client_lite/src/lib.rs
@@ -571,14 +571,14 @@ impl PostHogClient {
         let url = if self.config.server_api_key.starts_with("phs_") {
             // The new feature local evaluation secure API token
             format!(
-                "{}/api/projects/{}/feature_flags/local_evaluation",
-                self.config.private_api_url, self.config.project_id
+                "{}/api/feature_flag/local_evaluation",
+                self.config.private_api_url
             )
         } else {
             // The old personal API token
             format!(
-                "{}/api/feature_flag/local_evaluation",
-                self.config.private_api_url
+                "{}/api/projects/{}/feature_flags/local_evaluation",
+                self.config.private_api_url, self.config.project_id
             )
         };
         let response = self

--- a/libs/posthog_client_lite/src/lib.rs
+++ b/libs/posthog_client_lite/src/lib.rs
@@ -552,6 +552,13 @@ impl PostHogClient {
         })
     }
 
+    /// Check if the server API key is a feature flag secure API key. This key can only be
+    /// used to fetch the feature flag specs and can only be used on a undocumented API
+    /// endpoint.
+    fn is_feature_flag_secure_api_key(&self) -> bool {
+        self.config.server_api_key.starts_with("phs_")
+    }
+
     /// Fetch the feature flag specs from the server.
     ///
     /// This is unfortunately an undocumented API at:
@@ -568,7 +575,7 @@ impl PostHogClient {
         // OR
         // BASE_URL/api/feature_flag/local_evaluation/
         // with bearer token of feature flag specific self.server_api_key
-        let url = if self.config.server_api_key.starts_with("phs_") {
+        let url = if self.is_feature_flag_secure_api_key() {
             // The new feature local evaluation secure API token
             format!(
                 "{}/api/feature_flag/local_evaluation",


### PR DESCRIPTION
## Problem

Part of #11813 

PostHog has two endpoints to retrieve feature flags: the old project ID one that uses personal API token, and the new one using a special feature flag secure token that can only retrieve feature flag. The new API I added in this patch is not documented in the PostHog API doc but it's used in their Python SDK.

## Summary of changes

Add support for "feature flag secure token API". The API has no way of providing a project ID so we verify if the retrieved spec is consistent with the project ID specified by comparing the `team_id` field.