### PR TITLE
[DO NOT MERGE] run coverage-report on subset of runners

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -4,6 +4,7 @@ self-hosted-runner:
     - large
     - large-arm64
     - small
+    - small-debug
     - small-metal
     - small-arm64
     - unit-perf

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -534,6 +534,11 @@ jobs:
           REPORT_URL=https://${BUCKET}.s3.amazonaws.com/code-coverage/${COMMIT_SHA}/lcov/summary.json
           echo "summary-json=${REPORT_URL}" >> $GITHUB_OUTPUT
 
+      - name: Sleep for debug
+        if: always() && steps.upload-coverage-report-new.conclusion == 'failure'
+        run: |
+          sleep 3600
+
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           REPORT_URL_NEW: ${{ steps.upload-coverage-report-new.outputs.report-url }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -442,7 +442,7 @@ jobs:
       id-token: write # aws-actions/configure-aws-credentials
       statuses: write
       contents: write
-    runs-on: [ self-hosted, small ]
+    runs-on: [ self-hosted, small-debug ]
     container:
       image: ${{ needs.build-build-tools-image.outputs.image }}-bookworm
       credentials:


### PR DESCRIPTION
## Problem
Debug the issue with:
```
fatal: detected dubious ownership in repository at '/__w/neon/neon'
```

so for debug purpose run that job only on subset of runners where I can log in and check the state

## Summary of changes
