### PR TITLE
tests: adding dblink to build-tools image for use in regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,8 @@ postgres-%: postgres-configure-% \
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/$*/contrib/amcheck install
 	+@echo "Compiling test_decoding $*"
 	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/$*/contrib/test_decoding install
+	+@echo "Compiling dblink $*"
+	$(MAKE) -C $(POSTGRES_INSTALL_DIR)/build/$*/contrib/dblink install
 
 .PHONY: postgres-clean-%
 postgres-clean-%:

--- a/build-tools.Dockerfile
+++ b/build-tools.Dockerfile
@@ -144,6 +144,7 @@ RUN set -e \
         openssh-client \
         parallel \
         pkg-config \
+        postgresql-contrib \
         unzip \
         wget \
         xz-utils \


### PR DESCRIPTION
## Problem

For metrics that need to be collected across DBs we need to use `dblink` to connect to them and query. 

Example metrics:

- https://github.com/neondatabase/neon/pull/12197
- https://github.com/neondatabase/neon/pull/12208

## Summary of changes

Adds `postgresql-contrib` to the `build-tools` image and builds `dblink` for use in python regression tests