### PR TITLE
safekeeper: trim dead senders before adding more

### DIFF
--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -568,7 +568,9 @@ impl InterpretedWalReader {
                             let closed = sender.tx.is_closed();
 
                             let sender_id = ShardSenderId::new(shard_id, sender.sender_id);
-                            tracing::info!("Removed shard sender {}", sender_id);
+                            if closed {
+                                tracing::info!("Removed shard sender {}", sender_id);
+                            }
 
                             !closed
                         });

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -567,8 +567,8 @@ impl InterpretedWalReader {
                         senders.retain(|sender| {
                             let closed = sender.tx.is_closed();
 
-                            let sender_id = ShardSenderId::new(shard_id, sender.sender_id);
                             if closed {
+                                let sender_id = ShardSenderId::new(shard_id, sender.sender_id);
                                 tracing::info!("Removed shard sender {}", sender_id);
                             }
 

--- a/safekeeper/src/send_interpreted_wal.rs
+++ b/safekeeper/src/send_interpreted_wal.rs
@@ -564,16 +564,14 @@ impl InterpretedWalReader {
 
                         // Clean up any shard senders that have dropped out before adding the new
                         // one. This avoids a build up of dead senders.
-                        while let Some(sender) = senders.last() {
-                            if sender.tx.is_closed() {
-                                let sender_id = ShardSenderId::new(shard_id, sender.sender_id);
+                        senders.retain(|sender| {
+                            let closed = sender.tx.is_closed();
 
-                                senders.pop();
-                                tracing::info!("Removed shard sender {}", sender_id);
-                            } else {
-                                break;
-                            }
-                        }
+                            let sender_id = ShardSenderId::new(shard_id, sender.sender_id);
+                            tracing::info!("Removed shard sender {}", sender_id);
+
+                            !closed
+                        });
 
                         let new_sender_id = match senders.last() {
                             Some(sender) => sender.sender_id.next(),


### PR DESCRIPTION
## Problem

We only trim the senders if we tried to send a message to them and discovered that the channel is closed. This is problematic if the pageserver keeps connecting while there's nothing to send back for the shard. In this scenario we never trim down the senders list and can panic due to the u8 limit.

## Summary of Changes

Trim down the dead senders before adding a new one.

Closes LKB-178
