### PR TITLE
Move comment above metrics handler

### DIFF
--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -2070,10 +2070,10 @@ pub fn make_router(
 
     router
         .data(Arc::new(HttpState::new(service, auth, build_info)))
+        // Non-prefixed generic endpoints (status, metrics, profiling)
         .get("/metrics", |r| {
             named_request_span(r, measured_metrics_handler, RequestName("metrics"))
         })
-        // Non-prefixed generic endpoints (status, metrics, profiling)
         .get("/status", |r| {
             named_request_span(r, handle_status, RequestName("status"))
         })


### PR DESCRIPTION
## Problem

Comment is in incorrect place: `/metrics` code is above its description comment.

## Summary of changes

- `/metrics` code is now below the comment 