### PR TITLE
[proxy] refactor logging ID system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5406,6 +5406,7 @@ dependencies = [
  "tracing-test",
  "tracing-utils",
  "try-lock",
+ "type-safe-id",
  "typed-json",
  "url",
  "urlencoding",
@@ -8085,6 +8086,19 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "static_assertions",
+]
+
+[[package]]
+name = "type-safe-id"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd9267f90719e0433aae095640b294ff36ccbf89649ecb9ee34464ec504be157"
+dependencies = [
+ "arrayvec",
+ "rand 0.9.1",
+ "serde",
+ "thiserror 2.0.11",
+ "uuid",
 ]
 
 [[package]]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -98,6 +98,7 @@ tracing-log.workspace = true
 tracing-opentelemetry.workspace = true
 try-lock.workspace = true
 typed-json.workspace = true
+type-safe-id = { version = "0.3.3", features = ["serde"] }
 url.workspace = true
 urlencoding.workspace = true
 utils.workspace = true

--- a/proxy/src/cache/project_info.rs
+++ b/proxy/src/cache/project_info.rs
@@ -363,11 +363,12 @@ impl ProjectInfoCacheImpl {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::control_plane::messages::{Details, EndpointRateLimitConfig, ErrorInfo, Status};
     use crate::control_plane::{AccessBlockerFlags, AuthSecret};
     use crate::scram::ServerSecret;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_project_info_cache_settings() {

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -23,6 +23,7 @@ use crate::context::RequestContext;
 use crate::control_plane::ControlPlaneApi;
 use crate::error::ReportableError;
 use crate::ext::LockExt;
+use crate::id::RequestId;
 use crate::metrics::{CancelChannelSizeGuard, CancellationRequest, Metrics, RedisMsgKind};
 use crate::pqproto::CancelKeyData;
 use crate::rate_limiter::LeakyBucketRateLimiter;
@@ -486,7 +487,7 @@ impl Session {
     /// This is not cancel safe
     pub(crate) async fn maintain_cancel_key(
         &self,
-        session_id: uuid::Uuid,
+        session_id: RequestId,
         cancel: tokio::sync::oneshot::Receiver<Infallible>,
         cancel_closure: &CancelClosure,
         compute_config: &ComputeConfig,
@@ -599,7 +600,7 @@ impl Session {
             .await
         {
             tracing::warn!(
-                ?session_id,
+                %session_id,
                 ?err,
                 "could not cancel the query in the database"
             );

--- a/proxy/src/context/parquet.rs
+++ b/proxy/src/context/parquet.rs
@@ -124,7 +124,7 @@ impl serde::Serialize for Options<'_> {
 impl From<&RequestContextInner> for RequestData {
     fn from(value: &RequestContextInner) -> Self {
         Self {
-            session_id: value.session_id,
+            session_id: value.session_id.uuid(),
             peer_addr: value.conn_info.addr.ip().to_string(),
             timestamp: value.first_packet.naive_utc(),
             username: value.user.as_deref().map(String::from),

--- a/proxy/src/control_plane/mod.rs
+++ b/proxy/src/control_plane/mod.rs
@@ -20,6 +20,7 @@ use crate::cache::{Cached, TimedLru};
 use crate::config::ComputeConfig;
 use crate::context::RequestContext;
 use crate::control_plane::messages::{ControlPlaneErrorMessage, MetricsAuxInfo};
+use crate::id::ComputeConnId;
 use crate::intern::{AccountIdInt, EndpointIdInt, ProjectIdInt};
 use crate::protocol2::ConnectionInfoExtra;
 use crate::rate_limiter::{EndpointRateLimiter, LeakyBucketConfig};
@@ -77,8 +78,11 @@ impl NodeInfo {
         &self,
         ctx: &RequestContext,
         config: &ComputeConfig,
+        compute_conn_id: ComputeConnId,
     ) -> Result<compute::ComputeConnection, compute::ConnectionError> {
-        self.conn_info.connect(ctx, &self.aux, config).await
+        self.conn_info
+            .connect(ctx, &self.aux, config, compute_conn_id)
+            .await
     }
 }
 

--- a/proxy/src/id.rs
+++ b/proxy/src/id.rs
@@ -1,0 +1,33 @@
+//! Various ID types used by proxy.
+
+use type_safe_id::{StaticType, TypeSafeId};
+
+/// The ID used for the client connection
+pub type ClientConnId = TypeSafeId<ClientConn>;
+
+#[derive(Copy, Clone, Default, Hash, PartialEq, Eq)]
+pub struct ClientConn;
+
+impl StaticType for ClientConn {
+    // This is visible by customers, so we use 'neon' here instead of 'client'.
+    const TYPE: &'static str = "neon_conn";
+}
+
+/// The ID used for the compute connection
+pub type ComputeConnId = TypeSafeId<ComputeConn>;
+
+#[derive(Copy, Clone, Default, Hash, PartialEq, Eq)]
+pub struct ComputeConn;
+
+impl StaticType for ComputeConn {
+    const TYPE: &'static str = "compute_conn";
+}
+
+/// The ID used for the request to authenticate
+pub type RequestId = TypeSafeId<Request>;
+#[derive(Copy, Clone, Default, Hash, PartialEq, Eq)]
+pub struct Request;
+
+impl StaticType for Request {
+    const TYPE: &'static str = "request";
+}

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -91,6 +91,7 @@ mod control_plane;
 mod error;
 mod ext;
 mod http;
+mod id;
 mod intern;
 mod jemalloc;
 mod logging;

--- a/proxy/src/pglb/passthrough.rs
+++ b/proxy/src/pglb/passthrough.rs
@@ -8,6 +8,7 @@ use utils::measured_stream::MeasuredStream;
 use super::copy_bidirectional::ErrorSource;
 use crate::compute::MaybeRustlsStream;
 use crate::control_plane::messages::MetricsAuxInfo;
+use crate::id::ComputeConnId;
 use crate::metrics::{
     Direction, Metrics, NumClientConnectionsGuard, NumConnectionRequestsGuard,
     NumDbConnectionsGuard,
@@ -65,6 +66,8 @@ pub(crate) async fn proxy_pass(
 }
 
 pub(crate) struct ProxyPassthrough<S> {
+    pub(crate) compute_conn_id: ComputeConnId,
+
     pub(crate) client: Stream<S>,
     pub(crate) compute: MaybeRustlsStream,
 

--- a/proxy/src/proxy/mod.rs
+++ b/proxy/src/proxy/mod.rs
@@ -24,6 +24,7 @@ use crate::compute::ComputeConnection;
 use crate::config::ProxyConfig;
 use crate::context::RequestContext;
 use crate::control_plane::client::ControlPlaneClient;
+use crate::id::ComputeConnId;
 pub use crate::pglb::copy_bidirectional::{ErrorSource, copy_bidirectional_client_compute};
 use crate::pglb::{ClientMode, ClientRequestError};
 use crate::pqproto::{BeMessage, CancelKeyData, StartupMessageParams};
@@ -94,6 +95,8 @@ pub(crate) async fn handle_client<S: AsyncRead + AsyncWrite + Unpin + Send>(
     let mut attempt = 0;
     let connect = TcpMechanism {
         locks: &config.connect_compute_locks,
+        // for TCP/WS, we have client_id=session_id=compute_id for now.
+        compute_conn_id: ComputeConnId::from_uuid(ctx.session_id().uuid()),
     };
     let backend = auth::Backend::ControlPlane(cplane, creds.info);
 

--- a/proxy/src/serverless/http_util.rs
+++ b/proxy/src/serverless/http_util.rs
@@ -10,7 +10,6 @@ use http_body_util::{BodyExt, Full};
 use http_utils::error::ApiError;
 use serde::Serialize;
 use url::Url;
-use uuid::Uuid;
 
 use super::conn_pool::{AuthData, ConnInfoWithAuth};
 use super::conn_pool_lib::ConnInfo;
@@ -18,6 +17,7 @@ use super::error::{ConnInfoError, Credentials};
 use crate::auth::backend::ComputeUserInfo;
 use crate::config::AuthenticationConfig;
 use crate::context::RequestContext;
+use crate::id::RequestId;
 use crate::metrics::{Metrics, SniGroup, SniKind};
 use crate::pqproto::StartupMessageParams;
 use crate::proxy::NeonOptions;
@@ -34,9 +34,8 @@ pub(super) static TXN_ISOLATION_LEVEL: HeaderName =
 pub(super) static TXN_READ_ONLY: HeaderName = HeaderName::from_static("neon-batch-read-only");
 pub(super) static TXN_DEFERRABLE: HeaderName = HeaderName::from_static("neon-batch-deferrable");
 
-pub(crate) fn uuid_to_header_value(id: Uuid) -> HeaderValue {
-    let mut uuid = [0; uuid::fmt::Hyphenated::LENGTH];
-    HeaderValue::from_str(id.as_hyphenated().encode_lower(&mut uuid[..]))
+pub(crate) fn uuid_to_header_value(id: RequestId) -> HeaderValue {
+    HeaderValue::from_maybe_shared(Bytes::from(id.to_string().into_bytes()))
         .expect("uuid hyphenated format should be all valid header characters")
 }
 


### PR DESCRIPTION
Experimenting with typeid for proxy's logged IDs. They are UUIDv7 based and look like `request_01k0fpd8h6f3x97pdf25w8rveg`. They have a prefix which makes them distinct from different types.

Having the three ID types should fit nicely in PGLB as well. 
* PGLB can generate the ClientConnId when a client connects. 
* Neonkeeper generates the RequestId when PGLB opens a new stream.
* PGLB generates the ComputeConnId when PGLB opens a new compute stream.