### PR TITLE
test_runner: add gRPC endpoint support

### DIFF
--- a/test_runner/fixtures/neon_cli.py
+++ b/test_runner/fixtures/neon_cli.py
@@ -496,6 +496,7 @@ class NeonLocalCli(AbstractNeonCli):
         internal_http_port: int,
         tenant_id: TenantId,
         pg_version: PgVersion,
+        grpc: bool = False,
         endpoint_id: str | None = None,
         hot_standby: bool = False,
         lsn: Lsn | None = None,
@@ -521,6 +522,8 @@ class NeonLocalCli(AbstractNeonCli):
             args.extend(["--external-http-port", str(external_http_port)])
         if internal_http_port is not None:
             args.extend(["--internal-http-port", str(internal_http_port)])
+        if grpc:
+            args.append("--grpc")
         if endpoint_id is not None:
             args.append(endpoint_id)
         if hot_standby:


### PR DESCRIPTION
## Problem

`test_runner` integration tests should support gRPC.

Touches #11926.

## Summary of changes

Add a `grpc` parameter when creating endpoints, which is plumbed through to `neon_local endpoint create`.

No tests actually use gRPC yet, since computes don't support it yet.