### PR TITLE
fix(pageserver): buffered writer cancellation error handling

### DIFF
--- a/libs/utils/src/sync/gate.rs
+++ b/libs/utils/src/sync/gate.rs
@@ -86,6 +86,14 @@ pub enum GateError {
     GateClosed,
 }
 
+impl GateError {
+    pub fn is_cancel(&self) -> bool {
+        match self {
+            GateError::GateClosed => true,
+        }
+    }
+}
+
 impl Default for Gate {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
## Problem

The problem has been well described in already-commited PR #11853.
tl;dr: BufferedWriter is sensitive to cancellation, which the previous approach was not.

The write path was most affected (ingest & compaction), which was mostly fixed in #11853:
it introduced `PutError` and mapped instances of `PutError` that were due to cancellation of underlying buffered writer into `CreateImageLayersError::Cancelled`.

However, there is a long tail of remaining errors that weren't caught by #11853 that result in `CompactionError::Other`s, which we log with great noise.

## Solution

The stack trace logging for CompactionError::Other added in #11853 allows us to chop away at that long tail using the following pattern:
- look at the stack trace
- from leaf up, identify the place where we incorrectly map from the distinguished variant X indicating cancellation to an `anyhow::Error`
- follow that anyhow further up, ensuring it stays the same anyhow all the way up in the `CompactionError::Other` 
- since it stayed one anyhow chain all the way up, root_cause() will yield us X
- so, in `log_compaction_error`, add an additional `downcast_ref` check for X

This PR specifically adds checks for
- the flush task cancelling (FlushTaskError, BlobWriterError)
- opening of the layer writer (GateError)

That should cover all the reports in issues 
- https://github.com/neondatabase/cloud/issues/29434
- https://github.com/neondatabase/neon/issues/12162

## Refs
- follow-up to #11853
- fixup of / fixes https://github.com/neondatabase/neon/issues/11762
- fixes https://github.com/neondatabase/neon/issues/12162
- refs https://github.com/neondatabase/cloud/issues/29434

Post-merge edit: 
- @alexanderlaw points out that we should mention https://github.com/neondatabase/neon/pull/11868 as a ref here, which was merged after #11853, somehow made the type of errors that we're fixing here show up more often (unclear why).  