### PR TITLE
lock free semaphore map

### DIFF
--- a/proxy/src/binary/local_proxy.rs
+++ b/proxy/src/binary/local_proxy.rs
@@ -225,21 +225,14 @@ pub async fn run() -> anyhow::Result<()> {
 /// ProxyConfig is created at proxy startup, and lives forever.
 fn build_config(args: &LocalProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
     let config::ConcurrencyLockOptions {
-        shards,
         limiter,
         epoch,
         timeout,
     } = args.connect_compute_lock.parse()?;
-    info!(
-        ?limiter,
-        shards,
-        ?epoch,
-        "Using NodeLocks (connect_compute)"
-    );
+    info!(?limiter, ?epoch, "Using NodeLocks (connect_compute)");
     let connect_compute_locks = ApiLocks::new(
         "connect_compute_lock",
         limiter,
-        shards,
         timeout,
         epoch,
         &Metrics::get().proxy.connect_compute_lock,

--- a/proxy/src/binary/proxy.rs
+++ b/proxy/src/binary/proxy.rs
@@ -658,21 +658,14 @@ fn build_config(args: &ProxyCliArgs) -> anyhow::Result<&'static ProxyConfig> {
     };
 
     let config::ConcurrencyLockOptions {
-        shards,
         limiter,
         epoch,
         timeout,
     } = args.connect_compute_lock.parse()?;
-    info!(
-        ?limiter,
-        shards,
-        ?epoch,
-        "Using NodeLocks (connect_compute)"
-    );
+    info!(?limiter, ?epoch, "Using NodeLocks (connect_compute)");
     let connect_compute_locks = control_plane::locks::ApiLocks::new(
         "connect_compute_lock",
         limiter,
-        shards,
         timeout,
         epoch,
         &Metrics::get().proxy.connect_compute_lock,
@@ -796,16 +789,14 @@ fn build_auth_backend(
             )));
 
             let config::ConcurrencyLockOptions {
-                shards,
                 limiter,
                 epoch,
                 timeout,
             } = args.wake_compute_lock.parse()?;
-            info!(?limiter, shards, ?epoch, "Using NodeLocks (wake_compute)");
+            info!(?limiter, ?epoch, "Using NodeLocks (wake_compute)");
             let locks = Box::leak(Box::new(control_plane::locks::ApiLocks::new(
                 "wake_compute_lock",
                 limiter,
-                shards,
                 timeout,
                 epoch,
                 &Metrics::get().wake_compute_lock,
@@ -874,16 +865,14 @@ fn build_auth_backend(
             )));
 
             let config::ConcurrencyLockOptions {
-                shards,
                 limiter,
                 epoch,
                 timeout,
             } = args.wake_compute_lock.parse()?;
-            info!(?limiter, shards, ?epoch, "Using NodeLocks (wake_compute)");
+            info!(?limiter, ?epoch, "Using NodeLocks (wake_compute)");
             let locks = Box::leak(Box::new(control_plane::locks::ApiLocks::new(
                 "wake_compute_lock",
                 limiter,
-                shards,
                 timeout,
                 epoch,
                 &Metrics::get().wake_compute_lock,

--- a/proxy/src/rate_limiter/limit_algorithm/aimd.rs
+++ b/proxy/src/rate_limiter/limit_algorithm/aimd.rs
@@ -89,6 +89,7 @@ mod tests {
         let limiter = DynamicLimiter::new(config);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
@@ -97,6 +98,7 @@ mod tests {
         assert_eq!(limiter.state().limit(), 2);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
@@ -104,6 +106,7 @@ mod tests {
         assert_eq!(limiter.state().limit(), 2);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
@@ -111,6 +114,7 @@ mod tests {
         assert_eq!(limiter.state().limit(), 1);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
@@ -136,6 +140,7 @@ mod tests {
         let limiter = DynamicLimiter::new(config);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(100))
             .await
             .unwrap();
@@ -162,11 +167,13 @@ mod tests {
         let limiter = DynamicLimiter::new(config);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
         let now = tokio::time::Instant::now();
         limiter
+            .clone()
             .acquire_timeout(Duration::from_secs(1))
             .await
             .err()
@@ -197,14 +204,17 @@ mod tests {
         let limiter = DynamicLimiter::new(config);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
         let _token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
         let _token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
@@ -231,6 +241,7 @@ mod tests {
         let limiter = DynamicLimiter::new(config);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();
@@ -261,6 +272,7 @@ mod tests {
         let limiter = DynamicLimiter::new(config);
 
         let token = limiter
+            .clone()
             .acquire_timeout(Duration::from_millis(1))
             .await
             .unwrap();


### PR DESCRIPTION
## Problem

We have a hashmap of semaphores so we can limit things like number of concurrent connections to compute, or number of concurrent wake_compute requests. This is currently lock-based with a shards. This is not really a bottleneck, but the GC interval might be slow and cause the lock to be held throughout.

## Summary of changes

Switch to papaya for lock-free hashmap + GC.