### PR TITLE
storcon: reduce `MAX_OFFLINE_INTERVAL_DEFAULT` to 10s

### DIFF
--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -123,7 +123,7 @@ pub(crate) const STARTUP_RECONCILE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How long a node may be unresponsive to heartbeats before we declare it offline.
 /// This must be long enough to cover node restarts as well as normal operations: in future
-pub const MAX_OFFLINE_INTERVAL_DEFAULT: Duration = Duration::from_secs(30);
+pub const MAX_OFFLINE_INTERVAL_DEFAULT: Duration = Duration::from_secs(10);
 
 /// How long a node may be unresponsive to heartbeats during start up before we declare it
 /// offline.


### PR DESCRIPTION
## Problem

The default 30s timeout for marking a Pageserver as offline is too high. This determines how long a tenant will be unavailable in the case of a Pageserver failure.

Resolves https://github.com/neondatabase/cloud/issues/28852.

## Summary of changes

Reduce the timeout to 10s. This is more in line with user expectations, and still lenient enough to avoid spurious failovers during intermittent network issues.

We could consider lowering it even futher, but this seems like a good start.