### PR TITLE
Reduce redundant WAL on relation extension with a single marker FPI

### DIFF
--- a/docs/core_changes.md
+++ b/docs/core_changes.md
@@ -371,20 +371,6 @@ several GB, and downloading them all made the startup time too long.
 FUSE hook or LD_PRELOAD trick to intercept the reads on SLRU files
 
 
-## WAL-log an all-zeros page as one large hole
-
-- In XLogRecordAssemble()
-
-### Problem we're trying to solve
-
-This change was made in v16. Starting with v16, when PostgreSQL extends a relation, it first extends
-it with zeros, and it can extend the relation more than one block at a time. The all-zeros page is WAL-ogged, but it's very wasteful to include 8 kB of zeros in the WAL for that. This hack was made so that we WAL logged a compact record with a whole-page "hole". However, PostgreSQL has assertions that prevent that such WAL records from being replayed, so this breaks compatibility such that unmodified PostreSQL cannot process Neon-generated WAL.
-
-### How to get rid of the patch
-
-Find another compact representation for a full-page image of an all-zeros page. A compressed image perhaps.
-
-
 ## Shut down walproposer after checkpointer
 
 ```

--- a/pgxn/neon/pagestore_smgr.c
+++ b/pgxn/neon/pagestore_smgr.c
@@ -899,7 +899,6 @@ neon_extend(SMgrRelation reln, ForkNumber forkNum, BlockNumber blkno,
 #endif
 {
 	XLogRecPtr	lsn;
-	BlockNumber n_blocks = 0;
 
 	switch (reln->smgr_relpersistence)
 	{
@@ -946,15 +945,13 @@ neon_extend(SMgrRelation reln, ForkNumber forkNum, BlockNumber blkno,
 	}
 
 	/*
-	 * Usually Postgres doesn't extend relation on more than one page (leaving
-	 * holes). But this rule is violated in PG-15 where
-	 * CreateAndCopyRelationData call smgrextend for destination relation n
-	 * using size of source relation
+	 * If callers extend by more than one block at a time (e.g. PG 15
+	 * CreateAndCopyRelationData), the trailing neon_wallog_page below acts as
+	 * a single marker FPI for the last extended block. On ingest the
+	 * pageserver advances relsize to blkno + 1 and zero-fills the
+	 * intermediate blocks via its existing relation-extend gap-fill, so any
+	 * later read of an intermediate block returns an all-zero page.
 	 */
-	n_blocks = neon_nblocks(reln, forkNum);
-	while (n_blocks < blkno)
-		neon_wallog_page(reln, forkNum, n_blocks++, buffer, true);
-
 	neon_wallog_page(reln, forkNum, blkno, buffer, false);
 	set_cached_relsize(InfoFromSMgrRel(reln), forkNum, blkno + 1);
 
@@ -992,9 +989,9 @@ static void
 neon_zeroextend(SMgrRelation reln, ForkNumber forkNum, BlockNumber blocknum,
 				int nblocks, bool skipFsync)
 {
-	const PGIOAlignedBlock buffer = {0};
-	int			remblocks = nblocks;
-	XLogRecPtr	lsn = 0;
+	PGIOAlignedBlock marker;
+	BlockNumber last_block;
+	XLogRecPtr	lsn;
 
 	switch (reln->smgr_relpersistence)
 	{
@@ -1055,41 +1052,27 @@ neon_zeroextend(SMgrRelation reln, ForkNumber forkNum, BlockNumber blocknum,
 	if (!XLogInsertAllowed())
 		return;
 
-	/* ensure we have enough xlog buffers to log max-sized records */
-	XLogEnsureRecordSpace(Min(remblocks, (XLR_MAX_BLOCK_ID - 1)), 0);
-
 	/*
-	 * Iterate over all the pages. They are collected into batches of
-	 * XLR_MAX_BLOCK_ID pages, and a single WAL-record is written for each
-	 * batch.
+	 * Emit a single marker FPI for the last extended block. On ingest the
+	 * pageserver advances relsize to last_block + 1 and zero-fills the
+	 * intermediate blocks (blocknum .. last_block - 1) via its existing
+	 * relation-extend gap-fill, so any later read of those blocks returns an
+	 * all-zero page on the main GetPage@LSN path.
+	 *
+	 * The marker buffer is PageInit'd so vanilla PG's standard hole
+	 * compression (pd_lower..pd_upper) handles it -- no Neon-specific
+	 * PageIsNew hole hack needed.
 	 */
-	while (remblocks > 0)
-	{
-		int			count = Min(remblocks, XLR_MAX_BLOCK_ID);
+	PageInit((Page) marker.data, BLCKSZ, 0);
+	last_block = blocknum + nblocks - 1;
 
-		XLogBeginInsert();
-
-		for (int i = 0; i < count; i++)
-			XLogRegisterBlock(i, &InfoFromSMgrRel(reln), forkNum, blocknum + i,
-							  (char *) buffer.data, REGBUF_FORCE_IMAGE | REGBUF_STANDARD);
-
-		lsn = XLogInsert(RM_XLOG_ID, XLOG_FPI);
-
-		for (int i = 0; i < count; i++)
-		{
-			lfc_write(InfoFromSMgrRel(reln), forkNum, blocknum + i, buffer.data);
-			neon_set_lwlsn_block(lsn, InfoFromSMgrRel(reln), forkNum,
-									  blocknum + i);
-		}
-
-		blocknum += count;
-		remblocks -= count;
-	}
-
-	Assert(lsn != 0);
+	XLogBeginInsert();
+	XLogRegisterBlock(0, &InfoFromSMgrRel(reln), forkNum, last_block,
+					  (char *) marker.data, REGBUF_FORCE_IMAGE | REGBUF_STANDARD);
+	lsn = XLogInsert(RM_XLOG_ID, XLOG_FPI);
 
 	neon_set_lwlsn_relation(lsn, InfoFromSMgrRel(reln), forkNum);
-	set_cached_relsize(InfoFromSMgrRel(reln), forkNum, blocknum);
+	set_cached_relsize(InfoFromSMgrRel(reln), forkNum, blocknum + nblocks);
 }
 #endif
 

--- a/test_runner/regress/test_rel_extend_gap.py
+++ b/test_runner/regress/test_rel_extend_gap.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING
+
+from fixtures.log_helper import log
+from fixtures.neon_fixtures import wait_for_last_flush_lsn
+from fixtures.utils import query_scalar
+
+if TYPE_CHECKING:
+    from fixtures.neon_fixtures import NeonEnvBuilder
+
+EXTENSIONS = ["neon_test_utils", "pageinspect"]
+
+# One row is engineered to occupy exactly one heap block: a 26-char unit
+# repeated 196 times is 5096 bytes, which is more than half of an 8 KB page, so
+# only a single such tuple ever fits per block. STORAGE plain is mandatory --
+# without it the (highly compressible) text is TOAST-compressed down to a few
+# bytes and many rows would share a block, breaking the one-row-per-block
+# invariant the test relies on for locating gap blocks.
+UNIT = "abcdefghijklmnopqrstuvwxyz"
+ROW_BODY = UNIT * 196  # 5096 bytes
+
+# Small but enough for COPY's bulk-extension ramp to reach a multi-block
+# smgrzeroextend whose final extension over-allocates past the last row.
+NROWS = 100
+
+
+def test_rel_extend_gap_blocks_read_as_zero(neon_env_builder: NeonEnvBuilder):
+    """
+    Regression coverage for the marker-FPI relation-extend optimization.
+
+    When a relation is bulk-extended by N blocks at once, the compute no longer
+    emits one zero-page WAL record per block; it emits a single PageInit'd
+    marker FPI for the *last* block of the extension and relies on the
+    pageserver to materialize the intermediate (un-WAL'd) blocks as all-zero
+    pages at ingest. This test verifies that, end to end, purely through
+    observable behavior (no internal metric):
+
+      1. a multi-block extension actually happened, and the extension
+         over-allocated past the data we wrote -- so some in-bounds blocks were
+         never touched by a heap-insert and remain pure gap blocks; and
+      2. every such gap block reads back from the pageserver as a valid
+         all-zero page after the local caches are evicted -- a successful read
+         (not a MissingKey / I/O error) of a zeroed page, which is exactly what
+         the marker-FPI path delegates to the pageserver's gap-fill.
+
+    How the gap is constructed deterministically:
+
+    Each row is exactly one block wide (see ROW_BODY / STORAGE plain), so the
+    data occupies precisely blocks [0, NROWS). COPY uses heap_multi_insert,
+    which ramps its relation-extension chunk size up to 64 blocks
+    (RelationGetBufferForTuple -> RelationAddBlocks -> ExtendBufferedRelBy ->
+    smgrzeroextend), and the last chunk grabs many blocks but only fills the
+    few remaining rows. Because blocks are always appended at the end and filled
+    in order, every block with index >= NROWS is guaranteed never-written: those
+    are the surviving gap blocks. A plain INSERT would extend one block at a
+    time (bistate is NULL), never hitting the marker-FPI multi-block path, so we
+    deliberately use COPY.
+    """
+    env = neon_env_builder.init_start()
+
+    # Bulk relation extension is gated by LimitAdditionalPins(), which clamps the
+    # number of blocks extended at once to roughly NBuffers / max_backends. With
+    # the default tiny shared_buffers the clamp is 1, so the relation would only
+    # ever be extended one block at a time and the marker-FPI multi-block path
+    # would never fire. Give the compute enough buffers (and few enough backends)
+    # that a single smgrzeroextend can cover many blocks.
+    endpoint = env.endpoints.create_start(
+        "main",
+        config_lines=["shared_buffers=1GB", "max_connections=20"],
+    )
+    with endpoint.connect() as con:
+        con.autocommit = True
+        with con.cursor() as c:
+            for e in EXTENSIONS:
+                c.execute(f"CREATE EXTENSION IF NOT EXISTS {e}")
+            c.execute("CREATE TABLE t (v text) WITH (autovacuum_enabled = false)")
+            # Keep every value inline and uncompressed so each row fills exactly
+            # one block.
+            c.execute("ALTER TABLE t ALTER COLUMN v SET STORAGE plain")
+            buf = io.StringIO("".join(f"{ROW_BODY}{i}\n" for i in range(NROWS)))
+            c.copy_expert("COPY t (v) FROM STDIN", buf)
+
+    wait_for_last_flush_lsn(env, endpoint, env.initial_tenant, env.initial_timeline)
+
+    with endpoint.connect() as con:
+        con.autocommit = True
+        with con.cursor() as c:
+            nblocks = query_scalar(
+                c, "SELECT pg_relation_size('t') / current_setting('block_size')::int"
+            )
+    log.info(f"relation t has {nblocks} blocks for {NROWS} one-block rows")
+
+    # Guarantee 1: the bulk extension over-allocated past our data. With one row
+    # per block, data lives in [0, NROWS); anything beyond is a never-written
+    # gap block produced by the marker-FPI multi-block extension.
+    assert nblocks > NROWS, (
+        f"expected the bulk extension to over-allocate past {NROWS} data blocks "
+        f"(got {nblocks}); the marker-FPI multi-block path did not leave a gap"
+    )
+
+    with endpoint.connect() as con:
+        con.autocommit = True
+        with con.cursor() as c:
+            # Evict shared buffers and the LFC so every read below is served by
+            # the pageserver, not by a locally cached copy.
+            endpoint.clear_buffers()
+
+            # Guarantee 2: every over-allocated tail block reads back from the
+            # pageserver as an *empty* page, and at least one is an all-zero
+            # gap-filled page.
+            #
+            # The data occupies [0, NROWS). Each tail block (>= NROWS) was never
+            # touched by a heap-insert, so it must read back as one of exactly
+            # two empty shapes:
+            #   - (lower, upper) == (0, 0)        -> an all-zero gap block the
+            #     pageserver zero-filled at ingest, OR
+            #   - (lower, upper) == (24, 8192)    -> the PageInit'd marker FPI
+            #     for the last block of an extension (SizeOfPageHeaderData=24,
+            #     BLCKSZ=8192).
+            # Anything else (a partially-filled data page, or a failed read)
+            # means the marker-FPI gap-fill regressed: a lost gap-fill surfaces
+            # as a psycopg2 IoError ("could not read block ...") on the read
+            # itself, and a stale/garbage page would have a different header.
+            zero_gap_blocks = 0
+            for blk in range(NROWS, nblocks):
+                c.execute(
+                    "SELECT lower, upper FROM page_header("
+                    f"get_raw_page_at_lsn('t', 'main', {blk}, NULL, NULL))"
+                )
+                row = c.fetchone()
+                assert row is not None, f"tail block {blk} read back NULL"
+                lower, upper = row
+                assert (lower, upper) in {(0, 0), (24, 8192)}, (
+                    f"tail block {blk} is neither an all-zero gap page nor the "
+                    f"PageInit'd marker (lower={lower}, upper={upper})"
+                )
+                if (lower, upper) == (0, 0):
+                    zero_gap_blocks += 1
+
+            assert zero_gap_blocks > 0, (
+                "expected at least one all-zero gap block among the over-allocated "
+                "tail; the pageserver did not zero-fill any relation-extend gap"
+            )
+
+    log.info(
+        f"verified {nblocks - NROWS} tail blocks ({zero_gap_blocks} zero-filled gaps) "
+        "after cache eviction"
+    )


### PR DESCRIPTION
# Reduce redundant WAL on relation extension with a single marker FPI

## Summary

Replace the "WAL every newly extended block as a full-page image"
behavior in `neon_zeroextend` (PG 16+) and `neon_extend` (the PG-15
`CreateAndCopyRelationData` hole-fill path) with a **single marker FPI
for the last extended block**. The marker page is `PageInit`'d so vanilla
PostgreSQL's standard WAL hole compression applies.

The change:

- reduces WAL volume for bulk relation extension by removing the redundant
  per-block FPI framing — roughly an order of magnitude (~10–22×) on the
  batched `neon_zeroextend` path, and hundreds-fold on the PG-15
  per-block-record path (see *Benefits* for the accounting);
- removes the need for the `PageIsNew → hole_length = BLCKSZ` hack in
  `XLogRecordAssemble` (reverted in the companion `postgres` PR),
  restoring WAL-format compatibility for extension records;
- mirrors the established `_hash_alloc_buckets` pattern already used by
  vanilla PostgreSQL;
- lets one section be removed from `docs/core_changes.md`.

**Framing:** the single marker FPI is **required for correctness**, not
merely an optimization. The *current* per-block FPIs are redundant beyond
that one marker, but removing all FPIs would break cross-fork extent
consistency (see below). The marker FPI is the minimum signal that keeps
the invariant.

## Motivation

### Current behavior

When PostgreSQL extends a relation, Neon's SMGR emits one `XLOG_FPI`
entry per newly allocated block, each an all-zero page. On the PG ≥ 16
`neon_zeroextend` path these are batched up to `XLR_MAX_BLOCK_ID` (32)
blocks per record (so `nblocks=64` is ~2 records); on the PG-15
`neon_extend` hole-fill path each block is its own record
(`neon_wallog_page` → `log_newpage_copy`). Because all-zero pages don't
satisfy vanilla's hole-elision condition, a Neon-specific hack in
`XLogRecordAssemble` shrinks each image *body* to 0 bytes by declaring the
whole page a hole — at the cost of a WAL format that vanilla PostgreSQL's
redo rejects. The bodies are thus already ~free; what remains redundant is
the per-block FPI framing (and, on the PG-15 path, a record per block).

### Historical context — how we got here

- **neon#2986 (2022-12)** introduced the per-block WAL to fix a real
  "no unpinned buffers available" bug (#2904, surfaced while running
  pgbench); the fix lived in PG 15's `CreateAndCopyRelationData` and
  ensured the pageserver learned about every block produced.
- In that review, **MMeent flagged the cost up front**:
  > "I'm not super happy with doing N (!) WAL log operations to extend a
  > relation by N blocks, but that's how it is, apparently. I hope we can
  > correctly identify that these blocks are empty and thus don't need to
  > be stored as 8kB blocks in the pageserver."
  >
  > knizhnik: "Yes, I am also not so happy with it. Actually it
  > significantly slowdown 'create database' … 'create database' is not so
  > frequent operation (and actually prohibited for Neon users). **But it
  > will be bad if `CreateAndCopyRelation` will be used somewhere else
  > (right now I checked that it is used only in CREATE DATABASE).**"
- The trade-off was explicitly *"acceptable because `CREATE DATABASE` is
  rare."* But **neon#4761 (2023-09)** generalized the same per-block loop
  to PG 16's new `smgrzeroextend` via `neon_zeroextend` — silently moving
  the pattern from a low-frequency path (`CREATE DATABASE`) to a
  **high-frequency** one (every bulk `INSERT`/`COPY`/`VACUUM` extension).
  The original "acceptable because rare" justification no longer held,
  but the design wasn't revisited.
- Later PRs layered mitigations on the original choice rather than
  addressing it: **#5910** (the hole hack), **#5979** (pageserver skips
  materializing null FPIs), **#9492** (zeroed-page metric), **#11043**
  (walredo `inmem_read` returns zero for missing blocks). #9492's own
  description notes: *"Filling the gap in with zeroes is annoying for
  sharded ingest. We are not sure it even happens in reality."*

This PR revisits that implicit choice now that we have ~3 years of
operational data and several mitigations all pointing at the same root
cause.

### Why one FPI is enough

The pageserver already derives relation size from any WAL reference, in
`neon_extend_rel_size`:

```c
if (relsize < blkno + 1)
    update_cached_relsize(rinfo, forknum, blkno + 1);
```

A single reference to the highest block of an extension advances
`nblocks` to the full new extent. The intermediate blocks are not left
dangling: when the pageserver ingests that one marker FPI it both advances
`relsize` *and* zero-fills every intermediate block via its existing
relation-extend gap-fill (`handle_rel_extend` /
`DatadirModification::ingest_batch` → `zero_gaps`, the path whose
`gap_blocks_zeroed_on_rel_extend` metric was added in #9492). So each
untouched block is materialized as an all-zero (new) page at ingest time,
and any later read finds it — the same semantics vanilla PostgreSQL gives
for sparse-file regions (see *Prior art* below). Crucially, this means the
pageserver's final materialized state is identical whether we emit one FPI
per block or a single marker FPI; the change removes redundant *WAL* only,
and relies on an already-shipped, metered code path rather than new
behavior.

### Prior art: "log only the last block" is a native PostgreSQL pattern

The marker FPI is not a Neon invention — it is exactly how vanilla
PostgreSQL already extends a relation by many blocks at once. In
`_hash_alloc_buckets` (`src/backend/access/hash/hashpage.c`), when a hash
index grows by `nblocks` at a splitpoint, upstream PostgreSQL:

```c
lastblock = firstblock + nblocks - 1;
_hash_pageinit(page, BLCKSZ);          /* init only the last page */
...
if (RelationNeedsWAL(rel))
    log_newpage(&rel->rd_locator, MAIN_FORKNUM, lastblock,
                zerobuf.data, true /* page_std */);
smgrextend(RelationGetSmgr(rel), MAIN_FORKNUM, lastblock, zerobuf.data, false);
```

That is: it WAL-logs (and physically writes) **only the last block** of
the whole range, with `page_std = true` so the FPI uses standard hole
compression — and lets the intermediate region be a file-system hole. The
file size, persisted by the OS, is what tells recovery the relation is now
`lastblock + 1` blocks long.

This PR brings Neon's relation extension in line with that long-standing,
production-tested upstream pattern. The only Neon-specific twist is *why*
the single FPI is mandatory rather than incidental: Neon has no
file system to persist the new size, so the marker FPI is the explicit
signal that commits the new extent to the pageserver (see the next
section). Mechanically, though, it is the same "one `log_newpage` for the
last block" shape PostgreSQL has shipped for years.

### Why we cannot drop the marker FPI entirely

It is tempting to emit *zero* extension FPIs and rely on later
`INSERT` WAL (`REGBUF_WILL_INIT`) to advance `relsize`. **This is wrong**,
because of cross-fork extent consistency. Consider a `COPY`:

1. Bulk-extend main fork by 64 blocks (`100..163`).
2. `COPY` fills 32 (`100..131`), emitting heap-insert WAL.
3. `COPY` ends; free space on `132..163` is recorded into the **FSM
   fork** (separate WAL, separate fork).
4. A later `INSERT` asks FSM for free space → FSM says "block 133".
5. `ReadBuffer(MAIN, 133)` misses LFC → `GetPage@LSN(MAIN, 133)`.

With no marker FPI, the pageserver's main-fork extent is only
`max(main-fork WAL refs)+1 = 132` (blocks `100..131`). Block 133 is
**out of extent** → the request fails. FSM and main-fork extents have
diverged. Vanilla PostgreSQL never hits this because each fork's size is
persisted independently by the filesystem at extension time; Neon has no
filesystem, so the only way to commit "this fork's extent is now N" to
the pageserver is a WAL reference to a block ≥ N-1 in that fork.

**The marker FPI is the minimum signal that maintains this invariant**:
one FPI for the last block of every main-fork extension guarantees any
later FSM/VM/index reference within that range finds the extent already
advanced on the pageserver. The same applies to the visibility-map fork.

## Changes

- `pgxn/neon/pagestore_smgr.c`
  - `neon_zeroextend` (PG ≥ 16): replace the per-block FPI loop (and its
    per-block `lfc_write` + `neon_set_lwlsn_block`) with a single
    `PageInit`'d marker FPI for the last block.
  - `neon_extend`: drop the PG-15 per-block hole-fill loop; the trailing
    `neon_wallog_page` now acts as the marker.
- `docs/core_changes.md`: remove the obsolete "WAL-log an all-zeros page
  as one large hole" section.
- `vendor/postgres-v17`: bump to the commit that reverts the producer-side
  hole hack in `xloginsert.c` (companion `postgres` PR). That PR keeps
  postgres#327's reader-side exception in `xlogreader.c` so redo can still
  replay old WAL that contains whole-page-hole FPIs.

## Benefits

The savings are **not** in the page bodies — under the existing hole hack
each per-block zero FPI already stored a 0-byte image body. The redundant
WAL is the **per-block FPI framing** (block header + image header +
compress header + block number ≈ 15 B for each additional same-rel block)
plus, on some paths, one whole WAL record per block. The marker FPI
collapses all of that to a single record carrying one ~24 B `PageInit`'d
image. So the realistic reduction depends on how the old path framed its
FPIs:

| Scenario | Old path | Current WAL (with hole hack) | Proposed | Reduction |
|---|---|---|---|---|
| `neon_zeroextend(64)` | batched, ≤32 blk/record | ~2 records, ~1.0 KB | 1 record, ~75 B | **~14×** |
| `neon_zeroextend(100)` | batched, ≤32 blk/record | ~4 records, ~1.6 KB | 1 record, ~75 B | **~22×** |
| `neon_extend`, 1000 blocks (PG 15) | one record per block | ~1000 records, ~50 KB | 1 record, ~75 B | **~680×** |

Two distinct regimes:

- **Batched path (`neon_zeroextend`, PG ≥ 16, the high-frequency one):**
  the old code already packed up to `XLR_MAX_BLOCK_ID` (32) blocks per
  record, so the dominant cost was ~15 B of framing per extra block, not
  8 KB bodies. Realistic reduction is roughly an order of magnitude
  (~10–22× depending on `nblocks`), not the block count.
- **Per-block-record path (`neon_extend` PG-15 `CreateAndCopyRelationData`,
  which calls `neon_wallog_page` → `log_newpage_copy` once per block):**
  here each block paid a full ~24 B record header on top of its framing,
  so collapsing N records into one yields hundreds-fold reductions for
  large extents.

Beyond raw WAL bytes, the change also removes the per-block `lfc_write`
and `neon_set_lwlsn_block` calls (64 of each per 64-block extension) that
the old `neon_zeroextend` loop performed. WAL-byte savings are further
amplified ~3× by safekeeper quorum replication, and reduce pageserver
ingest/decode work and archived-WAL S3 volume. The change also unifies the
extension code path across PG 14/15/16/17.

## Correctness notes

- **Cross-fork extent consistency (FSM/VM):** the marker FPI advances the
  pageserver's main-fork extent to `last_block + 1` synchronously with
  the extension, so any later FSM/VM reference within the range is
  in-extent. This is the case that makes a "zero FPI" simplification
  incorrect.
- **Cross-backend bulk-extension reuse:** the cached relsize is set to the
  full new extent (`blocknum + nblocks`) synchronously after the FPI, so
  sibling backends observe the full new size; cross-replica/invalidated
  lookups go to the pageserver, whose extent the marker already advanced.
- **Pageserver / replica view:** ingesting the marker FPI runs the
  pageserver's relation-extend gap-fill, which materializes every
  intermediate block as an all-zero (new) page (`ZERO_PAGE`) in the
  storage layers. So for any LSN ≥ marker LSN a read of an untouched block
  hits a real zero-page image on the main `GetPage@LSN` path — it does not
  fall through to `MissingKey`, and does not depend on the walredo
  inmem-SMGR fallback (#11043). The marker block itself reads back
  `PageInit`'d; the intermediate blocks read back all-zero, matching what
  vanilla PostgreSQL produces for a freshly extended, never-written block.

## Dependency / ordering

Depends on the companion `postgres` PR. Recommended order: merge the
`postgres` PR first, then update `vendor/postgres-v17` here to its final
merged commit before merging this PR. The two should land together —
merging the `postgres` revert while this PR is still pending would
temporarily inflate extension WAL.

## Testing

- Clean rebuild of PG v17 + `neon.so`; compiles cleanly with the change.
- PG core regression: **222 / 222 passed**.
- The pageserver intermediate-block guarantee was verified by code reading
  (see *Pageserver support for intermediate blocks* above), not just
  assumed.
- New regression test `test_runner/regress/test_rel_extend_gap.py`
  (`test_rel_extend_gap_blocks_read_as_zero`) verifies the marker-FPI path
  end-to-end, purely through observable page contents — it does **not** read
  any internal pageserver metric, so it needs no pageserver-side change.

  Construction (a deterministic, surviving gap):
  - **One row == one block.** The text value is a 26-char unit repeated 196
    times = 5096 bytes (> half a page), so only one such tuple ever fits per
    block. The column is `ALTER ... SET STORAGE plain` — mandatory, because
    otherwise the highly compressible text is TOAST-compressed to a few bytes
    and many rows would share a block, breaking the one-row-per-block
    invariant.
  - **COPY, not INSERT.** `COPY` 100 such rows. `COPY`'s `heap_multi_insert`
    ramps its extension chunk up to 64 blocks per `smgrzeroextend`, and the
    final chunk over-allocates past the last row. A plain `INSERT` extends one
    block at a time (`bistate == NULL`) and would never hit the multi-block
    marker-FPI path. The endpoint runs with `shared_buffers=1GB` and
    `max_connections=20` so `LimitAdditionalPins()` does not clamp the
    extend-by count to 1 block (with the default tiny `shared_buffers` the
    multi-block path never fires).
  - **Gap blocks are deterministically locatable.** Data occupies exactly
    blocks `[0, 100)`; blocks are always appended at the end and filled in
    order, so every block with index `>= 100` is a never-written block left by
    the over-allocating extension.

  After `wait_for_last_flush_lsn` and evicting shared buffers + the LFC, it
  reads each tail block (`>= 100`) back from the pageserver via
  `page_header(get_raw_page_at_lsn(...))` and asserts:
  - the relation over-allocated (`nblocks > 100`), i.e. a multi-block
    extension left a tail;
  - every tail block reads back as an *empty* page of exactly one of two
    shapes — `(lower, upper) == (0, 0)` (an all-zero block the pageserver
    zero-filled at ingest) or `(24, 8192)` (the `PageInit`'d marker FPI for
    the last block of an extension; 24 = `SizeOfPageHeaderData`, 8192 =
    `BLCKSZ`) — never a partially-filled data page, and never a failed read
    (a lost gap-fill would surface as a `could not read block` I/O error); and
  - at least one tail block is an all-zero `(0, 0)` gap page, proving the
    pageserver's relation-extend gap-fill actually ran and the marker FPI did
    not carry the intermediate blocks.

  Observed: 100 one-block rows produce 104 blocks — blocks 100–102 read back
  all-zero (gap-filled) and block 103 is the `PageInit`'d marker.

## Pageserver support for intermediate blocks (verified)

The marker-FPI strategy relies on the pageserver returning a zero page for
an intermediate block (`blkno < relsize_at_LSN` with no FPI of its own).
This is guaranteed by the pre-existing relation-extend gap-fill, exercised
on every ingest path:

- legacy ingest: `WalIngest::handle_rel_extend`
  (`pageserver/src/walingest.rs`) loops `old_nblocks..blknum` and calls
  `put_rel_page_image_zero` for each gap block;
- batched/decoder ingest: `DatadirModification::ingest_batch`
  (`pageserver/src/pgdatadir_mapping.rs`) calls `find_gaps` and
  `SerializedValueBatch::zero_gaps`.

Both materialize `ZERO_PAGE` images for the gap at ingest time, so a later
`get_rel_page_at_lsn` for an intermediate block (which takes the
`blknum < nblocks` branch into `get_vectored`) finds a real image and
returns it — no `MissingKey`, and independent of the walredo inmem-SMGR
zero behavior from #11043. This is the same machinery whose
`gap_blocks_zeroed_on_rel_extend` metric was added in #9492.

## References

- neon#2986 (`c21104465`) — original per-block WAL for PG 15
- neon#4761 (`83e7e5dbb`) — generalized to `smgrzeroextend` / `neon_zeroextend`
- postgres#327 (`8d60df0cd637829e01f62013ff10450f5b25a626`, "Optimize
  stroing zero FPI in WAL") — added the `PageIsNew` hole hack in
  `xloginsert.c` and a matching reader exception in `xlogreader.c`; the
  companion `postgres` PR reverts only the producer side, keeping the
  reader exception for backward-compatible replay of old WAL
- neon#5910 / #5979 / #9492 / #11043 — layered mitigations
- `_hash_alloc_buckets` (`src/backend/access/hash/hashpage.c`) — vanilla
  "log only the last block" precedent
