### PR TITLE
Update Debain base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ARG DEBIAN_FLAVOR=${DEBIAN_VERSION}-slim
 #       -I | grep -i docker-content-digest
 # 3. As a next step, TODO(fedordikarev): create script and schedule workflow to run these checks
 #    and updates on regular bases and in automated way.
-ARG BOOKWORM_SLIM_SHA=sha256:40b107342c492725bc7aacbe93a49945445191ae364184a6d24fedb28172f6f7
-ARG BULLSEYE_SLIM_SHA=sha256:e831d9a884d63734fe3dd9c491ed9a5a3d4c6a6d32c5b14f2067357c49b0b7e1
+ARG BOOKWORM_SLIM_SHA=sha256:2424c1850714a4d94666ec928e24d86de958646737b1d113f5b2207be44d37d8
+ARG BULLSEYE_SLIM_SHA=sha256:c2c58af6e3ceeb3ed40adba85d24cfa62b7432091597ada9b76b56a51b62f4c6
 
 # Here we use ${var/search/replace} syntax, to check
 # if base image is one of the images, we pin image index for.

--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -12,8 +12,8 @@ ARG DEBIAN_FLAVOR=${DEBIAN_VERSION}-slim
 #       -I | grep -i docker-content-digest
 # 3. As a next step, TODO(fedordikarev): create script and schedule workflow to run these checks
 #    and updates on regular bases and in automated way.
-ARG BOOKWORM_SLIM_SHA=sha256:40b107342c492725bc7aacbe93a49945445191ae364184a6d24fedb28172f6f7
-ARG BULLSEYE_SLIM_SHA=sha256:e831d9a884d63734fe3dd9c491ed9a5a3d4c6a6d32c5b14f2067357c49b0b7e1
+ARG BOOKWORM_SLIM_SHA=sha256:2424c1850714a4d94666ec928e24d86de958646737b1d113f5b2207be44d37d8
+ARG BULLSEYE_SLIM_SHA=sha256:c2c58af6e3ceeb3ed40adba85d24cfa62b7432091597ada9b76b56a51b62f4c6
 
 # Here we use ${var/search/replace} syntax, to check
 # if base image is one of the images, we pin image index for.

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -92,8 +92,8 @@ ARG DEBIAN_FLAVOR=${DEBIAN_VERSION}-slim
 #       -I | grep -i docker-content-digest
 # 3. As a next step, TODO(fedordikarev): create script and schedule workflow to run these checks
 #    and updates on regular bases and in automated way.
-ARG BOOKWORM_SLIM_SHA=sha256:40b107342c492725bc7aacbe93a49945445191ae364184a6d24fedb28172f6f7
-ARG BULLSEYE_SLIM_SHA=sha256:e831d9a884d63734fe3dd9c491ed9a5a3d4c6a6d32c5b14f2067357c49b0b7e1
+ARG BOOKWORM_SLIM_SHA=sha256:2424c1850714a4d94666ec928e24d86de958646737b1d113f5b2207be44d37d8
+ARG BULLSEYE_SLIM_SHA=sha256:c2c58af6e3ceeb3ed40adba85d24cfa62b7432091597ada9b76b56a51b62f4c6
 
 # Here we use ${var/search/replace} syntax, to check
 # if base image is one of the images, we pin image index for.

--- a/compute/vm-image-spec-bookworm.yaml
+++ b/compute/vm-image-spec-bookworm.yaml
@@ -105,7 +105,7 @@ build: |
   # At time of migration to bookworm (2024-10-09), debian has a version of libcgroup/cgroup-tools 2.0.2,
   # and it _probably_ can be used as-is. However, we'll build it ourselves to minimise the changeset
   # for debian version migration.
-  ARG BOOKWORM_SLIM_SHA=sha256:40b107342c492725bc7aacbe93a49945445191ae364184a6d24fedb28172f6f7
+  ARG BOOKWORM_SLIM_SHA=sha256:2424c1850714a4d94666ec928e24d86de958646737b1d113f5b2207be44d37d8
   FROM debian@$BOOKWORM_SLIM_SHA as libcgroup-builder
   ENV LIBCGROUP_VERSION=v2.0.3
 

--- a/compute/vm-image-spec-bullseye.yaml
+++ b/compute/vm-image-spec-bullseye.yaml
@@ -101,7 +101,7 @@ build: |
   # At time of writing (2023-03-14), debian bullseye has a version of cgroup-tools (technically
   # libcgroup) that doesn't support cgroup v2 (version 0.41-11). Unfortunately, the vm-monitor
   # requires cgroup v2, so we'll build cgroup-tools ourselves.
-  ARG BULLSEYE_SLIM_SHA=sha256:e831d9a884d63734fe3dd9c491ed9a5a3d4c6a6d32c5b14f2067357c49b0b7e1
+  ARG BULLSEYE_SLIM_SHA=sha256:c2c58af6e3ceeb3ed40adba85d24cfa62b7432091597ada9b76b56a51b62f4c6
   FROM debian@$BULLSEYE_SLIM_SHA as libcgroup-builder
   ENV LIBCGROUP_VERSION=v2.0.3
 


### PR DESCRIPTION
## Problem

We haven't updated the base images for some time

## Summary of changes

```
$ docker buildx imagetools inspect --raw debian:bullseye-slim | openssl dgst -sha256
SHA2-256(stdin)= c2c58af6e3ceeb3ed40adba85d24cfa62b7432091597ada9b76b56a51b62f4c6
$ docker buildx imagetools inspect --raw debian:bookworm-slim | openssl dgst -sha256
SHA2-256(stdin)= 2424c1850714a4d94666ec928e24d86de958646737b1d113f5b2207be44d37d8
```