### PR TITLE
Don't error if timeline offload is already in progress

### DIFF
--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -2438,6 +2438,7 @@ async fn timeline_offload_handler(
             .map_err(|e| {
                 match e {
                     OffloadError::Cancelled => ApiError::ResourceUnavailable("Timeline shutting down".into()),
+                    OffloadError::AlreadyInProgress => ApiError::Conflict("Timeline already being offloaded or deleted".into()),
                     _ => ApiError::InternalServerError(anyhow!(e))
                 }
             })?;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3285,6 +3285,7 @@ impl TenantShard {
                     .or_else(|err| match err {
                         // Ignore this, we likely raced with unarchival.
                         OffloadError::NotArchived => Ok(()),
+                        OffloadError::AlreadyInProgress => Ok(()),
                         err => Err(err),
                     })?;
             }


### PR DESCRIPTION
Don't print errors like:
```
Compaction failed 1 times, retrying in 2s: Failed to offload timeline: Unexpected offload error: Timeline deletion is already in progress
```

https://github.com/neondatabase/cloud/issues/30666