### PR TITLE
Refresh pinned Debian slim image digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ARG DEBIAN_FLAVOR=${DEBIAN_VERSION}-slim
 #       -I | grep -i docker-content-digest
 # 3. As a next step, TODO(fedordikarev): create script and schedule workflow to run these checks
 #    and updates on regular bases and in automated way.
-ARG BOOKWORM_SLIM_SHA=sha256:40b107342c492725bc7aacbe93a49945445191ae364184a6d24fedb28172f6f7
-ARG BULLSEYE_SLIM_SHA=sha256:e831d9a884d63734fe3dd9c491ed9a5a3d4c6a6d32c5b14f2067357c49b0b7e1
+ARG BOOKWORM_SLIM_SHA=sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+ARG BULLSEYE_SLIM_SHA=sha256:1a4701c321b1d28b1ff5f0230e766791e4b79b1d4c6c7a70064f4b297b1a330f
 
 # Here we use ${var/search/replace} syntax, to check
 # if base image is one of the images, we pin image index for.

--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -12,8 +12,8 @@ ARG DEBIAN_FLAVOR=${DEBIAN_VERSION}-slim
 #       -I | grep -i docker-content-digest
 # 3. As a next step, TODO(fedordikarev): create script and schedule workflow to run these checks
 #    and updates on regular bases and in automated way.
-ARG BOOKWORM_SLIM_SHA=sha256:40b107342c492725bc7aacbe93a49945445191ae364184a6d24fedb28172f6f7
-ARG BULLSEYE_SLIM_SHA=sha256:e831d9a884d63734fe3dd9c491ed9a5a3d4c6a6d32c5b14f2067357c49b0b7e1
+ARG BOOKWORM_SLIM_SHA=sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+ARG BULLSEYE_SLIM_SHA=sha256:1a4701c321b1d28b1ff5f0230e766791e4b79b1d4c6c7a70064f4b297b1a330f
 
 # Here we use ${var/search/replace} syntax, to check
 # if base image is one of the images, we pin image index for.

--- a/compute/compute-node.Dockerfile
+++ b/compute/compute-node.Dockerfile
@@ -92,8 +92,8 @@ ARG DEBIAN_FLAVOR=${DEBIAN_VERSION}-slim
 #       -I | grep -i docker-content-digest
 # 3. As a next step, TODO(fedordikarev): create script and schedule workflow to run these checks
 #    and updates on regular bases and in automated way.
-ARG BOOKWORM_SLIM_SHA=sha256:40b107342c492725bc7aacbe93a49945445191ae364184a6d24fedb28172f6f7
-ARG BULLSEYE_SLIM_SHA=sha256:e831d9a884d63734fe3dd9c491ed9a5a3d4c6a6d32c5b14f2067357c49b0b7e1
+ARG BOOKWORM_SLIM_SHA=sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+ARG BULLSEYE_SLIM_SHA=sha256:1a4701c321b1d28b1ff5f0230e766791e4b79b1d4c6c7a70064f4b297b1a330f
 
 # Here we use ${var/search/replace} syntax, to check
 # if base image is one of the images, we pin image index for.


### PR DESCRIPTION
## Summary

Refresh the pinned Debian slim index digests used by the storage image, build-tools image, and compute-node image builds.

The current pinned `bookworm-slim` and `bullseye-slim` digests point at older Debian image indices. Because the final runtime images are assembled from these pinned bases, rebuilding against refreshed Debian indices should reduce stale OS package findings in downstream container scanners without changing Neon application code or Dockerfile structure.

## Why

We run Neon self-hosted and container vulnerability scans flagged stale Debian base packages in the published `ghcr.io/neondatabase/neon` and `ghcr.io/neondatabase/compute-node-v16` images. We are temporarily using derivative images that run a Debian package refresh, but the better long-term fix is for upstream Neon images to rebuild from current pinned Debian bases so downstream users do not need to maintain forks.

## Validation

- `git diff --check`
- Confirmed the new Debian index digests resolve with `docker buildx imagetools inspect`.
- Compared Trivy Critical/High findings on the old vs. new base image indices:
  - `bookworm-slim`: 2 Critical / 22 High -> 2 Critical / 10 High
  - `bullseye-slim`: 3 Critical / 27 High -> 3 Critical / 14 High

I did not run the full Neon image build locally because the compute image build is large; this PR only updates the pinned Debian index digest values used by the existing build flow.
