### PR TITLE
fix(libpagestore): update the default stripe size

### DIFF
--- a/pgxn/neon/libpagestore.c
+++ b/pgxn/neon/libpagestore.c
@@ -1410,7 +1410,7 @@ pg_init_libpagestore(void)
 							"sharding stripe size",
 							NULL,
 							&stripe_size,
-							32768, 1, INT_MAX,
+							2048, 1, INT_MAX,
 							PGC_SIGHUP,
 							GUC_UNIT_BLOCKS,
 							NULL, NULL, NULL);


### PR DESCRIPTION
## Problem

The pageserver connstrings are updated in the postmaster and then there's a hook to propagate it to the shared memory of all backends. However, the shard stripe doesn't. This would cause problems during shard splits:

* the compute has active reads/writes
* shard split happens and the cplane applies the new config (pageserver connstring + stripe size)
* pageserver connstring will be updated immediately once the postmaster receives the SIGHUP, and it will be copied over the the shared memory of all other backends.
* stripe size is a normal GUC and we don't have special handling around that, so if any active backend has ongoing txns the value won't be applied.
* now it's possible for backends to issue requests based on the wrong stripe size; what's worse, if a request gets cached in the prefetch buffer, it will get stuck forever.

## Summary of changes

To make sure it aligns with the current default in storcon.
