### PR TITLE
Clear error state before logging prewarm cancellation

### DIFF
--- a/pgxn/neon/file_cache.c
+++ b/pgxn/neon/file_cache.c
@@ -839,6 +839,7 @@ lfc_prewarm(FileCacheState* fcs, uint32 n_workers)
 			}
 			PG_CATCH();
 			{
+				FlushErrorState();
 				elog(LOG, "LFC: cancel prewarm");
 				lfc_ctl->prewarm_canceled = true;
 				interrupted = true;


### PR DESCRIPTION
## Problem

In `pgxn/neon/file_cache.c`, the prewarm cancellation path can enter `PG_CATCH()` when `WaitForBackgroundWorkerShutdown()` is interrupted, for example because of cancellation or another error.

The catch block currently calls `elog(LOG, ...)` before clearing the active error state. PostgreSQL keeps the backend in the error handling context until `FlushErrorState()` is called. If this path is hit repeatedly, the error data stack can keep growing. After 5 entries (`ERRORDATA_STACK_SIZE = 5`), PostgreSQL can raise:

```c
ereport(PANIC, (errmsg_internal("ERRORDATA_STACK_SIZE exceeded")));
```

## Summary of changes

Call `FlushErrorState()` before `elog(LOG, "LFC: cancel prewarm")` in the `PG_CATCH()` block, so the previous error state is cleared before the catch path calls back into PostgreSQL's error reporting machinery.

