### PR TITLE
pageserver: allow flush task cancelled error in sharding autosplit test

### DIFF
--- a/test_runner/performance/test_sharding_autosplit.py
+++ b/test_runner/performance/test_sharding_autosplit.py
@@ -62,7 +62,8 @@ def test_sharding_autosplit(neon_env_builder: NeonEnvBuilder, pg_bin: PgBin):
         ps.allowed_errors.extend(
             [
                 # We shut down pageservers while they might have some compaction work going on
-                ".*Compaction failed.*shutting down.*"
+                ".*Compaction failed.*shutting down.*",
+                ".*flush task cancelled.*",
             ]
         )
 


### PR DESCRIPTION
## Problem

Test is failing due to compaction shutdown noise (see https://github.com/neondatabase/neon/issues/12162).

## Summary of changes

Allow list the noise.
