### PR TITLE
Add new activating scheduling policy for safekeepers

### DIFF
--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -420,6 +420,7 @@ impl From<NodeSchedulingPolicy> for String {
 #[derive(Serialize, Deserialize, Clone, Copy, Eq, PartialEq, Debug)]
 pub enum SkSchedulingPolicy {
     Active,
+    Activating,
     Pause,
     Decomissioned,
 }
@@ -430,6 +431,7 @@ impl FromStr for SkSchedulingPolicy {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
             "active" => Self::Active,
+            "activating" => Self::Activating,
             "pause" => Self::Pause,
             "decomissioned" => Self::Decomissioned,
             _ => {
@@ -446,6 +448,7 @@ impl From<SkSchedulingPolicy> for String {
         use SkSchedulingPolicy::*;
         match value {
             Active => "active",
+            Activating => "activating",
             Pause => "pause",
             Decomissioned => "decomissioned",
         }

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -2438,6 +2438,7 @@ async fn timeline_offload_handler(
             .map_err(|e| {
                 match e {
                     OffloadError::Cancelled => ApiError::ResourceUnavailable("Timeline shutting down".into()),
+                    OffloadError::AlreadyInProgress => ApiError::Conflict("Timeline already being offloaded or deleted".into()),
                     _ => ApiError::InternalServerError(anyhow!(e))
                 }
             })?;

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -3285,6 +3285,7 @@ impl TenantShard {
                     .or_else(|err| match err {
                         // Ignore this, we likely raced with unarchival.
                         OffloadError::NotArchived => Ok(()),
+                        OffloadError::AlreadyInProgress => Ok(()),
                         err => Err(err),
                     })?;
             }

--- a/storage_controller/migrations/2025-07-02-170751_safekeeper_default_no_pause/down.sql
+++ b/storage_controller/migrations/2025-07-02-170751_safekeeper_default_no_pause/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE safekeepers ALTER COLUMN scheduling_policy SET DEFAULT 'pause';

--- a/storage_controller/migrations/2025-07-02-170751_safekeeper_default_no_pause/up.sql
+++ b/storage_controller/migrations/2025-07-02-170751_safekeeper_default_no_pause/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE safekeepers ALTER COLUMN scheduling_policy SET DEFAULT 'activating';

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -1387,6 +1387,7 @@ impl Service {
                     };
                     sk.set_scheduling_policy(SkSchedulingPolicy::Active);
                     locked.safekeepers = Arc::new(safekeepers);
+                    tracing::info!("Activation of safekeeper {sk_id} done");
                 }
             }
         }

--- a/storage_controller/src/service/safekeeper_service.rs
+++ b/storage_controller/src/service/safekeeper_service.rs
@@ -869,7 +869,9 @@ impl Service {
                         .safekeeper_reconcilers
                         .start_reconciler(node_id, self);
                 }
-                SkSchedulingPolicy::Decomissioned | SkSchedulingPolicy::Pause | SkSchedulingPolicy::Activating => {
+                SkSchedulingPolicy::Decomissioned
+                | SkSchedulingPolicy::Pause
+                | SkSchedulingPolicy::Activating => {
                     locked.safekeeper_reconcilers.stop_reconciler(node_id);
                 }
             }

--- a/storage_controller/src/service/safekeeper_service.rs
+++ b/storage_controller/src/service/safekeeper_service.rs
@@ -814,7 +814,7 @@ impl Service {
                         Safekeeper::from_persistence(
                             crate::persistence::SafekeeperPersistence::from_upsert(
                                 record,
-                                SkSchedulingPolicy::Pause,
+                                SkSchedulingPolicy::Activating,
                             ),
                             CancellationToken::new(),
                             use_https,
@@ -869,7 +869,7 @@ impl Service {
                         .safekeeper_reconcilers
                         .start_reconciler(node_id, self);
                 }
-                SkSchedulingPolicy::Decomissioned | SkSchedulingPolicy::Pause => {
+                SkSchedulingPolicy::Decomissioned | SkSchedulingPolicy::Pause | SkSchedulingPolicy::Activating => {
                     locked.safekeeper_reconcilers.stop_reconciler(node_id);
                 }
             }

--- a/storage_controller/src/service/safekeeper_service.rs
+++ b/storage_controller/src/service/safekeeper_service.rs
@@ -855,29 +855,36 @@ impl Service {
             .await?;
         let node_id = NodeId(id as u64);
         // After the change has been persisted successfully, update the in-memory state
-        {
-            let mut locked = self.inner.write().unwrap();
-            let mut safekeepers = (*locked.safekeepers).clone();
-            let sk = safekeepers
-                .get_mut(&node_id)
-                .ok_or(DatabaseError::Logical("Not found".to_string()))?;
-            sk.set_scheduling_policy(scheduling_policy);
+        self.set_safekeeper_scheduling_policy_in_mem(node_id, scheduling_policy)
+            .await
+    }
 
-            match scheduling_policy {
-                SkSchedulingPolicy::Active => {
-                    locked
-                        .safekeeper_reconcilers
-                        .start_reconciler(node_id, self);
-                }
-                SkSchedulingPolicy::Decomissioned
-                | SkSchedulingPolicy::Pause
-                | SkSchedulingPolicy::Activating => {
-                    locked.safekeeper_reconcilers.stop_reconciler(node_id);
-                }
+    pub(crate) async fn set_safekeeper_scheduling_policy_in_mem(
+        self: &Arc<Service>,
+        node_id: NodeId,
+        scheduling_policy: SkSchedulingPolicy,
+    ) -> Result<(), DatabaseError> {
+        let mut locked = self.inner.write().unwrap();
+        let mut safekeepers = (*locked.safekeepers).clone();
+        let sk = safekeepers
+            .get_mut(&node_id)
+            .ok_or(DatabaseError::Logical("Not found".to_string()))?;
+        sk.set_scheduling_policy(scheduling_policy);
+
+        match scheduling_policy {
+            SkSchedulingPolicy::Active => {
+                locked
+                    .safekeeper_reconcilers
+                    .start_reconciler(node_id, self);
             }
-
-            locked.safekeepers = Arc::new(safekeepers);
+            SkSchedulingPolicy::Decomissioned
+            | SkSchedulingPolicy::Pause
+            | SkSchedulingPolicy::Activating => {
+                locked.safekeeper_reconcilers.stop_reconciler(node_id);
+            }
         }
+
+        locked.safekeepers = Arc::new(safekeepers);
         Ok(())
     }
 


### PR DESCRIPTION
When deploying new safekeepers, we don't immediately want to send traffic to them. Maybe they are not ready yet by the time the deploy script is registering them with the storage controller.

For pageservers, the storcon solves the problem by not scheduling stuff to them unless there has been a positive heartbeat response. We can't do the same for safekeepers though, otherwise a single down safekeeper would mean we can't create new timelines in smaller regions where there is only three safekeepers in total.

So far we have created safekeepers as `pause` but this adds a manual step to safekeeper deployment which is prone to oversight. We want things to be automatted. So we introduce a new state `activating` that acts just like `pause`, except that we automatically transition the policy to `active` once we get a positive heartbeat from the safekeeper. For `pause`, we always keep the safekeeper paused.