### PR TITLE
add pg_tpcds extension - an extension to load TPC-DS tables and run the benchmark 

### DIFF
--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -552,12 +552,10 @@ WORKDIR /ext-src/
 
 RUN case "${PG_VERSION:?}" in \
     "v14" ) \
-        ;; \
-    *) \
-        echo "skipping the version of pg_tpcds for $PG_VERSION" && exit 0 \
-        ;; \
-    esac && \
-    git clone --recurse-submodules --depth 1 https://github.com/neondatabase-labs/pg_tpcds.git pg_tpcds-src
+        echo "Skipping pg_tpcds for PG_VERSION=$PG_VERSION" && exit 0 ;; \
+    * ) \
+        git clone --recurse-submodules --depth 1 https://github.com/neondatabase-labs/pg_tpcds.git pg_tpcds-src ;; \
+    esac
 
 FROM pg-build AS pg_tpcds-build
 COPY --from=pg_tpcds-src /ext-src/ /ext-src/

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -548,6 +548,7 @@ RUN make -j $(getconf _NPROCESSORS_ONLN) OPTFLAGS="" && \
 #########################################################################################
 FROM build-deps AS pg_tpcds-src
 ARG PG_VERSION
+WORKDIR /ext-src/
 
 RUN case "${PG_VERSION:?}" in \
     "v14" ) \

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -148,7 +148,7 @@ RUN case $DEBIAN_VERSION in \
     apt install --no-install-recommends --no-install-suggests -y \
     ninja-build git autoconf automake libtool build-essential bison flex libreadline-dev \
     zlib1g-dev libxml2-dev libcurl4-openssl-dev libossp-uuid-dev wget ca-certificates pkg-config libssl-dev \
-    libicu-dev libxslt1-dev liblz4-dev libzstd-dev zstd curl unzip g++ \
+    libicu-dev libxslt1-dev liblz4-dev libzstd-dev zstd curl unzip g++ libfmt-dev \
     libclang-dev \
     $VERSION_INSTALLS \
     && apt clean && rm -rf /var/lib/apt/lists/* && \

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -148,7 +148,7 @@ RUN case $DEBIAN_VERSION in \
     apt install --no-install-recommends --no-install-suggests -y \
     ninja-build git autoconf automake libtool build-essential bison flex libreadline-dev \
     zlib1g-dev libxml2-dev libcurl4-openssl-dev libossp-uuid-dev wget ca-certificates pkg-config libssl-dev \
-    libicu-dev libxslt1-dev liblz4-dev libzstd-dev zstd curl unzip g++ libfmt-dev \
+    libicu-dev libxslt1-dev liblz4-dev libzstd-dev zstd curl unzip g++ \
     libclang-dev \
     $VERSION_INSTALLS \
     && apt clean && rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
## Problem

The tools to load TPC-DS into a database are somewhat outdated.

## Summary of changes

Add a plug-and-play postgres extension to neon for testing tpcds, inspired by [duckdb](https://github.com/duckdb/duckdb/tree/main/extension/tpcds) and [hyrise](https://github.com/hyrise/hyrise.git), to avoid the cumbersome configuration in tpcds. Only need to install the extension, and then you can run the test.

Uses https://github.com/neondatabase-labs/pg_tpcds

For usage see https://github.com/neondatabase-labs/pg_tpcds/blob/main/README.MD

## Usage log on Neon

```sql
-- create extension pg_tpcds;
-- need cascade because it depends on extension dblink
neondb=> create extension pg_tpcds cascade;
CREATE EXTENSION
neondb=> \timing
Timing is on.
neondb=> select * from dsdgen(1);
          tab           | row_count 
------------------------+-----------
 call_center            |         6
 catalog_page           |     11718
 catalog_sales          |   1441548
 catalog_returns        |   1441548
 customer               |    100000
 customer_address       |     50000
 customer_demographics  |   1920800
 date_dim               |     73049
 household_demographics |      7200
 income_band            |        20
 inventory              |  11745000
 item                   |     18000
 promotion              |       300
 reason                 |        35
 ship_mode              |        20
 store                  |        12
 store_sales            |   2880404
 store_returns          |   2880404
 time_dim               |     86400
 warehouse              |         5
 web_page               |        60
 web_sales              |    719384
 web_returns            |    719384
 web_site               |        30
(24 rows)

Time: 269954.988 ms (04:29.955)

neondb=> \dt+
                                               List of relations
 Schema |          Name          | Type  |    Owner    | Persistence | Access method |    Size    | Description 
--------+------------------------+-------+-------------+-------------+---------------+------------+-------------
 public | call_center            | table | cloud_admin | permanent   | heap          | 16 kB      | 
 public | catalog_page           | table | cloud_admin | permanent   | heap          | 1968 kB    | 
 public | catalog_returns        | table | cloud_admin | permanent   | heap          | 23 MB      | 
 public | catalog_sales          | table | cloud_admin | permanent   | heap          | 292 MB     | 
 public | customer               | table | cloud_admin | permanent   | heap          | 15 MB      | 
 public | customer_address       | table | cloud_admin | permanent   | heap          | 6984 kB    | 
 public | customer_demographics  | table | cloud_admin | permanent   | heap          | 138 MB     | 
 public | date_dim               | table | cloud_admin | permanent   | heap          | 11 MB      | 
 public | household_demographics | table | cloud_admin | permanent   | heap          | 432 kB     | 
 public | income_band            | table | cloud_admin | permanent   | heap          | 8192 bytes | 
 public | inventory              | table | cloud_admin | permanent   | heap          | 496 MB     | 
 public | item                   | table | cloud_admin | permanent   | heap          | 5712 kB    | 
 public | promotion              | table | cloud_admin | permanent   | heap          | 72 kB      | 
 public | reason                 | table | cloud_admin | permanent   | heap          | 8192 bytes | 
 public | ship_mode              | table | cloud_admin | permanent   | heap          | 8192 bytes | 
 public | store                  | table | cloud_admin | permanent   | heap          | 16 kB      | 
 public | store_returns          | table | cloud_admin | permanent   | heap          | 37 MB      | 
 public | store_sales            | table | cloud_admin | permanent   | heap          | 404 MB     | 
 public | time_dim               | table | cloud_admin | permanent   | heap          | 8400 kB    | 
 public | warehouse              | table | cloud_admin | permanent   | heap          | 8192 bytes | 
 public | web_page               | table | cloud_admin | permanent   | heap          | 8192 bytes | 
 public | web_returns            | table | cloud_admin | permanent   | heap          | 10 MB      | 
 public | web_sales              | table | cloud_admin | permanent   | heap          | 147 MB     | 
 public | web_site               | table | cloud_admin | permanent   | heap          | 48 kB      | 
(24 rows)

```
### tests

tested with `"compute_image": "neondatabase/vm-compute-node-v16:15754732168",` on 
`psql (17.5, server 16.9)`
