### PR TITLE
compute_tools: use async client for zenith_admin fallback in get_maintenance_client

### DIFF
--- a/compute_tools/src/compute.rs
+++ b/compute_tools/src/compute.rs
@@ -1919,7 +1919,7 @@ impl ComputeNode {
                         "cannot connect to Postgres: {}, retrying with 'zenith_admin' username",
                         e
                     );
-                    let mut zenith_admin_conf = postgres::config::Config::from(conf.clone());
+                    let mut zenith_admin_conf = conf.clone();
                     zenith_admin_conf.application_name("compute_ctl:apply_config");
                     zenith_admin_conf.user("zenith_admin");
 
@@ -1928,20 +1928,32 @@ impl ComputeNode {
                     const ZENITH_OPTIONS: &str = "-c role=zenith_admin -c default_transaction_read_only=off -c search_path='' -c statement_timeout=0";
                     zenith_admin_conf.options(ZENITH_OPTIONS);
 
-                    let mut client =
+                    let (client, zenith_admin_conn) =
                         zenith_admin_conf.connect(NoTls)
+                            .await
                             .context("broken cloud_admin credential: tried connecting with cloud_admin but could not authenticate, and zenith_admin does not work either")?;
 
+                    let zenith_admin_conn_handle = spawn(async move {
+                        if let Err(e) = zenith_admin_conn.await {
+                            error!("zenith_admin connection error: {}", e);
+                        }
+                    });
+
                     // Disable forwarding so that users don't get a cloud_admin role
-                    let mut func = || {
-                        client.simple_query("SET neon.forward_ddl = false")?;
-                        client.simple_query("CREATE USER cloud_admin WITH SUPERUSER")?;
-                        client.simple_query("GRANT zenith_admin TO cloud_admin")?;
+                    let func = async {
+                        client.simple_query("SET neon.forward_ddl = false").await?;
+                        client
+                            .simple_query("CREATE USER cloud_admin WITH SUPERUSER")
+                            .await?;
+                        client
+                            .simple_query("GRANT zenith_admin TO cloud_admin")
+                            .await?;
                         Ok::<_, anyhow::Error>(())
                     };
-                    func().context("apply_config setup cloud_admin")?;
+                    func.await.context("apply_config setup cloud_admin")?;
 
                     drop(client);
+                    let _ = zenith_admin_conn_handle.await;
 
                     // Reconnect with connstring with expected name
                     conf.connect(NoTls).await?


### PR DESCRIPTION
## Problem

Fixes #12779

When `compute_ctl` cannot authenticate as `cloud_admin` and falls back to connecting as `zenith_admin`, the compute node panics with:

```
Cannot start a runtime from within a runtime. This happens because a function
(like `block_on`) attempted to block the current thread while the thread is
being used to drive asynchronous tasks.
```

Root cause: the `zenith_admin` fallback arm of `get_maintenance_client` (`compute_tools/src/compute.rs`) converts the `tokio_postgres::Config` into the **sync** `postgres` crate's `Config` and calls its blocking `connect()` (plus blocking `simple_query` calls). The sync `postgres` crate internally creates its own tokio runtime. But `get_maintenance_client` is an `async fn` running inside a runtime context — `apply_spec_sql`/`apply_spec_sql_db` drive it via `tokio::runtime::Handle::block_on` (`compute_tools/src/spec_apply.rs`). Creating a nested runtime there panics, killing the configurator thread, so any compute that legitimately needs the `zenith_admin` fallback fatals instead of migrating to `cloud_admin`.

## Summary of changes

Rewrite the fallback arm async-natively, removing the sync `postgres` crate from this path:

- Clone the `tokio_postgres::Config` directly (drop the `postgres::config::Config::from` conversion), set `user`, `application_name`, and the same `ZENITH_OPTIONS` as before.
- `connect(NoTls).await` and `tokio::spawn` the connection driver, matching how the surrounding code handles the `cloud_admin` connection.
- Run the same three setup statements (`SET neon.forward_ddl = false`, `CREATE USER cloud_admin WITH SUPERUSER`, `GRANT zenith_admin TO cloud_admin`) with `.await`, keeping the existing error contexts.
- Drop the `zenith_admin` client (and await its connection task), then reconnect as `cloud_admin` exactly as before.

The sync `postgres` dependency remains in `compute_tools/Cargo.toml` because other modules (`monitor.rs`, `lsn_lease.rs`, `catalog.rs`, `sync_sk.rs`, …) still use it. No `Cargo.toml`/`Cargo.lock` changes.

## Verification

All run on the fix branch (based on `main` @ `8f60b04`), Linux x86_64, Rust 1.88.0 (pinned by `rust-toolchain.toml`):

- `cargo build -p compute_tools` — success.
- `cargo test -p compute_tools` — 7 passed, 0 failed (1 unit test in `compute.rs`'s test module, plus `config_test` and `pg_helpers_tests`; the crate has no live-Postgres test harness, so no regression test was added — see below).
- `cargo clippy -p compute_tools --all-features --all-targets --no-deps --locked -- -A unknown_lints -D warnings -D clippy::todo` — clean. (Without `--no-deps` the run fails on 41 pre-existing clippy errors in `libs/remote_storage/src/gcs_bucket.rs` on current `main`, untouched by this PR.)
- `cargo fmt` — clean on the touched file.
- **Behavioral repro** against a local PostgreSQL 16 (role `zenith_admin` SUPERUSER LOGIN with trust auth; `cloud_admin` absent so the initial connect fails with SQLSTATE 28000): a scratch tokio program mimicking `apply_spec_sql`'s structure (std thread → `Handle::block_on` → `get_maintenance_client`), built with the same `neondatabase/rust-postgres` fork:
  - **Old sync pattern**: thread panics with `Cannot start a runtime from within a runtime` — reproduces the issue exactly.
  - **New async pattern**: fallback connects as `zenith_admin`, creates `cloud_admin`, reconnects; final session reports `current_user = cloud_admin` and the role exists.

No regression test added in-repo: `compute_tools` unit/integration tests are config/parsing-only with no live-Postgres harness, and inventing one for this path would be out of proportion for this fix.
