### PR TITLE
storcon: add force_upsert flag to timeline_import endpoint

### DIFF
--- a/libs/pageserver_api/src/controller_api.rs
+++ b/libs/pageserver_api/src/controller_api.rs
@@ -550,6 +550,7 @@ pub struct TimelineImportRequest {
     pub timeline_id: TimelineId,
     pub start_lsn: Lsn,
     pub sk_set: Vec<NodeId>,
+    pub force_upsert: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]

--- a/storage_controller/src/persistence.rs
+++ b/storage_controller/src/persistence.rs
@@ -1466,7 +1466,10 @@ impl Persistence {
 
     /// Update an already present timeline.
     /// VERY UNSAFE FUNCTION: this overrides in-progress migrations. Don't use this unless neccessary.
-    pub(crate) async fn update_timeline_unsafe(&self, entry: TimelineUpdate) -> DatabaseResult<bool> {
+    pub(crate) async fn update_timeline_unsafe(
+        &self,
+        entry: TimelineUpdate,
+    ) -> DatabaseResult<bool> {
         use crate::schema::timelines;
 
         let entry = &entry;

--- a/storage_controller/src/service/safekeeper_service.rs
+++ b/storage_controller/src/service/safekeeper_service.rs
@@ -9,7 +9,8 @@ use crate::heartbeater::SafekeeperState;
 use crate::id_lock_map::trace_shared_lock;
 use crate::metrics;
 use crate::persistence::{
-    DatabaseError, SafekeeperTimelineOpKind, TimelinePendingOpPersistence, TimelinePersistence, TimelineUpdate,
+    DatabaseError, SafekeeperTimelineOpKind, TimelinePendingOpPersistence, TimelinePersistence,
+    TimelineUpdate,
 };
 use crate::safekeeper::Safekeeper;
 use crate::safekeeper_client::SafekeeperClient;
@@ -467,7 +468,10 @@ impl Service {
             cplane_notified_generation: 1,
             deleted_at: None,
         };
-        let inserted = self.persistence.insert_timeline(persistence.clone()).await?;
+        let inserted = self
+            .persistence
+            .insert_timeline(persistence.clone())
+            .await?;
         if inserted {
             tracing::info!("imported timeline into db");
             return Ok(());
@@ -481,10 +485,7 @@ impl Service {
             sk_set: persistence.sk_set,
             new_sk_set: persistence.new_sk_set,
         };
-        self
-            .persistence
-            .update_timeline_unsafe(update)
-            .await?;
+        self.persistence.update_timeline_unsafe(update).await?;
         tracing::info!("timeline updated");
 
         Ok(())


### PR DESCRIPTION
It is useful to have ability to update an existing timeline entry, as a way to mirror legacy migrations to the storcon managed table.