### PR TITLE
refactor(compaction): rename skip_some to add and update implementation

### DIFF
--- a/pageserver/compaction/src/compact_tiered.rs
+++ b/pageserver/compaction/src/compact_tiered.rs
@@ -714,7 +714,7 @@ impl<K: CompactionKey> KeyspaceWindowPos<K> {
                 self.accum_keysize += distance as u64;
             } else {
                 // advance within the range
-                let skip_key = self.end_key.skip_some();
+                let skip_key = self.end_key.add(128);
                 let distance = K::key_range_size(&(self.end_key..skip_key), shard_identity);
                 if (self.accum_keysize + distance as u64) < max_size {
                     self.end_key = skip_key;

--- a/pageserver/compaction/src/interface.rs
+++ b/pageserver/compaction/src/interface.rs
@@ -109,10 +109,8 @@ pub trait CompactionKey: std::cmp::Ord + Clone + Copy + std::fmt::Display {
     // return "self + 1"
     fn next(&self) -> Self;
 
-    // return "self + <some decent amount to skip>". The amount to skip
-    // is left to the implementation.
-    // FIXME: why not just "add(u32)" ?  This is hard to use
-    fn skip_some(&self) -> Self;
+    // return "self + offset"
+    fn add(&self, offset: u32) -> Self;
 }
 
 impl CompactionKey for Key {
@@ -125,8 +123,8 @@ impl CompactionKey for Key {
     fn next(&self) -> Key {
         (self as &Key).next()
     }
-    fn skip_some(&self) -> Key {
-        self.add(128)
+    fn add(&self, offset: u32) -> Key {
+        (self as &Key).add(offset)
     }
 }
 

--- a/pageserver/compaction/src/simulator.rs
+++ b/pageserver/compaction/src/simulator.rs
@@ -75,9 +75,8 @@ impl interface::CompactionKey for Key {
     fn next(&self) -> Self {
         self + 1
     }
-    fn skip_some(&self) -> Self {
-        // round up to next xx
-        self + 100
+    fn add(&self, offset: u32) -> Self {
+        self + offset as u64
     }
 }
 


### PR DESCRIPTION
## Summary

  Refactors the `CompactionKey` trait to replace `skip_some()` with `add(u32)`, addressing the FIXME comment in       
  `pageserver/compaction/src/interface.rs:114`.

  ## Changes

  - **interface.rs**: Replace `skip_some()` method with `add(offset: u32)` in `CompactionKey` trait
  - **simulator.rs**: Update mock implementation to use new `add()` method
  - **compact_tiered.rs**: Update call site to explicitly use `add(128)`

  ## Motivation

  The previous `skip_some()` method was inflexible - it advanced by a hardcoded amount that implementors couldn't     
  control. The FIXME comment noted "why not just add(u32)? This is hard to use."

  This change makes the API more flexible by allowing callers to specify exactly how much to advance, making the      
  intent clearer at call sites.
