### PR TITLE
fix(neon_local): allow restart of crashed compute endpoints

### DIFF
--- a/control_plane/src/bin/neon_local.rs
+++ b/control_plane/src/bin/neon_local.rs
@@ -1415,7 +1415,7 @@ async fn handle_endpoint(subcmd: &EndpointCmd, env: &local_env::LocalEnv) -> Res
             }
 
             if !args.allow_multiple {
-                cplane.check_conflicting_endpoints(mode, tenant_id, timeline_id)?;
+                cplane.check_conflicting_endpoints(mode, tenant_id, timeline_id, None)?;
             }
 
             cplane.new_endpoint(
@@ -1464,6 +1464,7 @@ async fn handle_endpoint(subcmd: &EndpointCmd, env: &local_env::LocalEnv) -> Res
                     endpoint.mode,
                     endpoint.tenant_id,
                     endpoint.timeline_id,
+                    Some(endpoint_id),
                 )?;
             }
 

--- a/control_plane/src/endpoint.rs
+++ b/control_plane/src/endpoint.rs
@@ -285,12 +285,18 @@ impl ComputeControlPlane {
         mode: ComputeMode,
         tenant_id: TenantId,
         timeline_id: TimelineId,
+        exclude_id: Option<&str>,
     ) -> Result<()> {
         if matches!(mode, ComputeMode::Primary) {
             // this check is not complete, as you could have a concurrent attempt at
             // creating another primary, both reading the state before checking it here,
             // but it's better than nothing.
-            let mut duplicates = self.endpoints.iter().filter(|(_k, v)| {
+            let mut duplicates = self.endpoints.iter().filter(|(k, v)| {
+                if let Some(exclude) = exclude_id {
+                    if k.as_str() == exclude {
+                        return false;
+                    }
+                }
                 v.tenant_id == tenant_id
                     && v.timeline_id == timeline_id
                     && v.mode == mode
@@ -1142,6 +1148,36 @@ impl Endpoint {
         mode: EndpointTerminateMode,
         destroy: bool,
     ) -> Result<TerminateResponse> {
+        // If the endpoint has crashed (stale pidfile, process already dead),
+        // skip pg_ctl stop and just clean up.  Verify the postmaster is truly
+        // gone before deleting its pidfile, because Crashed is a heuristic
+        // (300ms TCP timeout) and could false-positive during startup.
+        // Note: kill(pid, None) only checks process existence (ESRCH check),
+        // it does not send a signal.
+        if self.status() == EndpointStatus::Crashed {
+            let pidfile = self.pgdata().join("postmaster.pid");
+            let postmaster_alive = std::fs::read_to_string(&pidfile)
+                .ok()
+                .and_then(|s| s.lines().next()?.trim().parse::<i32>().ok())
+                .map(|pid| kill(nix::unistd::Pid::from_raw(pid), None).is_ok())
+                .unwrap_or(false);
+            if !postmaster_alive {
+                // postgres is dead; make sure compute_ctl follows it down
+                // before cleanup.  wait_until_stopped handles dead PIDs
+                // immediately (ESRCH → returns on first retry), so it is
+                // safe to call unconditionally.
+                let _ = self.wait_for_compute_ctl_to_exit(true);
+                if destroy {
+                    std::fs::remove_dir_all(self.endpoint_path())?;
+                } else {
+                    let _ = std::fs::remove_file(&pidfile);
+                }
+                return Ok(TerminateResponse { lsn: None });
+            }
+            // Falls through: postmaster is alive despite Crashed heuristic;
+            // proceed with normal stop path.
+        }
+
         // pg_ctl stop is fast but doesn't allow us to collect LSN. /terminate is
         // slow, and test runs time out. Solution: special mode "immediate-terminate"
         // which uses /terminate


### PR DESCRIPTION
## Problem

When a compute endpoint is killed externally (kill -9), `neon_local` cannot restart it:

- `cargo neon endpoint stop` fails because `pg_ctl` cannot signal a dead PID
- `cargo neon endpoint start` fails because `check_conflicting_endpoints` sees the crashed endpoint as a "duplicate primary" (status is `Crashed`, not `Stopped`)
- User is stuck

## Root cause

`check_conflicting_endpoints` iterates all endpoints and never excludes the endpoint being operated on. The status filter only excluded `Stopped`, not `Crashed`. Additionally, `stop()` unconditionally called `pg_ctl stop` which fails when the postmaster is already dead.

## Fix

1. **`check_conflicting_endpoints`**: Added `exclude_id: Option<&str>` parameter so an endpoint does not conflict with itself when being restarted. The `Create` path passes `None` (no-op), the `Start` path passes the endpoint being started.

2. **`stop()`**: Before attempting `pg_ctl stop`, check if the endpoint is `Crashed`. If so, verify the postmaster process is truly dead via `kill(pid, None)` (signal 0 — existence check only), then clean up the stale `postmaster.pid` and let `compute_ctl` shut down. If the postmaster is alive despite the `Crashed` heuristic (300ms TCP timeout false-positive during startup), fall through to the normal stop path.

## Testing

Manual testing confirmed all three paths work:
- `kill -9` → direct `cargo neon endpoint start` ✅
- `kill -9` → `cargo neon endpoint stop` → `start` ✅  
- Normal `stop` / `start` unaffected ✅

A regression test in `test_runner/` is planned but not included in this PR.