### PR TITLE
proxy/logging: Add "ep" and "query_id" to list of extracted fields

### DIFF
--- a/proxy/src/logging.rs
+++ b/proxy/src/logging.rs
@@ -52,7 +52,7 @@ pub async fn init() -> anyhow::Result<LoggingGuard> {
             StderrWriter {
                 stderr: std::io::stderr(),
             },
-            &["request_id", "session_id", "conn_id"],
+            &["conn_id", "ep", "query_id", "request_id", "session_id"],
         ))
     } else {
         None


### PR DESCRIPTION
Extract two more interesting fields from spans: ep (endpoint) and query_id.
Useful for reliable filtering in logging.