### PR TITLE
impr(ci): Remove unnecessary 'make postgres-headers' build step

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -94,11 +94,6 @@ jobs:
         run: |
           make "neon-pg-ext-${{ matrix.postgres-version }}" -j$(sysctl -n hw.ncpu)
 
-      - name: Get postgres headers ${{ matrix.postgres-version }}
-        if: steps.cache_pg.outputs.cache-hit != 'true'
-        run: |
-          make postgres-headers-${{ matrix.postgres-version }} -j$(sysctl -n hw.ncpu)
-
       - name: Upload "pg_install/${{ matrix.postgres-version }}" artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,11 @@ postgres-configure-v15: $(BUILD_DIR)/v15/config.status
 .PHONY: postgres-configure-v14
 postgres-configure-v14: $(BUILD_DIR)/v14/config.status
 
-# Install the PostgreSQL header files into $(POSTGRES_INSTALL_DIR)/<version>/include
+# Install just the PostgreSQL header files into $(POSTGRES_INSTALL_DIR)/<version>/include
+#
+# This is implicitly included in the 'postgres-%' rule, but this can be handy if you
+# want to just install the headers without building PostgreSQL, e.g. for building
+# extensions.
 .PHONY: postgres-headers-%
 postgres-headers-%: postgres-configure-%
 	+@echo "Installing PostgreSQL $* headers"


### PR DESCRIPTION
The 'make postgres' step includes installation of the headers, no need to do that separately.
