### PR TITLE
compute_ctl: expose session/walsender/autovacuum counts in /status

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -179,6 +179,14 @@ pub struct ComputeState {
     pub last_active: Option<DateTime<Utc>>,
     pub error: Option<String>,
 
+    /// Activity counters from the last successful monitor check, exposed via
+    /// `/status` so an external control plane can make a precise suspend
+    /// decision (zero client sessions / walsenders / autovacuum) without a
+    /// separate SQL probe. `None` until the first successful check.
+    pub num_client_sessions: Option<i64>,
+    pub num_walsenders: Option<i64>,
+    pub num_autovacuum_workers: Option<i64>,
+
     /// Compute spec. This can be received from the CLI or - more likely -
     /// passed by the control plane with a /configure HTTP request.
     pub pspec: Option<ParsedSpec>,
@@ -215,6 +223,9 @@ impl ComputeState {
             status: ComputeStatus::Empty,
             last_active: None,
             error: None,
+            num_client_sessions: None,
+            num_walsenders: None,
+            num_autovacuum_workers: None,
             pspec: None,
             startup_span: None,
             metrics: ComputeMetrics::default(),
@@ -2278,6 +2289,36 @@ impl ComputeNode {
             state.last_active = last_active;
             debug!("set the last compute activity time to: {:?}", last_active);
         }
+    }
+
+    /// Update `last_active` and the activity counts (client sessions, logical
+    /// walsenders, autovacuum workers) in a single critical section, so a
+    /// concurrent `/status` read observes a consistent snapshot of all of them.
+    pub fn update_activity(
+        &self,
+        last_active: Option<DateTime<Utc>>,
+        num_client_sessions: i64,
+        num_walsenders: i64,
+        num_autovacuum_workers: i64,
+    ) {
+        let mut state = self.state.lock().unwrap();
+        // NB: `Some(<DateTime>)` is always greater than `None`.
+        if last_active > state.last_active {
+            state.last_active = last_active;
+        }
+        state.num_client_sessions = Some(num_client_sessions);
+        state.num_walsenders = Some(num_walsenders);
+        state.num_autovacuum_workers = Some(num_autovacuum_workers);
+    }
+
+    /// Reset the activity counts to `None` (unknown). Called whenever the monitor
+    /// cannot confirm Postgres is up, so `/status` never reports a stale `0`
+    /// (which would falsely read as "idle") nor a stale non-zero count.
+    pub fn clear_activity_counts(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.num_client_sessions = None;
+        state.num_walsenders = None;
+        state.num_autovacuum_workers = None;
     }
 
     // Look for core dumps and collect backtraces.

--- a/compute_tools/src/http/routes/mod.rs
+++ b/compute_tools/src/http/routes/mod.rs
@@ -35,6 +35,9 @@ impl From<&ComputeState> for ComputeStatusResponse {
             status: state.status,
             last_active: state.last_active,
             error: state.error.clone(),
+            num_client_sessions: state.num_client_sessions,
+            num_walsenders: state.num_walsenders,
+            num_autovacuum_workers: state.num_autovacuum_workers,
         }
     }
 }

--- a/compute_tools/src/monitor.rs
+++ b/compute_tools/src/monitor.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use compute_api::responses::ComputeStatus;
 use compute_api::spec::ComputeFeature;
 use postgres::{Client, NoTls};
-use tracing::{Level, error, info, instrument, span};
+use tracing::{Level, error, info, instrument, span, warn};
 
 use crate::compute::ComputeNode;
 use crate::metrics::{PG_CURR_DOWNTIME_MS, PG_TOTAL_DOWNTIME_MS};
@@ -61,6 +61,11 @@ impl ComputeMonitor {
             .signed_duration_since(self.last_checked)
             .num_milliseconds();
         PG_TOTAL_DOWNTIME_MS.inc_by(inc as u64);
+
+        // Postgres is not confirmed up: the `/status` activity counts are no
+        // longer trustworthy, so reset them to `None` (unknown) rather than
+        // letting a stale value (especially a stale `0`) read as "idle".
+        self.compute.clear_activity_counts();
     }
 
     fn report_up(&mut self) {
@@ -150,7 +155,27 @@ impl ComputeMonitor {
                         match self.check(cli) {
                             Ok(_) => {
                                 self.report_up();
-                                self.compute.update_last_active(self.last_active);
+                                // Collect activity counts and publish them together
+                                // with last_active in a single critical section, so a
+                                // concurrent `/status` sees a consistent snapshot.
+                                match self.collect_activity_counts(cli) {
+                                    Ok((sessions, walsenders, autovacuum_workers)) => {
+                                        self.compute.update_activity(
+                                            self.last_active,
+                                            sessions,
+                                            walsenders,
+                                            autovacuum_workers,
+                                        );
+                                    }
+                                    Err(e) => {
+                                        // Counts are unknown: update last_active but
+                                        // clear the counts so `/status` doesn't serve
+                                        // a stale (possibly "idle"-looking) value.
+                                        warn!("could not collect activity counts: {}", e);
+                                        self.compute.update_last_active(self.last_active);
+                                        self.compute.clear_activity_counts();
+                                    }
+                                }
                             }
                             Err(e) => {
                                 error!(
@@ -347,6 +372,32 @@ impl ComputeMonitor {
         }
 
         Ok(())
+    }
+
+    /// Collect activity counts (client sessions, logical walsenders, autovacuum
+    /// workers) for exposure via `/status`, returning `(sessions, walsenders,
+    /// autovacuum_workers)`. These mirror the conditions `check()` uses to decide
+    /// suspend, but are always computed (not short-circuited) so `/status` can
+    /// report each count. The client-sessions predicate is identical to
+    /// `get_backends_state_change()`: it excludes this connection
+    /// (`pg_backend_pid()`) and internal `cloud_admin` connections (the monitor,
+    /// vm-monitor, exporters, ...).
+    fn collect_activity_counts(&self, cli: &mut Client) -> anyhow::Result<(i64, i64, i64)> {
+        const CLIENT_SESSIONS_QUERY: &str = "select count(*) from pg_stat_activity \
+             where backend_type = 'client backend' \
+             and pid != pg_backend_pid() and usename != 'cloud_admin';";
+        const WALSENDERS_QUERY: &str =
+            "select count(*) from pg_stat_replication where application_name != 'walproposer';";
+        const AUTOVACUUM_QUERY: &str =
+            "select count(*) from pg_stat_activity where backend_type = 'autovacuum worker';";
+
+        let num_client_sessions: i64 = cli
+            .query_one(CLIENT_SESSIONS_QUERY, &[])?
+            .try_get("count")?;
+        let num_walsenders: i64 = cli.query_one(WALSENDERS_QUERY, &[])?.try_get("count")?;
+        let num_autovacuum_workers: i64 = cli.query_one(AUTOVACUUM_QUERY, &[])?.try_get("count")?;
+
+        Ok((num_client_sessions, num_walsenders, num_autovacuum_workers))
     }
 }
 

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -148,6 +148,24 @@ pub struct ComputeStatusResponse {
     #[serde(serialize_with = "rfc3339_serialize")]
     pub last_active: Option<DateTime<Utc>>,
     pub error: Option<String>,
+    /// Number of client backend sessions, excluding this connection and internal
+    /// `cloud_admin` connections (compute_ctl's own monitor, vm-monitor,
+    /// exporters, ...). `None` means "unknown": before the activity monitor's
+    /// first successful check (e.g. while `Empty`), and whenever the monitor
+    /// cannot currently confirm Postgres is up (the counts are reset to `None`
+    /// rather than left stale). Updated together with `last_active` in one
+    /// critical section, so a single read sees a consistent snapshot. These are a
+    /// coarse idle-detection hint; an authoritative "is idle now" decision should
+    /// use a fresh check (e.g. `/terminate?if_idle`), not these cached values.
+    #[serde(default)]
+    pub num_client_sessions: Option<i64>,
+    /// Number of logical WAL senders (`pg_stat_replication`, excluding the
+    /// physical `walproposer`). Same `None`/freshness semantics as above.
+    #[serde(default)]
+    pub num_walsenders: Option<i64>,
+    /// Number of running autovacuum workers. Same `None`/freshness semantics.
+    #[serde(default)]
+    pub num_autovacuum_workers: Option<i64>,
 }
 
 #[derive(Serialize, Clone, Copy, Debug, Deserialize, PartialEq, Eq, Default)]


### PR DESCRIPTION
## Problem

`compute_ctl`'s `/status` exposes only `last_active` for activity. Internally the
activity monitor folds several distinct keep-alive signals into that single field
(logical walsenders, autovacuum, and logical subscriptions all just bump
`last_active`). An external control plane that wants to make a *precise* suspend
decision — e.g. "terminate only when there are zero client sessions" — cannot get
the underlying counts from `/status` and has to run a separate SQL probe against
the compute.

## Summary

Adds three optional fields to `ComputeStatusResponse`:

- `num_client_sessions` — client backends, excluding this connection
  (`pg_backend_pid()`) and internal `cloud_admin` connections (the monitor,
  vm-monitor, exporters, …) — the same predicate `get_backends_state_change()`
  already uses.
- `num_walsenders` — logical WAL senders (`pg_stat_replication`, excluding the
  physical `walproposer`).
- `num_autovacuum_workers` — running autovacuum workers.

The activity monitor already issues these queries to decide suspend; it now also
collects the counts (always computed, not short-circuited) and publishes them
together with `last_active` in a single critical section, so a `/status` read sees
a consistent snapshot. The fields are `None` ("unknown") before the first
successful check and whenever the monitor cannot confirm Postgres is up — counts
are reset to `None` rather than left stale, so a stale `0` never reads as "idle".
They are a coarse idle-detection hint; an authoritative "is idle now" decision
should use a fresh check.

Adding optional fields is backward compatible (unknown fields are ignored).

Verified with `cargo check`/`cargo fmt`; not yet exercised against a live compute.
