### PR TITLE
Introduce force flag for new deletion API

### DIFF
--- a/storage_controller/src/http.rs
+++ b/storage_controller/src/http.rs
@@ -1091,9 +1091,10 @@ async fn handle_node_delete(req: Request<Body>) -> Result<Response<Body>, ApiErr
 
     let state = get_state(&req);
     let node_id: NodeId = parse_request_param(&req, "node_id")?;
+    let force: bool = parse_query_param(&req, "force")?.unwrap_or(false);
     json_response(
         StatusCode::OK,
-        state.service.start_node_delete(node_id).await?,
+        state.service.start_node_delete(node_id, force).await?,
     )
 }
 

--- a/storage_controller/src/service.rs
+++ b/storage_controller/src/service.rs
@@ -7467,7 +7467,8 @@ impl Service {
                 .await;
         }
 
-        if let Err(_) = pausable_failpoint!("delete-node-after-reconciles-spawned", &cancel) {
+        let pf = pausable_failpoint!("delete-node-after-reconciles-spawned", &cancel);
+        if pf.is_err() {
             // An error from pausable_failpoint indicates the cancel token was triggered.
             return Err(get_error_on_cancel().await);
         }

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2119,11 +2119,14 @@ class NeonStorageController(MetricsGetter, LogUtils):
             headers=self.headers(TokenScope.ADMIN),
         )
 
-    def node_delete(self, node_id):
+    def node_delete(self, node_id, force: bool = False):
         log.info(f"node_delete({node_id})")
+        query = f"{self.api}/control/v1/node/{node_id}/delete"
+        if force:
+            query += "?force=true"
         self.request(
             "PUT",
-            f"{self.api}/control/v1/node/{node_id}/delete",
+            query,
             headers=self.headers(TokenScope.ADMIN),
         )
 

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2634,7 +2634,7 @@ def test_storage_controller_node_deletion(
     elif deletion_api == DeletionAPIKind.OLD:
         env.storage_controller.node_delete_old(victim.id)
     else:
-        assert False, f"Invalid deletion API: {deletion_api}"
+        raise AssertionError(f"Invalid deletion API: {deletion_api}")
 
     if not while_offline:
 
@@ -2655,7 +2655,7 @@ def test_storage_controller_node_deletion(
     elif deletion_api == DeletionAPIKind.OLD:
         assert_node_is_gone()
     else:
-       assert False, f"Invalid deletion API: {deletion_api}"
+        raise AssertionError(f"Invalid deletion API: {deletion_api}")
 
     # No tenants should refer to the node in their intent
     for tenant_id in tenant_ids:
@@ -3285,8 +3285,7 @@ def test_storage_controller_ps_restarted_during_drain(neon_env_builder: NeonEnvB
 
 @pytest.mark.parametrize("deletion_api", [DeletionAPIKind.OLD, DeletionAPIKind.FORCE])
 def test_ps_unavailable_after_delete(
-    neon_env_builder: NeonEnvBuilder,
-    deletion_api: DeletionAPIKind
+    neon_env_builder: NeonEnvBuilder, deletion_api: DeletionAPIKind
 ):
     neon_env_builder.num_pageservers = 3
 
@@ -3308,7 +3307,7 @@ def test_ps_unavailable_after_delete(
         env.storage_controller.node_delete_old(ps.id)
         assert_nodes_count(2)
     else:
-        assert False, f"Invalid deletion API: {deletion_api}"
+        raise AssertionError(f"Invalid deletion API: {deletion_api}")
 
     # Running pageserver CLI init in a separate thread
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -2606,6 +2606,8 @@ def test_storage_controller_node_deletion(
     assert env.storage_controller.reconcile_all() == 0
 
     victim = env.pageservers[-1]
+    if deletion_api == DeletionAPIKind.FORCE and not while_offline:
+        victim.allowed_errors.append(".*request was dropped before completing.*")
 
     # The procedure a human would follow is:
     # 1. Mark pageserver scheduling=pause
@@ -3301,6 +3303,7 @@ def test_ps_unavailable_after_delete(
     ps = env.pageservers[0]
 
     if deletion_api == DeletionAPIKind.FORCE:
+        ps.allowed_errors.append(".*request was dropped before completing.*")
         env.storage_controller.node_delete(ps.id, force=True)
         wait_until(lambda: assert_nodes_count(2))
     elif deletion_api == DeletionAPIKind.OLD:


### PR DESCRIPTION
## Problem

The force deletion API should behave like the graceful deletion API - it needs to support cancellation, persistence, and be non-blocking.

## Summary of Changes

- Added a `force` flag to the `NodeStartDelete` command.
- Passed the `force` flag through the `start_node_delete` handler in the storage controller.
- Handled the `force` flag in the `delete_node` function.
- Set the tombstone after removing the node from memory.
- Minor cleanup, like adding a `get_error_on_cancel` closure.