### PR TITLE
Check prefetch response before assignment to slot

### DIFF
--- a/pgxn/neon/communicator.c
+++ b/pgxn/neon/communicator.c
@@ -1100,6 +1100,7 @@ communicator_prefetch_lookupv(NRelFileInfo rinfo, ForkNumber forknum, BlockNumbe
 			{
 				continue;
 			}
+			Assert(slot->response->tag == T_NeonGetPageResponse); /* checked by check_getpage_response when response was assigned to the slot */
 			memcpy(buffers[i], ((NeonGetPageResponse*)slot->response)->page, BLCKSZ);
 
 


### PR DESCRIPTION
## Problem

See [Slack Channel](https://databricks.enterprise.slack.com/archives/C091LHU6NNB)

Dropping connection without resetting prefetch state can cause  request/response mismatch.
And lack of check response correctness in communicator_prefetch_lookupv can cause data corruption.

## Summary of changes

1. Validate response before assignment to prefetch slot.
2. Consume prefetch requests before sending any other requests.
