### PR TITLE
Rename tenant shard request param

### DIFF
--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -676,7 +676,7 @@ async fn handle_tenant_timeline_passthrough(
     service: Arc<Service>,
     req: Request<Body>,
 ) -> Result<Response<Body>, ApiError> {
-    let tenant_or_shard_id: TenantShardId = parse_request_param(&req, "tenant_id")?;
+    let tenant_or_shard_id: TenantShardId = parse_request_param(&req, "tenant_shard_id")?;
     check_permissions(&req, Scope::PageServerApi)?;
     maybe_rate_limit(&req, tenant_or_shard_id.tenant_id).await;
 
@@ -2470,7 +2470,7 @@ pub fn make_router(
             },
         )
         // Tenant detail GET passthrough to shard zero:
-        .get("/v1/tenant/:tenant_id", |r| {
+        .get("/v1/tenant/:tenant_shard_id", |r| {
             tenant_service_handler(
                 r,
                 handle_tenant_timeline_passthrough,
@@ -2480,7 +2480,7 @@ pub fn make_router(
         // The `*` in the  URL is a wildcard: any tenant/timeline GET APIs on the pageserver
         // are implicitly exposed here.  This must be last in the list to avoid
         // taking precedence over other GET methods we might implement by hand.
-        .get("/v1/tenant/:tenant_id/*", |r| {
+        .get("/v1/tenant/:tenant_shard_id/*", |r| {
             tenant_service_handler(
                 r,
                 handle_tenant_timeline_passthrough,

--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -2489,7 +2489,7 @@ pub fn make_router(
         })
         // Tenant timeline mark_invisible passthrough to shard zero
         .put(
-            "/v1/tenant/:tenant_id/timeline/:timeline_id/mark_invisible",
+            "/v1/tenant/:tenant_shard_id/timeline/:timeline_id/mark_invisible",
             |r| {
                 tenant_service_handler(
                     r,


### PR DESCRIPTION
## Problem

"tenant_id" looks deprecated when we start parsing `TenantShardId` in #11026

## Summary of changes

- Rename request param `tenant_id` to `tenant_shard_id`