### PR TITLE
Fix typo in migration testing related to pg_monitor

### DIFF
--- a/compute_tools/src/migrations/tests/0004-grant_pg_monitor_to_neon_superuser.sql
+++ b/compute_tools/src/migrations/tests/0004-grant_pg_monitor_to_neon_superuser.sql
@@ -6,7 +6,7 @@ BEGIN
             admin_option AS admin
         INTO monitor
         FROM pg_auth_members
-        WHERE roleid = 'pg_monitor'::regrole
+        WHERE roleid = 'neon_superuser'::regrole
             AND member = 'pg_monitor'::regrole;
 
     IF NOT monitor.member THEN


### PR DESCRIPTION
We should be joining on the neon_superuser roleid, not the pg_monitor roleid.
