### PR TITLE
Add retrying in Random ops test if parent branch is not found.

### DIFF
--- a/test_runner/random_ops/test_random_ops.py
+++ b/test_runner/random_ops/test_random_ops.py
@@ -186,7 +186,6 @@ class NeonBranch:
         preserve_under_name: str | None = None,
     ) -> dict[str, Any] | None:
         if not self.project.check_limit_branches():
-            log.info("branch limit exceeded, skipping")
             return None
         endpoints = [ep for ep in self.endpoints.values() if ep.type == "read_only"]
         # Terminate all the benchmarks running to prevent errors. Errors in benchmark during pgbench are expected


### PR DESCRIPTION
## Problem
Due to a lag in replication, we sometimes cannot get the parent branch definition just after completion of the Public API restore call. This leads to the test failures.
https://databricks.atlassian.net/browse/LKB-279
## Summary of changes
The workaround is implemented. Now test retries up to 30 seconds, waiting for the branch definition to appear. 