### PR TITLE
test_runner: allow stuck reconciliation errors

### DIFF
--- a/test_runner/fixtures/pageserver/allowed_errors.py
+++ b/test_runner/fixtures/pageserver/allowed_errors.py
@@ -152,6 +152,8 @@ DEFAULT_STORAGE_CONTROLLER_ALLOWED_ERRORS = [
     ".*reconciler.*neon_local error.*",
     # Tenant rate limits may fire in tests that submit lots of API requests.
     ".*tenant \\S+ is rate limited.*",
+    # Reconciliations may get stuck/delayed e.g. in chaos tests.
+    ".*background_reconcile: Shard reconciliation is stuck.*",
 ]
 
 


### PR DESCRIPTION
This log message was added in #12589.

During chaos tests, reconciles may not succeed for some time, triggering the log message.

Resolves [LKB-2467](https://databricks.atlassian.net/browse/LKB-2467).