### PR TITLE
Check postgresql ALPN value for direct SSL connections

### DIFF
--- a/proxy/src/pglb/handshake.rs
+++ b/proxy/src/pglb/handshake.rs
@@ -139,7 +139,7 @@ pub(crate) async fn handshake<S: AsyncRead + AsyncWrite + Unpin + Send>(
                         match conn_info.alpn_protocol() {
                             None => {
                                 if direct.is_some() {
-                                    warn!("missing ALPN protocol 'postgresql'");
+                                    warn!("missing ALPN");
                                     return Err(HandshakeError::ProtocolViolation);
                                 }
                             }


### PR DESCRIPTION
## Problem

Neon proxy accepts direct SSL Postgres-protocol connections with no ALPN protocol specified, whereas a real Postgres server does not.

## Summary of changes

Make proxy reject direct SSL connections unless the ALPN protocol is `postgresql`. Traditional SSL connections (starting with an `SSLRequest` message) are unaffected.

## Testing

```bash
openssl s_client endpoint.local.neon.build:4432  # should quit with EOF error (previously it didn't)
openssl s_client -alpn postgresql endpoint.local.neon.build:4432  # should hang awaiting data
PGSSLROOTCERT=./server.crt psql "postgresql://proxy:password@endpoint.local.neon.build:4432/postgres?sslmode=verify-full&sslnegotiation=direct"  # should continue to work
```