### PR TITLE
Add databricks setting via write_postgres_conf

### DIFF
--- a/compute_tools/src/config.rs
+++ b/compute_tools/src/config.rs
@@ -7,11 +7,14 @@ use std::io::prelude::*;
 use std::path::Path;
 
 use compute_api::responses::TlsConfig;
-use compute_api::spec::{ComputeAudit, ComputeMode, ComputeSpec, GenericOption};
+use compute_api::spec::{
+    ComputeAudit, ComputeMode, ComputeSpec, DatabricksSettings, GenericOption,
+};
 
 use crate::compute::ComputeNodeParams;
 use crate::pg_helpers::{
-    GenericOptionExt, GenericOptionsSearch, PgOptionsSerialize, escape_conf_value,
+    DatabricksSettingsExt as _, GenericOptionExt, GenericOptionsSearch, PgOptionsSerialize,
+    escape_conf_value,
 };
 use crate::tls::{self, SERVER_CRT, SERVER_KEY};
 
@@ -46,6 +49,7 @@ pub fn write_postgres_conf(
     spec: &ComputeSpec,
     extension_server_port: u16,
     tls_config: &Option<TlsConfig>,
+    databricks_settings: Option<&DatabricksSettings>,
 ) -> Result<()> {
     let path = pgdata_path.join("postgresql.conf");
     // File::create() destroys the file content if it exists.
@@ -284,6 +288,17 @@ pub fn write_postgres_conf(
     if spec.logs_export_host.is_some() {
         writeln!(file, "log_destination='stderr,syslog'")?;
     }
+
+    // This is databricks specific settings.
+    // This should be at the end of the file but before `compute_ctl_temp_override.conf` below
+    // so that it can override any settings above.
+    // `compute_ctl_temp_override.conf` is intended to override any settings above during specific operations.
+    // To prevent potential breakage in the future, we keep it above `compute_ctl_temp_override.conf`.
+    writeln!(file, "# Databricks settings start")?;
+    if let Some(settings) = databricks_settings {
+        writeln!(file, "{}", settings.as_pg_settings())?;
+    }
+    writeln!(file, "# Databricks settings end")?;
 
     // This is essential to keep this line at the end of the file,
     // because it is intended to override any settings above.

--- a/libs/compute_api/src/spec.rs
+++ b/libs/compute_api/src/spec.rs
@@ -195,7 +195,6 @@ pub struct ComputeSpec {
     pub suspend_timeout_seconds: i64,
 
     // Databricks specific options for compute instance.
-    // These settings are not part of postgresql.conf.
     pub databricks_settings: Option<DatabricksSettings>,
 }
 


### PR DESCRIPTION
## Summary of changes

Move databricks settings that will be appended to postgres.conf to `write_postgres_conf`

## How is this tested?

Existing tests.
