### PR TITLE
add vary: origin header when needed

### DIFF
--- a/proxy/src/serverless/rest.rs
+++ b/proxy/src/serverless/rest.rs
@@ -765,10 +765,10 @@ fn apply_common_cors_headers(
             ACCESS_CONTROL_EXPOSE_HEADERS_VALUE,
         );
         if let Some(origin) = response_allow_origin {
-            h.insert(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
             if origin != HEADER_VALUE_ALLOW_ALL_ORIGINS {
                 h.insert(VARY, ACCESS_CONTROL_VARY_VALUE);
             }
+            h.insert(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
         }
     }
 }


### PR DESCRIPTION
## Problem
when returning cors headers, origin is fixed the Vary header is needed for things to function properly
```
Access-Control-Allow-Origin: https://developer.mozilla.org
Vary: Origin
```
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin#cors_and_caching

fix for the issues flagged in [this comment](https://github.com/neondatabase/neon/pull/12744#discussion_r2245357062)

## Summary of changes
* add the vary header
* add a note related to finding a solution for when we don't have a cached configuration for the "allowed_origins"
