### PR TITLE
Switch the billing metrics storage format to ndjson.

### DIFF
--- a/proxy/src/usage_metrics.rs
+++ b/proxy/src/usage_metrics.rs
@@ -683,15 +683,14 @@ mod tests {
                 let mut events: Vec<Event<Extra, String>> = Vec::new();
                 for line in reader.lines() {
                     let line = line.unwrap();
-                    if line.trim().is_empty() { continue; }
                     let event: Event<Extra, String> = serde_json::from_str(&line).unwrap();
                     events.push(event);
                 }
-                
-                let report = Report{
+
+                let report = Report {
                     events: Cow::Owned(events),
                 };
-                
+
                 stored_chunks.push(report);
             }
         }


### PR DESCRIPTION
## Problem

The billing team wants to change the billing events pipeline and use a common events format in S3 buckets across different event producers.

## Summary of changes

Change the events storage format for billing events from JSON to NDJSON.

Resolves: https://github.com/neondatabase/cloud/issues/29994
