### PR TITLE
fix(safekeeper): retry if open segment fail

### DIFF
--- a/safekeeper/src/wal_backup.rs
+++ b/safekeeper/src/wal_backup.rs
@@ -626,8 +626,8 @@ pub async fn read_object(
     let download = backoff::retry(
         || async { storage.download(file_path, &opts, &cancel).await },
         DownloadError::is_permanent,
-        1,
         2,
+        3,
         "download WAL segment",
         &cancel,
     )

--- a/safekeeper/src/wal_backup.rs
+++ b/safekeeper/src/wal_backup.rs
@@ -607,6 +607,9 @@ pub(crate) async fn copy_partial_segment(
     storage.copy_object(source, destination, &cancel).await
 }
 
+const WAL_READ_WARN_THRESHOLD: u32 = 2;
+const WAL_READ_MAX_RETRIES: u32 = 3;
+
 pub async fn read_object(
     storage: &GenericRemoteStorage,
     file_path: &RemotePath,
@@ -626,8 +629,8 @@ pub async fn read_object(
     let download = backoff::retry(
         || async { storage.download(file_path, &opts, &cancel).await },
         DownloadError::is_permanent,
-        2,
-        3,
+        WAL_READ_WARN_THRESHOLD,
+        WAL_READ_MAX_RETRIES,
         "download WAL segment",
         &cancel,
     )


### PR DESCRIPTION
## Problem

Fix LKB-2632.

The safekeeper wal read path does not seem to retry at all. This would cause client read errors on the customer side.

## Summary of changes

- Retry on `safekeeper::wal_backup::read_object`.
- Note that this only retries on S3 HTTP connection errors. Subsequent reads could fail, and that needs more refactors to make the retry mechanism work across the path.
