### PR TITLE
Limit number of parallel config apply connections to 100

### DIFF
--- a/compute_tools/src/spec_apply.rs
+++ b/compute_tools/src/spec_apply.rs
@@ -411,7 +411,8 @@ impl ComputeNode {
             .map(|limit| match limit {
                 0..10 => limit,
                 10..30 => 10,
-                30.. => limit / 3,
+                30..300 => limit / 3,
+				300.. => 100
             })
             // If we didn't find max_connections, default to 10 concurrent connections.
             .unwrap_or(10)


### PR DESCRIPTION
## Problem

See https://databricks.slack.com/archives/C092W8NBXC0/p1752924508578339

In case of larger number of databases and large `max_connections` we can open too many connection for parallel apply config which may cause `Too many open files` error.

## Summary of changes

Limit maximal number of parallel config apply connections by 100.
