### PR TITLE
compute_ctl: return LSN in /terminate

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -916,10 +916,13 @@ impl ComputeNode {
             info!("syncing safekeepers on shutdown");
             let storage_auth_token = pspec.storage_auth_token.clone();
             let lsn = self.sync_safekeepers(storage_auth_token)?;
-            info!("synced safekeepers at lsn {lsn}");
+            info!(%lsn, "synced safekeepers");
             lsn
         } else {
-            Lsn::INVALID
+            #[allow(non_upper_case_globals)] // for info!
+            const lsn: Lsn = Lsn::INVALID;
+            info!(%lsn, "not primary, not syncing safekeepers");
+            lsn
         };
 
         let mut delay_exit = false;

--- a/compute_tools/src/http/routes/terminate.rs
+++ b/compute_tools/src/http/routes/terminate.rs
@@ -27,9 +27,12 @@ pub(in crate::http) async fn terminate(
     let immediate = match terminate.unwrap_or_default().mode.as_str() {
         "fast" => false,
         "immediate" => true,
-        v => return JsonResponse::error(
-            StatusCode::BAD_REQUEST,
-            format!("Expected \"fast\" or \"immediate\", got {v}")),
+        v => {
+            return JsonResponse::error(
+                StatusCode::BAD_REQUEST,
+                format!("Expected \"fast\" or \"immediate\", got {v}"),
+            );
+        }
     };
 
     {

--- a/compute_tools/src/http/routes/terminate.rs
+++ b/compute_tools/src/http/routes/terminate.rs
@@ -10,12 +10,17 @@ use std::sync::Arc;
 use tokio::task;
 use tracing::info;
 
+fn fast() -> String {
+    "fast".to_string()
+}
+
 #[derive(Deserialize, Default)]
 pub struct TerminateQuery {
     //axum has issues deserializing enums i.e.
     // invalid type: string "immediate", expected internally tagged enum
     /// "fast": wait 30s till returning from /terminate to allow control plane to get the error
     /// "immediate": return from /terminate immediately as soon as all components are terminated
+    #[serde(default = "fast")]
     mode: String,
 }
 

--- a/compute_tools/src/http/routes/terminate.rs
+++ b/compute_tools/src/http/routes/terminate.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use compute_api::responses::ComputeStatus;
 use http::StatusCode;
 use tokio::task;
@@ -15,7 +15,7 @@ pub(in crate::http) async fn terminate(State(compute): State<Arc<ComputeNode>>) 
     {
         let mut state = compute.state.lock().unwrap();
         if state.status == ComputeStatus::Terminated {
-            return StatusCode::CREATED.into_response();
+            return JsonResponse::success(StatusCode::CREATED, state.terminate_flush_lsn);
         }
 
         if !matches!(state.status, ComputeStatus::Empty | ComputeStatus::Running) {
@@ -23,7 +23,6 @@ pub(in crate::http) async fn terminate(State(compute): State<Arc<ComputeNode>>) 
         }
 
         state.set_status(ComputeStatus::TerminationPending, &compute.state_changed);
-        drop(state);
     }
 
     forward_termination_signal(false);
@@ -34,7 +33,7 @@ pub(in crate::http) async fn terminate(State(compute): State<Arc<ComputeNode>>) 
     // be able to serve other requests while some particular request
     // is waiting for compute to finish configuration.
     let c = compute.clone();
-    task::spawn_blocking(move || {
+    let lsn = task::spawn_blocking(move || {
         let mut state = c.state.lock().unwrap();
         while state.status != ComputeStatus::Terminated {
             state = c.state_changed.wait(state).unwrap();
@@ -44,11 +43,11 @@ pub(in crate::http) async fn terminate(State(compute): State<Arc<ComputeNode>>) 
                 state.status
             );
         }
+        state.terminate_flush_lsn
     })
     .await
     .unwrap();
 
-    info!("terminated Postgres");
-
-    StatusCode::OK.into_response()
+    info!(%lsn, "terminated Postgres");
+    JsonResponse::success(StatusCode::OK, lsn)
 }

--- a/compute_tools/src/http/routes/terminate.rs
+++ b/compute_tools/src/http/routes/terminate.rs
@@ -1,17 +1,37 @@
-use std::sync::Arc;
-
+use crate::compute::{ComputeNode, forward_termination_signal};
+use crate::http::JsonResponse;
 use axum::extract::State;
 use axum::response::Response;
+use axum_extra::extract::OptionalQuery;
 use compute_api::responses::ComputeStatus;
 use http::StatusCode;
+use serde::Deserialize;
+use std::sync::Arc;
 use tokio::task;
 use tracing::info;
 
-use crate::compute::{ComputeNode, forward_termination_signal};
-use crate::http::JsonResponse;
+#[derive(Deserialize, Default)]
+pub struct TerminateQuery {
+    //axum has issues deserializing enums i.e.
+    // invalid type: string "immediate", expected internally tagged enum
+    /// "fast": wait 30s till returning from /terminate to allow control plane to get the error
+    /// "immediate": return from /terminate immediately as soon as all components are terminated
+    mode: String,
+}
 
 /// Terminate the compute.
-pub(in crate::http) async fn terminate(State(compute): State<Arc<ComputeNode>>) -> Response {
+pub(in crate::http) async fn terminate(
+    State(compute): State<Arc<ComputeNode>>,
+    OptionalQuery(terminate): OptionalQuery<TerminateQuery>,
+) -> Response {
+    let immediate = match terminate.unwrap_or_default().mode.as_str() {
+        "fast" => false,
+        "immediate" => true,
+        v => return JsonResponse::error(
+            StatusCode::BAD_REQUEST,
+            format!("Expected \"fast\" or \"immediate\", got {v}")),
+    };
+
     {
         let mut state = compute.state.lock().unwrap();
         if state.status == ComputeStatus::Terminated {
@@ -22,7 +42,12 @@ pub(in crate::http) async fn terminate(State(compute): State<Arc<ComputeNode>>) 
             return JsonResponse::invalid_status(state.status);
         }
 
-        state.set_status(ComputeStatus::TerminationPending, &compute.state_changed);
+        let status = if immediate {
+            ComputeStatus::Terminated
+        } else {
+            ComputeStatus::TerminationPending
+        };
+        state.set_status(status, &compute.state_changed);
     }
 
     forward_termination_signal(false);

--- a/compute_tools/src/monitor.rs
+++ b/compute_tools/src/monitor.rs
@@ -83,7 +83,9 @@ impl ComputeMonitor {
         let compute_status = self.compute.get_status();
         if matches!(
             compute_status,
-            ComputeStatus::Terminated | ComputeStatus::TerminationPending | ComputeStatus::Failed
+            ComputeStatus::Terminated
+                | ComputeStatus::TerminationPending { .. }
+                | ComputeStatus::Failed
         ) {
             info!(
                 "compute is in {} status, stopping compute monitor",

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -712,7 +712,7 @@ struct EndpointStopCmdArgs {
     destroy: bool,
 
     #[clap(long, help = "Postgres shutdown mode")]
-    #[clap(default_value = "EndpointTerminateMode::Fast")]
+    #[clap(default_value = "fast")]
     mode: EndpointTerminateMode,
 }
 

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -1658,7 +1658,8 @@ async fn handle_endpoint(subcmd: &EndpointCmd, env: &local_env::LocalEnv) -> Res
                 .endpoints
                 .get(endpoint_id)
                 .with_context(|| format!("postgres endpoint {endpoint_id} is not found"))?;
-            endpoint.stop(&args.mode, args.destroy)?;
+            let lsn = endpoint.stop(&args.mode, args.destroy).await?;
+            print!("{lsn}")
         }
         EndpointCmd::GenerateJwt(args) => {
             let endpoint = {
@@ -2094,7 +2095,10 @@ async fn try_stop_all(env: &local_env::LocalEnv, immediate: bool) {
     match ComputeControlPlane::load(env.clone()) {
         Ok(cplane) => {
             for (_k, node) in cplane.endpoints {
-                if let Err(e) = node.stop(if immediate { "immediate" } else { "fast" }, false) {
+                if let Err(e) = node
+                    .stop(if immediate { "immediate" } else { "fast" }, false)
+                    .await
+                {
                     eprintln!("postgres stop failed: {e:#}");
                 }
             }

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -1658,8 +1658,10 @@ async fn handle_endpoint(subcmd: &EndpointCmd, env: &local_env::LocalEnv) -> Res
                 .endpoints
                 .get(endpoint_id)
                 .with_context(|| format!("postgres endpoint {endpoint_id} is not found"))?;
-            let lsn = endpoint.stop(&args.mode, args.destroy).await?;
-            println!("{lsn}")
+            match endpoint.stop(&args.mode, args.destroy).await?.lsn {
+                Some(lsn) => println!("{lsn}"),
+                None => println!("null"),
+            }
         }
         EndpointCmd::GenerateJwt(args) => {
             let endpoint = {

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -712,6 +712,7 @@ struct EndpointStopCmdArgs {
     destroy: bool,
 
     #[clap(long, help = "Postgres shutdown mode")]
+    #[clap(default_value = "EndpointTerminateMode::Fast")]
     mode: EndpointTerminateMode,
 }
 

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -1656,7 +1656,7 @@ async fn handle_endpoint(subcmd: &EndpointCmd, env: &local_env::LocalEnv) -> Res
                 .endpoints
                 .get(endpoint_id)
                 .with_context(|| format!("postgres endpoint {endpoint_id} is not found"))?;
-            match endpoint.stop(args.mode.clone(), args.destroy).await?.lsn {
+            match endpoint.stop(args.mode, args.destroy).await?.lsn {
                 Some(lsn) => println!("{lsn}"),
                 None => println!("null"),
             }

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -1659,7 +1659,7 @@ async fn handle_endpoint(subcmd: &EndpointCmd, env: &local_env::LocalEnv) -> Res
                 .get(endpoint_id)
                 .with_context(|| format!("postgres endpoint {endpoint_id} is not found"))?;
             let lsn = endpoint.stop(&args.mode, args.destroy).await?;
-            print!("{lsn}")
+            println!("{lsn}")
         }
         EndpointCmd::GenerateJwt(args) => {
             let endpoint = {

--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -18,7 +18,7 @@ use clap::Parser;
 use compute_api::requests::ComputeClaimsScope;
 use compute_api::spec::ComputeMode;
 use control_plane::broker::StorageBroker;
-use control_plane::endpoint::{ComputeControlPlane, PageserverProtocol};
+use control_plane::endpoint::{ComputeControlPlane, EndpointTerminateMode, PageserverProtocol};
 use control_plane::endpoint_storage::{ENDPOINT_STORAGE_DEFAULT_ADDR, EndpointStorage};
 use control_plane::local_env;
 use control_plane::local_env::{
@@ -711,10 +711,8 @@ struct EndpointStopCmdArgs {
     )]
     destroy: bool,
 
-    #[clap(long, help = "Postgres shutdown mode, passed to \"pg_ctl -m <mode>\"")]
-    #[arg(value_parser(["smart", "fast", "immediate"]))]
-    #[arg(default_value = "fast")]
-    mode: String,
+    #[clap(long, help = "Postgres shutdown mode")]
+    mode: EndpointTerminateMode,
 }
 
 #[derive(clap::Args)]
@@ -1658,7 +1656,7 @@ async fn handle_endpoint(subcmd: &EndpointCmd, env: &local_env::LocalEnv) -> Res
                 .endpoints
                 .get(endpoint_id)
                 .with_context(|| format!("postgres endpoint {endpoint_id} is not found"))?;
-            match endpoint.stop(&args.mode, args.destroy).await?.lsn {
+            match endpoint.stop(args.mode.clone(), args.destroy).await?.lsn {
                 Some(lsn) => println!("{lsn}"),
                 None => println!("null"),
             }
@@ -2093,14 +2091,16 @@ async fn handle_stop_all(args: &StopCmdArgs, env: &local_env::LocalEnv) -> Resul
 }
 
 async fn try_stop_all(env: &local_env::LocalEnv, immediate: bool) {
+    let mode = if immediate {
+        EndpointTerminateMode::Immediate
+    } else {
+        EndpointTerminateMode::Fast
+    };
     // Stop all endpoints
     match ComputeControlPlane::load(env.clone()) {
         Ok(cplane) => {
             for (_k, node) in cplane.endpoints {
-                if let Err(e) = node
-                    .stop(if immediate { "immediate" } else { "fast" }, false)
-                    .await
-                {
+                if let Err(e) = node.stop(mode, false).await {
                     eprintln!("postgres stop failed: {e:#}");
                 }
             }

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -75,7 +75,6 @@ use spki::{SubjectPublicKeyInfo, SubjectPublicKeyInfoRef};
 use tracing::debug;
 use url::Host;
 use utils::id::{NodeId, TenantId, TimelineId};
-use utils::lsn::Lsn;
 
 use crate::local_env::LocalEnv;
 use crate::postgresql_conf::PostgresConf;

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -74,6 +74,7 @@ use spki::{SubjectPublicKeyInfo, SubjectPublicKeyInfoRef};
 use tracing::debug;
 use url::Host;
 use utils::id::{NodeId, TenantId, TimelineId};
+use utils::lsn::Lsn;
 
 use crate::local_env::LocalEnv;
 use crate::postgresql_conf::PostgresConf;
@@ -1040,8 +1041,22 @@ impl Endpoint {
         }
     }
 
-    pub fn stop(&self, mode: &str, destroy: bool) -> Result<()> {
-        self.pg_ctl(&["-m", mode, "stop"], &None)?;
+    pub async fn stop(&self, mode: &str, destroy: bool) -> Result<Lsn> {
+        // In production, control plane uses /terminate for shutting down endpoint
+        // which returns LSN after syncing safekeepers.
+        let response = reqwest::Client::new()
+            .post(format!(
+                "http://{}:{}/terminate",
+                self.external_http_address.ip(),
+                self.external_http_address.port()
+            ))
+            .bearer_auth(self.generate_jwt(Some(ComputeClaimsScope::Admin))?)
+            .send()
+            .await?;
+        let lsn: Lsn = serde_json::from_str(&response.text().await?)?;
+
+        // In case /terminate doesn't exit soon
+        let _ = self.pg_ctl(&["-m", mode, "stop"], &None);
 
         // Also wait for the compute_ctl process to die. It might have some
         // cleanup work to do after postgres stops, like syncing safekeepers,
@@ -1060,7 +1075,7 @@ impl Endpoint {
             );
             std::fs::remove_dir_all(self.endpoint_path())?;
         }
-        Ok(())
+        Ok(lsn)
     }
 
     pub fn connstr(&self, user: &str, db_name: &str) -> String {

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -83,6 +83,16 @@ pub struct ComputeStatusResponse {
     pub error: Option<String>,
 }
 
+#[derive(Serialize, Clone, Copy, Debug, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminateMode {
+    #[default]
+    /// wait 30s till returning from /terminate to allow control plane to get the error
+    Fast,
+    /// return from /terminate immediately as soon as all components are terminated
+    Immediate,
+}
+
 #[derive(Serialize, Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ComputeStatus {
@@ -103,10 +113,16 @@ pub enum ComputeStatus {
     // control-plane to terminate it.
     Failed,
     // Termination requested
-    TerminationPending,
+    TerminationPending { mode: TerminateMode },
     // Terminated Postgres
     Terminated,
 }
+
+#[derive(Deserialize, Serialize)]
+pub struct TerminateResponse {
+    pub lsn: Option<utils::lsn::Lsn>,
+}
+
 
 impl Display for ComputeStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -117,7 +133,7 @@ impl Display for ComputeStatus {
             ComputeStatus::Running => f.write_str("running"),
             ComputeStatus::Configuration => f.write_str("configuration"),
             ComputeStatus::Failed => f.write_str("failed"),
-            ComputeStatus::TerminationPending => f.write_str("termination-pending"),
+            ComputeStatus::TerminationPending { .. } => f.write_str("termination-pending"),
             ComputeStatus::Terminated => f.write_str("terminated"),
         }
     }

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -123,7 +123,6 @@ pub struct TerminateResponse {
     pub lsn: Option<utils::lsn::Lsn>,
 }
 
-
 impl Display for ComputeStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/libs/desim/src/executor.rs
+++ b/libs/desim/src/executor.rs
@@ -419,13 +419,13 @@ pub fn now() -> u64 {
     with_thread_context(|ctx| ctx.clock.get().unwrap().now())
 }
 
-pub fn exit(code: i32, msg: String) {
+pub fn exit(code: i32, msg: String) -> ! {
     with_thread_context(|ctx| {
         ctx.allow_panic.store(true, Ordering::SeqCst);
         let mut result = ctx.result.lock();
         *result = (code, msg);
         panic!("exit");
-    });
+    })
 }
 
 pub(crate) fn get_thread_ctx() -> Arc<ThreadContext> {

--- a/libs/walproposer/src/api_bindings.rs
+++ b/libs/walproposer/src/api_bindings.rs
@@ -311,7 +311,8 @@ extern "C" fn get_redo_start_lsn(wp: *mut WalProposer) -> XLogRecPtr {
     }
 }
 
-extern "C-unwind" fn finish_sync_safekeepers(wp: *mut WalProposer, lsn: XLogRecPtr) {
+unsafe extern "C-unwind" fn finish_sync_safekeepers(wp: *mut WalProposer, lsn: XLogRecPtr) -> !
+{
     unsafe {
         let callback_data = (*(*wp).config).callback_data;
         let api = callback_data as *mut Box<dyn ApiImpl>;

--- a/libs/walproposer/src/api_bindings.rs
+++ b/libs/walproposer/src/api_bindings.rs
@@ -311,8 +311,7 @@ extern "C" fn get_redo_start_lsn(wp: *mut WalProposer) -> XLogRecPtr {
     }
 }
 
-unsafe extern "C-unwind" fn finish_sync_safekeepers(wp: *mut WalProposer, lsn: XLogRecPtr) -> !
-{
+unsafe extern "C-unwind" fn finish_sync_safekeepers(wp: *mut WalProposer, lsn: XLogRecPtr) -> ! {
     unsafe {
         let callback_data = (*(*wp).config).callback_data;
         let api = callback_data as *mut Box<dyn ApiImpl>;

--- a/libs/walproposer/src/walproposer.rs
+++ b/libs/walproposer/src/walproposer.rs
@@ -144,7 +144,7 @@ pub trait ApiImpl {
         todo!()
     }
 
-    fn finish_sync_safekeepers(&self, _lsn: u64) {
+    fn finish_sync_safekeepers(&self, _lsn: u64) -> ! {
         todo!()
     }
 
@@ -469,7 +469,7 @@ mod tests {
             true
         }
 
-        fn finish_sync_safekeepers(&self, lsn: u64) {
+        fn finish_sync_safekeepers(&self, lsn: u64) -> ! {
             self.sync_channel.send(lsn).unwrap();
             panic!("sync safekeepers finished at lsn={}", lsn);
         }

--- a/pgxn/neon/walproposer.h
+++ b/pgxn/neon/walproposer.h
@@ -679,8 +679,7 @@ typedef struct walproposer_api
 	 * Finish sync safekeepers with the given LSN. This function should not
 	 * return and should exit the program.
 	 */
-	void		(*finish_sync_safekeepers) (WalProposer *wp, XLogRecPtr lsn);
-
+	void		(*finish_sync_safekeepers) (WalProposer *wp, XLogRecPtr lsn) __attribute__((noreturn)) ;
 	/*
 	 * Called after every AppendResponse from the safekeeper. Used to
 	 * propagate backpressure feedback and to confirm WAL persistence (has

--- a/pgxn/neon/walproposer_pg.c
+++ b/pgxn/neon/walproposer_pg.c
@@ -1890,7 +1890,7 @@ walprop_pg_wait_event_set(WalProposer *wp, long timeout, Safekeeper **sk, uint32
 	return rc;
 }
 
-static void
+static void __attribute__((noreturn))
 walprop_pg_finish_sync_safekeepers(WalProposer *wp, XLogRecPtr lsn)
 {
 	fprintf(stdout, "%X/%X\n", LSN_FORMAT_ARGS(lsn));

--- a/safekeeper/tests/walproposer_sim/walproposer_api.rs
+++ b/safekeeper/tests/walproposer_sim/walproposer_api.rs
@@ -499,7 +499,7 @@ impl ApiImpl for SimulationApi {
         true
     }
 
-    fn finish_sync_safekeepers(&self, lsn: u64) {
+    fn finish_sync_safekeepers(&self, lsn: u64) -> ! {
         debug!("finish_sync_safekeepers, lsn={}", lsn);
         executor::exit(0, Lsn(lsn).to_string());
     }

--- a/test_runner/fixtures/neon_cli.py
+++ b/test_runner/fixtures/neon_cli.py
@@ -620,7 +620,7 @@ class NeonLocalCli(AbstractNeonCli):
         destroy=False,
         check_return_code=True,
         mode: str | None = None,
-    ) -> tuple[Lsn, subprocess.CompletedProcess[str]]:
+    ) -> tuple[Lsn | None, subprocess.CompletedProcess[str]]:
         args = [
             "endpoint",
             "stop",
@@ -634,7 +634,8 @@ class NeonLocalCli(AbstractNeonCli):
 
         proc = self.raw_cli(args, check_return_code=check_return_code)
         log.debug(f"endpoint stop stdout: {proc.stdout}")
-        lsn = Lsn(proc.stdout.split()[-1])  # will always be last line of output
+        lsn_str = proc.stdout.split()[-1]
+        lsn: Lsn | None = None if lsn_str == "null" else Lsn(lsn_str)
         return lsn, proc
 
     def mappings_map_branch(

--- a/test_runner/fixtures/neon_cli.py
+++ b/test_runner/fixtures/neon_cli.py
@@ -633,7 +633,8 @@ class NeonLocalCli(AbstractNeonCli):
             args.append(endpoint_id)
 
         proc = self.raw_cli(args, check_return_code=check_return_code)
-        lsn = Lsn(proc.stdout.removeprefix(".\ncompute_ctl stopped\n"))
+        log.debug(f"endpoint stop stdout: {proc.stdout}")
+        lsn = Lsn(proc.stdout.split()[-1])  # will always be last line of output
         return lsn, proc
 
     def mappings_map_branch(

--- a/test_runner/fixtures/neon_cli.py
+++ b/test_runner/fixtures/neon_cli.py
@@ -620,7 +620,7 @@ class NeonLocalCli(AbstractNeonCli):
         destroy=False,
         check_return_code=True,
         mode: str | None = None,
-    ) -> subprocess.CompletedProcess[str]:
+    ) -> tuple[Lsn, subprocess.CompletedProcess[str]]:
         args = [
             "endpoint",
             "stop",
@@ -632,7 +632,9 @@ class NeonLocalCli(AbstractNeonCli):
         if endpoint_id is not None:
             args.append(endpoint_id)
 
-        return self.raw_cli(args, check_return_code=check_return_code)
+        proc = self.raw_cli(args, check_return_code=check_return_code)
+        lsn = Lsn(proc.stdout.removeprefix(".\ncompute_ctl stopped\n"))
+        return lsn, proc
 
     def mappings_map_branch(
         self, name: str, tenant_id: TenantId, timeline_id: TimelineId

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -4496,9 +4496,10 @@ class Endpoint(PgProtocol, LogUtils):
         running = self._running.acquire(blocking=False)
         if running:
             assert self.endpoint_id is not None
-            self.env.neon_cli.endpoint_stop(
+            lsn, _ = self.env.neon_cli.endpoint_stop(
                 self.endpoint_id, check_return_code=self.check_stop_result, mode=mode
             )
+            self.terminate_flush_lsn = lsn
 
         if sks_wait_walreceiver_gone is not None:
             for sk in sks_wait_walreceiver_gone[0]:
@@ -4516,9 +4517,10 @@ class Endpoint(PgProtocol, LogUtils):
         running = self._running.acquire(blocking=False)
         if running:
             assert self.endpoint_id is not None
-            self.env.neon_cli.endpoint_stop(
+            lsn, _ = self.env.neon_cli.endpoint_stop(
                 self.endpoint_id, True, check_return_code=self.check_stop_result, mode=mode
             )
+            self.terminate_flush_lsn = lsn
             self.endpoint_id = None
 
         return self

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -4192,6 +4192,8 @@ class Endpoint(PgProtocol, LogUtils):
         self._running = threading.Semaphore(0)
         self.__jwt: str | None = None
 
+        self.terminate_flush_lsn: Lsn | None = None
+
     def http_client(self, retries: Retry | None = None) -> EndpointHttpClient:
         assert self.__jwt is not None
         return EndpointHttpClient(

--- a/test_runner/regress/test_replica_promotes.py
+++ b/test_runner/regress/test_replica_promotes.py
@@ -15,7 +15,7 @@ from pytest import raises
 
 
 def stop_and_check_lsn(ep: Endpoint, expected_lsn: Lsn | None):
-    ep.stop(mode="immediate")
+    ep.stop(mode="immediate-terminate")
     lsn = ep.terminate_flush_lsn
     if expected_lsn is not None:
         assert lsn >= expected_lsn, f"{expected_lsn=} < {lsn=}"


### PR DESCRIPTION
- Add optional `?mode=fast|immediate` to `/terminate`, `fast` is default. Immediate avoids waiting 30
  seconds before returning from `terminate`.
- Add `TerminateMode` to `ComputeStatus::TerminationPending`
- Use `/terminate?mode=immediate` in `neon_local` instead of `pg_ctl stop` for `test_replica_promotes`.
- Change `test_replica_promotes` to check returned LSN
- Annotate `finish_sync_safekeepers` as `noreturn`.

https://github.com/neondatabase/cloud/issues/29807
