### PR TITLE
http-utils, vm_monitor: fix 'occured' -> 'occurred' typos

### DIFF
--- a/libs/http-utils/src/server.rs
+++ b/libs/http-utils/src/server.rs
@@ -40,7 +40,7 @@ static CONNECTION_STARTED_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 static CONNECTION_ERROR_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "http_server_connection_errors_total",
-        "Number of occured connection errors by type",
+        "Number of occurred connection errors by type",
         &["type"]
     )
     .expect("failed to define a metric")

--- a/libs/vm_monitor/src/protocol.rs
+++ b/libs/vm_monitor/src/protocol.rs
@@ -71,7 +71,7 @@ pub enum OutboundMsgKind {
     /// *Note*: this is a struct variant because of the way go serializes struct{}
     UpscaleRequest {},
     /// Returned to the agent once we have finished attempting to downscale. If
-    /// an error occured trying to do so, an `InternalError` will get returned instead.
+    /// an error occurred trying to do so, an `InternalError` will get returned instead.
     /// However, if we are simply unsuccessful (for example, do to needing the resources),
     /// that gets included in the `DownscaleResult`.
     DownscaleResult {


### PR DESCRIPTION
Two files contained `occured`:
- `libs/http-utils/src/server.rs` line 43: metric description string
- `libs/vm_monitor/src/protocol.rs` line 74: doc comment

Fixed to `occurred`. String-literal/comment-only change.