### PR TITLE
tests: more allowed errors for test_safekeeper_migration

### DIFF
--- a/test_runner/regress/test_safekeeper_migration.py
+++ b/test_runner/regress/test_safekeeper_migration.py
@@ -27,6 +27,7 @@ def test_safekeeper_migration_simple(neon_env_builder: NeonEnvBuilder):
         [
             ".*Timeline .* was cancelled and cannot be used anymore.*",
             ".*Timeline .* has been deleted.*",
+            ".*Timeline .* was not found in global map.*",
             ".*wal receiver task finished with an error.*",
         ]
     )


### PR DESCRIPTION
## Problem
Pageserver now writes errors in the log during the safekeeper migration. Some errors are added to allowed errors, but "timeline not found in global map" is not.

- Will be properly fixed in https://github.com/neondatabase/neon/issues/12191

## Summary of changes
Add "timeline not found in global map" error in a list of allowed errors in `test_safekeeper_migration_simple`