### PR TITLE
proxy: include client peer address in control plane requests

### DIFF
--- a/proxy/src/control_plane/client/cplane_proxy_v1.rs
+++ b/proxy/src/control_plane/client/cplane_proxy_v1.rs
@@ -145,6 +145,7 @@ impl NeonControlPlaneClient {
                         ("application_name", ctx.console_application_name().as_str()),
                         ("endpointish", endpoint.as_str()),
                         ("role", role.as_str()),
+                        ("peer_addr", &ctx.peer_addr().to_string()),
                     ])
                     .build()?;
 
@@ -286,6 +287,7 @@ impl NeonControlPlaneClient {
                 .query(&[
                     ("application_name", application_name.as_str()),
                     ("endpointish", user_info.endpoint.as_str()),
+                    ("peer_addr", &ctx.peer_addr().to_string()),
                 ]);
 
             let options = user_info.options.to_deep_object();


### PR DESCRIPTION
## Problem

The control plane requests `get_endpoint_access_control` and `wake_compute` carry `session_id`, `application_name`, `endpointish` and `role`, but not the client's peer address. A control plane that wants to apply per-source-IP rate limiting or lockout has no synchronous signal to do so — the only place the client IP is currently observable to the control plane is the asynchronous parquet telemetry (`RequestData::peer_addr`), which is a batch channel to S3, unsuitable for online decisions.

## Summary of changes

Add `peer_addr` (from `ctx.peer_addr()`, already used proxy-side for the IP allowlist check) as a query parameter on both `get_endpoint_access_control` and `wake_compute`. Backwards-compatible: an unknown query parameter is ignored by control planes that don't consume it; no config flag.

Note on semantics: both responses are cached on the proxy side (`project_info` TTL, `node_info`), so the control plane sees only a sample of client IPs here and must not vary the response by peer. `peer_addr` in these requests is therefore telemetry / an input for rate limiters, not a per-attempt signal; a per-attempt channel (authentication outcome reporting) would be a separate change.
