### PR TITLE
fix(pageserver): do not delete index_part.json during timeline deletion

### DIFF
--- a/storage_scrubber/src/pageserver_physical_gc.rs
+++ b/storage_scrubber/src/pageserver_physical_gc.rs
@@ -142,6 +142,12 @@ impl TenantRefAccumulator {
             .or_default()
             .insert(this_shard_idx);
 
+        // TODO: change this to "is X days ago?"
+        if index_part.deleted_at.is_some() {
+            tracing::info!(%ttid, "The timeline is already deleted, skipping");
+            return;
+        }
+
         let mut ancestor_refs = Vec::new();
         for (layer_name, layer_metadata) in &index_part.layer_metadata {
             if layer_metadata.shard != this_shard_idx {

--- a/test_runner/regress/test_remote_storage.py
+++ b/test_runner/regress/test_remote_storage.py
@@ -621,6 +621,7 @@ def test_timeline_deletion_with_files_stuck_in_upload_queue(
         path
         for path in remote_timeline_path.iterdir()
         if not (path.name.endswith("initdb.tar.zst"))
+        and not (path.name.startswith("index_part.json"))
     ]
     assert len(filtered) == 0
 

--- a/test_runner/regress/test_storage_scrubber.py
+++ b/test_runner/regress/test_storage_scrubber.py
@@ -410,6 +410,7 @@ def test_scrubber_physical_gc_timeline_deletion(neon_env_builder: NeonEnvBuilder
 
     # Delete the timeline
     env.storage_controller.pageserver_api().timeline_delete(tenant_id, timeline_id)
+    time.sleep(1)  # give scrubber some time to wait for min_age_secs
 
     # Subsequently doing physical GC should clean up the ancestor layers
     gc_summary = env.storage_scrubber.pageserver_physical_gc(min_age_secs=0, mode="full")


### PR DESCRIPTION
## Problem

close LKB-201.

Thinking about the following operation sequence:

- Pageserver 1 attaches the tenant with generation N and creates a timeline A.
- Pageserver 1 gets isolated from the network. Storcon attaches the tenant to pageserver 2 with generation N+1.
- Pageserver 2 delete timeline A, now the timeline directory is empty.
- Pageserver 1 rejoins the network, ingests the new data from safekeeper, and uploads the index_part.json
  with the old generation N.
- Now we are left with a timeline directory with index_part.json with generation N, but no layers
  except the newly-uploaded one from the isolated pageserver 1.

As a solution, we will keep the tombstone index_part.json (with `deleted_at` set) so that we don't
run into the issue above.

## Summary of changes

- Do not remove index_part.json as part of the timeline deletion. Storage scrubber will delete them during scrubbing. Scrubber only deletes index_parts older than 7 days (configurable) so as long as we don't get an isolated pageserver for 7 days (unlikely) things will be fine.
- Fix a bug that storage scrubber still counts towards ancestor reference if the timeline is already deleted.