### PR TITLE
ci: always approve ci run

### DIFF
--- a/.github/workflows/approved-for-ci-run.yml
+++ b/.github/workflows/approved-for-ci-run.yml
@@ -42,7 +42,8 @@ jobs:
 
     if: |
       contains(fromJSON('["opened", "synchronize", "reopened", "closed"]'), github.event.action) &&
-      contains(github.event.pull_request.labels.*.name, 'approved-for-ci-run')
+      contains(github.event.pull_request.labels.*.name, 'approved-for-ci-run') &&
+      !contains(github.event.pull_request.labels.*.name, 'always-approved-for-ci-run')
 
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
## Problem

Do not remove the "approved-for-ci-run" tag for people we trust but don't want to pay for the GitHub seat 🙈

## Summary of changes

As above