### PR TITLE
Set NEON_MOTD to null to fix regression tests

### DIFF
--- a/test_runner/cloud_regress/test_cloud_regress.py
+++ b/test_runner/cloud_regress/test_cloud_regress.py
@@ -40,6 +40,7 @@ def test_cloud_regress(
         "PGUSER": remote_pg.default_options["user"],
         "PGPASSWORD": remote_pg.default_options["password"],
         "PGDATABASE": remote_pg.default_options["dbname"],
+        "NEON_MOTD": "",  # Disable MOTD for tests
     }
     regress_cmd = [
         str(regress_bin),


### PR DESCRIPTION
NEON_MOTD env variable is set for psql greetings to be printed alogn with the session_id. Disable this for regression tests