### PR TITLE
fix(test): convert bool to lowercase when invoking neon-cli

### DIFF
--- a/test_runner/fixtures/neon_cli.py
+++ b/test_runner/fixtures/neon_cli.py
@@ -212,11 +212,13 @@ class NeonLocalCli(AbstractNeonCli):
             pg_version,
         ]
         if conf is not None:
-            args.extend(
-                chain.from_iterable(
-                    product(["-c"], (f"{key}:{value}" for key, value in conf.items()))
-                )
-            )
+            for key, value in conf.items():
+                if isinstance(value, bool):
+                    args.extend(
+                        ["-c", f"{key}:{str(value).lower()}"]
+                    )  # only accepts true/false not True/False
+                else:
+                    args.extend(["-c", f"{key}:{value}"])
 
         if set_default:
             args.append("--set-default")

--- a/test_runner/performance/test_perf_many_relations.py
+++ b/test_runner/performance/test_perf_many_relations.py
@@ -80,9 +80,7 @@ def test_perf_simple_many_relations_reldir(
     """
     Test creating many relations in a single database.
     """
-    env = neon_env_builder.init_start(
-        initial_tenant_conf={"rel_size_v2_enabled": "true" if reldir != "v1" else "false"}
-    )
+    env = neon_env_builder.init_start(initial_tenant_conf={"rel_size_v2_enabled": reldir != "v1"})
     ep = env.endpoints.create_start(
         "main",
         config_lines=[

--- a/test_runner/regress/test_compaction.py
+++ b/test_runner/regress/test_compaction.py
@@ -58,7 +58,7 @@ PREEMPT_GC_COMPACTION_TENANT_CONF = {
     "compaction_upper_limit": 6,
     "lsn_lease_length": "0s",
     # Enable gc-compaction
-    "gc_compaction_enabled": "true",
+    "gc_compaction_enabled": True,
     "gc_compaction_initial_threshold_kb": 1024,  # At a small threshold
     "gc_compaction_ratio_percent": 1,
     # No PiTR interval and small GC horizon
@@ -540,7 +540,7 @@ def test_pageserver_gc_compaction_trigger(neon_env_builder: NeonEnvBuilder):
         "pitr_interval": "0s",
         "gc_horizon": f"{1024 * 16}",
         "lsn_lease_length": "0s",
-        "gc_compaction_enabled": "true",
+        "gc_compaction_enabled": True,
         "gc_compaction_initial_threshold_kb": "16",
         "gc_compaction_ratio_percent": "50",
         # Do not generate image layers with create_image_layers

--- a/test_runner/regress/test_ondemand_slru_download.py
+++ b/test_runner/regress/test_ondemand_slru_download.py
@@ -16,7 +16,7 @@ def test_ondemand_download_pg_xact(neon_env_builder: NeonEnvBuilder, shard_count
         neon_env_builder.num_pageservers = shard_count
 
     tenant_conf = {
-        "lazy_slru_download": "true",
+        "lazy_slru_download": True,
         # set PITR interval to be small, so we can do GC
         "pitr_interval": "0 s",
     }
@@ -82,7 +82,7 @@ def test_ondemand_download_replica(neon_env_builder: NeonEnvBuilder, shard_count
         neon_env_builder.num_pageservers = shard_count
 
     tenant_conf = {
-        "lazy_slru_download": "true",
+        "lazy_slru_download": True,
     }
     env = neon_env_builder.init_start(
         initial_tenant_conf=tenant_conf, initial_tenant_shard_count=shard_count
@@ -141,7 +141,7 @@ def test_ondemand_download_after_wal_switch(neon_env_builder: NeonEnvBuilder):
     """
 
     tenant_conf = {
-        "lazy_slru_download": "true",
+        "lazy_slru_download": True,
     }
     env = neon_env_builder.init_start(initial_tenant_conf=tenant_conf)
 


### PR DESCRIPTION
## Problem

There has been some inconsistencies of providing tenant config via `tenant_create` and via other tenant config APIs due to how the properties are processed: in `tenant_create`, the test framework calls neon-cli and therefore puts those properties in the cmdline. In other cases, it's done via the HTTP API by directly serializing to a JSON. When using the cmdline, the program only accepts serde bool that is true/false.

## Summary of changes

Convert Python bool into `true`/`false` when using neon-cli.