### PR TITLE
fix(control_plane): Fix incorrect file path of identity.toml in error message

### DIFF
--- a/control_plane/src/pageserver.rs
+++ b/control_plane/src/pageserver.rs
@@ -233,8 +233,8 @@ impl PageServerNode {
         let mut identity_file = std::fs::OpenOptions::new()
             .create_new(true)
             .write(true)
-            .open(identity_file_path)
-            .with_context(|| format!("open identity toml for write: {config_file_path:?}"))?;
+            .open(&identity_file_path)
+            .with_context(|| format!("open identity toml for write: {identity_file_path:?}"))?;
         let identity_toml = self.pageserver_make_identity_toml(node_id);
         identity_file
             .write_all(identity_toml.to_string().as_bytes())


### PR DESCRIPTION
## Problem
Control_plane shows incorrect file path when identity.toml file open fails.

## Summary of changes
In the error context, when writing identity.toml, I changed it to use identity_file_path instead of config_file_path.