### PR TITLE
compute: metric for installed extensions (across all DBs)

### DIFF
--- a/compute/etc/neon_collector.jsonnet
+++ b/compute/etc/neon_collector.jsonnet
@@ -28,6 +28,7 @@
     import 'sql_exporter/getpage_wait_seconds_bucket.libsonnet',
     import 'sql_exporter/getpage_wait_seconds_count.libsonnet',
     import 'sql_exporter/getpage_wait_seconds_sum.libsonnet',
+    import 'sql_exporter/installed_extensions.libsonnet',
     import 'sql_exporter/lfc_approximate_working_set_size.libsonnet',
     import 'sql_exporter/lfc_approximate_working_set_size_windows.libsonnet',
     import 'sql_exporter/lfc_cache_size_limit.libsonnet',

--- a/compute/etc/sql_exporter/installed_extensions.libsonnet
+++ b/compute/etc/sql_exporter/installed_extensions.libsonnet
@@ -1,0 +1,14 @@
+{
+  metric_name: 'installed_extensions',
+  type: 'gauge',
+  help: 'List of extensions installed across databases',
+  key_labels: [
+    'extname',
+    'extversion',
+    'owned_by_superuser',
+  ],
+  values: [
+    'n_databases',
+  ],
+  query: importstr 'sql_exporter/installed_extensions.sql',
+}

--- a/compute/etc/sql_exporter/installed_extensions.sql
+++ b/compute/etc/sql_exporter/installed_extensions.sql
@@ -1,0 +1,32 @@
+WITH
+    dbs AS (
+        SELECT
+            datname
+        FROM
+            pg_catalog.pg_database
+        WHERE
+            datallowconn
+            AND datconnlimit <> - 2
+        LIMIT
+            500
+    )
+SELECT
+    t.extname,
+    t.extversion,
+    (t.extowner = 10) AS owned_by_superuser
+    COUNT(DISTINCT d.datname) AS n_databases,
+FROM
+    dbs d,
+    LATERAL (
+        SELECT
+            *
+        FROM
+            dblink (
+                'dbname=' || quote_ident (d.datname) || ' user=' || quote_ident (current_user) || ' connect_timeout=5',
+                'SELECT extname, extversion, extowner::integer FROM pg_catalog.pg_extension'
+            ) AS t (extname name, extversion text, extowner integer)
+    ) t
+GROUP BY
+    t.extname,
+    t.extversion,
+    t.extowner;


### PR DESCRIPTION
## Problem

Currently there is a [background worker](https://github.com/neondatabase/neon/pull/11939) that connects to all DBs once an hour, queries them and compiles a list of installed extensions. This can prevent computes with a suspend time > 1 hour from being suspended (https://github.com/neondatabase/cloud/issues/30147) as this is treated as activity on the compute.

## Summary of changes

Adds an SQL metric that can be queried from a grafana dashboard (To be added) instead of a background worker.
