### PR TITLE
tests: turn down error rate in test_compute_pageserver_connection_stress

### DIFF
--- a/test_runner/regress/test_bad_connection.py
+++ b/test_runner/regress/test_bad_connection.py
@@ -26,7 +26,7 @@ def test_compute_pageserver_connection_stress(neon_env_builder: NeonEnvBuilder):
     # Enable failpoint before starting everything else up so that we exercise the retry
     # on fetching basebackup
     pageserver_http = env.pageserver.http_client()
-    pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "50%return(15)"))
+    pageserver_http.configure_failpoints(("simulated-bad-compute-connection", "20%return(15)"))
 
     env.create_branch("test_compute_pageserver_connection_stress")
     endpoint = env.endpoints.create_start("test_compute_pageserver_connection_stress")


### PR DESCRIPTION
## Problem

Compute retries are finite (e.g. 5x in a basebackup) -- with a 50% failure rate we have pretty good chance of exceeding that and the test failing.

Fixes: https://databricks.atlassian.net/browse/LKB-2278

## Summary of changes

- Turn connection error rate down to 20%