### PR TITLE
neon_local: Fix cargo neon CLI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,4 +15,4 @@ rustflags = ["-Cforce-frame-pointers=yes"]
 
 [alias]
 build_testing = ["build", "--features", "testing"]
-neon = ["run", "--bin", "neon_local"]
+neon = ["run", "--bin", "neon_local", "--features", "storage_controller/testing"]

--- a/libs/postgres_versioninfo/src/lib.rs
+++ b/libs/postgres_versioninfo/src/lib.rs
@@ -113,10 +113,10 @@ impl PgMajorVersion {
 impl Display for PgMajorVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            PgMajorVersion::PG14 => "PgMajorVersion::PG14",
-            PgMajorVersion::PG15 => "PgMajorVersion::PG15",
-            PgMajorVersion::PG16 => "PgMajorVersion::PG16",
-            PgMajorVersion::PG17 => "PgMajorVersion::PG17",
+            PgMajorVersion::PG14 => "14",
+            PgMajorVersion::PG15 => "15",
+            PgMajorVersion::PG16 => "16",
+            PgMajorVersion::PG17 => "17",
         })
     }
 }


### PR DESCRIPTION
## Problem
On master, currently, `cargo neon tenant` commands are broken:

### First issue

```
cargo neon tenant create --set-default
   Compiling control_plane v0.1.0 (/Users/tdinh/git/neon/control_plane)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.32s
     Running `target/debug/neon_local tenant create --set-default`
error: invalid value 'PgMajorVersion::PG17' for '--pg-version <PG_VERSION>': PgMajorVersionParseError(PgMajorVersion::PG17)
```

The issue here is as follows:
* If not explicitly passed, `pg_version` is set to `DEFAULT_PG_VERSION` [here](https://github.com/neondatabase/neon/blob/8b4fbefc2945c930a1778fb3ae2a7602585352fe/control_plane/src/bin/neon_local.rs#L67);
* `clap` will then use the `Display` implementation of `PgMajorVersion` to parse `DEFAULT_PG_VERSION` to `PgMajorVersion::PG17` (the string): https://github.com/clap-rs/clap/blob/master/clap_derive/src/item.rs#L591
* Then `PgMajorVersion::PG17` as _a string_ is passed to `--pg-version` argument and this fails the `FromStr` validation of `PgMajorVersion`: https://github.com/neondatabase/neon/blob/8b4fbefc2945c930a1778fb3ae2a7602585352fe/libs/postgres_versioninfo/src/lib.rs#L164

There are a few ways to fix this. This PR proposes a way to keep `Display and `FromStr` implementation of `PgMajorVersion` consistent just so we can convert back and forth. Let me know what you think.

### After fixing the above issue
```
cargo neon tenant create --set-default
   Compiling control_plane v0.1.0 (/Users/tdinh/git/neon/control_plane)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.39s
     Running `target/debug/neon_local tenant create --set-default`
tenant a2350c2170817057e477e781fba38ea6 successfully created on the pageserver
command failed: pageserver API: couldn't find at least 3 safekeepers to put timeline to
```

This indicates that `cargo neon tenant` doesn't build `storage_controller` with the `testing` feature, I am fixing this in `config.toml`.

Both changes are small so I combine both changes into a PR. Let me know what you think. 

## Summary of changes

With this change:

```
cargo neon tenant create --set-default
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/neon_local tenant create --set-default`
tenant 3d43f278c3d33693c42d49a11721d1c0 successfully created on the pageserver
Created an initial timeline '732f96875f89a4db20472d8c5c9ec8fc' for tenant: 3d43f278c3d33693c42d49a11721d1c0
Setting tenant 3d43f278c3d33693c42d49a11721d1c0 as a default one
```