### PR TITLE
storcon: Follow-up for Fix migration for Attached(0)

### DIFF
--- a/storage_controller/src/main.rs
+++ b/storage_controller/src/main.rs
@@ -6,8 +6,6 @@ use std::time::Duration;
 use anyhow::{Context, anyhow};
 use camino::Utf8PathBuf;
 
-#[cfg(feature = "testing")]
-use clap::ArgAction;
 use clap::Parser;
 use futures::future::OptionFuture;
 use http_utils::tls_certs::ReloadingCertificateResolver;
@@ -220,8 +218,7 @@ struct Cli {
     /// When set, actively checks and initiates heatmap downloads/uploads during reconciliation.
     /// This speed up migrations by avoiding the default wait for the heatmap download interval.
     /// Primarily useful for testing to reduce test execution time.
-    #[cfg(feature = "testing")]
-    #[arg(long, default_value = "true", action=ArgAction::Set)]
+    #[arg(long, default_value = "false")]
     kick_secondary_downloads: bool,
 }
 
@@ -455,7 +452,6 @@ async fn async_main() -> anyhow::Result<()> {
         timelines_onto_safekeepers: args.timelines_onto_safekeepers,
         use_local_compute_notifications: args.use_local_compute_notifications,
         timeline_safekeeper_count: args.timeline_safekeeper_count,
-        #[cfg(feature = "testing")]
         kick_secondary_downloads: args.kick_secondary_downloads,
     };
 

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -471,7 +471,6 @@ pub struct Config {
     /// Safekeepers will be choosen from different availability zones.
     pub timeline_safekeeper_count: i64,
 
-    #[cfg(feature = "testing")]
     pub kick_secondary_downloads: bool,
 }
 
@@ -8360,7 +8359,6 @@ impl Service {
                             "Skipping migration of {tenant_shard_id} to {node} because secondary isn't ready: {progress:?}"
                         );
 
-                        #[cfg(feature = "testing")]
                         if progress.heatmap_mtime.is_none() {
                             // No heatmap might mean the attached location has never uploaded one, or that
                             // the secondary download hasn't happened yet.  This is relatively unusual in the field,
@@ -8385,7 +8383,6 @@ impl Service {
     /// happens on multi-minute timescales in the field, which is fine because optimisation is meant
     /// to be a lazy background thing. However, when testing, it is not practical to wait around, so
     /// we have this helper to move things along faster.
-    #[cfg(feature = "testing")]
     async fn kick_secondary_download(&self, tenant_shard_id: TenantShardId) {
         if !self.config.kick_secondary_downloads {
             // No-op if kick_secondary_downloads functionaliuty is not configured

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -453,7 +453,7 @@ class NeonEnvBuilder:
         pageserver_get_vectored_concurrent_io: str | None = None,
         pageserver_tracing_config: PageserverTracingConfig | None = None,
         pageserver_import_config: PageserverImportConfig | None = None,
-        storcon_kick_secondary_downloads: bool | None = None,
+        storcon_kick_secondary_downloads: bool = True,
     ):
         self.repo_dir = repo_dir
         self.rust_log_override = rust_log_override
@@ -1224,13 +1224,12 @@ class NeonEnv:
             else:
                 cfg["storage_controller"] = {"use_local_compute_notifications": False}
 
-        if config.storcon_kick_secondary_downloads is not None:
-            # Configure whether storage controller should actively kick off secondary downloads
-            if "storage_controller" not in cfg:
-                cfg["storage_controller"] = {}
-            cfg["storage_controller"]["kick_secondary_downloads"] = (
-                config.storcon_kick_secondary_downloads
-            )
+        # Configure whether storage controller should actively kick off secondary downloads
+        if "storage_controller" not in cfg:
+            cfg["storage_controller"] = {}
+        cfg["storage_controller"]["kick_secondary_downloads"] = (
+            config.storcon_kick_secondary_downloads
+        )
 
         # Create config for pageserver
         http_auth_type = "NeonJWT" if config.auth_enabled else "Trust"


### PR DESCRIPTION
## Problem

Some of the design decisions in PR #12256 were influenced by the requirements of consistency tests. These decisions introduced intermediate logic that is no longer needed and should be cleaned up.

## Summary of Changes
- Remove the `feature("testing")` flag related to `kick_secondary_download`.
- Set the default value of `kick_secondary_download` back to false, reflecting the intended production behavior.