### PR TITLE
remote_storage: add request/response size histograms

### DIFF
--- a/libs/remote_storage/src/metrics.rs
+++ b/libs/remote_storage/src/metrics.rs
@@ -1,5 +1,6 @@
 use metrics::{
-    Histogram, IntCounter, register_histogram_vec, register_int_counter, register_int_counter_vec,
+    Histogram, IntCounter, register_histogram, register_histogram_vec, register_int_counter,
+    register_int_counter_vec,
 };
 use once_cell::sync::Lazy;
 
@@ -176,6 +177,11 @@ pub(crate) struct BucketMetrics {
 
     /// Total amount of deleted objects in batches or single requests.
     pub(crate) deleted_objects_total: IntCounter,
+
+    /// Size in bytes of request bodies we upload (Put).
+    pub(crate) request_bytes: Histogram,
+    /// Size in bytes of response bodies we download (Get).
+    pub(crate) response_bytes: Histogram,
 }
 
 impl Default for BucketMetrics {
@@ -220,11 +226,38 @@ impl Default for BucketMetrics {
         )
         .unwrap();
 
+        // 1 KiB .. 1 GiB: uploads/downloads range from small index blobs to large layer files.
+        let byte_buckets = vec![
+            1024.0,
+            8192.0,
+            65536.0,
+            262144.0,
+            1048576.0,
+            8388608.0,
+            67108864.0,
+            268435456.0,
+            1073741824.0,
+        ];
+        let request_bytes = register_histogram!(
+            "remote_storage_s3_request_bytes",
+            "Size of request bodies uploaded to S3, in bytes",
+            byte_buckets.clone(),
+        )
+        .unwrap();
+        let response_bytes = register_histogram!(
+            "remote_storage_s3_response_bytes",
+            "Size of response bodies downloaded from S3, in bytes",
+            byte_buckets,
+        )
+        .unwrap();
+
         Self {
             req_seconds,
             wait_seconds,
             cancelled_waits,
             deleted_objects_total,
+            request_bytes,
+            response_bytes,
         }
     }
 }

--- a/libs/remote_storage/src/s3_bucket.rs
+++ b/libs/remote_storage/src/s3_bucket.rs
@@ -559,6 +559,7 @@ pin_project_lite::pin_project! {
     struct TimedDownload<S> {
         started_at: std::time::Instant,
         outcome: AttemptOutcome,
+        bytes: u64,
         #[pin]
         inner: S
     }
@@ -566,6 +567,7 @@ pin_project_lite::pin_project! {
     impl<S> PinnedDrop for TimedDownload<S> {
         fn drop(mut this: Pin<&mut Self>) {
             crate::metrics::BUCKET_METRICS.req_seconds.observe_elapsed(RequestKind::Get, this.outcome, this.started_at);
+            crate::metrics::BUCKET_METRICS.response_bytes.observe(this.bytes as f64);
         }
     }
 }
@@ -575,6 +577,7 @@ impl<S> TimedDownload<S> {
         TimedDownload {
             started_at,
             outcome: AttemptOutcome::Cancelled,
+            bytes: 0,
             inner,
         }
     }
@@ -590,7 +593,7 @@ impl<S: Stream<Item = std::io::Result<Bytes>>> Stream for TimedDownload<S> {
 
         let res = ready!(this.inner.poll_next(cx));
         match &res {
-            Some(Ok(_)) => {}
+            Some(Ok(chunk)) => *this.bytes += chunk.len() as u64,
             Some(Err(_)) => *this.outcome = AttemptOutcome::Err,
             None => *this.outcome = AttemptOutcome::Ok,
         }
@@ -872,6 +875,9 @@ impl RemoteStorage for S3Bucket {
             crate::metrics::BUCKET_METRICS
                 .req_seconds
                 .observe_elapsed(kind, inner, started_at);
+            crate::metrics::BUCKET_METRICS
+                .request_bytes
+                .observe(from_size_bytes as f64);
         }
 
         match res {
@@ -1139,6 +1145,32 @@ mod tests {
     use camino::Utf8Path;
 
     use crate::{RemotePath, S3Bucket, S3Config};
+
+    #[tokio::test]
+    async fn timed_download_observes_response_bytes() {
+        use bytes::Bytes;
+        use futures_util::StreamExt;
+
+        let metric = &crate::metrics::BUCKET_METRICS.response_bytes;
+        let count_before = metric.get_sample_count();
+        let sum_before = metric.get_sample_sum();
+
+        let chunks: Vec<std::io::Result<Bytes>> = vec![
+            Ok(Bytes::from(vec![0u8; 100])),
+            Ok(Bytes::from(vec![0u8; 250])),
+        ];
+        let mut download =
+            super::TimedDownload::new(std::time::Instant::now(), futures::stream::iter(chunks));
+
+        // drain the stream; response_bytes is observed when `download` is dropped
+        while download.next().await.is_some() {}
+        drop(download);
+
+        // download paths are the only producer of this metric and they don't run in unit tests,
+        // so this observation is the only one in the test binary.
+        assert_eq!(metric.get_sample_count(), count_before + 1);
+        assert_eq!(metric.get_sample_sum() - sum_before, 350.0);
+    }
 
     #[tokio::test]
     async fn relative_path() {


### PR DESCRIPTION
## Problem
We don't have visibility into S3 upload/download size distribution. #9819 asks for `remote_storage_s3_{request,response}_bytes` histograms.

## Summary of changes
- Add `remote_storage_s3_request_bytes` and `remote_storage_s3_response_bytes` histograms (byte buckets 1 KiB .. 1 GiB).
- `request_bytes` is observed from `from_size_bytes` on upload (Put).
- `response_bytes` counts the bytes streamed through `TimedDownload` and is observed on drop (Get), so ranged reads report their actual size.
- Unit test draining a `TimedDownload` and checking the observed bytes.

Closes #9819