### PR TITLE
CI(run-python-test-set): don't collect code coverage

### DIFF
--- a/.github/actions/run-python-test-set/action.yml
+++ b/.github/actions/run-python-test-set/action.yml
@@ -176,7 +176,11 @@ runs:
         fi
 
         if [[ $BUILD_TYPE == "debug" && $RUNNER_ARCH == 'X64' ]]; then
-          cov_prefix=(scripts/coverage "--profraw-prefix=$GITHUB_JOB" --dir=/tmp/coverage run)
+          # We don't use code coverage for regression tests (the step is disabled),
+          # so there's no need to collect it.
+          # Ref https://github.com/neondatabase/neon/issues/4540
+          # cov_prefix=(scripts/coverage "--profraw-prefix=$GITHUB_JOB" --dir=/tmp/coverage run)
+          cov_prefix=()
         else
           cov_prefix=()
         fi


### PR DESCRIPTION
## Problem

We don't use code coverage produced by `regress-tests` (neondatabase/neon#6798), so there's no need to collect it. Potentially, disabling it should reduce the load on disks and improve the stability of debug builds.

## Summary of changes
- Disable code coverage collection for regression tests
