### PR TITLE
[proxy] handle options request in rest broker (cors headers)

### DIFF
--- a/proxy/src/cache/project_info.rs
+++ b/proxy/src/cache/project_info.rs
@@ -363,11 +363,12 @@ impl ProjectInfoCacheImpl {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::control_plane::messages::{Details, EndpointRateLimitConfig, ErrorInfo, Status};
     use crate::control_plane::{AccessBlockerFlags, AuthSecret};
     use crate::scram::ServerSecret;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_project_info_cache_settings() {

--- a/proxy/src/serverless/rest.rs
+++ b/proxy/src/serverless/rest.rs
@@ -718,7 +718,7 @@ fn get_allow_origin_header_value<'a>(
 fn cors_response(
     origin: Option<&str>,
     headers: &HeaderMap,
-) -> Result<Response<BoxBody<Bytes, hyper::Error>>, RestError> {
+) -> Result<Response<BoxBody<Bytes, hyper::Error>>, http::Error> {
     match origin {
         Some(o) => {
             let allowed_headers = headers
@@ -738,18 +738,10 @@ fn cors_response(
                 .header("Access-Control-Allow-Headers", allowed_headers)
                 .header("Allow", "OPTIONS, GET, POST, PATCH, PUT, DELETE")
                 .body(Empty::new().map_err(|x| match x {}).boxed())
-                .map_err(|e| RestError::SubzeroCore(InternalError {
-                    message: e.to_string(),
-                }))
         }
         None => Response::builder()
             .status(StatusCode::OK)
-            .body(Empty::new().map_err(|x| match x {}).boxed())
-            .map_err(|e| {
-                RestError::SubzeroCore(InternalError {
-                    message: e.to_string(),
-                })
-            }),
+            .body(Empty::new().map_err(|x| match x {}).boxed()),
     }
 }
 
@@ -812,7 +804,11 @@ async fn handle_rest_inner(
         api_config.server_cors_allowed_origins.as_ref(),
     );
     if parts.method == Method::OPTIONS {
-        return cors_response(allow_origin, &parts.headers);
+        return cors_response(allow_origin, &parts.headers).map_err(|e| {
+            RestError::SubzeroCore(InternalError {
+                message: e.to_string(),
+            })
+        });
     }
     let db_schema = db_schema_owned.borrow_schema();
 

--- a/proxy/src/serverless/rest.rs
+++ b/proxy/src/serverless/rest.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use http::Method;
-use http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, AUTHORIZATION, CONTENT_TYPE, HOST, ORIGIN};
+use http::header::{
+    ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_REQUEST_HEADERS, AUTHORIZATION, CONTENT_TYPE, HOST,
+    ORIGIN,
+};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Empty, Full};
 use http_utils::error::ApiError;
@@ -700,14 +703,14 @@ fn get_allow_origin_header_value<'a>(
 ) -> Option<&'a str> {
     let origin_header = headers.get(ORIGIN);
     let origin = match origin_header {
-        Some(origin) => origin.to_str().unwrap_or("*"),
-        None => "*",
+        Some(origin) => origin.to_str().unwrap_or(""),
+        None => "",
     };
     let is_allowed = match (origin_header, allowed_origins) {
         (Some(_), Some(allowed_origins)) => allowed_origins.iter().any(|o| o == origin),
         (Some(_), None) => true,
         (None, Some(_)) => false,
-        (None, None) => true,
+        (None, None) => false,
     };
     if is_allowed { Some(origin) } else { None }
 }
@@ -717,14 +720,18 @@ fn cors_response(
     headers: &HeaderMap,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, RestError> {
     match origin {
-        Some(origin) => {
-            let allowed_headers = match headers.get("access-control-request-headers") {
-                Some(headers) => headers.to_str().unwrap_or("Authorization"),
-                None => "Authorization",
-            };
+        Some(o) => {
+            let allowed_headers = headers
+                .get(ACCESS_CONTROL_REQUEST_HEADERS)
+                .and_then(|a| a.to_str().ok())
+                .filter(|v| !v.is_empty())
+                .map_or_else(
+                    || "Authorization".to_string(),
+                    |v| format!("{v}, Authorization"),
+                );
             Response::builder()
                 .status(StatusCode::OK)
-                .header(ACCESS_CONTROL_ALLOW_ORIGIN, origin)
+                .header(ACCESS_CONTROL_ALLOW_ORIGIN, o)
                 .header("Access-Control-Allow-Methods", "GET, POST, PATCH, PUT, DELETE, OPTIONS")
                 .header("Access-Control-Max-Age", "86400")
                 .header("Access-Control-Expose-Headers", "Content-Encoding, Content-Location, Content-Range, Content-Type, Date, Location, Server, Transfer-Encoding, Range-Unit")
@@ -1209,7 +1216,7 @@ async fn handle_rest_inner(
     let mut response = Response::builder()
         .status(StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR))
         .header(CONTENT_TYPE, http_content_type)
-        .header(ACCESS_CONTROL_ALLOW_ORIGIN, allow_origin.unwrap_or("*"));
+        .header(ACCESS_CONTROL_ALLOW_ORIGIN, allow_origin.unwrap_or(""));
 
     // Add all headers from response_headers vector
     for (header_name, header_value) in response_headers {

--- a/proxy/src/serverless/rest.rs
+++ b/proxy/src/serverless/rest.rs
@@ -4,12 +4,12 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use http::Method;
-use http::header::{AUTHORIZATION, CONTENT_TYPE, HOST};
+use http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, AUTHORIZATION, CONTENT_TYPE, HOST, ORIGIN};
 use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Empty, Full};
 use http_utils::error::ApiError;
 use hyper::body::Incoming;
-use hyper::http::{HeaderName, HeaderValue};
+use hyper::http::{HeaderMap, HeaderName, HeaderValue};
 use hyper::{Request, Response, StatusCode};
 use indexmap::IndexMap;
 use ouroboros::self_referencing;
@@ -135,6 +135,8 @@ pub struct ApiConfig {
     pub role_claim_key: String,
     #[serde(default, deserialize_with = "deserialize_comma_separated_option")]
     pub db_extra_search_path: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_comma_separated_option")]
+    pub server_cors_allowed_origins: Option<Vec<String>>,
 }
 
 // The DbSchemaCache is a cache of the ApiConfig and DbSchemaOwned for each endpoint
@@ -171,6 +173,7 @@ impl DbSchemaCache {
                             db_allowed_select_functions: vec![],
                             role_claim_key: String::new(),
                             db_extra_search_path: None,
+                            server_cors_allowed_origins: None,
                         };
                         let value = Arc::new((api_config, schema_owned));
                         self.insert(endpoint_id.clone(), value);
@@ -503,7 +506,7 @@ pub(crate) async fn handle(
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, ApiError> {
     let result = handle_inner(cancel, config, &ctx, request, backend).await;
 
-    let mut response = match result {
+    let response = match result {
         Ok(r) => {
             ctx.set_success();
 
@@ -612,9 +615,6 @@ pub(crate) async fn handle(
         }
     };
 
-    response
-        .headers_mut()
-        .insert("Access-Control-Allow-Origin", HeaderValue::from_static("*"));
     Ok(response)
 }
 
@@ -694,6 +694,58 @@ async fn handle_inner(
     }
 }
 
+fn get_allow_origin_header_value<'a>(
+    headers: &'a HeaderMap,
+    allowed_origins: Option<&'a Vec<String>>,
+) -> Option<&'a str> {
+    let origin_header = headers.get(ORIGIN);
+    let origin = match origin_header {
+        Some(origin) => origin.to_str().unwrap_or("*"),
+        None => "*",
+    };
+    let is_allowed = match (origin_header, allowed_origins) {
+        (Some(_), Some(allowed_origins)) => allowed_origins.iter().any(|o| o == origin),
+        (Some(_), None) => true,
+        (None, Some(_)) => false,
+        (None, None) => true,
+    };
+    if is_allowed { Some(origin) } else { None }
+}
+
+fn cors_response(
+    origin: Option<&str>,
+    headers: &HeaderMap,
+) -> Result<Response<BoxBody<Bytes, hyper::Error>>, RestError> {
+    match origin {
+        Some(origin) => {
+            let allowed_headers = match headers.get("access-control-request-headers") {
+                Some(headers) => headers.to_str().unwrap_or("Authorization"),
+                None => "Authorization",
+            };
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(ACCESS_CONTROL_ALLOW_ORIGIN, origin)
+                .header("Access-Control-Allow-Methods", "GET, POST, PATCH, PUT, DELETE, OPTIONS")
+                .header("Access-Control-Max-Age", "86400")
+                .header("Access-Control-Expose-Headers", "Content-Encoding, Content-Location, Content-Range, Content-Type, Date, Location, Server, Transfer-Encoding, Range-Unit")
+                .header("Access-Control-Allow-Headers", allowed_headers)
+                .header("Allow", "OPTIONS, GET, POST, PATCH, PUT, DELETE")
+                .body(Empty::new().map_err(|x| match x {}).boxed())
+                .map_err(|e| RestError::SubzeroCore(InternalError {
+                    message: e.to_string(),
+                }))
+        }
+        None => Response::builder()
+            .status(StatusCode::OK)
+            .body(Empty::new().map_err(|x| match x {}).boxed())
+            .map_err(|e| {
+                RestError::SubzeroCore(InternalError {
+                    message: e.to_string(),
+                })
+            }),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_rest_inner(
     config: &'static ProxyConfig,
@@ -748,6 +800,13 @@ async fn handle_rest_inner(
         )
         .await?;
     let (api_config, db_schema_owned) = entry.as_ref();
+    let allow_origin = get_allow_origin_header_value(
+        &parts.headers,
+        api_config.server_cors_allowed_origins.as_ref(),
+    );
+    if parts.method == Method::OPTIONS {
+        return cors_response(allow_origin, &parts.headers);
+    }
     let db_schema = db_schema_owned.borrow_schema();
 
     let db_schemas = &api_config.db_schemas; // list of schemas available for the api
@@ -1149,7 +1208,8 @@ async fn handle_rest_inner(
     // build the response
     let mut response = Response::builder()
         .status(StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR))
-        .header(CONTENT_TYPE, http_content_type);
+        .header(CONTENT_TYPE, http_content_type)
+        .header(ACCESS_CONTROL_ALLOW_ORIGIN, allow_origin.unwrap_or("*"));
 
     // Add all headers from response_headers vector
     for (header_name, header_value) in response_headers {


### PR DESCRIPTION
## Problem
rest broker needs to respond with the correct cors headers for the api to be usable from other domains

## Summary of changes
added a code path in rest broker to handle the OPTIONS requests


note: project_info.rs was changed by cargo fmt