### PR TITLE
docs:Update postgres docs to use pytest script

### DIFF
--- a/docs/updating-postgres.md
+++ b/docs/updating-postgres.md
@@ -73,7 +73,7 @@ branch.
 minor Postgres release.
 
     ```shell
-    ./scripts/poetry -k pg15
+    ./scripts/pytest -k pg15
     ```
 
 1. Commit your changes.


### PR DESCRIPTION
## Problem
The updating-postgres.md file had an issue in the 12th step
<img width="1295" height="153" alt="image" src="https://github.com/user-attachments/assets/8c20ef13-96c7-48f5-9371-43d09acc0aa8" />
The scripts folder no longer had the poetry script, where it had a pytest.

## Summary of changes
Changed the line   `./scripts/poetry -k pg15`   to    `./scripts/pytest -k pg15` 
Fixes:  #11056