### PR TITLE
ci: Fix bogus skipping of 'make all' step in CI

### DIFF
--- a/.github/workflows/_build-and-test-locally.yml
+++ b/.github/workflows/_build-and-test-locally.yml
@@ -189,7 +189,6 @@ jobs:
           key: v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.build-type }}-pg-${{ steps.pg_v17_rev.outputs.pg_rev }}-bookworm-${{ hashFiles('Makefile', 'build-tools.Dockerfile') }}
 
       - name: Build all
-        if: steps.cache_pg_14.outputs.cache-hit != 'true'
         # Note: the Makefile picks up BUILD_TYPE and CARGO_PROFILE from the env variables
         run: mold -run make ${make_vars} all -j$(nproc) CARGO_BUILD_FLAGS="$CARGO_FLAGS"
 


### PR DESCRIPTION
The 'make all' step must run always. PR #12311 accidentally left the condition in there to skip it if there were no changes in postgres v14 sources. That condition belonged to a whole different step that was removed altogether in PR#12311, and the condition should've been removed too.

Per CI failure: https://github.com/neondatabase/neon/actions/runs/15820148967/job/44587394469
