### PR TITLE
feat(pageserver): store reldirv2 migration in key

### DIFF
--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -571,6 +571,11 @@ impl PageServerNode {
                 .map(|x| x.parse::<bool>())
                 .transpose()
                 .context("Failed to parse 'basebackup_cache_enabled' as bool")?,
+            rel_size_v1_access_disabled: settings
+                .remove("rel_size_v1_access_disabled")
+                .map(|x| x.parse::<bool>())
+                .transpose()
+                .context("Failed to parse 'rel_size_v1_access_disabled' as bool")?,
         };
         if !settings.is_empty() {
             bail!("Unrecognized tenant settings: {settings:?}")

--- a/libs/pageserver_api/src/config.rs
+++ b/libs/pageserver_api/src/config.rs
@@ -651,6 +651,9 @@ pub struct TenantConfigToml {
     // FIXME: Remove skip_serializing_if when the feature is stable.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub basebackup_cache_enabled: bool,
+
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub rel_size_v1_access_disabled: bool,
 }
 
 pub mod defaults {
@@ -959,6 +962,7 @@ impl Default for TenantConfigToml {
             sampling_ratio: None,
             relsize_snapshot_cache_capacity: DEFAULT_RELSIZE_SNAPSHOT_CACHE_CAPACITY,
             basebackup_cache_enabled: false,
+            rel_size_v1_access_disabled: false,
         }
     }
 }

--- a/libs/pageserver_api/src/key.rs
+++ b/libs/pageserver_api/src/key.rs
@@ -519,6 +519,15 @@ pub fn rel_dir_to_key(spcnode: Oid, dbnode: Oid) -> Key {
     }
 }
 
+pub const REL_DIR_MIGRATION_KEY: Key = Key {
+    field1: REL_DIR_KEY_PREFIX,
+    field2: 0,
+    field3: 0,
+    field4: 0,
+    field5: 0,
+    field6: 0,
+};
+
 #[inline(always)]
 pub fn rel_tag_sparse_key(spcnode: Oid, dbnode: Oid, relnode: Oid, forknum: u8) -> Key {
     Key {

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -646,6 +646,8 @@ pub struct TenantConfigPatch {
     pub relsize_snapshot_cache_capacity: FieldPatch<usize>,
     #[serde(skip_serializing_if = "FieldPatch::is_noop")]
     pub basebackup_cache_enabled: FieldPatch<bool>,
+    #[serde(skip_serializing_if = "FieldPatch::is_noop")]
+    pub rel_size_v1_access_disabled: FieldPatch<bool>,
 }
 
 /// Like [`crate::config::TenantConfigToml`], but preserves the information
@@ -783,6 +785,9 @@ pub struct TenantConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub basebackup_cache_enabled: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rel_size_v1_access_disabled: Option<bool>,
 }
 
 impl TenantConfig {
@@ -830,6 +835,7 @@ impl TenantConfig {
             mut sampling_ratio,
             mut relsize_snapshot_cache_capacity,
             mut basebackup_cache_enabled,
+            mut rel_size_v1_access_disabled,
         } = self;
 
         patch.checkpoint_distance.apply(&mut checkpoint_distance);
@@ -939,6 +945,7 @@ impl TenantConfig {
         patch
             .basebackup_cache_enabled
             .apply(&mut basebackup_cache_enabled);
+        patch.rel_size_v1_access_disabled.apply(&mut rel_size_v1_access_disabled);
 
         Ok(Self {
             checkpoint_distance,
@@ -980,6 +987,7 @@ impl TenantConfig {
             sampling_ratio,
             relsize_snapshot_cache_capacity,
             basebackup_cache_enabled,
+            rel_size_v1_access_disabled,
         })
     }
 
@@ -1094,6 +1102,9 @@ impl TenantConfig {
             basebackup_cache_enabled: self
                 .basebackup_cache_enabled
                 .unwrap_or(global_conf.basebackup_cache_enabled),
+            rel_size_v1_access_disabled: self
+                .rel_size_v1_access_disabled
+                .unwrap_or(global_conf.rel_size_v1_access_disabled),
         }
     }
 }
@@ -1526,12 +1537,15 @@ pub struct OffloadedTimelineInfo {
     pub archived_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// The state of the rel size migration. This is persisted in the DbDir key and index part. Do not change without considering
+/// compatibility.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum RelSizeMigration {
     /// The tenant is using the old rel_size format.
     /// Note that this enum is persisted as `Option<RelSizeMigration>` in the index part, so
     /// `None` is the same as `Some(RelSizeMigration::Legacy)`.
+    #[default]
     Legacy,
     /// The tenant is migrating to the new rel_size format. Both old and new rel_size format are
     /// persisted in the storage. The read path will read both formats and validate them.

--- a/libs/pageserver_api/src/models.rs
+++ b/libs/pageserver_api/src/models.rs
@@ -945,7 +945,9 @@ impl TenantConfig {
         patch
             .basebackup_cache_enabled
             .apply(&mut basebackup_cache_enabled);
-        patch.rel_size_v1_access_disabled.apply(&mut rel_size_v1_access_disabled);
+        patch
+            .rel_size_v1_access_disabled
+            .apply(&mut rel_size_v1_access_disabled);
 
         Ok(Self {
             checkpoint_distance,

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -484,7 +484,7 @@ async fn build_timeline_info_common(
         *timeline.get_applied_gc_cutoff_lsn(),
     );
 
-    let (rel_size_migration, rel_size_migrated_at) = timeline.get_rel_size_v2_status();
+    let (rel_size_migration, rel_size_migrated_at) = timeline.get_rel_size_v2_cached_status();
 
     let info = TimelineInfo {
         tenant_id: timeline.tenant_shard_id,

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -723,6 +723,9 @@ impl Timeline {
                             v2_exists
                         );
                     }
+                    Err(e) if e.is_cancel() => {
+                        // Cancellation errors are fine to ignore, do not log.
+                    }
                     Err(e) => {
                         tracing::warn!("failed to get rel exists in v2: {e}");
                     }
@@ -862,6 +865,9 @@ impl Timeline {
                             rels_v1.len(),
                             rels_v2.len()
                         );
+                    }
+                    Err(e) if e.is_cancel() => {
+                        // Cancellation errors are fine to ignore, do not log.
                     }
                     Err(e) => {
                         tracing::warn!("failed to list rels in v2: {e}");
@@ -2599,6 +2605,12 @@ impl DatadirModification<'_> {
                                 dropped_rels_v2.len()
                             );
                         }
+                    }
+                    Err(WalIngestError {
+                        kind: WalIngestErrorKind::Cancelled,
+                        ..
+                    }) => {
+                        // Cancellation errors are fine to ignore, do not log.
                     }
                     Err(e) => {
                         tracing::warn!("error dropping rels: {}", e);

--- a/pageserver/src/pgdatadir_mapping.rs
+++ b/pageserver/src/pgdatadir_mapping.rs
@@ -2469,7 +2469,7 @@ impl DatadirModification<'_> {
             self.tline
                 .update_rel_size_v2_status(
                     reldir_migration_history.status.clone(),
-                    reldir_migration_history.v1_disabled_at,
+                    reldir_migration_history.v2_enabled_at,
                 )
                 .map_err(WalIngestErrorKind::RelSizeV2Error)?;
             self.put(

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -5090,7 +5090,7 @@ impl TenantShard {
             src_timeline.pg_version,
         );
 
-        let (rel_size_v2_status, rel_size_migrated_at) = src_timeline.get_rel_size_v2_status();
+        let (rel_size_v2_status, rel_size_migrated_at) = src_timeline.get_rel_size_v2_cached_status();
         let (uninitialized_timeline, _timeline_ctx) = self
             .prepare_new_timeline(
                 dst_id,

--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -5090,7 +5090,8 @@ impl TenantShard {
             src_timeline.pg_version,
         );
 
-        let (rel_size_v2_status, rel_size_migrated_at) = src_timeline.get_rel_size_v2_cached_status();
+        let (rel_size_v2_status, rel_size_migrated_at) =
+            src_timeline.get_rel_size_v2_cached_status();
         let (uninitialized_timeline, _timeline_ctx) = self
             .prepare_new_timeline(
                 dst_id,

--- a/pageserver/src/tenant/remote_timeline_client/index.rs
+++ b/pageserver/src/tenant/remote_timeline_client/index.rs
@@ -83,6 +83,7 @@ pub struct IndexPart {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub(crate) last_aux_file_policy: Option<AuxFilePolicy>,
 
+    /// Deprecated: the field is not used anymore and the source of truth is now stored in the dbdir key.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub(crate) rel_size_migration: Option<RelSizeMigration>,
 
@@ -115,8 +116,7 @@ pub struct IndexPart {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub(crate) marked_invisible_at: Option<NaiveDateTime>,
 
-    /// The LSN at which we started the rel size migration. Accesses below this LSN should be
-    /// processed with the v1 read path. Usually this LSN should be set together with `rel_size_migration`.
+    /// Deprecated: the field is not used anymore and the source of truth is now stored in the dbdir key.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub(crate) rel_size_migrated_at: Option<Lsn>,
 }

--- a/pageserver/src/tenant/timeline/import_pgdata/flow.rs
+++ b/pageserver/src/tenant/timeline/import_pgdata/flow.rs
@@ -177,6 +177,7 @@ impl Planner {
                 .iter()
                 .map(|db| ((db.spcnode, db.dboid), true))
                 .collect(),
+            rel_dir_migration_status: None,
         })?);
         self.tasks
             .push(ImportSingleKeyTask::new(DBDIR_KEY, dbdir_buf).into());

--- a/pageserver/src/tenant/timeline/import_pgdata/flow.rs
+++ b/pageserver/src/tenant/timeline/import_pgdata/flow.rs
@@ -177,7 +177,6 @@ impl Planner {
                 .iter()
                 .map(|db| ((db.spcnode, db.dboid), true))
                 .collect(),
-            rel_dir_migration_status: None,
         })?);
         self.tasks
             .push(ImportSingleKeyTask::new(DBDIR_KEY, dbdir_buf).into());

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -135,7 +135,7 @@ pub enum WalIngestErrorKind {
     #[error(transparent)]
     EncodeAuxFileError(anyhow::Error),
     #[error(transparent)]
-    MaybeRelSizeV2Error(anyhow::Error),
+    RelSizeV2Error(anyhow::Error),
 
     #[error("timeline shutting down")]
     Cancelled,

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -1312,8 +1312,8 @@ class NeonEnv:
                 )
 
             tenant_config = ps_cfg.setdefault("tenant_config", {})
-            # This feature is pending rollout.
-            # tenant_config["rel_size_v2_enabled"] = True
+            # Enable relsize_v2 by default in tests.
+            tenant_config["rel_size_v2_enabled"] = True
 
             # Test authors tend to forget about the default 10min initial lease deadline
             # when writing tests, which turns their immediate gc requests via mgmt API

--- a/test_runner/performance/test_perf_many_relations.py
+++ b/test_runner/performance/test_perf_many_relations.py
@@ -80,7 +80,12 @@ def test_perf_simple_many_relations_reldir(
     """
     Test creating many relations in a single database.
     """
-    env = neon_env_builder.init_start(initial_tenant_conf={"rel_size_v2_enabled": reldir != "v1"})
+    env = neon_env_builder.init_start(
+        initial_tenant_conf={
+            "rel_size_v2_enabled": reldir != "v1",
+            "rel_size_v1_access_disabled": reldir == "v2",
+        }
+    )
     ep = env.endpoints.create_start(
         "main",
         config_lines=[
@@ -108,10 +113,6 @@ def test_perf_simple_many_relations_reldir(
             == "migrating"
         )
     elif reldir == "v2":
-        # only read/write to the v2 keyspace
-        env.pageserver.http_client().timeline_patch_index_part(
-            env.initial_tenant, env.initial_timeline, {"rel_size_migration": "migrated"}
-        )
         assert (
             env.pageserver.http_client().timeline_detail(env.initial_tenant, env.initial_timeline)[
                 "rel_size_migration"

--- a/test_runner/regress/test_attach_tenant_config.py
+++ b/test_runner/regress/test_attach_tenant_config.py
@@ -183,7 +183,7 @@ def test_fully_custom_config(positive_env: NeonEnv):
         "lsn_lease_length": "1m",
         "lsn_lease_length_for_ts": "5s",
         "timeline_offloading": False,
-        "rel_size_v2_enabled": True,
+        "rel_size_v2_enabled": False,
         "relsize_snapshot_cache_capacity": 10000,
         "gc_compaction_enabled": False,
         "gc_compaction_verification": False,
@@ -194,6 +194,7 @@ def test_fully_custom_config(positive_env: NeonEnv):
             "numerator": 0,
             "denominator": 10,
         },
+        "rel_size_v1_access_disabled": True,
     }
 
     vps_http = env.storage_controller.pageserver_api()

--- a/test_runner/regress/test_compatibility.py
+++ b/test_runner/regress/test_compatibility.py
@@ -581,12 +581,10 @@ def test_historic_storage_formats(
         # This dataset was created at a time where we decided to migrate to v2 reldir by simply disabling writes to v1
         # and starting writing to v2. This was too risky and we have reworked the migration plan. Therefore, we should
         # opt in full relv2 mode for this dataset.
-        for timeline in timelines:
-            env.pageserver.http_client().timeline_patch_index_part(
-                dataset.tenant_id,
-                timeline["timeline_id"],
-                {"force_index_update": True, "rel_size_migration": "migrated"},
-            )
+        env.pageserver.http_client().patch_tenant_config(
+            dataset.tenant_id,
+            {"rel_size_v1_access_disabled": True, "rel_size_v2_enabled": True},
+        )
 
     # Import tenant does not create the timeline on safekeepers,
     # because it is a debug handler and the timeline may have already been

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -124,6 +124,7 @@ def patch_tenant_conf(tenant_conf: dict[str, Any], reldir_type: str) -> dict[str
     tenant_conf = tenant_conf.copy()
     if reldir_type == "v2":
         tenant_conf["rel_size_v2_enabled"] = True
+        tenant_conf["rel_size_v1_access_disabled"] = True
     else:
         tenant_conf["rel_size_v2_enabled"] = False
     return tenant_conf
@@ -439,14 +440,6 @@ def test_tx_abort_with_many_relations(
             "max_locks_per_transaction=16384",
         ],
     )
-
-    if reldir_type == "v2":
-        # v2-only mode instead of v1-v2 validation mode
-        env.pageserver.http_client().timeline_patch_index_part(
-            env.initial_tenant,
-            env.initial_timeline,
-            {"rel_size_migration": "migrated"},
-        )
 
     # How many relations: this number is tuned to be long enough to take tens of seconds
     # if the rollback code path is buggy, tripping the test's timeout.

--- a/test_runner/regress/test_pg_regress.py
+++ b/test_runner/regress/test_pg_regress.py
@@ -123,9 +123,9 @@ def post_checks(env: NeonEnv, test_output_dir: Path, db_name: str, endpoint: End
 def patch_tenant_conf(tenant_conf: dict[str, Any], reldir_type: str) -> dict[str, Any]:
     tenant_conf = tenant_conf.copy()
     if reldir_type == "v2":
-        tenant_conf["rel_size_v2_enabled"] = "true"
+        tenant_conf["rel_size_v2_enabled"] = True
     else:
-        tenant_conf["rel_size_v2_enabled"] = "false"
+        tenant_conf["rel_size_v2_enabled"] = False
     return tenant_conf
 
 
@@ -439,6 +439,14 @@ def test_tx_abort_with_many_relations(
             "max_locks_per_transaction=16384",
         ],
     )
+
+    if reldir_type == "v2":
+        # v2-only mode instead of v1-v2 validation mode
+        env.pageserver.http_client().timeline_patch_index_part(
+            env.initial_tenant,
+            env.initial_timeline,
+            {"rel_size_migration": "migrated"},
+        )
 
     # How many relations: this number is tuned to be long enough to take tens of seconds
     # if the rollback code path is buggy, tripping the test's timeout.


### PR DESCRIPTION
## Problem

- we cannot use dbdir unfortunately.
- one more read, but we can cache it (in next few patches).

## Summary of changes

- index_part.json is no longer used for reldir migration status, will clean up in the future.
- we store the migration status in a key in the reldir sparse keyspace.
- new `rel_size_v1_access_disabled` field to completely disable v1 writes and reads.
- adjust test cases accordingly.
- enable reldirv2 in tests by default.