### PR TITLE
Replica promotion fixes

### DIFF
--- a/compute_tools/src/compute_promote.rs
+++ b/compute_tools/src/compute_promote.rs
@@ -40,7 +40,9 @@ impl ComputeNode {
     }
 
     async fn promote_impl(self: &Arc<Self>, cfg: PromoteConfig) -> anyhow::Result<PromoteState> {
-        let safekeepers_str = cfg.spec.safekeeper_connstrings.join(",");
+        #[allow(unused_mut)]
+        let mut new_pspec = crate::compute::ParsedSpec::try_from(cfg.spec).expect("invalid spec");
+        let safekeepers_str = new_pspec.safekeeper_connstrings.join(",");
         if safekeepers_str.is_empty() {
             bail!("empty safekeepers list");
         }
@@ -131,8 +133,6 @@ impl ComputeNode {
         }
 
         // Already checked validity in http handler
-        #[allow(unused_mut)]
-        let mut new_pspec = crate::compute::ParsedSpec::try_from(cfg.spec).expect("invalid spec");
         {
             let mut state = self.state.lock().unwrap();
 

--- a/test_runner/regress/test_replica_promotes.py
+++ b/test_runner/regress/test_replica_promotes.py
@@ -184,11 +184,14 @@ def test_replica_promote_handler_disconnects(neon_simple_env: NeonEnv):
     once, and no error is thrown
     """
     env: NeonEnv = neon_simple_env
-    primary: Endpoint = env.endpoints.create_start(branch_name="main", endpoint_id="primary")
+    primary: Endpoint = env.endpoints.create(branch_name="main", endpoint_id="primary")
+    # Also test catalog updates don't trigger any issues
+    primary.respec(skip_pg_catalog_updates=False)
+    primary.start()
+
     secondary: Endpoint = env.endpoints.new_replica_start(origin=primary, endpoint_id="secondary")
 
     with primary.connect() as conn, conn.cursor() as cur:
-        cur.execute("create schema neon;create extension neon with schema neon")
         cur.execute("create table t(pk bigint GENERATED ALWAYS AS IDENTITY, payload integer)")
         cur.execute("INSERT INTO t(payload) SELECT generate_series(1, 100)")
 


### PR DESCRIPTION
- Launch `reconfigure()` on a blocking thread to avoid nested runtime panic
- Catch empty safekeepers list early
