### PR TITLE
Filter obsolete layer files from an older generation from heatmap

### DIFF
--- a/pageserver/src/tenant.rs
+++ b/pageserver/src/tenant.rs
@@ -1580,7 +1580,7 @@ impl TenantShard {
     }
 
     #[instrument(skip_all)]
-    pub(crate) async fn preload(
+    pub(crate) async fn  preload(
         self: &Arc<Self>,
         remote_storage: &GenericRemoteStorage,
         cancel: CancellationToken,

--- a/pageserver/src/tenant/timeline/layer_manager.rs
+++ b/pageserver/src/tenant/timeline/layer_manager.rs
@@ -645,8 +645,13 @@ impl OpenLayerManager {
 
     #[cfg(test)]
     pub(crate) fn force_insert_layer(&mut self, layer: ResidentLayer) {
+        self.force_insert_optionally_resident_layer(layer.as_ref().clone());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn force_insert_optionally_resident_layer(&mut self, layer: Layer) {
         let mut updates = self.layer_map.batch_update();
-        Self::insert_historic_layer(layer.as_ref().clone(), &mut updates, &mut self.layer_fmgr);
+        Self::insert_historic_layer(layer, &mut updates, &mut self.layer_fmgr);
         updates.flush()
     }
 


### PR DESCRIPTION
## Problem

 * Fixes LKB-2399

In some edge case in production we've seen a tenant stuck with a secondary that downloads an older generation layer file than the one in the index and then when it becomes primary each time we do a deploy it logs an error about the file on disk being the wrong length. This is generally harmless for user correctness but is not optimal and an alarming error.

## Summary of changes

This PR contains the 3 lines of fix (which is to check generation matches while including existing files in the next layer map) but is mostly testing method changes to setup the right state to test that. It feels like a low-risk enough change that a huge effort or refactor of testing code to make it testable probably isn't warranted, but this seemed to be small enough and not too unpleasant to be worth keeping. I'm open to feedback though if reviewers disagree.

There is one FIXME comment in timeline `reconcile` because I found a subtle issue that is kind of a bug but neutralised by  implicit semantics right now. We should probably keep that in mind in future so a comment seems useful, but the fix seemed like too much scope creep to include here since there will be zero impact immediately anyway. If others would prefer a fix and agree we could make that a follow on but I suspect there is higher value work to do!
