### PR TITLE
safekeeper: use last_log_term in mconf switch + choose most advanced sk in pull timeline

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -33,6 +33,9 @@ use std::{env, fs};
 use tokio::{spawn, sync::watch, task::JoinHandle, time};
 use tracing::{Instrument, debug, error, info, instrument, warn};
 use url::Url;
+use utils::backoff::{
+    DEFAULT_BASE_BACKOFF_SECONDS, DEFAULT_MAX_BACKOFF_SECONDS, exponential_backoff_duration,
+};
 use utils::id::{TenantId, TimelineId};
 use utils::lsn::Lsn;
 use utils::measured_stream::MeasuredReader;
@@ -1448,6 +1451,41 @@ impl ComputeNode {
         Ok(lsn)
     }
 
+    fn sync_safekeepers_with_retries(&self, storage_auth_token: Option<String>) -> Result<Lsn> {
+        let max_retries = 5;
+        let mut attempts = 0;
+        loop {
+            let result = self.sync_safekeepers(storage_auth_token.clone());
+            match &result {
+                Ok(_) => {
+                    if attempts > 0 {
+                        tracing::info!("sync_safekeepers succeeded after {attempts} retries");
+                    }
+                    return result;
+                }
+                Err(e) if attempts < max_retries => {
+                    tracing::info!(
+                        "sync_safekeepers failed, will retry (attempt {attempts}): {e:#}"
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "sync_safekeepers still failed after {attempts} retries, giving up: {err:?}"
+                    );
+                    return result;
+                }
+            }
+            // sleep and retry
+            let backoff = exponential_backoff_duration(
+                attempts,
+                DEFAULT_BASE_BACKOFF_SECONDS,
+                DEFAULT_MAX_BACKOFF_SECONDS,
+            );
+            std::thread::sleep(backoff);
+            attempts += 1;
+        }
+    }
+
     /// Do all the preparations like PGDATA directory creation, configuration,
     /// safekeepers sync, basebackup, etc.
     #[instrument(skip_all)]
@@ -1483,7 +1521,7 @@ impl ComputeNode {
                     lsn
                 } else {
                     info!("starting safekeepers syncing");
-                    self.sync_safekeepers(pspec.storage_auth_token.clone())
+                    self.sync_safekeepers_with_retries(pspec.storage_auth_token.clone())
                         .with_context(|| "failed to sync safekeepers")?
                 };
                 info!("safekeepers synced at LSN {}", lsn);

--- a/safekeeper/src/timeline.rs
+++ b/safekeeper/src/timeline.rs
@@ -195,12 +195,14 @@ impl StateSK {
         to: Configuration,
     ) -> Result<TimelineMembershipSwitchResponse> {
         let result = self.state_mut().membership_switch(to).await?;
+        let flush_lsn = self.flush_lsn();
+        let last_log_term = self.state().acceptor_state.get_last_log_term(flush_lsn);
 
         Ok(TimelineMembershipSwitchResponse {
             previous_conf: result.previous_conf,
             current_conf: result.current_conf,
-            last_log_term: self.state().acceptor_state.term,
-            flush_lsn: self.flush_lsn(),
+            last_log_term,
+            flush_lsn,
         })
     }
 

--- a/test_runner/fixtures/neon_fixtures.py
+++ b/test_runner/fixtures/neon_fixtures.py
@@ -2314,6 +2314,7 @@ class NeonStorageController(MetricsGetter, LogUtils):
         timeline_id: TimelineId,
         new_sk_set: list[int],
     ):
+        log.info(f"migrate_safekeepers({tenant_id}, {timeline_id}, {new_sk_set})")
         response = self.request(
             "POST",
             f"{self.api}/v1/tenant/{tenant_id}/timeline/{timeline_id}/safekeeper_migrate",

--- a/test_runner/regress/test_safekeeper_migration.py
+++ b/test_runner/regress/test_safekeeper_migration.py
@@ -382,8 +382,8 @@ def test_safekeeper_migration_stale_timeline(neon_env_builder: NeonEnvBuilder):
 
 def test_pull_from_most_advanced_sk(neon_env_builder: NeonEnvBuilder):
     """
-    Test that we pull timeline from the most advanced safekeeper during the
-    migration and do not loose committed WAL.
+    Test that we pull the timeline from the most advanced safekeeper during the
+    migration and do not lose committed WAL.
     """
     neon_env_builder.num_safekeepers = 4
     neon_env_builder.storage_controller_config = {

--- a/test_runner/regress/test_safekeeper_migration.py
+++ b/test_runner/regress/test_safekeeper_migration.py
@@ -352,7 +352,7 @@ def test_safekeeper_migration_stale_timeline(neon_env_builder: NeonEnvBuilder):
     # TODO(diko): now it fails because the timeline on other_sk is stale and there is no compute
     # to catch up it with active_sk. It might be fixed in https://databricks.atlassian.net/browse/LKB-946
     # if we delete stale timelines before starting the migration.
-    # But the rest of the test is still valid: we should not loose committed WAL after the migration.
+    # But the rest of the test is still valid: we should not lose committed WAL after the migration.
     with pytest.raises(
         StorageControllerApiException, match="not enough successful .* to reach quorum"
     ):
@@ -372,7 +372,7 @@ def test_safekeeper_migration_stale_timeline(neon_env_builder: NeonEnvBuilder):
         env.initial_tenant, env.initial_timeline, [other_sk.id]
     )
 
-    # Check that we didn't loose committed WAL.
+    # Check that we didn't lose committed WAL.
     assert (
         other_sk.http_client().timeline_status(env.initial_tenant, env.initial_timeline).flush_lsn
         >= commit_lsn
@@ -454,7 +454,7 @@ def test_pull_from_most_advanced_sk(neon_env_builder: NeonEnvBuilder):
 
     commit_lsn_after_migration = get_commit_lsn(new_sk_set2)
 
-    # We should not loose committed WAL.
+    # We should not lose committed WAL.
     # If we have choosen the lagging sk to pull the timeline from, this might fail.
     assert commit_lsn_before_migration <= commit_lsn_after_migration
 


### PR DESCRIPTION
## Problem
I discovered two bugs corresponding to safekeeper migration, which together might lead to a data loss during the migration. The second bug is from a hadron patch and might lead to a data loss during the safekeeper restore in hadron as well.

1. `switch_membership` returns the current `term` instead of `last_log_term`. It is used to choose the `sync_position` in the algorithm, so we might choose the wrong one and break the correctness guarantees.
2. The current `term` is used to choose the most advanced SK in `pull_timeline` with higher priority than `flush_lsn`. It is incorrect because the most advanced safekeeper is the one with the highest `(last_log_term, flush_lsn)` pair. The compute might bump term on the least advanced sk, making it the best choice to pull from, and thus making committed log entries "uncommitted" after `pull_timeline`

Part of https://databricks.atlassian.net/browse/LKB-1017

## Summary of changes
- Return `last_log_term` in `switch_membership`
- Use `(last_log_term, flush_lsn)` as a primary key for choosing the most advanced sk in `pull_timeline` and deny pulling if the `max_term` is higher than on the most advanced sk (hadron only)
- Write tests for both cases
- Retry `sync_safekeepers` in `compute_ctl`
- Take into the account the quorum size when calculating `sync_position`
