### PR TITLE
[proxy]: BatchQueue::call is not cancel safe - make it directly cancellation aware

### DIFF
--- a/proxy/src/batch.rs
+++ b/proxy/src/batch.rs
@@ -107,7 +107,7 @@ impl<P: QueueProcessing> BatchQueue<P> {
             // send response values.
             for (tx, value) in std::iter::zip(resps, values) {
                 if tx.send(value).is_err() {
-                    // sender hung up but that's fine.
+                    // receiver hung up but that's fine.
                 }
             }
 

--- a/proxy/src/redis/keys.rs
+++ b/proxy/src/redis/keys.rs
@@ -23,9 +23,8 @@ impl KeyPrefix {
 
 #[cfg(test)]
 mod tests {
-    use crate::pqproto::id_to_cancel_key;
-
     use super::*;
+    use crate::pqproto::id_to_cancel_key;
 
     #[test]
     fn test_build_redis_key() {


### PR DESCRIPTION
## Problem

https://github.com/neondatabase/cloud/issues/30539

If the current leader cancels the `call` function, then it has removed the jobs from the queue, but will never finish sending the responses. Because of this, it is not cancellation safe.

## Summary of changes

Document these functions as not cancellation safe. Move cancellation of the queued jobs into the queue itself.

## Alternatives considered

1. We could spawn the task that runs the batch, since that won't get cancelled. 
    * This requires `fn call(self: Arc<Self>)` or `fn call(&'static self)`.
2. We could add another scopeguard and return the requests back to the queue.
    * This requires that requests are always retry safe, and also requires requests to be `Clone`.