### PR TITLE
tests: stop ps immediately in test_ps_unavailable_after_delete

### DIFF
--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -3309,6 +3309,7 @@ def test_ps_unavailable_after_delete(
         ps.allowed_errors.append(".*request was dropped before completing.*")
         env.storage_controller.node_delete(ps.id, force=True)
         wait_until(lambda: assert_nodes_count(2))
+        env.storage_controller.reconcile_until_idle()
     elif deletion_api == DeletionAPIKind.OLD:
         env.storage_controller.node_delete_old(ps.id)
         assert_nodes_count(2)
@@ -3318,7 +3319,7 @@ def test_ps_unavailable_after_delete(
     # Running pageserver CLI init in a separate thread
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
         log.info("Restarting tombstoned pageserver...")
-        ps.stop(immediate=True)
+        ps.stop()
         ps_start_fut = executor.submit(lambda: ps.start(await_active=False))
 
         # After deleted pageserver restart, the node count must remain the same

--- a/test_runner/regress/test_storage_controller.py
+++ b/test_runner/regress/test_storage_controller.py
@@ -3318,7 +3318,7 @@ def test_ps_unavailable_after_delete(
     # Running pageserver CLI init in a separate thread
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
         log.info("Restarting tombstoned pageserver...")
-        ps.stop()
+        ps.stop(immediate=True)
         ps_start_fut = executor.submit(lambda: ps.start(await_active=False))
 
         # After deleted pageserver restart, the node count must remain the same


### PR DESCRIPTION
## Problem
test_ps_unavailable_after_delete is flaky. All test failures I've looked at are because of ERROR log messages in pageserver, which happen because storage controller tries runs a reconciliations during the graceful shutdown of the pageserver.

I wasn't able to reproduce it locally, but I think stopping PS immediately instead of gracefully should help. If not, we might just silence those errors.

- Closes: https://databricks.atlassian.net/browse/LKB-745