### PR TITLE
Store read_only flag in pageserver timelines

### DIFF
--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -1602,6 +1602,10 @@ pub struct TimelineInfo {
     /// The status of the rel_size migration.
     pub rel_size_migration: Option<RelSizeMigration>,
 
+    /// Whether the timeline is read-only (doesn't support WAL advancing).
+    /// The property is not recursive; child timelines can be non-read-only.
+    pub read_only: bool,
+
     /// Whether the timeline is invisible in synthetic size calculations.
     pub is_invisible: Option<bool>,
 }

--- a/pageserver/src/tenant/timeline.rs
+++ b/pageserver/src/tenant/timeline.rs
@@ -2349,6 +2349,10 @@ impl Timeline {
         self.remote_client.is_invisible()
     }
 
+    pub(crate) fn is_read_only(&self) -> Option<bool> {
+        self.remote_client.is_read_only()
+    }
+
     pub(crate) fn is_stopping(&self) -> bool {
         self.current_state() == TimelineState::Stopping
     }


### PR DESCRIPTION
It is useful also for the pageserver to store whether a timeline was `read_only` or not: we can stop/not run internal processes, not look for safekeepers at all, etc. Also, for the outside it is nicer if the `TimelineInfo` contains whether a timeline is read only or not.

So introduce a new `read_only` field to `index-part.json`. Currently, it's a one time choice one can't change (in either direction), and read-only property is non-recursive. Also, we only support it for branch timelines, so not for root timelines or imported timelines.

Of course this only applies to new timelines, so the existing snapshots don't have this applied.

Follow-up of #12015