### PR TITLE
fix(test): test_readonly_node_gc compute needs time to acquire lease

### DIFF
--- a/test_runner/regress/test_readonly_node.py
+++ b/test_runner/regress/test_readonly_node.py
@@ -130,7 +130,7 @@ def test_readonly_node_gc(neon_env_builder: NeonEnvBuilder):
     """
 
     LSN_LEASE_LENGTH = (
-        20  # This value needs to be large enough for compute_ctl to send two lease requests.
+        14  # This value needs to be large enough for compute_ctl to send two lease requests.
     )
 
     neon_env_builder.num_pageservers = 2
@@ -292,6 +292,9 @@ def test_readonly_node_gc(neon_env_builder: NeonEnvBuilder):
                 env.pageservers[0].id, {"availability": "Offline"}
             )
             env.storage_controller.reconcile_until_idle()
+
+            # Wait for static compute to renew lease on the new pageserver.
+            time.sleep(LSN_LEASE_LENGTH)
 
             trigger_gc_and_select(
                 env,

--- a/test_runner/regress/test_readonly_node.py
+++ b/test_runner/regress/test_readonly_node.py
@@ -275,6 +275,9 @@ def test_readonly_node_gc(neon_env_builder: NeonEnvBuilder):
             for ps in env.pageservers:
                 ps.start()
 
+            # Wait for static compute to renew lease at least once.
+            time.sleep(LSN_LEASE_LENGTH)
+
             trigger_gc_and_select(
                 env,
                 ep_static,


### PR DESCRIPTION
## Problem

Part of LKB-2368. Compute fails to obtain LSN lease in this test case. There're many assumptions around how compute obtains the leases, and in this particular test case, as the LSN lease length is only 8s (which is shorter than the amount of time where pageserver can restart and compute can reconnect in terms of force stop), it sometimes cause issues.

## Summary of changes

Add more sleeps around the test case to ensure it's stable at least. We need to find a more reliable way to test this in the future.
