### PR TITLE
Improve logging for gc-compaction

### DIFF
--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -3124,12 +3124,12 @@ impl Timeline {
                 .await?;
             let jobs_len = jobs.len();
             for (idx, job) in jobs.into_iter().enumerate() {
-                info!(
-                    "running enhanced gc bottom-most compaction, sub-compaction {}/{}",
-                    idx + 1,
-                    jobs_len
-                );
+                let sub_compaction_progress = format!("{}/{}", idx + 1, jobs_len);
                 self.compact_with_gc_inner(cancel, job, ctx, yield_for_l0)
+                    .instrument(info_span!(
+                        "sub_compaction",
+                        sub_compaction_progress = sub_compaction_progress
+                    ))
                     .await?;
             }
             if jobs_len == 0 {


### PR DESCRIPTION
## Problem
* Inside `compact_with_gc_inner`, there is a similar log line:
https://github.com/neondatabase/neon/blob/db24ba95d1991a90c50d25f322eb07435cf31936/pageserver/src/tenant/timeline/compaction.rs#L3181-L3187

* Also, I think it would be useful when debugging to have the ability to select a particular sub-compaction job (e.g., `1/100`) to see all the logs for that job. 

## Summary of changes
* Attach a span to the `compact_with_gc_inner`. 

CC: @skyzh 