### PR TITLE
remove obsolete comment - this is a dummy commit

### DIFF
--- a/.github/workflows/large_oltp_growth.yml
+++ b/.github/workflows/large_oltp_growth.yml
@@ -2,9 +2,6 @@ name: large oltp growth
 # workflow to grow the reuse branch of large oltp benchmark continuously (about 16 GB per run)
 
 on:
-  # uncomment to run on push for debugging your PR
-  # push:
-  #  branches: [ bodobolero/increase_large_oltp_workload ]
 
   schedule:
     # * is a special character in YAML so you have to quote this string


### PR DESCRIPTION
## Problem

we ran out of commit comment on same commit sha, [see](https://github.com/neondatabase/neon/actions/runs/17190868211/job/48766305883#step:10:591)

## Summary of changes

Push another commit to neondatabase/neon.git to create a new commit sha on main branch