### PR TITLE
feat: support OTEL_SERVICE_NAME env var for compute_ctl

### DIFF
--- a/compute_tools/src/logger.rs
+++ b/compute_tools/src/logger.rs
@@ -57,8 +57,10 @@ pub fn init_tracing_and_logging(
     };
 
     // Initialize OpenTelemetry
+    let service_name = std::env::var("OTEL_SERVICE_NAME")
+        .unwrap_or_else(|_| "compute_ctl".to_string());
     let provider =
-        tracing_utils::init_tracing("compute_ctl", tracing_utils::ExportConfig::default());
+        tracing_utils::init_tracing(&service_name, tracing_utils::ExportConfig::default());
     let otlp_layer = provider.as_ref().map(tracing_utils::layer);
 
     // Put it all together


### PR DESCRIPTION
## Problem

The OpenTelemetry service name in compute_ctl is hardcoded as "compute_ctl" and cannot be customized for monitoring integrations.

## Summary of changes

Allow overriding the default "compute_ctl" service name via OTEL_SERVICE_NAME environment variable for OpenTelemetry tracing. Falls back to "compute_ctl" if not set.
