### PR TITLE
Explicitly set port in postgresql.conf

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -1459,11 +1459,7 @@ impl ComputeNode {
         let tls_config = self.tls_config(&pspec.spec);
         let databricks_settings = spec.databricks_settings.as_ref();
 
-        let postgres_port = self
-            .params
-            .connstr
-            .port()
-            .expect("port must be present in connstr");
+        let postgres_port = self.params.connstr.port();
         // Remove/create an empty pgdata directory and put configuration there.
         self.create_pgdata()?;
         config::write_postgres_conf(
@@ -1474,6 +1470,7 @@ impl ComputeNode {
             self.params.internal_http_port,
             tls_config,
             databricks_settings,
+            self.params.lakebase_mode,
         )?;
 
         // Syncing safekeepers is only safe with primary nodes: if a primary
@@ -1966,11 +1963,7 @@ impl ComputeNode {
 
         // Write new config
         let pgdata_path = Path::new(&self.params.pgdata);
-        let postgres_port = self
-            .params
-            .connstr
-            .port()
-            .expect("port must be present in connstr");
+        let postgres_port = self.params.connstr.port();
         config::write_postgres_conf(
             pgdata_path,
             &self.params,
@@ -1979,6 +1972,7 @@ impl ComputeNode {
             self.params.internal_http_port,
             tls_config,
             spec.databricks_settings.as_ref(),
+            self.params.lakebase_mode,
         )?;
 
         self.pg_reload_conf()?;

--- a/compute_tools/src/spec.rs
+++ b/compute_tools/src/spec.rs
@@ -137,7 +137,6 @@ pub fn get_config_from_control_plane(base_uri: &str, compute_id: &str) -> Result
 /// Check `pg_hba.conf` and update if needed to allow external connections.
 pub fn update_pg_hba(pgdata_path: &Path, databricks_pg_hba: Option<&String>) -> Result<()> {
     // XXX: consider making it a part of config.json
-    info!("checking pg_hba.conf");
     let pghba_path = pgdata_path.join("pg_hba.conf");
 
     // Update pg_hba to contains databricks specfic settings before adding neon settings


### PR DESCRIPTION
Hadron doesn't bind Postgres to the default Postgres port of 5432 it seems, and requires using a different port. Neon binds to the default port. Writing out the default port makes no difference, so do it always regardless of Lakebase mode.
