### PR TITLE
Fix lastWrittenLsnCache eviction order

### DIFF
--- a/pgxn/neon/neon_lwlsncache.c
+++ b/pgxn/neon/neon_lwlsncache.c
@@ -332,8 +332,8 @@ SetLastWrittenLSNForBlockRangeInternal(XLogRecPtr lsn,
 		for (i = 0; i < n_blocks; i++)
 		{
 			key.blockNum = from + i;
-			entry = hash_search(lastWrittenLsnCache, &key, HASH_ENTER, &found);
-			if (found)
+			entry = hash_search(lastWrittenLsnCache, &key, HASH_FIND, NULL);
+			if (entry != NULL)
 			{
 				if (lsn > entry->lsn)
 					entry->lsn = lsn;
@@ -344,8 +344,7 @@ SetLastWrittenLSNForBlockRangeInternal(XLogRecPtr lsn,
 			}
 			else
 			{
-				entry->lsn = lsn;
-				if (hash_get_num_entries(lastWrittenLsnCache) > LwLsnCache->lastWrittenLsnCacheSize)
+				if (hash_get_num_entries(lastWrittenLsnCache) >= LwLsnCache->lastWrittenLsnCacheSize)
 				{
 					/* Replace least recently used entry */
 					LastWrittenLsnCacheEntry* victim = dlist_container(LastWrittenLsnCacheEntry, lru_node, dlist_pop_head_node(&LwLsnCache->lastWrittenLsnLRU));
@@ -355,6 +354,10 @@ SetLastWrittenLSNForBlockRangeInternal(XLogRecPtr lsn,
 
 					hash_search(lastWrittenLsnCache, victim, HASH_REMOVE, NULL);
 				}
+
+				entry = hash_search(lastWrittenLsnCache, &key, HASH_ENTER, &found);
+				Assert(!found);
+				entry->lsn = lsn;
 			}
 			/* Link to the end of LRU list */
 			dlist_push_tail(&LwLsnCache->lastWrittenLsnLRU, &entry->lru_node);
@@ -429,8 +432,8 @@ neon_set_lwlsn_block_v(const XLogRecPtr *lsns, NRelFileInfo relfilenode,
 
 		Assert(lsn >= WalSegMinSize);
 		key.blockNum = blockno + i;
-		entry = hash_search(lastWrittenLsnCache, &key, HASH_ENTER, &found);
-		if (found)
+		entry = hash_search(lastWrittenLsnCache, &key, HASH_FIND, NULL);
+		if (entry != NULL)
 		{
 			if (lsn > entry->lsn)
 				entry->lsn = lsn;
@@ -441,8 +444,7 @@ neon_set_lwlsn_block_v(const XLogRecPtr *lsns, NRelFileInfo relfilenode,
 		}
 		else
 		{
-			entry->lsn = lsn;
-			if (hash_get_num_entries(lastWrittenLsnCache) > LwLsnCache->lastWrittenLsnCacheSize)
+			if (hash_get_num_entries(lastWrittenLsnCache) >= LwLsnCache->lastWrittenLsnCacheSize)
 			{
 				/* Replace least recently used entry */
 				LastWrittenLsnCacheEntry* victim = dlist_container(LastWrittenLsnCacheEntry, lru_node, dlist_pop_head_node(&LwLsnCache->lastWrittenLsnLRU));
@@ -452,6 +454,9 @@ neon_set_lwlsn_block_v(const XLogRecPtr *lsns, NRelFileInfo relfilenode,
 
 				hash_search(lastWrittenLsnCache, victim, HASH_REMOVE, NULL);
 			}
+			entry = hash_search(lastWrittenLsnCache, &key, HASH_ENTER, &found);
+			Assert(!found);
+			entry->lsn = lsn;
 		}
 		/* Link to the end of LRU list */
 		dlist_push_tail(&LwLsnCache->lastWrittenLsnLRU, &entry->lru_node);


### PR DESCRIPTION
## Problem

`lastWrittenLsnCache` is expected to stay within `neon.last_written_lsn_cache_size`. However, when the cache is full, inserting before eviction can require one extra shared hash entry.

With a fixed-size shared hash table, this can fail with `out-of-shared-memory`.

## Summary

Fixes #12905.

This PR changes `lastWrittenLsnCache` so that when a new entry needs to be inserted and the cache is already full, an existing entry is evicted before inserting the new one.

Previously, the code inserted the new entry first and evicted afterwards. This could temporarily require `neon.last_written_lsn_cache_size + 1` hash entries.


## Fix

For new keys, the code now ensures capacity before calling `HASH_ENTER`:

1. Check whether the entry already exists.
2. If it does not exist and the cache is full, evict an existing entry first.
3. Insert the new entry only after capacity has been made available.

## Testing

- Manually reproduced the issue by setting `neon.last_written_lsn_cache_size = 10` and adding `HASH_FIXED_SIZE` to the `ShmemInitHash` call for `lastWrittenLsnCache`.
- Verified that after the fix, the same workload no longer fails with `out-of-shared-memory`.

I did not add an automated test because the failure depends on shared hash table sizing and concurrent workload behavior. I would appreciate guidance on the best test location for this case.


