### PR TITLE
storcon: do not retry sk migration ops if the quorum is reached

### DIFF
--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1540,6 +1540,17 @@ class NeonEnv:
 
         raise RuntimeError(f"Pageserver with ID {id} not found")
 
+    def get_safekeeper(self, id: int) -> Safekeeper:
+        """
+        Look up a safekeeper by its ID.
+        """
+
+        for sk in self.safekeepers:
+            if sk.id == id:
+                return sk
+
+        raise RuntimeError(f"Safekeeper with ID {id} not found")
+
     def get_tenant_pageserver(self, tenant_id: TenantId | TenantShardId):
         """
         Get the NeonPageserver where this tenant shard is currently attached, according


### PR DESCRIPTION
## Problem
Currently sk migration algorithm retries requests to unavailable sk even if the quorum is reached. It slows down the algorithm if the sk is down.

- Closes: https://databricks.atlassian.net/browse/LKB-905
- Closes: https://github.com/neondatabase/neon/issues/12483

## Summary of changes
- Cancel retries when the quorum of successful responses is reached.
- Do not retry `exclude` requests on the `finishing` stage
- Write test for migration the timeline from an unavailable sk.