### PR TITLE
compute_ctl: add /terminate?if_idle to terminate only when idle

### DIFF
--- a/compute_tools/src/http/routes/terminate.rs
+++ b/compute_tools/src/http/routes/terminate.rs
@@ -3,16 +3,70 @@ use crate::http::JsonResponse;
 use axum::extract::State;
 use axum::response::{IntoResponse, Response};
 use axum_extra::extract::OptionalQuery;
-use compute_api::responses::{ComputeStatus, TerminateMode, TerminateResponse};
+use compute_api::responses::{
+    ComputeStatus, TerminateMode, TerminateNotIdleResponse, TerminateResponse,
+};
 use http::StatusCode;
 use serde::Deserialize;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::task;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Deserialize, Default)]
 pub struct TerminateQuery {
+    #[serde(default)]
     mode: TerminateMode,
+    /// If set, only terminate when the compute is idle (no client sessions,
+    /// logical walsenders, or autovacuum workers). If it is not idle, the
+    /// compute is left running and `/terminate` returns 409 Conflict.
+    #[serde(default)]
+    if_idle: bool,
+}
+
+/// Check whether the compute is idle by querying Postgres directly, returning
+/// the current counts (the caller decides idleness = all zero). Mirrors the
+/// queries the activity monitor uses; `num_client_sessions` excludes internal
+/// `cloud_admin` connections (e.g. compute_ctl's own monitor).
+async fn check_idle(compute: &ComputeNode) -> anyhow::Result<TerminateNotIdleResponse> {
+    // Same predicate as the activity monitor's get_backends_state_change():
+    // exclude this very connection (pg_backend_pid) and internal cloud_admin
+    // connections (compute_ctl's own monitor, vm-monitor, exporters, ...).
+    const CLIENT_SESSIONS_QUERY: &str = "select count(*) from pg_stat_activity \
+         where backend_type = 'client backend' \
+         and pid != pg_backend_pid() and usename != 'cloud_admin';";
+    const WALSENDERS_QUERY: &str =
+        "select count(*) from pg_stat_replication where application_name != 'walproposer';";
+    const AUTOVACUUM_QUERY: &str =
+        "select count(*) from pg_stat_activity where backend_type = 'autovacuum worker';";
+
+    let conf = compute.get_tokio_conn_conf(Some("compute_ctl:terminate_idle_check"));
+    let (client, connection) = conf.connect(tokio_postgres::NoTls).await?;
+    let conn_task = tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            warn!("terminate idle-check connection error: {}", e);
+        }
+    });
+
+    let num_client_sessions: i64 = client
+        .query_one(CLIENT_SESSIONS_QUERY, &[])
+        .await?
+        .try_get("count")?;
+    let num_walsenders: i64 = client
+        .query_one(WALSENDERS_QUERY, &[])
+        .await?
+        .try_get("count")?;
+    let num_autovacuum_workers: i64 = client
+        .query_one(AUTOVACUUM_QUERY, &[])
+        .await?
+        .try_get("count")?;
+
+    conn_task.abort();
+    Ok(TerminateNotIdleResponse {
+        num_client_sessions,
+        num_walsenders,
+        num_autovacuum_workers,
+    })
 }
 
 /// Terminate the compute.
@@ -20,7 +74,57 @@ pub(in crate::http) async fn terminate(
     State(compute): State<Arc<ComputeNode>>,
     OptionalQuery(terminate): OptionalQuery<TerminateQuery>,
 ) -> Response {
-    let mode = terminate.unwrap_or_default().mode;
+    let query = terminate.unwrap_or_default();
+    let mode = query.mode;
+
+    // When `if_idle` is set, only terminate a Running compute if it has no
+    // client sessions, logical walsenders, or autovacuum workers. This collapses
+    // the "probe for idleness, then terminate" sequence an external control plane
+    // would otherwise do over two HTTP calls into a single call. NOTE: it narrows
+    // but does not fully eliminate the race -- a connection that arrives after the
+    // check but before Postgres shuts down still loses -- so an external barrier
+    // (e.g. restricting who may connect) remains necessary for a hard guarantee.
+    // Non-Running statuses (e.g. Empty) have no Postgres / no client sessions, so
+    // they fall through to normal termination.
+    if query.if_idle {
+        let status = compute.state.lock().unwrap().status;
+        if status == ComputeStatus::Running {
+            // Bound the check: Postgres may be up but unresponsive (saturated,
+            // blocked, slow pageserver). Without a timeout the await could hang
+            // indefinitely; on timeout we take the same fail-safe path as an
+            // outright error and do NOT terminate.
+            const IDLE_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+            match tokio::time::timeout(IDLE_CHECK_TIMEOUT, check_idle(&compute)).await {
+                Ok(Ok(counts)) => {
+                    if counts.num_client_sessions > 0
+                        || counts.num_walsenders > 0
+                        || counts.num_autovacuum_workers > 0
+                    {
+                        info!(
+                            "not terminating: compute is not idle ({} client sessions, {} walsenders, {} autovacuum workers)",
+                            counts.num_client_sessions,
+                            counts.num_walsenders,
+                            counts.num_autovacuum_workers
+                        );
+                        return JsonResponse::create_response(StatusCode::CONFLICT, counts);
+                    }
+                }
+                Ok(Err(e)) => {
+                    // Fail safe: if we cannot determine idleness, do NOT terminate.
+                    warn!("if_idle check failed, not terminating: {}", e);
+                    return JsonResponse::error(StatusCode::SERVICE_UNAVAILABLE, e);
+                }
+                Err(_elapsed) => {
+                    warn!("if_idle check timed out, not terminating");
+                    return JsonResponse::error(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "idle check timed out",
+                    );
+                }
+            }
+        }
+    }
+
     {
         let mut state = compute.state.lock().unwrap();
         if state.status == ComputeStatus::Terminated {

--- a/libs/compute_api/src/responses.rs
+++ b/libs/compute_api/src/responses.rs
@@ -206,6 +206,16 @@ pub struct TerminateResponse {
     pub lsn: Option<utils::lsn::Lsn>,
 }
 
+/// Response of `/terminate?if_idle=true` when the compute is NOT idle and was
+/// therefore left running (returned with HTTP 409 Conflict). Reports the counts
+/// that made the compute non-idle so the caller can decide what to do.
+#[derive(Deserialize, Serialize)]
+pub struct TerminateNotIdleResponse {
+    pub num_client_sessions: i64,
+    pub num_walsenders: i64,
+    pub num_autovacuum_workers: i64,
+}
+
 impl Display for ComputeStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
## Problem

To suspend a compute safely, an external control plane wants to terminate it only
when nothing is connected, so it does not roll back an in-flight session
(`SQLSTATE 57P01`). Today that takes two calls — a probe (e.g. a SQL query
counting sessions) followed by `/terminate` — with a race window in between where
a new connection can arrive and then be killed by the terminate.

## Summary

Adds an optional query parameter `if_idle` to `/terminate`. When set, a `Running`
compute is terminated only if it currently has zero client sessions (excluding
this connection and internal `cloud_admin` connections), zero logical walsenders,
and zero autovacuum workers, checked by querying Postgres directly. If it is not
idle, the compute is left running and `/terminate` returns `409 Conflict` with the
counts that made it non-idle (`TerminateNotIdleResponse`).

The idle check is bounded by a 10s timeout and fails safe: if the check errors
(e.g. Postgres unreachable) or times out (e.g. Postgres up but unresponsive), the
request returns `503` and does **not** terminate. Non-`Running` statuses (e.g.
`Empty`) have no Postgres / no sessions and fall through to normal termination.

This collapses the probe-then-terminate sequence into a single call. Note it
narrows but does not fully eliminate the race: a connection arriving after the
check but before Postgres shuts down still loses, so an external barrier
(restricting who may connect during suspend) remains necessary for a hard
guarantee. `if_idle` defaults to false, so existing `/terminate` behavior is
unchanged.

Verified with `cargo check`/`cargo fmt`; not yet exercised against a live compute.
