### PR TITLE
pagebench: add `basebackup` gRPC support

### DIFF
--- a/pageserver/page_api/src/client.rs
+++ b/pageserver/page_api/src/client.rs
@@ -121,7 +121,7 @@ impl Client {
     pub async fn get_base_backup(
         &mut self,
         req: model::GetBaseBackupRequest,
-    ) -> Result<impl Stream<Item = Result<Bytes, tonic::Status>>, tonic::Status> {
+    ) -> Result<impl Stream<Item = Result<Bytes, tonic::Status>> + 'static, tonic::Status> {
         let proto_req = proto::GetBaseBackupRequest::from(req);
 
         let response_stream: Streaming<proto::GetBaseBackupResponseChunk> =

--- a/pageserver/pagebench/src/cmd/basebackup.rs
+++ b/pageserver/pagebench/src/cmd/basebackup.rs
@@ -41,7 +41,7 @@ pub(crate) struct Args {
     #[clap(long, default_value = "1")]
     num_clients: NonZeroUsize,
     #[clap(long)]
-    compression: bool,
+    no_compression: bool,
     #[clap(long)]
     runtime: Option<humantime::Duration>,
     #[clap(long)]
@@ -163,10 +163,10 @@ async fn main_impl(
 
         let client: Box<dyn Client> = match connurl.scheme() {
             "postgresql" | "postgres" => Box::new(
-                LibpqClient::new(&args.page_service_connstring, tl, args.compression).await?,
+                LibpqClient::new(&args.page_service_connstring, tl, !args.no_compression).await?,
             ),
             "grpc" => Box::new(
-                GrpcClient::new(&args.page_service_connstring, tl, args.compression).await?,
+                GrpcClient::new(&args.page_service_connstring, tl, !args.no_compression).await?,
             ),
             scheme => return Err(anyhow!("invalid scheme {scheme}")),
         };

--- a/pageserver/pagebench/src/cmd/basebackup.rs
+++ b/pageserver/pagebench/src/cmd/basebackup.rs
@@ -339,6 +339,7 @@ impl Client for GrpcClient {
         let req = page_api::proto::GetBaseBackupRequest {
             lsn: lsn.unwrap_or(Lsn(0)).0,
             replica: false,
+            full: false,
         };
         let mut req = tonic::Request::new(req);
         let metadata = req.metadata_mut();

--- a/pageserver/pagebench/src/cmd/basebackup.rs
+++ b/pageserver/pagebench/src/cmd/basebackup.rs
@@ -267,7 +267,7 @@ trait Client: Send {
     async fn basebackup(
         &mut self,
         lsn: Option<Lsn>,
-    ) -> anyhow::Result<Pin<Box<dyn AsyncRead + Send + 'static>>>;
+    ) -> anyhow::Result<Pin<Box<dyn AsyncRead + Send>>>;
 }
 
 /// A libpq-based Pageserver client.

--- a/pageserver/pagebench/src/cmd/basebackup.rs
+++ b/pageserver/pagebench/src/cmd/basebackup.rs
@@ -269,7 +269,7 @@ async fn run_worker(
     all_work_done_barrier.wait().await;
 }
 
-/// A basebackup client. This allows swithcing out the client protocol implementation.
+/// A basebackup client. This allows switching out the client protocol implementation.
 #[async_trait]
 trait Client: Send {
     async fn basebackup(


### PR DESCRIPTION
## Problem

Pagebench does not support gRPC for `basebackup` benchmarks.

Requires #12243.
Touches #11728.

## Summary of changes

Add gRPC support via gRPC connstrings, e.g. `pagebench basebackup --page-service-connstring grpc://localhost:51051`.

Also change `--gzip-probability` to `--no-compression`, since this must be specified per-client for gRPC.