### PR TITLE
fix(pageserver): do not allow delete to bypass upload metadata

### DIFF
--- a/pageserver/src/tenant/upload_queue.rs
+++ b/pageserver/src/tenant/upload_queue.rs
@@ -544,12 +544,8 @@ impl UploadOp {
                 let uname = u.layer_desc().layer_name();
                 !i.references(&uname, umeta) && !index.references(&uname, umeta)
             }
-            (UploadOp::Delete(d), UploadOp::UploadMetadata { uploaded: i })
-            | (UploadOp::UploadMetadata { uploaded: i }, UploadOp::Delete(d)) => {
-                d.layers.iter().all(|(dname, dmeta)| {
-                    !i.references(dname, dmeta) && !index.references(dname, dmeta)
-                })
-            }
+            (UploadOp::Delete(_), UploadOp::UploadMetadata { .. })
+            | (UploadOp::UploadMetadata { .. }, UploadOp::Delete(_)) => false,
 
             // Indexes can never bypass each other. They can coalesce though, and
             // `UploadQueue::next_ready()` currently does this when possible.


### PR DESCRIPTION
## Problem

https://databricks.slack.com/archives/C09254R641L/p1751489611513609?thread_ts=1751487720.772869&cid=C09254R641L

## Summary of changes

delete + upload metadata should not bypass each other; an alternative fix is to pass "second-to-last index_part" to the function so that we can decide whether it can be scheduled ahead.