### PR TITLE
fix(compute_ctl): race if pageserver connstr changes

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -2648,7 +2648,11 @@ LIMIT 100",
     /// the pageserver connection strings has changed.
     ///
     /// The operation will time out after a specified duration.
-    pub fn wait_timeout_while_pageserver_connstr_unchanged(&self, duration: Duration) {
+    pub fn wait_timeout_while_pageserver_connstr_unchanged(
+        &self,
+        duration: Duration,
+        request_pageserver_conninfo: &PageserverConnectionInfo,
+    ) {
         let state = self.state.lock().unwrap();
         let old_pageserver_conninfo = state
             .pspec
@@ -2656,6 +2660,10 @@ LIMIT 100",
             .expect("spec must be set")
             .pageserver_conninfo
             .clone();
+        if request_pageserver_conninfo != &old_pageserver_conninfo {
+            info!("Pageserver config changed during the previous request");
+            return;
+        }
         let mut unchanged = true;
         let _ = self
             .state_changed


### PR DESCRIPTION
## Problem

close LKB-2634

If the connstring changes through the request, we currently don't issue lease requests again, which might cause issues if the lease length is too small. 10m in prod is fine, but in some test cases we only have a few seconds.

## Summary of changes

- We check connstring changes through the request so that we wait fewer time before the next retry.