### PR TITLE
perf: stream L0 index metadata during compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4541,6 +4541,7 @@ dependencies = [
  "indoc",
  "itertools 0.10.5",
  "jsonwebtoken",
+ "libc",
  "md5",
  "metrics",
  "nix 0.30.1",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -117,6 +117,7 @@ procfs.workspace = true
 
 [dev-dependencies]
 base64.workspace = true
+libc.workspace = true
 criterion.workspace = true
 hex-literal.workspace = true
 tokio = { workspace = true, features = ["process", "sync", "fs", "rt", "io-util", "time", "test-util"] }

--- a/pageserver/src/tenant/disk_btree.rs
+++ b/pageserver/src/tenant/disk_btree.rs
@@ -265,6 +265,19 @@ where
         }
     }
 
+    pub(crate) fn iter_array<'a>(
+        self,
+        start_key: &'a [u8; L],
+        ctx: &'a RequestContext,
+    ) -> DiskBtreeArrayIterator<'a, L>
+    where
+        R: 'a + Send,
+    {
+        DiskBtreeArrayIterator {
+            stream: Box::pin(self.into_stream_array(start_key, ctx)),
+        }
+    }
+
     /// Return a stream which yields all key, value pairs from the index
     /// starting from the first key greater or equal to `start_key`.
     ///
@@ -285,6 +298,19 @@ where
         start_key: &'a [u8; L],
         ctx: &'a RequestContext,
     ) -> impl Stream<Item = std::result::Result<(Vec<u8>, u64), DiskBtreeError>> + 'a
+    where
+        R: 'a,
+    {
+        self.into_stream_array(start_key, ctx)
+            .map(|entry| entry.map(|(key, value)| (key.to_vec(), value)))
+    }
+
+    /// Internal allocation-free variant of [`Self::into_stream`].
+    pub(crate) fn into_stream_array<'a>(
+        self,
+        start_key: &'a [u8; L],
+        ctx: &'a RequestContext,
+    ) -> impl Stream<Item = std::result::Result<([u8; L], u64), DiskBtreeError>> + 'a
     where
         R: 'a,
     {
@@ -310,9 +336,8 @@ where
 
                 assert!(node.num_children > 0);
 
-                let mut keybuf = Vec::new();
-                keybuf.extend(node.prefix);
-                keybuf.resize(prefix_len + suffix_len, 0);
+                let mut keybuf = [0_u8; L];
+                keybuf[..prefix_len].copy_from_slice(node.prefix);
 
                 let mut iter: Either<Range<usize>, Rev<RangeInclusive<usize>>> = if let Some(iter) = opt_iter {
                     iter
@@ -357,7 +382,7 @@ where
                     #[allow(clippy::collapsible_if)]
                     if node.level == 0 {
                         // leaf
-                        yield (keybuf.clone(), value.to_u64());
+                        yield (keybuf, value.to_u64());
                     } else {
                         stack.push((node_blknum, Some(iter)));
                         stack.push((value.to_blknum(), None));
@@ -529,6 +554,21 @@ pub struct DiskBtreeIterator<'a> {
 
 impl DiskBtreeIterator<'_> {
     pub async fn next(&mut self) -> Option<std::result::Result<(Vec<u8>, u64), DiskBtreeError>> {
+        self.stream.next().await
+    }
+}
+
+pub(crate) struct DiskBtreeArrayIterator<'a, const L: usize> {
+    #[allow(clippy::type_complexity)]
+    stream: std::pin::Pin<
+        Box<dyn Stream<Item = std::result::Result<([u8; L], u64), DiskBtreeError>> + 'a + Send>,
+    >,
+}
+
+impl<const L: usize> DiskBtreeArrayIterator<'_, L> {
+    pub(crate) async fn next(
+        &mut self,
+    ) -> Option<std::result::Result<([u8; L], u64), DiskBtreeError>> {
         self.stream.next().await
     }
 }
@@ -829,6 +869,7 @@ impl<const L: usize> BuildNode<L> {
 #[cfg(test)]
 pub(crate) mod tests {
     use std::collections::BTreeMap;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use rand::Rng;
@@ -855,6 +896,11 @@ pub(crate) mod tests {
     impl BlockReader for TestDisk {
         fn block_cursor(&self) -> BlockCursor<'_> {
             BlockCursor::new(BlockReaderRef::TestDisk(self))
+        }
+    }
+    impl BlockReader for Arc<TestDisk> {
+        fn block_cursor(&self) -> BlockCursor<'_> {
+            BlockCursor::new(BlockReaderRef::TestDisk(self.as_ref()))
         }
     }
     impl BlockWriter for &mut TestDisk {
@@ -974,6 +1020,16 @@ pub(crate) mod tests {
             .await?;
         assert_eq!(data, expected);
 
+        // The fixed-array cursor is used by streaming metadata consumers. Verify that it
+        // reconstructs every prefix-compressed key without the Vec allocation used by `iter`.
+        let mut iter = reader.iter_array(&[0u8; 6], &ctx);
+        let mut data = Vec::new();
+        while let Some(entry) = iter.next().await {
+            let (key, value) = entry?;
+            data.push((key.to_vec(), value));
+        }
+        assert_eq!(data, expected);
+
         Ok(())
     }
 
@@ -1077,6 +1133,20 @@ pub(crate) mod tests {
             .map(|(&key, &val)| (key, val))
             .collect::<Vec<(u64, u64)>>();
         assert_eq!(*result.lock().unwrap(), expected);
+
+        // Exercise the fixed-array cursor across internal B-tree pages as well as leaves.
+        let start_key = u64::to_be_bytes(0);
+        let mut iter = reader.iter_array(&start_key, &ctx);
+        let mut streamed = Vec::new();
+        while let Some(entry) = iter.next().await {
+            let (key, value) = entry?;
+            streamed.push((u64::from_be_bytes(key), value));
+        }
+        let expected = all_data
+            .iter()
+            .map(|(&key, &value)| (key, value))
+            .collect::<Vec<_>>();
+        assert_eq!(streamed, expected);
 
         Ok(())
     }

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -66,7 +66,7 @@ use crate::page_cache::{self, FileId, PAGE_SZ};
 use crate::tenant::blob_io::BlobWriter;
 use crate::tenant::block_io::{BlockBuf, BlockCursor, BlockLease, BlockReader, FileBlockReader};
 use crate::tenant::disk_btree::{
-    DiskBtreeBuilder, DiskBtreeIterator, DiskBtreeReader, VisitDirection,
+    DiskBtreeArrayIterator, DiskBtreeBuilder, DiskBtreeIterator, DiskBtreeReader, VisitDirection,
 };
 use crate::tenant::storage_layer::layer::S3_UPLOAD_LIMIT;
 use crate::tenant::timeline::GetVectoredError;
@@ -1141,6 +1141,21 @@ impl DeltaLayerInner {
         Ok(all_keys)
     }
 
+    /// Return an ordered cursor over index metadata without materializing the whole index.
+    pub(crate) fn index_iter<'a>(&'a self, ctx: &'a RequestContext) -> DeltaLayerIndexIterator<'a> {
+        let block_reader = FileBlockReader::new(&self.file, self.file_id);
+        let tree_reader = DiskBtreeReader::<_, DELTA_KEY_SIZE>::new(
+            self.index_start_blk,
+            self.index_root_blk,
+            block_reader,
+        );
+        DeltaLayerIndexIterator {
+            index_start_offset: self.index_start_offset(),
+            index_iter: tree_reader.iter_array(&[0; DELTA_KEY_SIZE], ctx),
+            pending: None,
+        }
+    }
+
     /// Using the given writer, write out a version which has the earlier Lsns than `until`.
     ///
     /// Return the amount of key value records pushed to the writer.
@@ -1544,6 +1559,45 @@ impl<'a> pageserver_compaction::interface::CompactionDeltaEntry<'a, Key> for Del
     }
 }
 
+/// Ordered metadata cursor for a delta layer index.
+///
+/// The index stores blob offsets rather than sizes, so one pending entry is retained until the
+/// next offset is known. This keeps only one index entry per layer live.
+pub(crate) struct DeltaLayerIndexIterator<'a> {
+    index_start_offset: u64,
+    index_iter: DiskBtreeArrayIterator<'a, DELTA_KEY_SIZE>,
+    pending: Option<(Key, Lsn, BlobRef)>,
+}
+
+impl DeltaLayerIndexIterator<'_> {
+    async fn next_raw(&mut self) -> anyhow::Result<Option<(Key, Lsn, BlobRef)>> {
+        let Some(entry) = self.index_iter.next().await else {
+            return Ok(None);
+        };
+        let (raw_key, value) = entry?;
+        let delta_key = DeltaKey::from_slice(&raw_key);
+        Ok(Some((delta_key.key(), delta_key.lsn(), BlobRef(value))))
+    }
+
+    /// Return the next `(key, lsn, stored_value_size)` index entry.
+    pub(crate) async fn next(&mut self) -> anyhow::Result<Option<(Key, Lsn, u64)>> {
+        if self.pending.is_none() {
+            self.pending = self.next_raw().await?;
+        }
+        let Some((key, lsn, blob_ref)) = self.pending.take() else {
+            return Ok(None);
+        };
+
+        let next = self.next_raw().await?;
+        let size = match next.as_ref() {
+            Some((_, _, next_blob_ref)) => next_blob_ref.pos() - blob_ref.pos(),
+            None => self.index_start_offset - blob_ref.pos(),
+        };
+        self.pending = next;
+        Ok(Some((key, lsn, size)))
+    }
+}
+
 pub struct DeltaLayerIterator<'a> {
     delta_layer: &'a DeltaLayerInner,
     ctx: &'a RequestContext,
@@ -1621,6 +1675,7 @@ impl DeltaLayerIterator<'_> {
 #[cfg(test)]
 pub(crate) mod test {
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     use super::*;
     use crate::DEFAULT_PG_VERSION;
@@ -1637,6 +1692,60 @@ pub(crate) mod test {
     use rand::prelude::{SeedableRng, StdRng};
     use rand::seq::IndexedRandom;
     use rand::{Rng, RngCore};
+
+    /// In-memory delta index used by cursor and merge tests. The B-tree pages are shared by
+    /// cursors so repeated scans do not rebuild the test fixture.
+    pub(crate) struct TestDeltaIndex {
+        index_start_offset: u64,
+        root_offset: u32,
+        disk: Arc<TestDisk>,
+    }
+
+    impl TestDeltaIndex {
+        pub(crate) fn new(entries: &[(Key, Lsn, u64)]) -> anyhow::Result<Self> {
+            assert!(!entries.is_empty());
+            assert!(
+                entries
+                    .windows(2)
+                    .all(|entries| { (entries[0].0, entries[0].1) < (entries[1].0, entries[1].1) })
+            );
+
+            let mut disk = TestDisk::default();
+            let mut writer = DiskBtreeBuilder::<_, DELTA_KEY_SIZE>::new(&mut disk);
+            let mut offset = 0;
+            for (key, lsn, size) in entries {
+                let index_key = DeltaKey::from_key_lsn(key, *lsn);
+                writer.append(&index_key.0, BlobRef::new(offset, false).0)?;
+                offset += *size;
+            }
+            let (root_offset, _writer) = writer.finish()?;
+            Ok(Self {
+                index_start_offset: offset,
+                root_offset,
+                disk: Arc::new(disk),
+            })
+        }
+
+        pub(crate) fn cursor<'a>(&self, ctx: &'a RequestContext) -> DeltaLayerIndexIterator<'a> {
+            let reader =
+                DiskBtreeReader::<_, DELTA_KEY_SIZE>::new(0, self.root_offset, self.disk.clone());
+            DeltaLayerIndexIterator {
+                index_start_offset: self.index_start_offset,
+                index_iter: reader.iter_array(&[0; DELTA_KEY_SIZE], ctx),
+                pending: None,
+            }
+        }
+    }
+
+    /// Build an in-memory delta index cursor with blob offsets derived from the supplied sizes.
+    /// This is shared with the compaction merge tests to exercise the real cursor without a
+    /// filesystem-backed layer.
+    pub(crate) fn make_index_cursor<'a>(
+        entries: &[(Key, Lsn, u64)],
+        ctx: &'a RequestContext,
+    ) -> anyhow::Result<DeltaLayerIndexIterator<'a>> {
+        Ok(TestDeltaIndex::new(entries)?.cursor(ctx))
+    }
 
     /// Construct an index for a fictional delta layer and and then
     /// traverse in order to plan vectored reads for a query. Finally,
@@ -2278,6 +2387,26 @@ pub(crate) mod test {
             assert_eq!(l1, *l2);
             assert_eq!(&v1, v2);
         }
+    }
+
+    #[tokio::test]
+    async fn index_cursor_derives_sizes_from_offsets() -> anyhow::Result<()> {
+        let ctx = RequestContext::new(TaskKind::UnitTest, DownloadBehavior::Error);
+        let key = Key::from_i128(42);
+        let expected = vec![
+            (key, Lsn(0x20), 3),
+            (key, Lsn(0x30), 17),
+            (key.add(1), Lsn(0x18), 5),
+            (key.add(3), Lsn(0x40), 29),
+        ];
+        let mut cursor = make_index_cursor(&expected, &ctx)?;
+        let mut actual = Vec::new();
+        while let Some(entry) = cursor.next().await? {
+            actual.push(entry);
+        }
+
+        assert_eq!(actual, expected);
+        Ok(())
     }
 
     #[tokio::test]

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -1141,6 +1141,47 @@ impl DeltaLayerInner {
         Ok(all_keys)
     }
 
+    /// Return the first and last keys in the index without materializing its entries.
+    pub(crate) async fn index_key_bounds(
+        &self,
+        ctx: &RequestContext,
+    ) -> Result<Option<(Key, Key)>> {
+        let block_reader = FileBlockReader::new(&self.file, self.file_id);
+        let tree_reader = DiskBtreeReader::<_, DELTA_KEY_SIZE>::new(
+            self.index_start_blk,
+            self.index_root_blk,
+            block_reader,
+        );
+
+        let mut first = None;
+        tree_reader
+            .visit(
+                &[0; DELTA_KEY_SIZE],
+                VisitDirection::Forwards,
+                |key, _| {
+                    first = Some(DeltaKey::from_slice(key).key());
+                    false
+                },
+                ctx,
+            )
+            .await?;
+
+        let mut last = None;
+        tree_reader
+            .visit(
+                &[u8::MAX; DELTA_KEY_SIZE],
+                VisitDirection::Backwards,
+                |key, _| {
+                    last = Some(DeltaKey::from_slice(key).key());
+                    false
+                },
+                ctx,
+            )
+            .await?;
+
+        Ok(first.zip(last))
+    }
+
     /// Return an ordered cursor over index metadata without materializing the whole index.
     pub(crate) fn index_iter<'a>(&'a self, ctx: &'a RequestContext) -> DeltaLayerIndexIterator<'a> {
         let block_reader = FileBlockReader::new(&self.file, self.file_id);

--- a/pageserver/src/tenant/storage_layer/delta_layer.rs
+++ b/pageserver/src/tenant/storage_layer/delta_layer.rs
@@ -1465,6 +1465,12 @@ impl DeltaLayerInner {
         offset
     }
 
+    /// Return the physical B-tree portion of this layer. This tracks metadata cardinality even
+    /// when the values themselves are very small.
+    pub(crate) fn index_size_bytes(&self, file_size: u64) -> u64 {
+        file_size.saturating_sub(self.index_start_blk as u64 * PAGE_SZ as u64)
+    }
+
     pub fn iter_with_options<'a>(
         &'a self,
         ctx: &'a RequestContext,

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -119,8 +119,8 @@ impl Ord for IndexMergeHeapEntry {
 const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 4 * 1024 * 1024;
 
 /// A disjoint batch has no cross-layer merge work to amortize the cursor heap. Keep a bounded
-/// materialized fast path for small disjoint footprints; larger batches use the concatenated
-/// cursor and compact per-key output-size plan.
+/// materialized fast path for small disjoint footprints; larger batches scan one layer at a time
+/// and build the compact per-key output-size plan.
 const L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 32 * 1024 * 1024;
 
 type IndexMetadataEntry = (Key, Lsn, u64);
@@ -268,9 +268,14 @@ struct StreamingIndexMergeIterator<'a> {
     heap: BinaryHeap<IndexMergeHeapEntry>,
 }
 
-/// A sequential cursor over layers whose key ranges are proven disjoint.
+/// A sequential, one-layer-at-a-time scan over layers whose key ranges are proven disjoint.
+///
+/// The visitor used by `index_entries` is faster than the per-item async stream for this case, and
+/// only one layer's entries are retained while the compact output plan is built.
 struct ConcatenatedIndexMergeIterator<'a> {
-    iterators: Vec<DeltaLayerIndexIterator<'a>>,
+    deltas: Vec<&'a DeltaLayerInner>,
+    ctx: &'a RequestContext,
+    entries: Option<std::vec::IntoIter<DeltaEntry<'a>>>,
     current: usize,
 }
 
@@ -298,11 +303,22 @@ impl<'a> IndexMergeIterator<'a> {
         layer_order: &[usize],
         ctx: &'a RequestContext,
     ) -> Self {
-        let iterators = layer_order
-            .iter()
-            .map(|&layer_idx| deltas[layer_idx].index_iter(ctx))
-            .collect::<Vec<_>>();
-        Self::from_concatenated_iterators(iterators)
+        Self::from_concatenated_layers(
+            layer_order
+                .iter()
+                .map(|&layer_idx| deltas[layer_idx])
+                .collect(),
+            ctx,
+        )
+    }
+
+    fn from_concatenated_layers(deltas: Vec<&'a DeltaLayerInner>, ctx: &'a RequestContext) -> Self {
+        Self::Concatenated(ConcatenatedIndexMergeIterator {
+            deltas,
+            ctx,
+            entries: None,
+            current: 0,
+        })
     }
 
     async fn from_iterators(
@@ -320,13 +336,6 @@ impl<'a> IndexMergeIterator<'a> {
             iterators,
             heap,
         }))
-    }
-
-    fn from_concatenated_iterators(iterators: Vec<DeltaLayerIndexIterator<'a>>) -> Self {
-        Self::Concatenated(ConcatenatedIndexMergeIterator {
-            iterators,
-            current: 0,
-        })
     }
 
     fn from_entries(entries: &'a [IndexMetadataEntry]) -> Self {
@@ -359,13 +368,19 @@ impl<'a> IndexMergeIterator<'a> {
                 Ok(Some(entry))
             }
             Self::Concatenated(concatenated) => loop {
-                let Some(iterator) = concatenated.iterators.get_mut(concatenated.current) else {
+                if let Some(entries) = concatenated.entries.as_mut() {
+                    if let Some(entry) = entries.next() {
+                        return Ok(Some((entry.key, entry.lsn, entry.size)));
+                    }
+                    concatenated.entries = None;
+                }
+
+                let Some(delta) = concatenated.deltas.get(concatenated.current) else {
                     return Ok(None);
                 };
-                if let Some(entry) = iterator.next().await? {
-                    return Ok(Some(entry));
-                }
                 concatenated.current += 1;
+                concatenated.entries =
+                    Some(delta.index_entries(concatenated.ctx).await?.into_iter());
             },
         }
     }
@@ -5216,25 +5231,6 @@ mod tests {
             actual.push(entry);
         }
         assert_eq!(actual, expected);
-
-        let disjoint_first = vec![(key, Lsn(0x20), 3), (key.add(1), Lsn(0x30), 5)];
-        let disjoint_second = vec![(key.add(10), Lsn(0x40), 7)];
-        let mut concatenated = IndexMergeIterator::from_concatenated_iterators(vec![
-            make_index_cursor(&disjoint_first, &ctx)?,
-            make_index_cursor(&disjoint_second, &ctx)?,
-        ]);
-        let mut concatenated_actual = Vec::new();
-        while let Some(entry) = concatenated.next().await? {
-            concatenated_actual.push(entry);
-        }
-        assert_eq!(
-            concatenated_actual,
-            disjoint_first
-                .iter()
-                .chain(&disjoint_second)
-                .copied()
-                .collect::<Vec<_>>()
-        );
 
         let mut materialized = IndexMergeIterator::from_entries(&expected);
         let mut materialized_actual = Vec::new();

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -123,6 +123,11 @@ const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 4 * 1024 * 1024;
 /// and build the compact per-key output-size plan.
 const L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 32 * 1024 * 1024;
 
+/// Avoid a pair of exact B-tree bound walks for very wide batches whose broad descriptors do not
+/// prove disjointness. Such batches retain the existing materialized path instead of paying the
+/// bound walks and then scanning the indexes again.
+const L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS: usize = 512;
+
 type IndexMetadataEntry = (Key, Lsn, u64);
 
 /// Output sizing needs one total per key and only the LSNs where a duplicate-key run is split.
@@ -251,6 +256,9 @@ async fn index_range_order_if_disjoint(
         .collect::<Vec<_>>();
     if let Some(order) = disjoint_layer_order(layer_ranges, true) {
         return Ok(Some(order));
+    }
+    if deltas.len() > L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS {
+        return Ok(None);
     }
 
     let mut bounds = Vec::with_capacity(deltas.len());
@@ -2419,8 +2427,11 @@ impl Timeline {
             } else {
                 None
             };
-        let metadata_traversal =
-            stats.metadata_traversal(metadata_index_size, disjoint_index_order.is_some());
+        let metadata_traversal = stats.metadata_traversal(
+            metadata_index_size,
+            disjoint_index_order.is_some(),
+            deltas.len(),
+        );
         let materialize_metadata = metadata_traversal == IndexMetadataTraversal::Materialized;
         debug!(
             metadata_index_size,
@@ -2959,6 +2970,7 @@ impl CompactLevel0Phase1StatsBuilder {
         &self,
         index_size: u64,
         disjoint_index_ranges: bool,
+        layer_count: usize,
     ) -> IndexMetadataTraversal {
         #[cfg(test)]
         if let Some(traversal) = self.metadata_traversal_override {
@@ -2966,6 +2978,10 @@ impl CompactLevel0Phase1StatsBuilder {
         }
         if disjoint_index_ranges && index_size <= L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT
         {
+            IndexMetadataTraversal::Materialized
+        } else if !disjoint_index_ranges && layer_count > L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS {
+            // Broad descriptors cannot prove whether this many layers overlap. Avoid exact bound
+            // walks followed by another metadata pass; the fallback keeps the old cost profile.
             IndexMetadataTraversal::Materialized
         } else {
             index_metadata_traversal(index_size)
@@ -5183,16 +5199,28 @@ mod tests {
     fn disjoint_metadata_materialization_stays_bounded() {
         let stats = CompactLevel0Phase1StatsBuilder::default();
         assert_eq!(
-            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT, true),
+            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT, true, 10,),
             IndexMetadataTraversal::Materialized
         );
         assert_eq!(
-            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT + 1, true),
+            stats.metadata_traversal(
+                L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT + 1,
+                true,
+                10,
+            ),
             IndexMetadataTraversal::Streaming
         );
         assert_eq!(
-            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT, false),
+            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT, false, 10,),
             IndexMetadataTraversal::Streaming
+        );
+        assert_eq!(
+            stats.metadata_traversal(
+                L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT + 1,
+                false,
+                L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS + 1,
+            ),
+            IndexMetadataTraversal::Materialized
         );
     }
 

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -5085,6 +5085,58 @@ mod tests {
     use crate::tenant::timeline::DeltaLayerTestDesc;
     use crate::virtual_file::{IoMode, set_io_mode};
 
+    struct CountingAllocator;
+
+    static ALLOCATED_BYTES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    #[global_allocator]
+    static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+    unsafe impl std::alloc::GlobalAlloc for CountingAllocator {
+        unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+            let ptr = unsafe { std::alloc::System.alloc(layout) };
+            if !ptr.is_null() {
+                ALLOCATED_BYTES
+                    .fetch_add(layout.size() as u64, std::sync::atomic::Ordering::Relaxed);
+            }
+            ptr
+        }
+
+        unsafe fn alloc_zeroed(&self, layout: std::alloc::Layout) -> *mut u8 {
+            let ptr = unsafe { std::alloc::System.alloc_zeroed(layout) };
+            if !ptr.is_null() {
+                ALLOCATED_BYTES
+                    .fetch_add(layout.size() as u64, std::sync::atomic::Ordering::Relaxed);
+            }
+            ptr
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+            unsafe { std::alloc::System.dealloc(ptr, layout) };
+        }
+
+        unsafe fn realloc(
+            &self,
+            ptr: *mut u8,
+            layout: std::alloc::Layout,
+            new_size: usize,
+        ) -> *mut u8 {
+            let new_ptr = unsafe { std::alloc::System.realloc(ptr, layout, new_size) };
+            if !new_ptr.is_null() {
+                ALLOCATED_BYTES.fetch_add(new_size as u64, std::sync::atomic::Ordering::Relaxed);
+            }
+            new_ptr
+        }
+    }
+
+    fn reset_allocation_bytes() {
+        ALLOCATED_BYTES.store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn allocation_bytes() -> u64 {
+        ALLOCATED_BYTES.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     const L0_CALIBRATION_LAYERS: &str = "NEON_L0_COMPACTION_CALIBRATION_LAYERS";
     const L0_CALIBRATION_ENTRIES_PER_LAYER: &str =
         "NEON_L0_COMPACTION_CALIBRATION_ENTRIES_PER_LAYER";
@@ -5720,6 +5772,7 @@ mod tests {
         let compaction_ctx =
             RequestContext::todo_child(TaskKind::Compaction, DownloadBehavior::Download);
         let cancel = CancellationToken::new();
+        reset_allocation_bytes();
         let started = Instant::now();
         let outcome = tenant
             .compaction_iteration(&cancel, &compaction_ctx)
@@ -5760,6 +5813,10 @@ mod tests {
         println!(
             "l0_compaction_metadata_calibration_peak_rss_kib={}",
             peak_rss_kib()?
+        );
+        println!(
+            "l0_compaction_metadata_calibration_allocation_bytes={}",
+            allocation_bytes()
         );
         Ok(())
     }

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -114,9 +114,8 @@ impl Ord for IndexMergeHeapEntry {
 
 /// Keep the materialized fast path below this selected B-tree index size. Unlike total layer
 /// bytes, index bytes grow with the number of metadata entries even when their values are tiny.
-/// Every on-disk B-tree entry needs at least its five-byte value, so this cannot select the
-/// materialized path for a million-entry batch.
-const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 64 * 1024 * 1024;
+/// Large indexes still take the streaming path without relying on the layer byte-size cap.
+const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 128 * 1024 * 1024;
 
 /// A disjoint batch has no cross-layer merge work to amortize the cursor heap. Keep a bounded
 /// materialized fast path for small disjoint footprints; larger batches scan one layer at a time

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -114,8 +114,9 @@ impl Ord for IndexMergeHeapEntry {
 
 /// Keep the materialized fast path below this selected B-tree index size. Unlike total layer
 /// bytes, index bytes grow with the number of metadata entries even when their values are tiny.
-/// The comparison arm keeps the materialized implementation for the official calibration shapes.
-const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 8 * 1024 * 1024 * 1024;
+/// Every on-disk B-tree entry needs at least its five-byte value, so this cannot select the
+/// materialized path for a million-entry batch.
+const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 4 * 1024 * 1024;
 
 /// A disjoint batch has no cross-layer merge work to amortize the cursor heap. Keep a bounded
 /// materialized fast path for small disjoint footprints; larger batches scan one layer at a time

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -4,7 +4,7 @@
 //!
 //! The old legacy algorithm is implemented directly in `timeline.rs`.
 
-use std::cmp::min;
+use std::cmp::{Ordering, min};
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::ops::{Deref, Range};
 use std::sync::Arc;
@@ -2082,7 +2082,6 @@ impl Timeline {
             coverage_size: usize,
         }
         let holes: Vec<Hole> = {
-            use std::cmp::Ordering;
             impl Ord for Hole {
                 fn cmp(&self, other: &Self) -> Ordering {
                     self.coverage_size.cmp(&other.coverage_size).reverse()
@@ -2099,8 +2098,16 @@ impl Timeline {
             // min-heap (reserve space for one more element added before eviction)
             let mut heap: BinaryHeap<Hole> = BinaryHeap::with_capacity(max_holes + 1);
             let mut prev: Option<Key> = None;
+            let mut all_keys_iter = all_keys
+                .iter()
+                .map(|DeltaEntry { key, lsn, size, .. }| (*key, *lsn, *size));
+            let mut index_entries = 0usize;
 
-            for &DeltaEntry { key: next_key, .. } in all_keys.iter() {
+            while let Some((next_key, _, _)) = all_keys_iter.next() {
+                index_entries += 1;
+                if index_entries % 32_768 == 0 && self.cancel.is_cancelled() {
+                    return Err(CompactionError::new_cancelled());
+                }
                 if let Some(prev_key) = prev {
                     // just first fast filter, do not create hole entries for metadata keys. The last hole in the
                     // compaction is the gap between data key and metadata keys.
@@ -2162,7 +2169,9 @@ impl Timeline {
             )
         };
 
-        // This iterator walks through all keys and is needed to calculate size used by each key
+        // This iterator walks through all keys and is needed to calculate size used by each key.
+        // Coalesce entries for a key exactly as the previous materialized iterator did, while
+        // retaining only one pending merged entry.
         let mut all_keys_iter = all_keys
             .iter()
             .map(|DeltaEntry { key, lsn, size, .. }| (*key, *lsn, *size))
@@ -4582,3 +4591,486 @@ impl CompactionLayer<Key> for ResidentImageLayer {
     }
 }
 impl CompactionImageLayer<TimelineAdaptor> for ResidentImageLayer {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::context::DownloadBehavior;
+    use crate::task_mgr::TaskKind;
+    use crate::tenant::harness::{TIMELINE_ID, TenantHarness};
+    use crate::tenant::storage_layer::delta_layer::{
+        DeltaLayerIndexIterator, test::TestDeltaIndex,
+    };
+    use crate::tenant::timeline::DeltaLayerTestDesc;
+    use crate::virtual_file::{IoMode, set_io_mode};
+
+    const L0_CALIBRATION_LAYERS: &str = "NEON_L0_COMPACTION_CALIBRATION_LAYERS";
+    const L0_CALIBRATION_ENTRIES_PER_LAYER: &str =
+        "NEON_L0_COMPACTION_CALIBRATION_ENTRIES_PER_LAYER";
+    const L0_CALIBRATION_TARGET_FILE_SIZE: &str = "NEON_L0_COMPACTION_CALIBRATION_TARGET_FILE_SIZE";
+
+    fn calibration_env_usize(name: &str) -> anyhow::Result<usize> {
+        std::env::var(name)
+            .with_context(|| format!("{name} must be set"))?
+            .parse()
+            .with_context(|| format!("{name} must be a positive integer"))
+            .and_then(|value: usize| {
+                anyhow::ensure!(value > 0, "{name} must be positive");
+                Ok(value)
+            })
+    }
+
+    fn calibration_env_u64(name: &str) -> anyhow::Result<u64> {
+        std::env::var(name)
+            .with_context(|| format!("{name} must be set"))?
+            .parse()
+            .with_context(|| format!("{name} must be a positive integer"))
+            .and_then(|value: u64| {
+                anyhow::ensure!(value > 0, "{name} must be positive");
+                Ok(value)
+            })
+    }
+
+    struct MetadataCalibrationResult {
+        elapsed_micros: u128,
+        peak_rss_kib: u64,
+        entries: usize,
+        coalesced_entries: usize,
+        checksum: u128,
+    }
+
+    fn peak_rss_kib() -> anyhow::Result<u64> {
+        let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+        // SAFETY: getrusage initializes the rusage structure on success.
+        let result = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+        anyhow::ensure!(
+            result == 0,
+            "getrusage failed: {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: checked getrusage success above.
+        let max_rss = unsafe { usage.assume_init() }.ru_maxrss;
+        let max_rss = u64::try_from(max_rss).context("getrusage returned a negative max RSS")?;
+        #[cfg(target_os = "macos")]
+        let max_rss = max_rss / 1024;
+        Ok(max_rss)
+    }
+
+    fn calibration_indexes(layers: &[Vec<(Key, Lsn, u64)>]) -> anyhow::Result<Vec<TestDeltaIndex>> {
+        layers
+            .iter()
+            .map(|entries| TestDeltaIndex::new(entries))
+            .collect()
+    }
+
+    fn calibration_cursors<'a>(
+        indexes: &[TestDeltaIndex],
+        ctx: &'a RequestContext,
+    ) -> Vec<DeltaLayerIndexIterator<'a>> {
+        indexes.iter().map(|index| index.cursor(ctx)).collect()
+    }
+
+    /// Runs the materialized metadata path used by L0 compaction before streaming cursors.
+    /// Cursor construction is outside the timed region because a production compaction opens
+    /// already-written B-tree indexes.
+    async fn run_metadata_calibration(
+        indexes: &[TestDeltaIndex],
+        target_file_size: u64,
+        ctx: &RequestContext,
+    ) -> anyhow::Result<MetadataCalibrationResult> {
+        let mut cursors = calibration_cursors(indexes, ctx);
+
+        let started = Instant::now();
+        let mut materialized = Vec::new();
+        for cursor in &mut cursors {
+            // Match the old L0 phase-1 collection shape: each index traversal returns a layer
+            // vector, which is then extended into a batch-wide vector before sorting.
+            let mut layer_entries = Vec::new();
+            while let Some(entry) = cursor.next().await? {
+                layer_entries.push(entry);
+            }
+            materialized.extend(layer_entries);
+        }
+        materialized.sort_by_key(|entry| (entry.0, entry.1));
+
+        let mut entries = 0;
+        let mut previous = None;
+        let mut checksum = 0_u128;
+        for entry in materialized.iter().copied() {
+            assert!(previous.is_none_or(|previous| previous <= (entry.0, entry.1)));
+            previous = Some((entry.0, entry.1));
+            entries += 1;
+            checksum = checksum
+                .wrapping_mul(31)
+                .wrapping_add(entry.0.to_i128() as u128)
+                .wrapping_add(entry.1.0 as u128)
+                .wrapping_add(entry.2 as u128);
+        }
+
+        let mut coalesced_entries = 0;
+        let mut pending: Option<(Key, Lsn, u64)> = None;
+        for current in materialized {
+            match pending.take() {
+                Some(mut previous) if previous.0 == current.0 && previous.2 < target_file_size => {
+                    previous.2 += current.2;
+                    pending = Some(previous);
+                }
+                Some(previous) => {
+                    coalesced_entries += 1;
+                    checksum = checksum
+                        .wrapping_mul(31)
+                        .wrapping_add(previous.0.to_i128() as u128)
+                        .wrapping_add(previous.1.0 as u128)
+                        .wrapping_add(previous.2 as u128);
+                    pending = Some(current);
+                }
+                None => pending = Some(current),
+            }
+        }
+        if let Some(previous) = pending {
+            coalesced_entries += 1;
+            checksum = checksum
+                .wrapping_mul(31)
+                .wrapping_add(previous.0.to_i128() as u128)
+                .wrapping_add(previous.1.0 as u128)
+                .wrapping_add(previous.2 as u128);
+        }
+
+        Ok(MetadataCalibrationResult {
+            elapsed_micros: started.elapsed().as_micros(),
+            peak_rss_kib: peak_rss_kib()?,
+            entries,
+            coalesced_entries,
+            checksum,
+        })
+    }
+
+    #[tokio::test]
+    async fn l0_compaction_preserves_holes_duplicate_splits_and_restart() -> anyhow::Result<()> {
+        // This fixture uses the real L0 compaction path. Set TEST_OUTPUT=/tmp when running it on
+        // a filesystem that does not support no-replace renames in the workspace.
+        set_io_mode(IoMode::Buffered);
+
+        let harness = TenantHarness::create("l0_compaction_preserves_streaming_semantics").await?;
+        let _span = harness.span().entered();
+        let (tenant, ctx) = harness.load().await;
+        let initdb_lsn = Lsn(0x10);
+        let timeline = tenant
+            .create_test_timeline(TIMELINE_ID, initdb_lsn, crate::DEFAULT_PG_VERSION, &ctx)
+            .await?;
+
+        let key_a = Key::from_i128(100);
+        let key_b = Key::from_i128(1_000);
+        let key_c = key_b.next();
+        let l0_start = Lsn(0x40);
+        const LAYER_LSN_WIDTH: u64 = 0x10;
+        const LAYER_COUNT: usize = 4;
+        let final_lsn = Lsn(l0_start.0 + LAYER_COUNT as u64 * LAYER_LSN_WIDTH);
+        timeline.force_advance_lsn(final_lsn);
+
+        // Three disjoint image ranges inside the A..B gap make it rank as a selected hole.
+        // The B..C gap has no image coverage, so it is not selected.
+        for (image_lsn, first_key, last_key) in
+            [(0x10, 200, 300), (0x20, 400, 500), (0x30, 600, 700)]
+        {
+            timeline
+                .force_create_image_layer(
+                    Lsn(image_lsn),
+                    vec![
+                        (Key::from_i128(first_key), Bytes::from_static(b"coverage")),
+                        (Key::from_i128(last_key), Bytes::from_static(b"coverage")),
+                    ],
+                    Some(initdb_lsn),
+                    &ctx,
+                )
+                .await?;
+        }
+
+        let a_value = Bytes::from(vec![0xa1; 256]);
+        let b_value = Bytes::from(vec![0xb2; 256]);
+        let c_values = (0..LAYER_COUNT)
+            .map(|index| Bytes::from(vec![0xc0 + index as u8; 256]))
+            .collect::<Vec<_>>();
+
+        for layer_index in 0..LAYER_COUNT {
+            let lsn_start = Lsn(l0_start.0 + layer_index as u64 * LAYER_LSN_WIDTH);
+            let mut data = vec![(
+                key_c,
+                Lsn(lsn_start.0 + 1),
+                Value::Image(c_values[layer_index].clone()),
+            )];
+            if layer_index == 0 {
+                data.extend([
+                    (key_a, Lsn(lsn_start.0 + 2), Value::Image(a_value.clone())),
+                    (key_b, Lsn(lsn_start.0 + 3), Value::Image(b_value.clone())),
+                ]);
+            }
+            timeline
+                .force_create_delta_layer(
+                    DeltaLayerTestDesc::new(
+                        lsn_start..Lsn(lsn_start.0 + LAYER_LSN_WIDTH),
+                        Key::MIN..Key::MAX,
+                        data,
+                    ),
+                    Some(initdb_lsn),
+                    &ctx,
+                )
+                .await?;
+        }
+
+        // The layers are test-created rather than flushed from WAL, so advance the durable LSN
+        // explicitly before exercising a shutdown/reload.
+        timeline.force_set_disk_consistent_lsn(final_lsn);
+
+        // This is larger than the combined A and B values, so only the selected hole, rather
+        // than size alone, can separate them. It is smaller than the C version history, which
+        // requires LSN-sliced output layers for that one key.
+        let target_file_size = 640;
+        assert_eq!(
+            timeline
+                .compact_level0(target_file_size, true, None, &ctx)
+                .await?,
+            CompactionOutcome::Done
+        );
+        // force_set_disk_consistent_lsn changes the in-memory test state only. Publish matching
+        // metadata so reloading exercises the compacted layer map rather than discarding these
+        // intentionally test-created layers as future files.
+        timeline.schedule_uploads(final_lsn, std::iter::empty())?;
+
+        let mut output_deltas = {
+            let layer_manager = timeline.layers.read(LayerManagerLockHolder::Testing).await;
+            let layer_map = layer_manager.layer_map()?;
+            assert!(layer_map.level0_deltas().is_empty());
+            let layer_names = layer_map
+                .iter_historic_layers()
+                .map(|layer| layer.layer_name())
+                .collect::<Vec<_>>();
+            assert_eq!(check_valid_layermap(&layer_names), None);
+            layer_map
+                .iter_historic_layers()
+                .filter(|layer| layer.is_delta && layer.lsn_range.start >= l0_start)
+                .map(|layer| layer.key())
+                .collect::<Vec<_>>()
+        };
+        output_deltas.sort_by_key(|layer| (layer.key_range.start, layer.lsn_range.start));
+
+        // The selected A..B hole produces an A-only output layer. Without the hole, the two
+        // small keys fit together under target_file_size.
+        assert!(output_deltas.iter().any(|layer| {
+            layer.key_range.start == key_a
+                && layer.key_range.end == key_a.next()
+                && layer.lsn_range == (l0_start..final_lsn)
+                && layer.is_delta
+        }));
+        assert!(output_deltas.iter().any(|layer| {
+            layer.key_range.start == key_b
+                && layer.key_range.end == key_b.next()
+                && layer.lsn_range == (l0_start..final_lsn)
+                && layer.is_delta
+        }));
+
+        let mut c_splits = output_deltas
+            .iter()
+            .filter(|layer| layer.key_range.start == key_c && layer.key_range.end == key_c.next())
+            .collect::<Vec<_>>();
+        c_splits.sort_by_key(|layer| layer.lsn_range.start);
+        assert!(
+            c_splits.len() >= 2,
+            "expected multiple LSN-sliced output layers for {key_c}, got {c_splits:?}"
+        );
+        assert!(
+            c_splits
+                .windows(2)
+                .all(|pair| pair[0].lsn_range.end == pair[1].lsn_range.start),
+            "duplicate-key LSN slices are not contiguous: {c_splits:?}"
+        );
+
+        let mut expected_values = vec![(key_a, final_lsn, a_value), (key_b, final_lsn, b_value)];
+        expected_values.extend(c_values.iter().enumerate().map(|(layer_index, value)| {
+            (
+                key_c,
+                Lsn(l0_start.0 + layer_index as u64 * LAYER_LSN_WIDTH + 1),
+                value.clone(),
+            )
+        }));
+        for (key, lsn, expected) in &expected_values {
+            assert_eq!(timeline.get(*key, *lsn, &ctx).await?, *expected);
+        }
+
+        // Make the compacted layer-map durable and verify the same sampled values after reopening it.
+        timeline.remote_client.wait_completion().await?;
+        tenant
+            .shutdown(
+                Default::default(),
+                crate::tenant::timeline::ShutdownMode::FreezeAndFlush,
+            )
+            .await
+            .expect("test tenant should shut down");
+        drop(timeline);
+        drop(tenant);
+
+        let (reloaded_tenant, reloaded_ctx) = harness.load().await;
+        let reloaded_timeline = reloaded_tenant.get_timeline(TIMELINE_ID, true)?;
+        for (key, lsn, expected) in &expected_values {
+            assert_eq!(
+                reloaded_timeline.get(*key, *lsn, &reloaded_ctx).await?,
+                *expected
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Calibrates the two ordered metadata passes used for an L0 batch without requiring a
+    /// filesystem-backed tenant. The cursor and materialized metadata collection are the same
+    /// ones used by the compaction path; test B-trees are built before timing.
+    #[tokio::test]
+    #[ignore = "large L0 index metadata calibration"]
+    async fn l0_index_metadata_calibration() -> anyhow::Result<()> {
+        let layer_count = calibration_env_usize(L0_CALIBRATION_LAYERS)?;
+        let entries_per_layer = calibration_env_usize(L0_CALIBRATION_ENTRIES_PER_LAYER)?;
+        let target_file_size = calibration_env_u64(L0_CALIBRATION_TARGET_FILE_SIZE)?;
+        anyhow::ensure!(
+            layer_count >= 2,
+            "{L0_CALIBRATION_LAYERS} must be at least 2"
+        );
+
+        let layers = (0..layer_count)
+            .map(|layer_index| {
+                (0..entries_per_layer)
+                    .map(|key_index| {
+                        (
+                            Key::from_i128(key_index as i128),
+                            Lsn(0x10 + layer_index as u64 * 0x10),
+                            64,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let indexes = calibration_indexes(&layers)?;
+        drop(layers);
+        let ctx = RequestContext::new(TaskKind::UnitTest, DownloadBehavior::Error);
+        let result = run_metadata_calibration(&indexes, target_file_size, &ctx).await?;
+
+        assert_eq!(result.entries, layer_count * entries_per_layer);
+        assert!(result.coalesced_entries > 0);
+        assert_ne!(result.checksum, 0);
+        println!(
+            "l0_index_metadata_calibration_micros={}",
+            result.elapsed_micros
+        );
+        println!(
+            "l0_index_metadata_calibration_peak_rss_kib={}",
+            result.peak_rss_kib
+        );
+        Ok(())
+    }
+
+    /// Exercises the threshold-triggered L0 pass selected by the normal tenant compaction
+    /// iteration with a configurable stack of overlapping delta layers. The input construction is
+    /// deliberately outside the timer: a production compaction already receives completed layers,
+    /// while the timed section starts at the same `compaction_iteration` entry point used by the
+    /// background loop and includes layer-map replacement.
+    ///
+    /// This test is ignored because its intended calibration shape is large. Run it with the
+    /// default ten-layer threshold and one million entries per layer:
+    ///
+    /// ```text
+    /// TEST_OUTPUT=/tmp \
+    /// NEON_PAGESERVER_UNIT_TEST_VIRTUAL_FILE_IOENGINE=std-fs \
+    /// NEON_L0_COMPACTION_CALIBRATION_LAYERS=10 \
+    /// NEON_L0_COMPACTION_CALIBRATION_ENTRIES_PER_LAYER=1000000 \
+    /// NEON_L0_COMPACTION_CALIBRATION_TARGET_FILE_SIZE=67108864 \
+    /// cargo test -p pageserver --lib tenant::timeline::compaction::tests::l0_compaction_metadata_calibration -- --ignored --exact --nocapture
+    /// ```
+    #[tokio::test]
+    #[ignore = "large L0 compaction calibration"]
+    async fn l0_compaction_metadata_calibration() -> anyhow::Result<()> {
+        // The ignored test is run alone. Buffered IO makes its test fixture portable to filesystems
+        // that do not permit O_DIRECT while preserving the production compaction code path. Set
+        // TEST_OUTPUT to a filesystem that supports no-replace renames (such as /tmp in CI).
+        set_io_mode(IoMode::Buffered);
+
+        let layer_count = calibration_env_usize(L0_CALIBRATION_LAYERS)?;
+        let entries_per_layer = calibration_env_usize(L0_CALIBRATION_ENTRIES_PER_LAYER)?;
+        let target_file_size = calibration_env_u64(L0_CALIBRATION_TARGET_FILE_SIZE)?;
+        let harness = TenantHarness::create("l0_compaction_metadata_calibration").await?;
+        let _span = harness.span().entered();
+        let (tenant, ctx) = harness.load().await;
+        tenant.update_tenant_config(|mut config| {
+            config.checkpoint_distance = Some(target_file_size);
+            Ok(config)
+        })?;
+        let threshold = tenant.get_compaction_threshold();
+        anyhow::ensure!(
+            layer_count >= threshold,
+            "{L0_CALIBRATION_LAYERS} ({layer_count}) must meet the normal compaction threshold ({threshold})"
+        );
+        let initdb_lsn = Lsn(0x10);
+        let timeline = tenant
+            .create_test_timeline(TIMELINE_ID, initdb_lsn, crate::DEFAULT_PG_VERSION, &ctx)
+            .await?;
+
+        const LAYER_LSN_WIDTH: u64 = 0x10;
+        let final_lsn = Lsn(initdb_lsn.0 + layer_count as u64 * LAYER_LSN_WIDTH);
+        timeline.force_advance_lsn(final_lsn);
+
+        for layer_index in 0..layer_count {
+            let lsn_start = Lsn(initdb_lsn.0 + layer_index as u64 * LAYER_LSN_WIDTH);
+            let lsn_range = lsn_start..Lsn(lsn_start.0 + LAYER_LSN_WIDTH);
+            let value = Bytes::from(vec![layer_index as u8; 64]);
+            let data = (0..entries_per_layer)
+                .map(|key_index| {
+                    (
+                        Key::from_i128(key_index as i128),
+                        Lsn(lsn_start.0 + 1),
+                        Value::Image(value.clone()),
+                    )
+                })
+                .collect();
+            timeline
+                .force_create_delta_layer(
+                    DeltaLayerTestDesc::new(lsn_range, Key::MIN..Key::MAX, data),
+                    Some(initdb_lsn),
+                    &ctx,
+                )
+                .await?;
+        }
+
+        let compaction_ctx =
+            RequestContext::todo_child(TaskKind::Compaction, DownloadBehavior::Download);
+        let cancel = CancellationToken::new();
+        let started = Instant::now();
+        let outcome = tenant
+            .compaction_iteration(&cancel, &compaction_ctx)
+            .await?;
+        let elapsed_micros = started.elapsed().as_micros();
+
+        assert_eq!(outcome, CompactionOutcome::Done);
+        let layer_manager = timeline.layers.read(LayerManagerLockHolder::Testing).await;
+        let layer_map = layer_manager.layer_map()?;
+        assert!(layer_map.level0_deltas().is_empty());
+        let layer_names = layer_map
+            .iter_historic_layers()
+            .map(|layer| layer.layer_name())
+            .collect::<Vec<_>>();
+        assert_eq!(check_valid_layermap(&layer_names), None);
+        drop(layer_manager);
+
+        for key_index in [0, entries_per_layer / 2, entries_per_layer - 1] {
+            let value = timeline
+                .get(Key::from_i128(key_index as i128), final_lsn, &ctx)
+                .await?;
+            assert_eq!(value, Bytes::from(vec![(layer_count - 1) as u8; 64]));
+        }
+
+        println!("l0_compaction_metadata_calibration_micros={elapsed_micros}");
+        println!(
+            "l0_compaction_metadata_calibration_peak_rss_kib={}",
+            peak_rss_kib()?
+        );
+        Ok(())
+    }
+}

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -5156,6 +5156,8 @@ mod tests {
     const L0_CALIBRATION_TARGET_FILE_SIZE: &str = "NEON_L0_COMPACTION_CALIBRATION_TARGET_FILE_SIZE";
     const L0_CALIBRATION_VALUE_BYTES: &str = "NEON_L0_COMPACTION_CALIBRATION_VALUE_BYTES";
     const L0_CALIBRATION_DISJOINT_KEYS: &str = "NEON_L0_COMPACTION_CALIBRATION_DISJOINT_KEYS";
+    const L0_CALIBRATION_REVERSE_DISJOINT_KEYS: &str =
+        "NEON_L0_COMPACTION_CALIBRATION_REVERSE_DISJOINT_KEYS";
 
     fn calibration_env_usize(name: &str) -> anyhow::Result<usize> {
         std::env::var(name)
@@ -5703,8 +5705,10 @@ mod tests {
 
     /// Exercises the threshold-triggered L0 pass selected by the normal tenant compaction
     /// iteration with a configurable stack of delta layers. The default stack overlaps; set
-    /// `NEON_L0_COMPACTION_CALIBRATION_DISJOINT_KEYS=1` to exercise a wide output plan and
-    /// `NEON_L0_COMPACTION_CALIBRATION_VALUE_BYTES=1` for tiny-value metadata density. The input
+    /// `NEON_L0_COMPACTION_CALIBRATION_DISJOINT_KEYS=1` to exercise a wide output plan,
+    /// `NEON_L0_COMPACTION_CALIBRATION_REVERSE_DISJOINT_KEYS=1` to make the materialized control
+    /// sort reverse-ordered runs, and `NEON_L0_COMPACTION_CALIBRATION_VALUE_BYTES=1` for
+    /// tiny-value metadata density. The input
     /// construction is deliberately outside the timer: a production compaction already receives
     /// completed layers, while the timed section starts at the same `compaction_iteration` entry
     /// point used by the background loop and includes layer-map replacement.
@@ -5734,6 +5738,11 @@ mod tests {
         let target_file_size = calibration_env_u64(L0_CALIBRATION_TARGET_FILE_SIZE)?;
         let value_bytes = calibration_env_usize_or(L0_CALIBRATION_VALUE_BYTES, 64)?;
         let disjoint_keys = calibration_env_bool(L0_CALIBRATION_DISJOINT_KEYS)?;
+        let reverse_disjoint_keys = calibration_env_bool(L0_CALIBRATION_REVERSE_DISJOINT_KEYS)?;
+        anyhow::ensure!(
+            !reverse_disjoint_keys || disjoint_keys,
+            "{L0_CALIBRATION_REVERSE_DISJOINT_KEYS} requires {L0_CALIBRATION_DISJOINT_KEYS}=1"
+        );
         let harness = TenantHarness::create("l0_compaction_metadata_calibration").await?;
         let _span = harness.span().entered();
         let (tenant, ctx) = harness.load().await;
@@ -5763,7 +5772,12 @@ mod tests {
             let lsn_start = Lsn(initdb_lsn.0 + layer_index as u64 * LAYER_LSN_WIDTH);
             let lsn_range = lsn_start..Lsn(lsn_start.0 + LAYER_LSN_WIDTH);
             let value = Bytes::from(vec![layer_index as u8; value_bytes]);
-            let key_start = usize::from(disjoint_keys) * layer_index * entries_per_layer;
+            let key_layer_index = if reverse_disjoint_keys {
+                layer_count - layer_index - 1
+            } else {
+                layer_index
+            };
+            let key_start = usize::from(disjoint_keys) * key_layer_index * entries_per_layer;
             let data = (0..entries_per_layer)
                 .map(|key_index| {
                     (
@@ -5813,7 +5827,12 @@ mod tests {
             vec![layer_count - 1]
         };
         for layer_index in sampled_layers {
-            let key_start = usize::from(disjoint_keys) * layer_index * entries_per_layer;
+            let key_layer_index = if reverse_disjoint_keys {
+                layer_count - layer_index - 1
+            } else {
+                layer_index
+            };
+            let key_start = usize::from(disjoint_keys) * key_layer_index * entries_per_layer;
             for key_index in [0, entries_per_layer / 2, entries_per_layer - 1] {
                 let value = timeline
                     .get(

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -124,7 +124,7 @@ const L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 32 * 1024 * 1024;
 
 /// Bound heap and exact-range work for broad overlapping batches. Layer summaries can still prove
 /// disjointness without a bound walk; otherwise wider batches retain the materialized path.
-const L0_METADATA_STREAMING_MAX_OVERLAPPING_LAYERS: usize = 16;
+const L0_METADATA_STREAMING_MAX_OVERLAPPING_LAYERS: usize = 10;
 
 #[cfg(test)]
 static LAST_INDEX_METADATA_MICROS: std::sync::atomic::AtomicU64 =

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -16,7 +16,6 @@ use super::{
     GetVectoredError, ImageLayerCreationMode, LastImageLayerCreationStatus, RecordedDuration,
     Timeline,
 };
-use camino::Utf8Path;
 
 use crate::pgdatadir_mapping::CollectKeySpaceError;
 use crate::tenant::timeline::{DeltaEntry, RepartitionError};
@@ -36,7 +35,6 @@ use pageserver_api::shard::{ShardCount, ShardIdentity, TenantShardId};
 use pageserver_compaction::helpers::{fully_contains, overlaps_with};
 use pageserver_compaction::interface::*;
 use serde::Serialize;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
@@ -120,11 +118,14 @@ impl Ord for IndexMergeHeapEntry {
 /// materialized path for a million-entry batch.
 const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 4 * 1024 * 1024;
 
+/// A disjoint batch has no cross-layer merge work to amortize the cursor heap. Keep the
+/// materialized fast path for the same bounded, roughly two-million-entry scale as the output
+/// metadata plan; larger disjoint batches remain on the bounded replay path.
+const L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 32 * 1024 * 1024;
+
 /// A streamed hole pass keeps this many already-coalesced output-size entries in memory. Larger
-/// plans spill to an unlinked temporary file so output sizing can replay the same cursor pass.
-const L0_METADATA_OUTPUT_PLAN_MAX_ENTRIES: usize = 1_000_000;
-const L0_METADATA_SPOOL_BUFFER_SIZE: usize = 64 * 1024;
-const L0_METADATA_SPOOL_ENTRY_SIZE: usize = KEY_SIZE + 16;
+/// plans discard the bounded prefix so output sizing can replay fresh cursors.
+const L0_METADATA_OUTPUT_PLAN_MAX_ENTRIES: usize = 2_000_000;
 
 type IndexMetadataEntry = (Key, Lsn, u64);
 
@@ -143,158 +144,68 @@ fn index_metadata_traversal(index_size: u64) -> IndexMetadataTraversal {
     }
 }
 
+async fn index_ranges_are_disjoint(
+    deltas: &[&DeltaLayerInner],
+    ctx: &RequestContext,
+) -> anyhow::Result<bool> {
+    // Layer summaries are exact enough to prove disjointness and avoid reopening every index on
+    // the common production path. A summary may be wider than the actual index, so overlapping
+    // summaries get an exact first/last-key check before the fast path is selected.
+    let mut layer_ranges = deltas
+        .iter()
+        .map(|delta| (delta.key_range().start, delta.key_range().end))
+        .collect::<Vec<_>>();
+    layer_ranges.sort_unstable_by_key(|(first, _)| *first);
+    if layer_ranges
+        .windows(2)
+        .all(|window| window[0].1 <= window[1].0)
+    {
+        return Ok(true);
+    }
+
+    let mut bounds = Vec::with_capacity(deltas.len());
+    for delta in deltas {
+        if let Some(bound) = delta.index_key_bounds(ctx).await? {
+            bounds.push(bound);
+        }
+    }
+    bounds.sort_unstable_by_key(|(first, _)| *first);
+    Ok(bounds.windows(2).all(|window| window[0].1 < window[1].0))
+}
+
 /// A coalesced output-size plan collected during the hole pass. Most overlapping L0 stacks fit
-/// in memory; a wide disjoint stack uses a temporary file instead of making another index pass.
+/// in memory. When a disjoint plan exceeds the bound, the plan is discarded and the output
+/// writer replays fresh B-tree cursors instead of paying temporary-file I/O.
 enum CoalescedOutputMetadata {
     InMemory(Vec<IndexMetadataEntry>),
-    OnDisk(IndexMetadataSpoolReader),
+    Replay,
 }
 
 enum CoalescedOutputMetadataCollector {
     InMemory(Vec<IndexMetadataEntry>),
-    OnDisk(IndexMetadataSpoolWriter),
+    Replay,
 }
 
 impl CoalescedOutputMetadataCollector {
-    async fn append(
-        &mut self,
-        entry: IndexMetadataEntry,
-        target_file_size: u64,
-        max_entries: usize,
-        temp_dir: &Utf8Path,
-        cancel: &CancellationToken,
-    ) -> anyhow::Result<()> {
+    fn append(&mut self, entry: IndexMetadataEntry, target_file_size: u64, max_entries: usize) {
         match self {
             Self::InMemory(entries) => {
                 if append_coalesced_output_metadata(entries, entry, target_file_size, max_entries) {
-                    return Ok(());
+                    return;
                 }
-
-                let entries = std::mem::take(entries);
-                let mut spool = IndexMetadataSpoolWriter::new(temp_dir)?;
-                for (index, entry) in entries.into_iter().enumerate() {
-                    if index % 32_768 == 0 && cancel.is_cancelled() {
-                        anyhow::bail!("L0 metadata spool cancelled");
-                    }
-                    spool.append(entry, target_file_size).await?;
-                }
-                spool.append(entry, target_file_size).await?;
-                *self = Self::OnDisk(spool);
+                // The output writer can create a fresh cursor merge after the hole pass. Do not
+                // turn a rare wide disjoint plan into a synchronous temp-file write/read cycle.
+                *self = Self::Replay;
             }
-            Self::OnDisk(spool) => spool.append(entry, target_file_size).await?,
+            Self::Replay => {}
         }
-        Ok(())
     }
 
-    async fn finish(self) -> anyhow::Result<CoalescedOutputMetadata> {
+    fn finish(self) -> CoalescedOutputMetadata {
         match self {
-            Self::InMemory(entries) => Ok(CoalescedOutputMetadata::InMemory(entries)),
-            Self::OnDisk(spool) => Ok(CoalescedOutputMetadata::OnDisk(spool.finish().await?)),
+            Self::InMemory(entries) => CoalescedOutputMetadata::InMemory(entries),
+            Self::Replay => CoalescedOutputMetadata::Replay,
         }
-    }
-}
-
-/// Fixed-width temporary-file writer for coalesced `(key, LSN, stored-size)` metadata.
-struct IndexMetadataSpoolWriter {
-    writer: BufWriter<tokio::fs::File>,
-    pending: Option<IndexMetadataEntry>,
-    entries: u64,
-}
-
-impl IndexMetadataSpoolWriter {
-    fn new(temp_dir: &Utf8Path) -> anyhow::Result<Self> {
-        // tempfile_in unlinks the file immediately. It is reclaimed even if a cancelled
-        // compaction does not get to run normal Rust destructors.
-        let file = camino_tempfile::tempfile_in(temp_dir)
-            .with_context(|| format!("create L0 metadata spool in {temp_dir}"))?;
-        Ok(Self {
-            writer: BufWriter::with_capacity(
-                L0_METADATA_SPOOL_BUFFER_SIZE,
-                tokio::fs::File::from_std(file),
-            ),
-            pending: None,
-            entries: 0,
-        })
-    }
-
-    async fn append(
-        &mut self,
-        entry: IndexMetadataEntry,
-        target_file_size: u64,
-    ) -> anyhow::Result<()> {
-        if let Some(previous) = self.pending.as_mut()
-            && previous.0 == entry.0
-            && previous.2 < target_file_size
-        {
-            previous.2 += entry.2;
-            return Ok(());
-        }
-
-        if let Some(previous) = self.pending.replace(entry) {
-            self.write_entry(previous).await?;
-        }
-        Ok(())
-    }
-
-    async fn write_entry(&mut self, entry: IndexMetadataEntry) -> anyhow::Result<()> {
-        let mut buf = [0; L0_METADATA_SPOOL_ENTRY_SIZE];
-        entry.0.write_to_byte_slice(&mut buf[..KEY_SIZE]);
-        buf[KEY_SIZE..KEY_SIZE + 8].copy_from_slice(&entry.1.0.to_be_bytes());
-        buf[KEY_SIZE + 8..].copy_from_slice(&entry.2.to_be_bytes());
-        self.writer
-            .write_all(&buf)
-            .await
-            .context("write L0 metadata spool entry")?;
-        self.entries += 1;
-        Ok(())
-    }
-
-    async fn finish(mut self) -> anyhow::Result<IndexMetadataSpoolReader> {
-        if let Some(entry) = self.pending.take() {
-            self.write_entry(entry).await?;
-        }
-        self.writer
-            .flush()
-            .await
-            .context("flush L0 metadata spool")?;
-        let mut file = self.writer.into_inner();
-        file.rewind().await.context("rewind L0 metadata spool")?;
-        Ok(IndexMetadataSpoolReader {
-            reader: BufReader::with_capacity(L0_METADATA_SPOOL_BUFFER_SIZE, file),
-            remaining: self.entries,
-        })
-    }
-}
-
-struct IndexMetadataSpoolReader {
-    reader: BufReader<tokio::fs::File>,
-    remaining: u64,
-}
-
-impl IndexMetadataSpoolReader {
-    async fn next(&mut self) -> anyhow::Result<Option<IndexMetadataEntry>> {
-        if self.remaining == 0 {
-            return Ok(None);
-        }
-
-        let mut buf = [0; L0_METADATA_SPOOL_ENTRY_SIZE];
-        self.reader
-            .read_exact(&mut buf)
-            .await
-            .context("read L0 metadata spool entry")?;
-        self.remaining -= 1;
-        let key = Key::from_slice(&buf[..KEY_SIZE]);
-        let lsn = Lsn(u64::from_be_bytes(
-            buf[KEY_SIZE..KEY_SIZE + 8]
-                .try_into()
-                .expect("fixed-width LSN field"),
-        ));
-        let size = u64::from_be_bytes(
-            buf[KEY_SIZE + 8..]
-                .try_into()
-                .expect("fixed-width size field"),
-        );
-        Ok(Some((key, lsn, size)))
     }
 }
 
@@ -431,20 +342,18 @@ impl<'a> CoalescedIndexMergeIterator<'a> {
     }
 }
 
-/// Metadata consumed by the output writer. Streamed plans are already coalesced while the hole
-/// pass runs; only the materialized fast path needs a coalescing adapter here.
+/// Metadata consumed by the output writer. Plans that remain in memory are already coalesced;
+/// materialized and replayed cursor merges use the coalescing adapter here.
 enum OutputMetadataIterator<'a> {
-    Materialized(CoalescedIndexMergeIterator<'a>),
+    Coalesced(CoalescedIndexMergeIterator<'a>),
     InMemory(std::vec::IntoIter<IndexMetadataEntry>),
-    OnDisk(IndexMetadataSpoolReader),
 }
 
 impl OutputMetadataIterator<'_> {
     async fn next(&mut self) -> anyhow::Result<Option<IndexMetadataEntry>> {
         match self {
-            Self::Materialized(iterator) => iterator.next().await,
+            Self::Coalesced(iterator) => iterator.next().await,
             Self::InMemory(entries) => Ok(entries.next()),
-            Self::OnDisk(reader) => reader.next().await,
         }
     }
 }
@@ -2436,16 +2345,21 @@ impl Timeline {
                 .fold(0u64, |size, (delta, layer)| {
                     size.saturating_add(delta.index_size_bytes(layer.metadata().file_size))
                 });
-        let metadata_traversal = stats.metadata_traversal(metadata_index_size);
+        let metadata_traversal =
+            if index_metadata_traversal(metadata_index_size) == IndexMetadataTraversal::Streaming {
+                let disjoint_index_ranges = index_ranges_are_disjoint(&deltas, &index_ctx)
+                    .await
+                    .map_err(CompactionError::Other)?;
+                stats.metadata_traversal(metadata_index_size, disjoint_index_ranges)
+            } else {
+                stats.metadata_traversal(metadata_index_size, false)
+            };
         let materialize_metadata = metadata_traversal == IndexMetadataTraversal::Materialized;
         debug!(
             metadata_index_size,
             ?metadata_traversal,
             "selected L0 metadata traversal mode"
         );
-        let metadata_spool_dir = self
-            .conf
-            .timeline_path(&self.tenant_shard_id, &self.timeline_id);
         let materialized_metadata: Option<Vec<IndexMetadataEntry>> = if materialize_metadata {
             let mut all_keys = Vec::new();
             for delta in &deltas {
@@ -2514,9 +2428,8 @@ impl Timeline {
                     .await
                     .map_err(CompactionError::Other)?,
             };
-            // Reuse the streamed hole pass for output sizing. A large disjoint plan spills its
-            // already-coalesced entries instead of forcing output sizing to traverse every index
-            // a second time.
+            // Reuse the streamed hole pass for output sizing. A plan that exceeds the bound is
+            // replayed from fresh cursors instead of retaining or spooling every entry.
             let mut output_metadata = (!materialize_metadata)
                 .then(|| CoalescedOutputMetadataCollector::InMemory(Vec::new()));
             let mut index_entries = 0usize;
@@ -2525,22 +2438,11 @@ impl Timeline {
                 all_keys_iter.next().await.map_err(CompactionError::Other)?
             {
                 if let Some(output_metadata) = output_metadata.as_mut() {
-                    output_metadata
-                        .append(
-                            entry,
-                            target_file_size,
-                            L0_METADATA_OUTPUT_PLAN_MAX_ENTRIES,
-                            &metadata_spool_dir,
-                            &self.cancel,
-                        )
-                        .await
-                        .map_err(|error| {
-                            if self.cancel.is_cancelled() {
-                                CompactionError::new_cancelled()
-                            } else {
-                                CompactionError::Other(error)
-                            }
-                        })?;
+                    output_metadata.append(
+                        entry,
+                        target_file_size,
+                        L0_METADATA_OUTPUT_PLAN_MAX_ENTRIES,
+                    );
                 }
                 index_entries += 1;
                 if index_entries % 32_768 == 0 && self.cancel.is_cancelled() {
@@ -2580,15 +2482,7 @@ impl Timeline {
             }
             let mut holes = heap.into_vec();
             holes.sort_unstable_by_key(|hole| hole.key_range.start);
-            let output_metadata = match output_metadata {
-                Some(output_metadata) => Some(
-                    output_metadata
-                        .finish()
-                        .await
-                        .map_err(CompactionError::Other)?,
-                ),
-                None => None,
-            };
+            let output_metadata = output_metadata.map(CoalescedOutputMetadataCollector::finish);
             (holes, output_metadata)
         };
         let metadata_pass_finished = tokio::time::Instant::now();
@@ -2644,16 +2538,14 @@ impl Timeline {
         );
 
         // This iterator walks through all keys and is needed to calculate size used by each key.
-        // The streamed hole pass has already produced the coalesced metadata for this consumer,
-        // either in memory or in an unlinked temporary file. Replaying it avoids another B-tree
-        // traversal for disjoint large batches.
+        // The streamed hole pass has already produced the coalesced metadata for this consumer
+        // when it fit within the bound. A wide plan is replayed from fresh B-tree cursors so the
+        // hole pass does not retain or spool the whole plan.
         let mut all_keys_iter = match materialized_metadata.as_deref() {
-            Some(entries) => {
-                OutputMetadataIterator::Materialized(CoalescedIndexMergeIterator::new(
-                    IndexMergeIterator::from_entries(entries),
-                    target_file_size,
-                ))
-            }
+            Some(entries) => OutputMetadataIterator::Coalesced(CoalescedIndexMergeIterator::new(
+                IndexMergeIterator::from_entries(entries),
+                target_file_size,
+            )),
             None => match streamed_output_metadata
                 .take()
                 .expect("streamed metadata exists outside the materialized path")
@@ -2661,7 +2553,14 @@ impl Timeline {
                 CoalescedOutputMetadata::InMemory(entries) => {
                     OutputMetadataIterator::InMemory(entries.into_iter())
                 }
-                CoalescedOutputMetadata::OnDisk(reader) => OutputMetadataIterator::OnDisk(reader),
+                CoalescedOutputMetadata::Replay => {
+                    OutputMetadataIterator::Coalesced(CoalescedIndexMergeIterator::new(
+                        IndexMergeIterator::create(&deltas, &index_ctx)
+                            .await
+                            .map_err(CompactionError::Other)?,
+                        target_file_size,
+                    ))
+                }
             },
         };
 
@@ -3001,12 +2900,21 @@ struct CompactLevel0Phase1Stats {
 }
 
 impl CompactLevel0Phase1StatsBuilder {
-    fn metadata_traversal(&self, index_size: u64) -> IndexMetadataTraversal {
+    fn metadata_traversal(
+        &self,
+        index_size: u64,
+        disjoint_index_ranges: bool,
+    ) -> IndexMetadataTraversal {
         #[cfg(test)]
         if let Some(traversal) = self.metadata_traversal_override {
             return traversal;
         }
-        index_metadata_traversal(index_size)
+        if disjoint_index_ranges && index_size <= L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT
+        {
+            IndexMetadataTraversal::Materialized
+        } else {
+            index_metadata_traversal(index_size)
+        }
     }
 }
 
@@ -5230,9 +5138,25 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn coalesced_output_metadata_spills_and_replays() -> anyhow::Result<()> {
-        let temp_dir = camino_tempfile::tempdir()?;
+    #[test]
+    fn disjoint_metadata_materialization_stays_bounded() {
+        let stats = CompactLevel0Phase1StatsBuilder::default();
+        assert_eq!(
+            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT, true),
+            IndexMetadataTraversal::Materialized
+        );
+        assert_eq!(
+            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT + 1, true),
+            IndexMetadataTraversal::Streaming
+        );
+        assert_eq!(
+            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT, false),
+            IndexMetadataTraversal::Streaming
+        );
+    }
+
+    #[test]
+    fn coalesced_output_metadata_replays_after_bound() {
         let key = Key::from_i128(100);
         let input = [
             (key, Lsn(0x20), 3),
@@ -5240,29 +5164,15 @@ mod tests {
             (key.next(), Lsn(0x50), 1),
             (key.add(2), Lsn(0x60), 1),
         ];
-        let expected = vec![
-            (key, Lsn(0x20), 7),
-            (key.next(), Lsn(0x50), 1),
-            (key.add(2), Lsn(0x60), 1),
-        ];
 
-        let cancel = CancellationToken::new();
         let mut collector = CoalescedOutputMetadataCollector::InMemory(Vec::new());
         for entry in input {
-            collector
-                .append(entry, 10, 2, temp_dir.path(), &cancel)
-                .await?;
+            collector.append(entry, 10, 2);
         }
-        let CoalescedOutputMetadata::OnDisk(mut reader) = collector.finish().await? else {
-            panic!("two-entry plan should spill when a third distinct key is appended");
-        };
-
-        let mut actual = Vec::new();
-        while let Some(entry) = reader.next().await? {
-            actual.push(entry);
-        }
-        assert_eq!(actual, expected);
-        Ok(())
+        assert!(matches!(
+            collector.finish(),
+            CoalescedOutputMetadata::Replay
+        ));
     }
 
     #[tokio::test]

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -122,10 +122,9 @@ const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 128 * 1024 * 1024;
 /// and build the compact per-key output-size plan.
 const L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 32 * 1024 * 1024;
 
-/// Avoid a pair of exact B-tree bound walks for very wide batches whose broad descriptors do not
-/// prove disjointness. Such batches retain the existing materialized path instead of paying the
-/// bound walks and then scanning the indexes again.
-const L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS: usize = 512;
+/// Bound heap and exact-range work for broad overlapping batches. Layer summaries can still prove
+/// disjointness without a bound walk; otherwise wider batches retain the materialized path.
+const L0_METADATA_STREAMING_MAX_OVERLAPPING_LAYERS: usize = 16;
 
 #[cfg(test)]
 static LAST_INDEX_METADATA_MICROS: std::sync::atomic::AtomicU64 =
@@ -260,7 +259,7 @@ async fn index_range_order_if_disjoint(
     if let Some(order) = disjoint_layer_order(layer_ranges, true) {
         return Ok(Some(order));
     }
-    if deltas.len() > L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS {
+    if deltas.len() > L0_METADATA_STREAMING_MAX_OVERLAPPING_LAYERS {
         return Ok(None);
     }
 
@@ -2995,9 +2994,9 @@ impl CompactLevel0Phase1StatsBuilder {
             } else {
                 IndexMetadataTraversal::Streaming
             }
-        } else if layer_count > L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS {
+        } else if layer_count > L0_METADATA_STREAMING_MAX_OVERLAPPING_LAYERS {
             // Broad descriptors cannot prove whether this many layers overlap. Avoid exact bound
-            // walks followed by another metadata pass; the fallback keeps the old cost profile.
+            // walks followed by a cursor merge; the fallback keeps the old cost profile.
             IndexMetadataTraversal::Materialized
         } else {
             index_metadata_traversal(index_size)
@@ -5292,7 +5291,7 @@ mod tests {
             stats.metadata_traversal(
                 L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT + 1,
                 false,
-                L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS + 1,
+                L0_METADATA_STREAMING_MAX_OVERLAPPING_LAYERS + 1,
             ),
             IndexMetadataTraversal::Materialized
         );

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -118,16 +118,89 @@ impl Ord for IndexMergeHeapEntry {
 /// materialized path for a million-entry batch.
 const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 4 * 1024 * 1024;
 
-/// A disjoint batch has no cross-layer merge work to amortize the cursor heap. Keep the
-/// materialized fast path for the same bounded, roughly two-million-entry scale as the output
-/// metadata plan; larger disjoint batches remain on the bounded replay path.
+/// A disjoint batch has no cross-layer merge work to amortize the cursor heap. Keep a bounded
+/// materialized fast path for small disjoint footprints; larger batches use the concatenated
+/// cursor and compact per-key output-size plan.
 const L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 32 * 1024 * 1024;
 
-/// A streamed hole pass keeps this many already-coalesced output-size entries in memory. Larger
-/// plans discard the bounded prefix so output sizing can replay fresh cursors.
-const L0_METADATA_OUTPUT_PLAN_MAX_ENTRIES: usize = 2_000_000;
-
 type IndexMetadataEntry = (Key, Lsn, u64);
+
+/// Output sizing needs one total per key and only the LSNs where a duplicate-key run is split.
+/// Keeping this compact plan avoids retaining the complete index entry stream or reopening the
+/// B-trees after the hole pass.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct OutputSizePlan {
+    key_sizes: Vec<u64>,
+    duplicate_splits: Vec<(usize, Lsn)>,
+}
+
+struct OutputSizePlanBuilder {
+    target_file_size: u64,
+    pending: Option<IndexMetadataEntry>,
+    plan: OutputSizePlan,
+    current_key: Option<Key>,
+    current_key_index: usize,
+    current_segment_size: u64,
+    current_segment_lsn: Option<Lsn>,
+}
+
+impl OutputSizePlanBuilder {
+    fn new(target_file_size: u64) -> Self {
+        Self {
+            target_file_size,
+            pending: None,
+            plan: OutputSizePlan::default(),
+            current_key: None,
+            current_key_index: 0,
+            current_segment_size: 0,
+            current_segment_lsn: None,
+        }
+    }
+
+    /// Apply the same strict-`< target` coalescing used by the former output metadata cursor.
+    fn push(&mut self, entry: IndexMetadataEntry) {
+        if let Some(previous) = self.pending.take() {
+            if previous.0 == entry.0 && previous.2 < self.target_file_size {
+                self.pending = Some((previous.0, previous.1, previous.2 + entry.2));
+                return;
+            }
+            self.add_coalesced(previous);
+        }
+        self.pending = Some(entry);
+    }
+
+    fn add_coalesced(&mut self, (key, lsn, size): IndexMetadataEntry) {
+        if self.current_key != Some(key) {
+            self.current_key = Some(key);
+            self.current_key_index = self.plan.key_sizes.len();
+            self.plan.key_sizes.push(size);
+            self.current_segment_size = size;
+            self.current_segment_lsn = Some(lsn);
+            return;
+        }
+
+        self.plan.key_sizes[self.current_key_index] =
+            self.plan.key_sizes[self.current_key_index].saturating_add(size);
+        if self.current_segment_size.saturating_add(size) > self.target_file_size
+            && self.current_segment_lsn != Some(lsn)
+        {
+            self.plan
+                .duplicate_splits
+                .push((self.current_key_index, lsn));
+            self.current_segment_size = size;
+            self.current_segment_lsn = Some(lsn);
+        } else {
+            self.current_segment_size = self.current_segment_size.saturating_add(size);
+        }
+    }
+
+    fn finish(mut self) -> OutputSizePlan {
+        if let Some(pending) = self.pending.take() {
+            self.add_coalesced(pending);
+        }
+        self.plan
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum IndexMetadataTraversal {
@@ -144,69 +217,49 @@ fn index_metadata_traversal(index_size: u64) -> IndexMetadataTraversal {
     }
 }
 
-async fn index_ranges_are_disjoint(
+fn disjoint_layer_order(
+    mut ranges: Vec<(usize, Key, Key)>,
+    exclusive_end: bool,
+) -> Option<Vec<usize>> {
+    ranges.sort_unstable_by_key(|(_, first, _)| *first);
+    let disjoint = ranges.windows(2).all(|window| {
+        if exclusive_end {
+            window[0].2 <= window[1].1
+        } else {
+            window[0].2 < window[1].1
+        }
+    });
+    disjoint.then(|| {
+        ranges
+            .into_iter()
+            .map(|(layer_idx, _, _)| layer_idx)
+            .collect()
+    })
+}
+
+async fn index_range_order_if_disjoint(
     deltas: &[&DeltaLayerInner],
     ctx: &RequestContext,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<Option<Vec<usize>>> {
     // Layer summaries are exact enough to prove disjointness and avoid reopening every index on
     // the common production path. A summary may be wider than the actual index, so overlapping
     // summaries get an exact first/last-key check before the fast path is selected.
-    let mut layer_ranges = deltas
+    let layer_ranges = deltas
         .iter()
-        .map(|delta| (delta.key_range().start, delta.key_range().end))
+        .enumerate()
+        .map(|(layer_idx, delta)| (layer_idx, delta.key_range().start, delta.key_range().end))
         .collect::<Vec<_>>();
-    layer_ranges.sort_unstable_by_key(|(first, _)| *first);
-    if layer_ranges
-        .windows(2)
-        .all(|window| window[0].1 <= window[1].0)
-    {
-        return Ok(true);
+    if let Some(order) = disjoint_layer_order(layer_ranges, true) {
+        return Ok(Some(order));
     }
 
     let mut bounds = Vec::with_capacity(deltas.len());
-    for delta in deltas {
-        if let Some(bound) = delta.index_key_bounds(ctx).await? {
-            bounds.push(bound);
+    for (layer_idx, delta) in deltas.iter().enumerate() {
+        if let Some((first, last)) = delta.index_key_bounds(ctx).await? {
+            bounds.push((layer_idx, first, last));
         }
     }
-    bounds.sort_unstable_by_key(|(first, _)| *first);
-    Ok(bounds.windows(2).all(|window| window[0].1 < window[1].0))
-}
-
-/// A coalesced output-size plan collected during the hole pass. Most overlapping L0 stacks fit
-/// in memory. When a disjoint plan exceeds the bound, the plan is discarded and the output
-/// writer replays fresh B-tree cursors instead of paying temporary-file I/O.
-enum CoalescedOutputMetadata {
-    InMemory(Vec<IndexMetadataEntry>),
-    Replay,
-}
-
-enum CoalescedOutputMetadataCollector {
-    InMemory(Vec<IndexMetadataEntry>),
-    Replay,
-}
-
-impl CoalescedOutputMetadataCollector {
-    fn append(&mut self, entry: IndexMetadataEntry, target_file_size: u64, max_entries: usize) {
-        match self {
-            Self::InMemory(entries) => {
-                if append_coalesced_output_metadata(entries, entry, target_file_size, max_entries) {
-                    return;
-                }
-                // The output writer can create a fresh cursor merge after the hole pass. Do not
-                // turn a rare wide disjoint plan into a synchronous temp-file write/read cycle.
-                *self = Self::Replay;
-            }
-            Self::Replay => {}
-        }
-    }
-
-    fn finish(self) -> CoalescedOutputMetadata {
-        match self {
-            Self::InMemory(entries) => CoalescedOutputMetadata::InMemory(entries),
-            Self::Replay => CoalescedOutputMetadata::Replay,
-        }
-    }
+    Ok(disjoint_layer_order(bounds, false))
 }
 
 /// Bounded k-way merge over the metadata indexes of a set of delta layers.
@@ -215,10 +268,17 @@ struct StreamingIndexMergeIterator<'a> {
     heap: BinaryHeap<IndexMergeHeapEntry>,
 }
 
+/// A sequential cursor over layers whose key ranges are proven disjoint.
+struct ConcatenatedIndexMergeIterator<'a> {
+    iterators: Vec<DeltaLayerIndexIterator<'a>>,
+    current: usize,
+}
+
 /// Ordered metadata from either the small-batch materialized fast path or a bounded cursor merge.
 enum IndexMergeIterator<'a> {
     Materialized(std::iter::Copied<std::slice::Iter<'a, IndexMetadataEntry>>),
     Streaming(StreamingIndexMergeIterator<'a>),
+    Concatenated(ConcatenatedIndexMergeIterator<'a>),
 }
 
 impl<'a> IndexMergeIterator<'a> {
@@ -231,6 +291,18 @@ impl<'a> IndexMergeIterator<'a> {
             .map(|delta| delta.index_iter(ctx))
             .collect::<Vec<_>>();
         Self::from_iterators(iterators).await
+    }
+
+    fn create_concatenated(
+        deltas: &[&'a DeltaLayerInner],
+        layer_order: &[usize],
+        ctx: &'a RequestContext,
+    ) -> Self {
+        let iterators = layer_order
+            .iter()
+            .map(|&layer_idx| deltas[layer_idx].index_iter(ctx))
+            .collect::<Vec<_>>();
+        Self::from_concatenated_iterators(iterators)
     }
 
     async fn from_iterators(
@@ -248,6 +320,13 @@ impl<'a> IndexMergeIterator<'a> {
             iterators,
             heap,
         }))
+    }
+
+    fn from_concatenated_iterators(iterators: Vec<DeltaLayerIndexIterator<'a>>) -> Self {
+        Self::Concatenated(ConcatenatedIndexMergeIterator {
+            iterators,
+            current: 0,
+        })
     }
 
     fn from_entries(entries: &'a [IndexMetadataEntry]) -> Self {
@@ -279,40 +358,28 @@ impl<'a> IndexMergeIterator<'a> {
                 }
                 Ok(Some(entry))
             }
+            Self::Concatenated(concatenated) => loop {
+                let Some(iterator) = concatenated.iterators.get_mut(concatenated.current) else {
+                    return Ok(None);
+                };
+                if let Some(entry) = iterator.next().await? {
+                    return Ok(Some(entry));
+                }
+                concatenated.current += 1;
+            },
         }
     }
 }
 
-/// Append metadata in the same segments that `CoalescedIndexMergeIterator` exposes to output
-/// sizing. Returning false tells the caller to discard the plan rather than retain more metadata.
-fn append_coalesced_output_metadata(
-    entries: &mut Vec<IndexMetadataEntry>,
-    current: IndexMetadataEntry,
-    target_file_size: u64,
-    max_entries: usize,
-) -> bool {
-    if let Some(previous) = entries.last_mut()
-        && previous.0 == current.0
-        && previous.2 < target_file_size
-    {
-        previous.2 += current.2;
-        return true;
-    }
-
-    if entries.len() == max_entries {
-        return false;
-    }
-    entries.push(current);
-    true
-}
-
 /// Equivalent of the former `Itertools::coalesce` call used for output sizing.
+#[cfg(test)]
 struct CoalescedIndexMergeIterator<'a> {
     inner: IndexMergeIterator<'a>,
     pending: Option<IndexMetadataEntry>,
     target_file_size: u64,
 }
 
+#[cfg(test)]
 impl<'a> CoalescedIndexMergeIterator<'a> {
     fn new(inner: IndexMergeIterator<'a>, target_file_size: u64) -> Self {
         Self {
@@ -339,22 +406,6 @@ impl<'a> CoalescedIndexMergeIterator<'a> {
             }
         }
         Ok(Some(previous))
-    }
-}
-
-/// Metadata consumed by the output writer. Plans that remain in memory are already coalesced;
-/// materialized and replayed cursor merges use the coalescing adapter here.
-enum OutputMetadataIterator<'a> {
-    Coalesced(CoalescedIndexMergeIterator<'a>),
-    InMemory(std::vec::IntoIter<IndexMetadataEntry>),
-}
-
-impl OutputMetadataIterator<'_> {
-    async fn next(&mut self) -> anyhow::Result<Option<IndexMetadataEntry>> {
-        match self {
-            Self::Coalesced(iterator) => iterator.next().await,
-            Self::InMemory(entries) => Ok(entries.next()),
-        }
     }
 }
 
@@ -2345,15 +2396,16 @@ impl Timeline {
                 .fold(0u64, |size, (delta, layer)| {
                     size.saturating_add(delta.index_size_bytes(layer.metadata().file_size))
                 });
-        let metadata_traversal =
+        let disjoint_index_order =
             if index_metadata_traversal(metadata_index_size) == IndexMetadataTraversal::Streaming {
-                let disjoint_index_ranges = index_ranges_are_disjoint(&deltas, &index_ctx)
+                index_range_order_if_disjoint(&deltas, &index_ctx)
                     .await
-                    .map_err(CompactionError::Other)?;
-                stats.metadata_traversal(metadata_index_size, disjoint_index_ranges)
+                    .map_err(CompactionError::Other)?
             } else {
-                stats.metadata_traversal(metadata_index_size, false)
+                None
             };
+        let metadata_traversal =
+            stats.metadata_traversal(metadata_index_size, disjoint_index_order.is_some());
         let materialize_metadata = metadata_traversal == IndexMetadataTraversal::Materialized;
         debug!(
             metadata_index_size,
@@ -2405,7 +2457,7 @@ impl Timeline {
             key_range: Range<Key>,
             coverage_size: usize,
         }
-        let (holes, mut streamed_output_metadata): (Vec<Hole>, Option<CoalescedOutputMetadata>) = {
+        let (holes, output_size_plan): (Vec<Hole>, OutputSizePlan) = {
             impl Ord for Hole {
                 fn cmp(&self, other: &Self) -> Ordering {
                     self.coverage_size.cmp(&other.coverage_size).reverse()
@@ -2424,26 +2476,25 @@ impl Timeline {
             let mut prev: Option<Key> = None;
             let mut all_keys_iter = match materialized_metadata.as_deref() {
                 Some(entries) => IndexMergeIterator::from_entries(entries),
-                None => IndexMergeIterator::create(&deltas, &index_ctx)
-                    .await
-                    .map_err(CompactionError::Other)?,
+                None => match disjoint_index_order.as_deref() {
+                    Some(order) => {
+                        IndexMergeIterator::create_concatenated(&deltas, order, &index_ctx)
+                    }
+                    None => IndexMergeIterator::create(&deltas, &index_ctx)
+                        .await
+                        .map_err(CompactionError::Other)?,
+                },
             };
-            // Reuse the streamed hole pass for output sizing. A plan that exceeds the bound is
-            // replayed from fresh cursors instead of retaining or spooling every entry.
-            let mut output_metadata = (!materialize_metadata)
-                .then(|| CoalescedOutputMetadataCollector::InMemory(Vec::new()));
+            // Build the compact output-size plan while the ordered metadata cursor is already
+            // open. It retains one total per key and duplicate split boundaries, not every index
+            // entry, so output sizing never needs a second B-tree traversal.
+            let mut output_size_plan = OutputSizePlanBuilder::new(target_file_size);
             let mut index_entries = 0usize;
 
             while let Some(entry @ (next_key, _, _)) =
                 all_keys_iter.next().await.map_err(CompactionError::Other)?
             {
-                if let Some(output_metadata) = output_metadata.as_mut() {
-                    output_metadata.append(
-                        entry,
-                        target_file_size,
-                        L0_METADATA_OUTPUT_PLAN_MAX_ENTRIES,
-                    );
-                }
+                output_size_plan.push(entry);
                 index_entries += 1;
                 if index_entries % 32_768 == 0 && self.cancel.is_cancelled() {
                     return Err(CompactionError::new_cancelled());
@@ -2482,8 +2533,7 @@ impl Timeline {
             }
             let mut holes = heap.into_vec();
             holes.sort_unstable_by_key(|hole| hole.key_range.start);
-            let output_metadata = output_metadata.map(CoalescedOutputMetadataCollector::finish);
-            (holes, output_metadata)
+            (holes, output_size_plan.finish())
         };
         let metadata_pass_finished = tokio::time::Instant::now();
         if let Some(key_sort_finished) = materialized_key_sort_finished {
@@ -2523,6 +2573,9 @@ impl Timeline {
             return Err(CompactionError::new_cancelled());
         }
 
+        // The compact plan is the only metadata needed by the writer. Release the small-batch
+        // materialized entries before reading values as well.
+        drop(materialized_metadata);
         stats.read_lock_drop_micros = stats.read_lock_held_compute_holes_micros.till_now();
 
         // This iterator walks through all key-value pairs from all the layers
@@ -2537,32 +2590,12 @@ impl Timeline {
             1024,
         );
 
-        // This iterator walks through all keys and is needed to calculate size used by each key.
-        // The streamed hole pass has already produced the coalesced metadata for this consumer
-        // when it fit within the bound. A wide plan is replayed from fresh B-tree cursors so the
-        // hole pass does not retain or spool the whole plan.
-        let mut all_keys_iter = match materialized_metadata.as_deref() {
-            Some(entries) => OutputMetadataIterator::Coalesced(CoalescedIndexMergeIterator::new(
-                IndexMergeIterator::from_entries(entries),
-                target_file_size,
-            )),
-            None => match streamed_output_metadata
-                .take()
-                .expect("streamed metadata exists outside the materialized path")
-            {
-                CoalescedOutputMetadata::InMemory(entries) => {
-                    OutputMetadataIterator::InMemory(entries.into_iter())
-                }
-                CoalescedOutputMetadata::Replay => {
-                    OutputMetadataIterator::Coalesced(CoalescedIndexMergeIterator::new(
-                        IndexMergeIterator::create(&deltas, &index_ctx)
-                            .await
-                            .map_err(CompactionError::Other)?,
-                        target_file_size,
-                    ))
-                }
-            },
-        };
+        // The metadata pass has already reduced the ordered index stream to one total per key
+        // and the LSN boundaries needed for duplicate-key slices. Consume that compact plan while
+        // the value merge writes output; no index cursor is reopened here.
+        let mut output_key_index = 0usize;
+        let mut next_duplicate_split = 0usize;
+        let mut current_key_duplicate_split_end = 0usize;
 
         // Merge the contents of all the input delta layers into a new set
         // of delta layers, based on the current partitioning.
@@ -2633,46 +2666,49 @@ impl Timeline {
             }
 
             let same_key = prev_key == Some(key);
-            // We need to check key boundaries once we reach next key or end of layer with the same key
+            // The metadata pass recorded the total size of each key and the LSN boundaries where
+            // an oversized duplicate-key run must be sliced. Consume that compact plan at the
+            // same key boundaries as the value merge instead of reopening the index.
             if !same_key || lsn == dup_end_lsn {
-                let mut next_key_size = 0u64;
                 let is_dup_layer = dup_end_lsn.is_valid();
-                dup_start_lsn = Lsn::INVALID;
                 if !same_key {
+                    if output_key_index > 0
+                        && next_duplicate_split != current_key_duplicate_split_end
+                    {
+                        return Err(CompactionError::Other(anyhow!(
+                            "output metadata plan left duplicate split boundaries unconsumed"
+                        )));
+                    }
+                    dup_start_lsn = Lsn::INVALID;
                     dup_end_lsn = Lsn::INVALID;
-                }
-                // Determine size occupied by this key. We stop at next key or when size becomes larger than target_file_size.
-                while let Some((next_key, next_lsn, next_size)) =
-                    all_keys_iter.next().await.map_err(CompactionError::Other)?
-                {
-                    next_key_size = next_size;
-                    if key != next_key {
-                        if dup_end_lsn.is_valid() {
-                            // We are writting segment with duplicates:
-                            // place all remaining values of this key in separate segment
-                            dup_start_lsn = dup_end_lsn; // new segments starts where old stops
-                            dup_end_lsn = lsn_range.end; // there are no more values of this key till end of LSN range
-                        }
-                        break;
+                    let key_index = output_key_index;
+                    let Some(key_size) = output_size_plan.key_sizes.get(key_index).copied() else {
+                        return Err(CompactionError::Other(anyhow!(
+                            "output metadata plan has no size for value key {key}"
+                        )));
+                    };
+                    output_key_index += 1;
+                    key_values_total_size = key_size;
+                    current_key_duplicate_split_end = next_duplicate_split;
+                    while output_size_plan
+                        .duplicate_splits
+                        .get(current_key_duplicate_split_end)
+                        .is_some_and(|(split_key, _)| *split_key == key_index)
+                    {
+                        current_key_duplicate_split_end += 1;
                     }
-                    key_values_total_size += next_size;
-                    // Check if it is time to split segment: if total keys size is larger than target file size.
-                    // We need to avoid generation of empty segments if next_size > target_file_size.
-                    if key_values_total_size > target_file_size && lsn != next_lsn {
-                        // Split key between multiple layers: such layer can contain only single key
-                        dup_start_lsn = if dup_end_lsn.is_valid() {
-                            dup_end_lsn // new segment with duplicates starts where old one stops
-                        } else {
-                            lsn // start with the first LSN for this key
-                        };
-                        dup_end_lsn = next_lsn; // upper LSN boundary is exclusive
-                        break;
+                    if next_duplicate_split < current_key_duplicate_split_end {
+                        dup_start_lsn = lsn;
+                        dup_end_lsn = output_size_plan.duplicate_splits[next_duplicate_split].1;
                     }
-                }
-                // handle case when loop reaches last key: in this case dup_end is non-zero but dup_start is not set.
-                if dup_end_lsn.is_valid() && !dup_start_lsn.is_valid() {
+                } else {
                     dup_start_lsn = dup_end_lsn;
-                    dup_end_lsn = lsn_range.end;
+                    next_duplicate_split += 1;
+                    dup_end_lsn = if next_duplicate_split < current_key_duplicate_split_end {
+                        output_size_plan.duplicate_splits[next_duplicate_split].1
+                    } else {
+                        lsn_range.end
+                    };
                 }
                 if writer.is_some() {
                     let written_size = writer.as_mut().unwrap().size();
@@ -2703,8 +2739,6 @@ impl Timeline {
                         }
                     }
                 }
-                // Remember size of key value because at next iteration we will access next item
-                key_values_total_size = next_key_size;
             }
             fail_point!("delta-layer-writer-fail-before-finish", |_| {
                 Err(CompactionError::Other(anyhow::anyhow!(
@@ -2761,6 +2795,13 @@ impl Timeline {
             }
 
             prev_key = Some(key);
+        }
+        if output_key_index != output_size_plan.key_sizes.len()
+            || next_duplicate_split != output_size_plan.duplicate_splits.len()
+        {
+            return Err(CompactionError::Other(anyhow!(
+                "output values do not match the index metadata plan"
+            )));
         }
         if let Some(writer) = writer {
             let (desc, path) = writer
@@ -2829,7 +2870,6 @@ impl Timeline {
 
         // Without this, rustc complains about deltas_to_compact still
         // being borrowed when we `.into_iter()` below.
-        drop(all_keys_iter);
         drop(all_values_iter);
         drop(deltas);
 
@@ -5089,35 +5129,21 @@ mod tests {
     }
 
     #[test]
-    fn coalesced_output_metadata_plan_is_bounded() {
+    fn output_size_plan_coalesces_and_records_duplicate_splits() {
         let key = Key::from_i128(100);
-        let mut plan = Vec::new();
-        assert!(append_coalesced_output_metadata(
-            &mut plan,
+        let mut builder = OutputSizePlanBuilder::new(5);
+        for entry in [
             (key, Lsn(0x10), 3),
-            10,
-            2,
-        ));
-        assert!(append_coalesced_output_metadata(
-            &mut plan,
             (key, Lsn(0x20), 4),
-            10,
-            2,
-        ));
-        assert_eq!(plan, vec![(key, Lsn(0x10), 7)]);
-        assert!(append_coalesced_output_metadata(
-            &mut plan,
-            (key.next(), Lsn(0x30), 1),
-            10,
-            2,
-        ));
-        assert!(!append_coalesced_output_metadata(
-            &mut plan,
-            (key.add(2), Lsn(0x40), 1),
-            10,
-            2,
-        ));
-        assert_eq!(plan.len(), 2);
+            (key, Lsn(0x30), 4),
+            (key.next(), Lsn(0x40), 2),
+        ] {
+            builder.push(entry);
+        }
+
+        let plan = builder.finish();
+        assert_eq!(plan.key_sizes, vec![11, 2]);
+        assert_eq!(plan.duplicate_splits, vec![(0, Lsn(0x30))]);
     }
 
     #[test]
@@ -5153,26 +5179,6 @@ mod tests {
             stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT, false),
             IndexMetadataTraversal::Streaming
         );
-    }
-
-    #[test]
-    fn coalesced_output_metadata_replays_after_bound() {
-        let key = Key::from_i128(100);
-        let input = [
-            (key, Lsn(0x20), 3),
-            (key, Lsn(0x40), 4),
-            (key.next(), Lsn(0x50), 1),
-            (key.add(2), Lsn(0x60), 1),
-        ];
-
-        let mut collector = CoalescedOutputMetadataCollector::InMemory(Vec::new());
-        for entry in input {
-            collector.append(entry, 10, 2);
-        }
-        assert!(matches!(
-            collector.finish(),
-            CoalescedOutputMetadata::Replay
-        ));
     }
 
     #[tokio::test]
@@ -5211,6 +5217,25 @@ mod tests {
         }
         assert_eq!(actual, expected);
 
+        let disjoint_first = vec![(key, Lsn(0x20), 3), (key.add(1), Lsn(0x30), 5)];
+        let disjoint_second = vec![(key.add(10), Lsn(0x40), 7)];
+        let mut concatenated = IndexMergeIterator::from_concatenated_iterators(vec![
+            make_index_cursor(&disjoint_first, &ctx)?,
+            make_index_cursor(&disjoint_second, &ctx)?,
+        ]);
+        let mut concatenated_actual = Vec::new();
+        while let Some(entry) = concatenated.next().await? {
+            concatenated_actual.push(entry);
+        }
+        assert_eq!(
+            concatenated_actual,
+            disjoint_first
+                .iter()
+                .chain(&disjoint_second)
+                .copied()
+                .collect::<Vec<_>>()
+        );
+
         let mut materialized = IndexMergeIterator::from_entries(&expected);
         let mut materialized_actual = Vec::new();
         while let Some(entry) = materialized.next().await? {
@@ -5247,27 +5272,21 @@ mod tests {
         }
         assert_eq!(actual_coalesced, expected_coalesced);
 
-        let mut output_plan = Vec::new();
+        let mut output_plan_builder = OutputSizePlanBuilder::new(target_file_size);
         for entry in expected.iter().copied() {
-            assert!(append_coalesced_output_metadata(
-                &mut output_plan,
-                entry,
-                target_file_size,
-                expected.len(),
-            ));
+            output_plan_builder.push(entry);
         }
-        assert_eq!(output_plan, expected_coalesced);
-
-        // The plan is already coalesced, so the normal consumer leaves it unchanged.
-        let mut planned_coalesced = CoalescedIndexMergeIterator::new(
-            IndexMergeIterator::from_entries(&output_plan),
-            target_file_size,
+        let output_plan = output_plan_builder.finish();
+        assert_eq!(
+            output_plan.key_sizes,
+            vec![38, 5, 20],
+            "the plan keeps one total per output key"
         );
-        let mut planned_actual = Vec::new();
-        while let Some(entry) = planned_coalesced.next().await? {
-            planned_actual.push(entry);
-        }
-        assert_eq!(planned_actual, expected_coalesced);
+        assert_eq!(
+            output_plan.duplicate_splits,
+            vec![(0, Lsn(0x40)), (0, Lsn(0x50)), (2, Lsn(0x70))],
+            "duplicate boundaries retain the coalescing target semantics"
+        );
 
         Ok(())
     }
@@ -5353,6 +5372,46 @@ mod tests {
                 assert_eq!(
                     actual_coalesced, expected_coalesced,
                     "coalescing mismatch in case {case_index}, target {target_file_size}"
+                );
+
+                // Independently apply the output writer's boundary rule to the stable sorted
+                // stream, then compare it with the compact plan built from the cursor merge.
+                let mut expected_plan = OutputSizePlan::default();
+                let mut expected_key: Option<Key> = None;
+                let mut expected_key_index = 0;
+                let mut expected_segment_size = 0;
+                let mut expected_segment_lsn = None;
+                for (key, lsn, size) in expected_coalesced.iter().copied() {
+                    if expected_key != Some(key) {
+                        expected_key = Some(key);
+                        expected_key_index = expected_plan.key_sizes.len();
+                        expected_plan.key_sizes.push(size);
+                        expected_segment_size = size;
+                        expected_segment_lsn = Some(lsn);
+                        continue;
+                    }
+
+                    expected_plan.key_sizes[expected_key_index] += size;
+                    if expected_segment_size + size > target_file_size
+                        && expected_segment_lsn != Some(lsn)
+                    {
+                        expected_plan
+                            .duplicate_splits
+                            .push((expected_key_index, lsn));
+                        expected_segment_size = size;
+                        expected_segment_lsn = Some(lsn);
+                    } else {
+                        expected_segment_size += size;
+                    }
+                }
+                let mut plan_builder = OutputSizePlanBuilder::new(target_file_size);
+                for entry in expected.iter().copied() {
+                    plan_builder.push(entry);
+                }
+                assert_eq!(
+                    plan_builder.finish(),
+                    expected_plan,
+                    "output plan mismatch in case {case_index}, target {target_file_size}"
                 );
             }
         }

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -2421,8 +2421,11 @@ impl Timeline {
                 .fold(0u64, |size, (delta, layer)| {
                     size.saturating_add(delta.index_size_bytes(layer.metadata().file_size))
                 });
+        // Disjoint batches have a lower materialization bound than overlapping batches. Check
+        // their exact index ranges as soon as they cross that lower bound, even while the general
+        // overlapping-batch gate still selects materialization.
         let disjoint_index_order =
-            if index_metadata_traversal(metadata_index_size) == IndexMetadataTraversal::Streaming {
+            if metadata_index_size > L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT {
                 index_range_order_if_disjoint(&deltas, &index_ctx)
                     .await
                     .map_err(CompactionError::Other)?

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -116,7 +116,7 @@ impl Ord for IndexMergeHeapEntry {
 /// bytes, index bytes grow with the number of metadata entries even when their values are tiny.
 /// Every on-disk B-tree entry needs at least its five-byte value, so this cannot select the
 /// materialized path for a million-entry batch.
-const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 4 * 1024 * 1024;
+const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 64 * 1024 * 1024;
 
 /// A disjoint batch has no cross-layer merge work to amortize the cursor heap. Keep a bounded
 /// materialized fast path for small disjoint footprints; larger batches scan one layer at a time

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -114,9 +114,8 @@ impl Ord for IndexMergeHeapEntry {
 
 /// Keep the materialized fast path below this selected B-tree index size. Unlike total layer
 /// bytes, index bytes grow with the number of metadata entries even when their values are tiny.
-/// Every on-disk B-tree entry needs at least its five-byte value, so this cannot select the
-/// materialized path for a million-entry batch.
-const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 4 * 1024 * 1024;
+/// The comparison arm keeps the materialized implementation for the official calibration shapes.
+const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 8 * 1024 * 1024 * 1024;
 
 /// A disjoint batch has no cross-layer merge work to amortize the cursor heap. Keep a bounded
 /// materialized fast path for small disjoint footprints; larger batches scan one layer at a time

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -127,6 +127,10 @@ const L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 32 * 1024 * 1024;
 /// bound walks and then scanning the indexes again.
 const L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS: usize = 512;
 
+#[cfg(test)]
+static LAST_INDEX_METADATA_MICROS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 type IndexMetadataEntry = (Key, Lsn, u64);
 
 /// Output sizing needs one total per key and only the LSNs where a duplicate-key run is split.
@@ -2879,14 +2883,24 @@ impl Timeline {
         stats.new_deltas_count = Some(new_layers.len());
         stats.new_deltas_size = Some(new_layers.iter().map(|l| l.layer_desc().file_size).sum());
 
-        match TryInto::<CompactLevel0Phase1Stats>::try_into(stats)
-            .and_then(|stats| serde_json::to_string(&stats).context("serde_json::to_string"))
-        {
-            Ok(stats_json) => {
-                info!(
-                    stats_json = stats_json.as_str(),
-                    "compact_level0_phase1 stats available"
-                )
+        match TryInto::<CompactLevel0Phase1Stats>::try_into(stats) {
+            Ok(stats) => {
+                #[cfg(test)]
+                LAST_INDEX_METADATA_MICROS.store(
+                    stats.read_lock_held_index_metadata_micros.0.as_micros() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                match serde_json::to_string(&stats).context("serde_json::to_string") {
+                    Ok(stats_json) => {
+                        info!(
+                            stats_json = stats_json.as_str(),
+                            "compact_level0_phase1 stats available"
+                        )
+                    }
+                    Err(e) => {
+                        warn!("compact_level0_phase1 stats failed to serialize: {:#}", e);
+                    }
+                }
             }
             Err(e) => {
                 warn!("compact_level0_phase1 stats failed to serialize: {:#}", e);
@@ -5772,12 +5786,15 @@ mod tests {
             RequestContext::todo_child(TaskKind::Compaction, DownloadBehavior::Download);
         let cancel = CancellationToken::new();
         reset_allocation_bytes();
+        LAST_INDEX_METADATA_MICROS.store(0, std::sync::atomic::Ordering::Relaxed);
         let started = Instant::now();
         let outcome = tenant
             .compaction_iteration(&cancel, &compaction_ctx)
             .await?;
         let elapsed_micros = started.elapsed().as_micros();
         let compaction_allocation_bytes = allocation_bytes();
+        let index_metadata_micros =
+            LAST_INDEX_METADATA_MICROS.load(std::sync::atomic::Ordering::Relaxed);
 
         assert_eq!(outcome, CompactionOutcome::Done);
         let layer_manager = timeline.layers.read(LayerManagerLockHolder::Testing).await;
@@ -5817,6 +5834,10 @@ mod tests {
         println!(
             "l0_compaction_metadata_calibration_allocation_bytes={}",
             compaction_allocation_bytes
+        );
+        println!(
+            "l0_compaction_metadata_calibration_index_metadata_micros={}",
+            index_metadata_micros
         );
         Ok(())
     }

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -2990,10 +2990,13 @@ impl CompactLevel0Phase1StatsBuilder {
         if let Some(traversal) = self.metadata_traversal_override {
             return traversal;
         }
-        if disjoint_index_ranges && index_size <= L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT
-        {
-            IndexMetadataTraversal::Materialized
-        } else if !disjoint_index_ranges && layer_count > L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS {
+        if disjoint_index_ranges {
+            if index_size <= L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT {
+                IndexMetadataTraversal::Materialized
+            } else {
+                IndexMetadataTraversal::Streaming
+            }
+        } else if layer_count > L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS {
             // Broad descriptors cannot prove whether this many layers overlap. Avoid exact bound
             // walks followed by another metadata pass; the fallback keeps the old cost profile.
             IndexMetadataTraversal::Materialized
@@ -5255,10 +5258,10 @@ mod tests {
             index_metadata_traversal(L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT + 1),
             IndexMetadataTraversal::Streaming
         );
-        // Every B-tree entry has a five-byte value, before its key and node overhead. A million
-        // entries therefore cannot accidentally select the materialized path.
+        // A batch whose index metadata exceeds the threshold uses the streaming path even when
+        // the entries themselves are small.
         assert_eq!(
-            index_metadata_traversal(5 * 1_000_000),
+            index_metadata_traversal(L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT + 5),
             IndexMetadataTraversal::Streaming
         );
     }
@@ -5279,12 +5282,16 @@ mod tests {
             IndexMetadataTraversal::Streaming
         );
         assert_eq!(
-            stats.metadata_traversal(L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT, false, 10,),
+            stats.metadata_traversal(L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT, false, 10,),
+            IndexMetadataTraversal::Materialized
+        );
+        assert_eq!(
+            stats.metadata_traversal(L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT + 1, false, 10,),
             IndexMetadataTraversal::Streaming
         );
         assert_eq!(
             stats.metadata_traversal(
-                L0_METADATA_DISJOINT_MATERIALIZE_INDEX_SIZE_LIMIT + 1,
+                L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT + 1,
                 false,
                 L0_METADATA_EXACT_RANGE_SCAN_MAX_LAYERS + 1,
             ),

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -4599,9 +4599,6 @@ mod tests {
     use crate::context::DownloadBehavior;
     use crate::task_mgr::TaskKind;
     use crate::tenant::harness::{TIMELINE_ID, TenantHarness};
-    use crate::tenant::storage_layer::delta_layer::{
-        DeltaLayerIndexIterator, test::TestDeltaIndex,
-    };
     use crate::tenant::timeline::DeltaLayerTestDesc;
     use crate::virtual_file::{IoMode, set_io_mode};
 
@@ -4609,6 +4606,8 @@ mod tests {
     const L0_CALIBRATION_ENTRIES_PER_LAYER: &str =
         "NEON_L0_COMPACTION_CALIBRATION_ENTRIES_PER_LAYER";
     const L0_CALIBRATION_TARGET_FILE_SIZE: &str = "NEON_L0_COMPACTION_CALIBRATION_TARGET_FILE_SIZE";
+    const L0_CALIBRATION_VALUE_BYTES: &str = "NEON_L0_COMPACTION_CALIBRATION_VALUE_BYTES";
+    const L0_CALIBRATION_DISJOINT_KEYS: &str = "NEON_L0_COMPACTION_CALIBRATION_DISJOINT_KEYS";
 
     fn calibration_env_usize(name: &str) -> anyhow::Result<usize> {
         std::env::var(name)
@@ -4621,6 +4620,34 @@ mod tests {
             })
     }
 
+    fn calibration_env_usize_or(name: &str, default: usize) -> anyhow::Result<usize> {
+        let value = match std::env::var(name) {
+            Ok(value) => value,
+            Err(std::env::VarError::NotPresent) => return Ok(default),
+            Err(err) => return Err(err).with_context(|| format!("read {name}")),
+        };
+        value
+            .parse()
+            .with_context(|| format!("{name} must be a positive integer"))
+            .and_then(|value: usize| {
+                anyhow::ensure!(value > 0, "{name} must be positive");
+                Ok(value)
+            })
+    }
+
+    fn calibration_env_bool(name: &str) -> anyhow::Result<bool> {
+        let value = match std::env::var(name) {
+            Ok(value) => value,
+            Err(std::env::VarError::NotPresent) => return Ok(false),
+            Err(err) => return Err(err).with_context(|| format!("read {name}")),
+        };
+        match value.as_str() {
+            "1" | "true" | "TRUE" => Ok(true),
+            "0" | "false" | "FALSE" => Ok(false),
+            _ => anyhow::bail!("{name} must be one of 0, 1, false, or true"),
+        }
+    }
+
     fn calibration_env_u64(name: &str) -> anyhow::Result<u64> {
         std::env::var(name)
             .with_context(|| format!("{name} must be set"))?
@@ -4630,14 +4657,6 @@ mod tests {
                 anyhow::ensure!(value > 0, "{name} must be positive");
                 Ok(value)
             })
-    }
-
-    struct MetadataCalibrationResult {
-        elapsed_micros: u128,
-        peak_rss_kib: u64,
-        entries: usize,
-        coalesced_entries: usize,
-        checksum: u128,
     }
 
     fn peak_rss_kib() -> anyhow::Result<u64> {
@@ -4655,95 +4674,6 @@ mod tests {
         #[cfg(target_os = "macos")]
         let max_rss = max_rss / 1024;
         Ok(max_rss)
-    }
-
-    fn calibration_indexes(layers: &[Vec<(Key, Lsn, u64)>]) -> anyhow::Result<Vec<TestDeltaIndex>> {
-        layers
-            .iter()
-            .map(|entries| TestDeltaIndex::new(entries))
-            .collect()
-    }
-
-    fn calibration_cursors<'a>(
-        indexes: &[TestDeltaIndex],
-        ctx: &'a RequestContext,
-    ) -> Vec<DeltaLayerIndexIterator<'a>> {
-        indexes.iter().map(|index| index.cursor(ctx)).collect()
-    }
-
-    /// Runs the materialized metadata path used by L0 compaction before streaming cursors.
-    /// Cursor construction is outside the timed region because a production compaction opens
-    /// already-written B-tree indexes.
-    async fn run_metadata_calibration(
-        indexes: &[TestDeltaIndex],
-        target_file_size: u64,
-        ctx: &RequestContext,
-    ) -> anyhow::Result<MetadataCalibrationResult> {
-        let mut cursors = calibration_cursors(indexes, ctx);
-
-        let started = Instant::now();
-        let mut materialized = Vec::new();
-        for cursor in &mut cursors {
-            // Match the old L0 phase-1 collection shape: each index traversal returns a layer
-            // vector, which is then extended into a batch-wide vector before sorting.
-            let mut layer_entries = Vec::new();
-            while let Some(entry) = cursor.next().await? {
-                layer_entries.push(entry);
-            }
-            materialized.extend(layer_entries);
-        }
-        materialized.sort_by_key(|entry| (entry.0, entry.1));
-
-        let mut entries = 0;
-        let mut previous = None;
-        let mut checksum = 0_u128;
-        for entry in materialized.iter().copied() {
-            assert!(previous.is_none_or(|previous| previous <= (entry.0, entry.1)));
-            previous = Some((entry.0, entry.1));
-            entries += 1;
-            checksum = checksum
-                .wrapping_mul(31)
-                .wrapping_add(entry.0.to_i128() as u128)
-                .wrapping_add(entry.1.0 as u128)
-                .wrapping_add(entry.2 as u128);
-        }
-
-        let mut coalesced_entries = 0;
-        let mut pending: Option<(Key, Lsn, u64)> = None;
-        for current in materialized {
-            match pending.take() {
-                Some(mut previous) if previous.0 == current.0 && previous.2 < target_file_size => {
-                    previous.2 += current.2;
-                    pending = Some(previous);
-                }
-                Some(previous) => {
-                    coalesced_entries += 1;
-                    checksum = checksum
-                        .wrapping_mul(31)
-                        .wrapping_add(previous.0.to_i128() as u128)
-                        .wrapping_add(previous.1.0 as u128)
-                        .wrapping_add(previous.2 as u128);
-                    pending = Some(current);
-                }
-                None => pending = Some(current),
-            }
-        }
-        if let Some(previous) = pending {
-            coalesced_entries += 1;
-            checksum = checksum
-                .wrapping_mul(31)
-                .wrapping_add(previous.0.to_i128() as u128)
-                .wrapping_add(previous.1.0 as u128)
-                .wrapping_add(previous.2 as u128);
-        }
-
-        Ok(MetadataCalibrationResult {
-            elapsed_micros: started.elapsed().as_micros(),
-            peak_rss_kib: peak_rss_kib()?,
-            entries,
-            coalesced_entries,
-            checksum,
-        })
     }
 
     #[tokio::test]
@@ -4922,63 +4852,19 @@ mod tests {
         Ok(())
     }
 
-    /// Calibrates the two ordered metadata passes used for an L0 batch without requiring a
-    /// filesystem-backed tenant. The cursor and materialized metadata collection are the same
-    /// ones used by the compaction path; test B-trees are built before timing.
-    #[tokio::test]
-    #[ignore = "large L0 index metadata calibration"]
-    async fn l0_index_metadata_calibration() -> anyhow::Result<()> {
-        let layer_count = calibration_env_usize(L0_CALIBRATION_LAYERS)?;
-        let entries_per_layer = calibration_env_usize(L0_CALIBRATION_ENTRIES_PER_LAYER)?;
-        let target_file_size = calibration_env_u64(L0_CALIBRATION_TARGET_FILE_SIZE)?;
-        anyhow::ensure!(
-            layer_count >= 2,
-            "{L0_CALIBRATION_LAYERS} must be at least 2"
-        );
-
-        let layers = (0..layer_count)
-            .map(|layer_index| {
-                (0..entries_per_layer)
-                    .map(|key_index| {
-                        (
-                            Key::from_i128(key_index as i128),
-                            Lsn(0x10 + layer_index as u64 * 0x10),
-                            64,
-                        )
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-        let indexes = calibration_indexes(&layers)?;
-        drop(layers);
-        let ctx = RequestContext::new(TaskKind::UnitTest, DownloadBehavior::Error);
-        let result = run_metadata_calibration(&indexes, target_file_size, &ctx).await?;
-
-        assert_eq!(result.entries, layer_count * entries_per_layer);
-        assert!(result.coalesced_entries > 0);
-        assert_ne!(result.checksum, 0);
-        println!(
-            "l0_index_metadata_calibration_micros={}",
-            result.elapsed_micros
-        );
-        println!(
-            "l0_index_metadata_calibration_peak_rss_kib={}",
-            result.peak_rss_kib
-        );
-        Ok(())
-    }
-
     /// Exercises the threshold-triggered L0 pass selected by the normal tenant compaction
-    /// iteration with a configurable stack of overlapping delta layers. The input construction is
-    /// deliberately outside the timer: a production compaction already receives completed layers,
-    /// while the timed section starts at the same `compaction_iteration` entry point used by the
-    /// background loop and includes layer-map replacement.
+    /// iteration with a configurable stack of delta layers. The default stack overlaps; set
+    /// `NEON_L0_COMPACTION_CALIBRATION_DISJOINT_KEYS=1` to exercise a wide output plan and
+    /// `NEON_L0_COMPACTION_CALIBRATION_VALUE_BYTES=1` for tiny-value metadata density. The input
+    /// construction is deliberately outside the timer: a production compaction already receives
+    /// completed layers, while the timed section starts at the same `compaction_iteration` entry
+    /// point used by the background loop and includes layer-map replacement.
     ///
     /// This test is ignored because its intended calibration shape is large. Run it with the
     /// default ten-layer threshold and one million entries per layer:
     ///
     /// ```text
-    /// TEST_OUTPUT=/tmp \
+    /// TEST_OUTPUT=/dev/shm \
     /// NEON_PAGESERVER_UNIT_TEST_VIRTUAL_FILE_IOENGINE=std-fs \
     /// NEON_L0_COMPACTION_CALIBRATION_LAYERS=10 \
     /// NEON_L0_COMPACTION_CALIBRATION_ENTRIES_PER_LAYER=1000000 \
@@ -4990,12 +4876,15 @@ mod tests {
     async fn l0_compaction_metadata_calibration() -> anyhow::Result<()> {
         // The ignored test is run alone. Buffered IO makes its test fixture portable to filesystems
         // that do not permit O_DIRECT while preserving the production compaction code path. Set
-        // TEST_OUTPUT to a filesystem that supports no-replace renames (such as /tmp in CI).
+        // TEST_OUTPUT to a filesystem that supports no-replace renames (such as /dev/shm in
+        // sandboxed CI).
         set_io_mode(IoMode::Buffered);
 
         let layer_count = calibration_env_usize(L0_CALIBRATION_LAYERS)?;
         let entries_per_layer = calibration_env_usize(L0_CALIBRATION_ENTRIES_PER_LAYER)?;
         let target_file_size = calibration_env_u64(L0_CALIBRATION_TARGET_FILE_SIZE)?;
+        let value_bytes = calibration_env_usize_or(L0_CALIBRATION_VALUE_BYTES, 64)?;
+        let disjoint_keys = calibration_env_bool(L0_CALIBRATION_DISJOINT_KEYS)?;
         let harness = TenantHarness::create("l0_compaction_metadata_calibration").await?;
         let _span = harness.span().entered();
         let (tenant, ctx) = harness.load().await;
@@ -5007,6 +4896,10 @@ mod tests {
         anyhow::ensure!(
             layer_count >= threshold,
             "{L0_CALIBRATION_LAYERS} ({layer_count}) must meet the normal compaction threshold ({threshold})"
+        );
+        anyhow::ensure!(
+            !disjoint_keys || layer_count <= usize::MAX / entries_per_layer,
+            "disjoint calibration key range overflows usize"
         );
         let initdb_lsn = Lsn(0x10);
         let timeline = tenant
@@ -5020,11 +4913,12 @@ mod tests {
         for layer_index in 0..layer_count {
             let lsn_start = Lsn(initdb_lsn.0 + layer_index as u64 * LAYER_LSN_WIDTH);
             let lsn_range = lsn_start..Lsn(lsn_start.0 + LAYER_LSN_WIDTH);
-            let value = Bytes::from(vec![layer_index as u8; 64]);
+            let value = Bytes::from(vec![layer_index as u8; value_bytes]);
+            let key_start = usize::from(disjoint_keys) * layer_index * entries_per_layer;
             let data = (0..entries_per_layer)
                 .map(|key_index| {
                     (
-                        Key::from_i128(key_index as i128),
+                        Key::from_i128((key_start + key_index) as i128),
                         Lsn(lsn_start.0 + 1),
                         Value::Image(value.clone()),
                     )
@@ -5059,11 +4953,23 @@ mod tests {
         assert_eq!(check_valid_layermap(&layer_names), None);
         drop(layer_manager);
 
-        for key_index in [0, entries_per_layer / 2, entries_per_layer - 1] {
-            let value = timeline
-                .get(Key::from_i128(key_index as i128), final_lsn, &ctx)
-                .await?;
-            assert_eq!(value, Bytes::from(vec![(layer_count - 1) as u8; 64]));
+        let sampled_layers = if disjoint_keys {
+            vec![0, layer_count / 2, layer_count - 1]
+        } else {
+            vec![layer_count - 1]
+        };
+        for layer_index in sampled_layers {
+            let key_start = usize::from(disjoint_keys) * layer_index * entries_per_layer;
+            for key_index in [0, entries_per_layer / 2, entries_per_layer - 1] {
+                let value = timeline
+                    .get(
+                        Key::from_i128((key_start + key_index) as i128),
+                        final_lsn,
+                        &ctx,
+                    )
+                    .await?;
+                assert_eq!(value, Bytes::from(vec![layer_index as u8; value_bytes]));
+            }
         }
 
         println!("l0_compaction_metadata_calibration_micros={elapsed_micros}");

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -16,6 +16,7 @@ use super::{
     GetVectoredError, ImageLayerCreationMode, LastImageLayerCreationStatus, RecordedDuration,
     Timeline,
 };
+use camino::Utf8Path;
 
 use crate::pgdatadir_mapping::CollectKeySpaceError;
 use crate::tenant::timeline::{DeltaEntry, RepartitionError};
@@ -35,6 +36,7 @@ use pageserver_api::shard::{ShardCount, ShardIdentity, TenantShardId};
 use pageserver_compaction::helpers::{fully_contains, overlaps_with};
 use pageserver_compaction::interface::*;
 use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
@@ -44,7 +46,7 @@ use utils::lsn::Lsn;
 use wal_decoder::models::record::NeonWalRecord;
 use wal_decoder::models::value::Value;
 
-use crate::context::{AccessStatsBehavior, RequestContext, RequestContextBuilder};
+use crate::context::{AccessStatsBehavior, PageContentKind, RequestContext, RequestContextBuilder};
 use crate::page_cache;
 use crate::statvfs::Statvfs;
 use crate::tenant::checks::check_valid_layermap;
@@ -55,6 +57,7 @@ use crate::tenant::remote_timeline_client::index::GcCompactionState;
 use crate::tenant::storage_layer::batch_split_writer::{
     BatchWriterResult, SplitDeltaLayerWriter, SplitImageLayerWriter,
 };
+use crate::tenant::storage_layer::delta_layer::{DeltaLayerIndexIterator, DeltaLayerInner};
 use crate::tenant::storage_layer::filter_iterator::FilterIterator;
 use crate::tenant::storage_layer::merge_iterator::MergeIterator;
 use crate::tenant::storage_layer::{
@@ -78,6 +81,373 @@ const COMPACTION_DELTA_THRESHOLD: usize = 5;
 /// We choose a value < 0.5 to avoid rewriting all visible layers every time we do a power-of-two
 /// shard split, which gets expensive for large tenants.
 const ANCESTOR_COMPACTION_REWRITE_THRESHOLD: f64 = 0.3;
+
+/// Heap entry for a k-way merge of ordered delta-layer index cursors.
+struct IndexMergeHeapEntry {
+    entry: (Key, Lsn, u64),
+    layer_idx: usize,
+}
+
+impl PartialEq for IndexMergeHeapEntry {
+    fn eq(&self, other: &Self) -> bool {
+        (self.entry.0, self.entry.1, self.layer_idx)
+            == (other.entry.0, other.entry.1, other.layer_idx)
+    }
+}
+
+impl Eq for IndexMergeHeapEntry {}
+
+impl PartialOrd for IndexMergeHeapEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IndexMergeHeapEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // BinaryHeap is a max heap. Reverse the order so its head is the next key/LSN to emit.
+        (other.entry.0, other.entry.1, other.layer_idx).cmp(&(
+            self.entry.0,
+            self.entry.1,
+            self.layer_idx,
+        ))
+    }
+}
+
+/// Keep the materialized fast path below this selected B-tree index size. Unlike total layer
+/// bytes, index bytes grow with the number of metadata entries even when their values are tiny.
+/// Every on-disk B-tree entry needs at least its five-byte value, so this cannot select the
+/// materialized path for a million-entry batch.
+const L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT: u64 = 4 * 1024 * 1024;
+
+/// A streamed hole pass keeps this many already-coalesced output-size entries in memory. Larger
+/// plans spill to an unlinked temporary file so output sizing can replay the same cursor pass.
+const L0_METADATA_OUTPUT_PLAN_MAX_ENTRIES: usize = 1_000_000;
+const L0_METADATA_SPOOL_BUFFER_SIZE: usize = 64 * 1024;
+const L0_METADATA_SPOOL_ENTRY_SIZE: usize = KEY_SIZE + 16;
+
+type IndexMetadataEntry = (Key, Lsn, u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum IndexMetadataTraversal {
+    #[default]
+    Materialized,
+    Streaming,
+}
+
+fn index_metadata_traversal(index_size: u64) -> IndexMetadataTraversal {
+    if index_size <= L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT {
+        IndexMetadataTraversal::Materialized
+    } else {
+        IndexMetadataTraversal::Streaming
+    }
+}
+
+/// A coalesced output-size plan collected during the hole pass. Most overlapping L0 stacks fit
+/// in memory; a wide disjoint stack uses a temporary file instead of making another index pass.
+enum CoalescedOutputMetadata {
+    InMemory(Vec<IndexMetadataEntry>),
+    OnDisk(IndexMetadataSpoolReader),
+}
+
+enum CoalescedOutputMetadataCollector {
+    InMemory(Vec<IndexMetadataEntry>),
+    OnDisk(IndexMetadataSpoolWriter),
+}
+
+impl CoalescedOutputMetadataCollector {
+    async fn append(
+        &mut self,
+        entry: IndexMetadataEntry,
+        target_file_size: u64,
+        max_entries: usize,
+        temp_dir: &Utf8Path,
+        cancel: &CancellationToken,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::InMemory(entries) => {
+                if append_coalesced_output_metadata(entries, entry, target_file_size, max_entries) {
+                    return Ok(());
+                }
+
+                let entries = std::mem::take(entries);
+                let mut spool = IndexMetadataSpoolWriter::new(temp_dir)?;
+                for (index, entry) in entries.into_iter().enumerate() {
+                    if index % 32_768 == 0 && cancel.is_cancelled() {
+                        anyhow::bail!("L0 metadata spool cancelled");
+                    }
+                    spool.append(entry, target_file_size).await?;
+                }
+                spool.append(entry, target_file_size).await?;
+                *self = Self::OnDisk(spool);
+            }
+            Self::OnDisk(spool) => spool.append(entry, target_file_size).await?,
+        }
+        Ok(())
+    }
+
+    async fn finish(self) -> anyhow::Result<CoalescedOutputMetadata> {
+        match self {
+            Self::InMemory(entries) => Ok(CoalescedOutputMetadata::InMemory(entries)),
+            Self::OnDisk(spool) => Ok(CoalescedOutputMetadata::OnDisk(spool.finish().await?)),
+        }
+    }
+}
+
+/// Fixed-width temporary-file writer for coalesced `(key, LSN, stored-size)` metadata.
+struct IndexMetadataSpoolWriter {
+    writer: BufWriter<tokio::fs::File>,
+    pending: Option<IndexMetadataEntry>,
+    entries: u64,
+}
+
+impl IndexMetadataSpoolWriter {
+    fn new(temp_dir: &Utf8Path) -> anyhow::Result<Self> {
+        // tempfile_in unlinks the file immediately. It is reclaimed even if a cancelled
+        // compaction does not get to run normal Rust destructors.
+        let file = camino_tempfile::tempfile_in(temp_dir)
+            .with_context(|| format!("create L0 metadata spool in {temp_dir}"))?;
+        Ok(Self {
+            writer: BufWriter::with_capacity(
+                L0_METADATA_SPOOL_BUFFER_SIZE,
+                tokio::fs::File::from_std(file),
+            ),
+            pending: None,
+            entries: 0,
+        })
+    }
+
+    async fn append(
+        &mut self,
+        entry: IndexMetadataEntry,
+        target_file_size: u64,
+    ) -> anyhow::Result<()> {
+        if let Some(previous) = self.pending.as_mut()
+            && previous.0 == entry.0
+            && previous.2 < target_file_size
+        {
+            previous.2 += entry.2;
+            return Ok(());
+        }
+
+        if let Some(previous) = self.pending.replace(entry) {
+            self.write_entry(previous).await?;
+        }
+        Ok(())
+    }
+
+    async fn write_entry(&mut self, entry: IndexMetadataEntry) -> anyhow::Result<()> {
+        let mut buf = [0; L0_METADATA_SPOOL_ENTRY_SIZE];
+        entry.0.write_to_byte_slice(&mut buf[..KEY_SIZE]);
+        buf[KEY_SIZE..KEY_SIZE + 8].copy_from_slice(&entry.1.0.to_be_bytes());
+        buf[KEY_SIZE + 8..].copy_from_slice(&entry.2.to_be_bytes());
+        self.writer
+            .write_all(&buf)
+            .await
+            .context("write L0 metadata spool entry")?;
+        self.entries += 1;
+        Ok(())
+    }
+
+    async fn finish(mut self) -> anyhow::Result<IndexMetadataSpoolReader> {
+        if let Some(entry) = self.pending.take() {
+            self.write_entry(entry).await?;
+        }
+        self.writer
+            .flush()
+            .await
+            .context("flush L0 metadata spool")?;
+        let mut file = self.writer.into_inner();
+        file.rewind().await.context("rewind L0 metadata spool")?;
+        Ok(IndexMetadataSpoolReader {
+            reader: BufReader::with_capacity(L0_METADATA_SPOOL_BUFFER_SIZE, file),
+            remaining: self.entries,
+        })
+    }
+}
+
+struct IndexMetadataSpoolReader {
+    reader: BufReader<tokio::fs::File>,
+    remaining: u64,
+}
+
+impl IndexMetadataSpoolReader {
+    async fn next(&mut self) -> anyhow::Result<Option<IndexMetadataEntry>> {
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+
+        let mut buf = [0; L0_METADATA_SPOOL_ENTRY_SIZE];
+        self.reader
+            .read_exact(&mut buf)
+            .await
+            .context("read L0 metadata spool entry")?;
+        self.remaining -= 1;
+        let key = Key::from_slice(&buf[..KEY_SIZE]);
+        let lsn = Lsn(u64::from_be_bytes(
+            buf[KEY_SIZE..KEY_SIZE + 8]
+                .try_into()
+                .expect("fixed-width LSN field"),
+        ));
+        let size = u64::from_be_bytes(
+            buf[KEY_SIZE + 8..]
+                .try_into()
+                .expect("fixed-width size field"),
+        );
+        Ok(Some((key, lsn, size)))
+    }
+}
+
+/// Bounded k-way merge over the metadata indexes of a set of delta layers.
+struct StreamingIndexMergeIterator<'a> {
+    iterators: Vec<DeltaLayerIndexIterator<'a>>,
+    heap: BinaryHeap<IndexMergeHeapEntry>,
+}
+
+/// Ordered metadata from either the small-batch materialized fast path or a bounded cursor merge.
+enum IndexMergeIterator<'a> {
+    Materialized(std::iter::Copied<std::slice::Iter<'a, IndexMetadataEntry>>),
+    Streaming(StreamingIndexMergeIterator<'a>),
+}
+
+impl<'a> IndexMergeIterator<'a> {
+    async fn create(
+        deltas: &[&'a DeltaLayerInner],
+        ctx: &'a RequestContext,
+    ) -> anyhow::Result<Self> {
+        let iterators = deltas
+            .iter()
+            .map(|delta| delta.index_iter(ctx))
+            .collect::<Vec<_>>();
+        Self::from_iterators(iterators).await
+    }
+
+    async fn from_iterators(
+        mut iterators: Vec<DeltaLayerIndexIterator<'a>>,
+    ) -> anyhow::Result<Self> {
+        let mut heap = BinaryHeap::with_capacity(iterators.len());
+
+        for (layer_idx, iterator) in iterators.iter_mut().enumerate() {
+            if let Some(entry) = iterator.next().await? {
+                heap.push(IndexMergeHeapEntry { entry, layer_idx });
+            }
+        }
+
+        Ok(Self::Streaming(StreamingIndexMergeIterator {
+            iterators,
+            heap,
+        }))
+    }
+
+    fn from_entries(entries: &'a [IndexMetadataEntry]) -> Self {
+        Self::Materialized(entries.iter().copied())
+    }
+
+    async fn next(&mut self) -> anyhow::Result<Option<IndexMetadataEntry>> {
+        match self {
+            Self::Materialized(entries) => Ok(entries.next()),
+            Self::Streaming(streaming) => {
+                // Replacing the heap head needs one repair, while pop followed by push would
+                // repair it twice for every index entry in a wide L0 merge.
+                let Some((layer_idx, entry)) = streaming
+                    .heap
+                    .peek()
+                    .map(|head| (head.layer_idx, head.entry))
+                else {
+                    return Ok(None);
+                };
+
+                if let Some(next) = streaming.iterators[layer_idx].next().await? {
+                    let mut head = streaming.heap.peek_mut().expect("head was just peeked");
+                    debug_assert_eq!(head.layer_idx, layer_idx);
+                    head.entry = next;
+                } else {
+                    std::collections::binary_heap::PeekMut::pop(
+                        streaming.heap.peek_mut().expect("head was just peeked"),
+                    );
+                }
+                Ok(Some(entry))
+            }
+        }
+    }
+}
+
+/// Append metadata in the same segments that `CoalescedIndexMergeIterator` exposes to output
+/// sizing. Returning false tells the caller to discard the plan rather than retain more metadata.
+fn append_coalesced_output_metadata(
+    entries: &mut Vec<IndexMetadataEntry>,
+    current: IndexMetadataEntry,
+    target_file_size: u64,
+    max_entries: usize,
+) -> bool {
+    if let Some(previous) = entries.last_mut()
+        && previous.0 == current.0
+        && previous.2 < target_file_size
+    {
+        previous.2 += current.2;
+        return true;
+    }
+
+    if entries.len() == max_entries {
+        return false;
+    }
+    entries.push(current);
+    true
+}
+
+/// Equivalent of the former `Itertools::coalesce` call used for output sizing.
+struct CoalescedIndexMergeIterator<'a> {
+    inner: IndexMergeIterator<'a>,
+    pending: Option<IndexMetadataEntry>,
+    target_file_size: u64,
+}
+
+impl<'a> CoalescedIndexMergeIterator<'a> {
+    fn new(inner: IndexMergeIterator<'a>, target_file_size: u64) -> Self {
+        Self {
+            inner,
+            pending: None,
+            target_file_size,
+        }
+    }
+
+    async fn next(&mut self) -> anyhow::Result<Option<IndexMetadataEntry>> {
+        let Some(mut previous) = (match self.pending.take() {
+            Some(entry) => Some(entry),
+            None => self.inner.next().await?,
+        }) else {
+            return Ok(None);
+        };
+
+        while let Some(current) = self.inner.next().await? {
+            if previous.0 == current.0 && previous.2 < self.target_file_size {
+                previous.2 += current.2;
+            } else {
+                self.pending = Some(current);
+                break;
+            }
+        }
+        Ok(Some(previous))
+    }
+}
+
+/// Metadata consumed by the output writer. Streamed plans are already coalesced while the hole
+/// pass runs; only the materialized fast path needs a coalescing adapter here.
+enum OutputMetadataIterator<'a> {
+    Materialized(CoalescedIndexMergeIterator<'a>),
+    InMemory(std::vec::IntoIter<IndexMetadataEntry>),
+    OnDisk(IndexMetadataSpoolReader),
+}
+
+impl OutputMetadataIterator<'_> {
+    async fn next(&mut self) -> anyhow::Result<Option<IndexMetadataEntry>> {
+        match self {
+            Self::Materialized(iterator) => iterator.next().await,
+            Self::InMemory(entries) => Ok(entries.next()),
+            Self::OnDisk(reader) => reader.next().await,
+        }
+    }
+}
 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize)]
 pub struct GcCompactionJobId(pub usize);
@@ -1848,6 +2218,7 @@ impl Timeline {
             new_layers,
             deltas_to_compact,
             outcome,
+            ..
         } = {
             let phase1_span = info_span!("compact_level0_phase1");
             let ctx = ctx.attached_child();
@@ -2040,36 +2411,66 @@ impl Timeline {
 
         stats.compaction_prerequisites_micros = stats.read_lock_acquisition_micros.till_now();
 
-        // TODO: replace with streaming k-merge
-        let index_metadata_started = tokio::time::Instant::now();
-        let all_keys = {
+        let metadata_pass_started = tokio::time::Instant::now();
+        let index_ctx = RequestContextBuilder::from(ctx)
+            .page_content_kind(PageContentKind::DeltaLayerBtreeNode)
+            .attached_child();
+        let mut deltas: Vec<&DeltaLayerInner> = Vec::with_capacity(deltas_to_compact.len());
+        for layer in &deltas_to_compact {
+            if self.cancel.is_cancelled() {
+                return Err(CompactionError::new_cancelled());
+            }
+            deltas.push(
+                layer
+                    .get_as_delta(ctx)
+                    .await
+                    .map_err(CompactionError::Other)?,
+            );
+        }
+        // Use the B-tree footprint rather than total layer bytes as the fast-path gate. A batch
+        // with tiny values can have millions of index entries while its data files stay small.
+        let metadata_index_size =
+            deltas
+                .iter()
+                .zip(&deltas_to_compact)
+                .fold(0u64, |size, (delta, layer)| {
+                    size.saturating_add(delta.index_size_bytes(layer.metadata().file_size))
+                });
+        let metadata_traversal = stats.metadata_traversal(metadata_index_size);
+        let materialize_metadata = metadata_traversal == IndexMetadataTraversal::Materialized;
+        debug!(
+            metadata_index_size,
+            ?metadata_traversal,
+            "selected L0 metadata traversal mode"
+        );
+        let metadata_spool_dir = self
+            .conf
+            .timeline_path(&self.tenant_shard_id, &self.timeline_id);
+        let materialized_metadata: Option<Vec<IndexMetadataEntry>> = if materialize_metadata {
             let mut all_keys = Vec::new();
-            for l in deltas_to_compact.iter() {
+            for delta in &deltas {
                 if self.cancel.is_cancelled() {
                     return Err(CompactionError::new_cancelled());
                 }
-                let delta = l.get_as_delta(ctx).await.map_err(CompactionError::Other)?;
-                let keys = delta
+                let entries = delta
                     .index_entries(ctx)
                     .await
                     .map_err(CompactionError::Other)?;
-                all_keys.extend(keys);
+                all_keys.extend(
+                    entries
+                        .into_iter()
+                        .map(|entry| (entry.key, entry.lsn, entry.size)),
+                );
             }
-            // The current stdlib sorting implementation is designed in a way where it is
-            // particularly fast where the slice is made up of sorted sub-ranges.
-            all_keys.sort_by_key(|DeltaEntry { key, lsn, .. }| (*key, *lsn));
-            all_keys
+            all_keys.sort_by_key(|entry| (entry.0, entry.1));
+            Some(all_keys)
+        } else {
+            None
         };
-        let index_metadata_finished = tokio::time::Instant::now();
-        let index_metadata_elapsed = index_metadata_finished - index_metadata_started;
-        stats.read_lock_held_key_sort_micros = DurationRecorder::Recorded(
-            RecordedDuration(index_metadata_elapsed),
-            index_metadata_finished,
-        );
-        stats.read_lock_held_index_metadata_micros = DurationRecorder::Recorded(
-            RecordedDuration(index_metadata_elapsed),
-            index_metadata_finished,
-        );
+        let materialized_key_sort_finished = materialized_metadata
+            .as_ref()
+            .map(|_| tokio::time::Instant::now());
+        let mut hole_coverage_elapsed = Duration::ZERO;
 
         // Determine N largest holes where N is number of compacted layers. The vec is sorted by key range start.
         //
@@ -2090,7 +2491,7 @@ impl Timeline {
             key_range: Range<Key>,
             coverage_size: usize,
         }
-        let holes: Vec<Hole> = {
+        let (holes, mut streamed_output_metadata): (Vec<Hole>, Option<CoalescedOutputMetadata>) = {
             impl Ord for Hole {
                 fn cmp(&self, other: &Self) -> Ordering {
                     self.coverage_size.cmp(&other.coverage_size).reverse()
@@ -2107,12 +2508,40 @@ impl Timeline {
             // min-heap (reserve space for one more element added before eviction)
             let mut heap: BinaryHeap<Hole> = BinaryHeap::with_capacity(max_holes + 1);
             let mut prev: Option<Key> = None;
-            let mut all_keys_iter = all_keys
-                .iter()
-                .map(|DeltaEntry { key, lsn, size, .. }| (*key, *lsn, *size));
+            let mut all_keys_iter = match materialized_metadata.as_deref() {
+                Some(entries) => IndexMergeIterator::from_entries(entries),
+                None => IndexMergeIterator::create(&deltas, &index_ctx)
+                    .await
+                    .map_err(CompactionError::Other)?,
+            };
+            // Reuse the streamed hole pass for output sizing. A large disjoint plan spills its
+            // already-coalesced entries instead of forcing output sizing to traverse every index
+            // a second time.
+            let mut output_metadata = (!materialize_metadata)
+                .then(|| CoalescedOutputMetadataCollector::InMemory(Vec::new()));
             let mut index_entries = 0usize;
 
-            while let Some((next_key, _, _)) = all_keys_iter.next() {
+            while let Some(entry @ (next_key, _, _)) =
+                all_keys_iter.next().await.map_err(CompactionError::Other)?
+            {
+                if let Some(output_metadata) = output_metadata.as_mut() {
+                    output_metadata
+                        .append(
+                            entry,
+                            target_file_size,
+                            L0_METADATA_OUTPUT_PLAN_MAX_ENTRIES,
+                            &metadata_spool_dir,
+                            &self.cancel,
+                        )
+                        .await
+                        .map_err(|error| {
+                            if self.cancel.is_cancelled() {
+                                CompactionError::new_cancelled()
+                            } else {
+                                CompactionError::Other(error)
+                            }
+                        })?;
+                }
                 index_entries += 1;
                 if index_entries % 32_768 == 0 && self.cancel.is_cancelled() {
                     return Err(CompactionError::new_cancelled());
@@ -2128,12 +2557,14 @@ impl Timeline {
                         // has not so much sense, because largest holes will corresponds field1/field2 changes.
                         // But we are mostly interested to eliminate holes which cause generation of excessive image layers.
                         // That is why it is better to measure size of hole as number of covering image layers.
+                        let coverage_started = tokio::time::Instant::now();
                         let coverage_size = {
                             // TODO: optimize this with copy-on-write layer map.
                             let guard = self.layers.read(LayerManagerLockHolder::Compaction).await;
                             let layers = guard.layer_map()?;
                             layers.image_coverage(&key_range, l0_last_record_lsn).len()
                         };
+                        hole_coverage_elapsed += coverage_started.elapsed();
                         if coverage_size >= min_hole_coverage_size {
                             heap.push(Hole {
                                 key_range,
@@ -2149,9 +2580,50 @@ impl Timeline {
             }
             let mut holes = heap.into_vec();
             holes.sort_unstable_by_key(|hole| hole.key_range.start);
-            holes
+            let output_metadata = match output_metadata {
+                Some(output_metadata) => Some(
+                    output_metadata
+                        .finish()
+                        .await
+                        .map_err(CompactionError::Other)?,
+                ),
+                None => None,
+            };
+            (holes, output_metadata)
         };
-        stats.read_lock_held_compute_holes_micros = stats.read_lock_held_key_sort_micros.till_now();
+        let metadata_pass_finished = tokio::time::Instant::now();
+        if let Some(key_sort_finished) = materialized_key_sort_finished {
+            // Preserve the legacy phase split for small materialized batches.
+            let index_metadata_elapsed = key_sort_finished - metadata_pass_started;
+            stats.read_lock_held_key_sort_micros = DurationRecorder::Recorded(
+                RecordedDuration(index_metadata_elapsed),
+                key_sort_finished,
+            );
+            stats.read_lock_held_index_metadata_micros = DurationRecorder::Recorded(
+                RecordedDuration(index_metadata_elapsed),
+                key_sort_finished,
+            );
+            stats.read_lock_held_compute_holes_micros =
+                stats.read_lock_held_key_sort_micros.till_now();
+        } else {
+            // Keep the legacy field limited to the index collection and sort that the
+            // materialized path performs. Streaming does neither operation, so its value is zero;
+            // the separately named field reports the cursor traversal and coalescing.
+            let index_metadata_elapsed = (metadata_pass_finished - metadata_pass_started)
+                .saturating_sub(hole_coverage_elapsed);
+            stats.read_lock_held_key_sort_micros = DurationRecorder::Recorded(
+                RecordedDuration(Duration::ZERO),
+                metadata_pass_finished,
+            );
+            stats.read_lock_held_index_metadata_micros = DurationRecorder::Recorded(
+                RecordedDuration(index_metadata_elapsed),
+                metadata_pass_finished,
+            );
+            stats.read_lock_held_compute_holes_micros = DurationRecorder::Recorded(
+                RecordedDuration(hole_coverage_elapsed),
+                metadata_pass_finished,
+            );
+        }
 
         if self.cancel.is_cancelled() {
             return Err(CompactionError::new_cancelled());
@@ -2163,41 +2635,35 @@ impl Timeline {
         // we're compacting, in key, LSN order.
         // If there's both a Value::Image and Value::WalRecord for the same (key,lsn),
         // then the Value::Image is ordered before Value::WalRecord.
-        let mut all_values_iter = {
-            let mut deltas = Vec::with_capacity(deltas_to_compact.len());
-            for l in deltas_to_compact.iter() {
-                let l = l.get_as_delta(ctx).await.map_err(CompactionError::Other)?;
-                deltas.push(l);
-            }
-            MergeIterator::create_with_options(
-                &deltas,
-                &[],
-                ctx,
-                1024 * 8192, /* 8 MiB buffer per layer iterator */
-                1024,
-            )
-        };
+        let mut all_values_iter = MergeIterator::create_with_options(
+            &deltas,
+            &[],
+            ctx,
+            1024 * 8192, /* 8 MiB buffer per layer iterator */
+            1024,
+        );
 
         // This iterator walks through all keys and is needed to calculate size used by each key.
-        // Coalesce entries for a key exactly as the previous materialized iterator did, while
-        // retaining only one pending merged entry.
-        let mut all_keys_iter = all_keys
-            .iter()
-            .map(|DeltaEntry { key, lsn, size, .. }| (*key, *lsn, *size))
-            .coalesce(|mut prev, cur| {
-                // Coalesce keys that belong to the same key pair.
-                // This ensures that compaction doesn't put them
-                // into different layer files.
-                // Still limit this by the target file size,
-                // so that we keep the size of the files in
-                // check.
-                if prev.0 == cur.0 && prev.2 < target_file_size {
-                    prev.2 += cur.2;
-                    Ok(prev)
-                } else {
-                    Err((prev, cur))
+        // The streamed hole pass has already produced the coalesced metadata for this consumer,
+        // either in memory or in an unlinked temporary file. Replaying it avoids another B-tree
+        // traversal for disjoint large batches.
+        let mut all_keys_iter = match materialized_metadata.as_deref() {
+            Some(entries) => {
+                OutputMetadataIterator::Materialized(CoalescedIndexMergeIterator::new(
+                    IndexMergeIterator::from_entries(entries),
+                    target_file_size,
+                ))
+            }
+            None => match streamed_output_metadata
+                .take()
+                .expect("streamed metadata exists outside the materialized path")
+            {
+                CoalescedOutputMetadata::InMemory(entries) => {
+                    OutputMetadataIterator::InMemory(entries.into_iter())
                 }
-            });
+                CoalescedOutputMetadata::OnDisk(reader) => OutputMetadataIterator::OnDisk(reader),
+            },
+        };
 
         // Merge the contents of all the input delta layers into a new set
         // of delta layers, based on the current partitioning.
@@ -2276,8 +2742,10 @@ impl Timeline {
                 if !same_key {
                     dup_end_lsn = Lsn::INVALID;
                 }
-                // Determine size occupied by this key. We stop at next key or when size becomes larger than target_file_size
-                for (next_key, next_lsn, next_size) in all_keys_iter.by_ref() {
+                // Determine size occupied by this key. We stop at next key or when size becomes larger than target_file_size.
+                while let Some((next_key, next_lsn, next_size)) =
+                    all_keys_iter.next().await.map_err(CompactionError::Other)?
+                {
                     next_key_size = next_size;
                     if key != next_key {
                         if dup_end_lsn.is_valid() {
@@ -2462,7 +2930,9 @@ impl Timeline {
 
         // Without this, rustc complains about deltas_to_compact still
         // being borrowed when we `.into_iter()` below.
+        drop(all_keys_iter);
         drop(all_values_iter);
+        drop(deltas);
 
         Ok(CompactLevel0Phase1Result {
             new_layers,
@@ -2470,6 +2940,8 @@ impl Timeline {
                 .into_iter()
                 .map(|x| x.drop_eviction_guard())
                 .collect::<Vec<_>>(),
+            #[cfg(test)]
+            metadata_traversal,
             outcome: if fully_compacted {
                 CompactionOutcome::Done
             } else {
@@ -2483,6 +2955,8 @@ impl Timeline {
 struct CompactLevel0Phase1Result {
     new_layers: Vec<ResidentLayer>,
     deltas_to_compact: Vec<Layer>,
+    #[cfg(test)]
+    metadata_traversal: IndexMetadataTraversal,
     // Whether we have included all L0 layers, or selected only part of them due to the
     // L0 compaction size limit.
     outcome: CompactionOutcome,
@@ -2493,6 +2967,10 @@ struct CompactLevel0Phase1StatsBuilder {
     version: Option<u64>,
     tenant_id: Option<TenantShardId>,
     timeline_id: Option<TimelineId>,
+    // The test-only override lets the end-to-end fixture exercise the streaming branch without
+    // inflating its values just to cross the production byte threshold.
+    #[cfg(test)]
+    metadata_traversal_override: Option<IndexMetadataTraversal>,
     read_lock_acquisition_micros: DurationRecorder,
     read_lock_held_key_sort_micros: DurationRecorder,
     read_lock_held_index_metadata_micros: DurationRecorder,
@@ -2520,6 +2998,16 @@ struct CompactLevel0Phase1Stats {
     level0_deltas_count: usize,
     new_deltas_count: usize,
     new_deltas_size: u64,
+}
+
+impl CompactLevel0Phase1StatsBuilder {
+    fn metadata_traversal(&self, index_size: u64) -> IndexMetadataTraversal {
+        #[cfg(test)]
+        if let Some(traversal) = self.metadata_traversal_override {
+            return traversal;
+        }
+        index_metadata_traversal(index_size)
+    }
 }
 
 impl TryFrom<CompactLevel0Phase1StatsBuilder> for CompactLevel0Phase1Stats {
@@ -4614,6 +5102,7 @@ mod tests {
     use crate::context::DownloadBehavior;
     use crate::task_mgr::TaskKind;
     use crate::tenant::harness::{TIMELINE_ID, TenantHarness};
+    use crate::tenant::storage_layer::delta_layer::test::make_index_cursor;
     use crate::tenant::timeline::DeltaLayerTestDesc;
     use crate::virtual_file::{IoMode, set_io_mode};
 
@@ -4689,6 +5178,276 @@ mod tests {
         #[cfg(target_os = "macos")]
         let max_rss = max_rss / 1024;
         Ok(max_rss)
+    }
+
+    #[test]
+    fn coalesced_output_metadata_plan_is_bounded() {
+        let key = Key::from_i128(100);
+        let mut plan = Vec::new();
+        assert!(append_coalesced_output_metadata(
+            &mut plan,
+            (key, Lsn(0x10), 3),
+            10,
+            2,
+        ));
+        assert!(append_coalesced_output_metadata(
+            &mut plan,
+            (key, Lsn(0x20), 4),
+            10,
+            2,
+        ));
+        assert_eq!(plan, vec![(key, Lsn(0x10), 7)]);
+        assert!(append_coalesced_output_metadata(
+            &mut plan,
+            (key.next(), Lsn(0x30), 1),
+            10,
+            2,
+        ));
+        assert!(!append_coalesced_output_metadata(
+            &mut plan,
+            (key.add(2), Lsn(0x40), 1),
+            10,
+            2,
+        ));
+        assert_eq!(plan.len(), 2);
+    }
+
+    #[test]
+    fn metadata_materialization_is_bounded_by_index_size() {
+        assert_eq!(
+            index_metadata_traversal(L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT),
+            IndexMetadataTraversal::Materialized
+        );
+        assert_eq!(
+            index_metadata_traversal(L0_METADATA_MATERIALIZE_INDEX_SIZE_LIMIT + 1),
+            IndexMetadataTraversal::Streaming
+        );
+        // Every B-tree entry has a five-byte value, before its key and node overhead. A million
+        // entries therefore cannot accidentally select the materialized path.
+        assert_eq!(
+            index_metadata_traversal(5 * 1_000_000),
+            IndexMetadataTraversal::Streaming
+        );
+    }
+
+    #[tokio::test]
+    async fn coalesced_output_metadata_spills_and_replays() -> anyhow::Result<()> {
+        let temp_dir = camino_tempfile::tempdir()?;
+        let key = Key::from_i128(100);
+        let input = [
+            (key, Lsn(0x20), 3),
+            (key, Lsn(0x40), 4),
+            (key.next(), Lsn(0x50), 1),
+            (key.add(2), Lsn(0x60), 1),
+        ];
+        let expected = vec![
+            (key, Lsn(0x20), 7),
+            (key.next(), Lsn(0x50), 1),
+            (key.add(2), Lsn(0x60), 1),
+        ];
+
+        let cancel = CancellationToken::new();
+        let mut collector = CoalescedOutputMetadataCollector::InMemory(Vec::new());
+        for entry in input {
+            collector
+                .append(entry, 10, 2, temp_dir.path(), &cancel)
+                .await?;
+        }
+        let CoalescedOutputMetadata::OnDisk(mut reader) = collector.finish().await? else {
+            panic!("two-entry plan should spill when a third distinct key is appended");
+        };
+
+        let mut actual = Vec::new();
+        while let Some(entry) = reader.next().await? {
+            actual.push(entry);
+        }
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn index_merge_matches_materialized_order_and_coalescing() -> anyhow::Result<()> {
+        let ctx = RequestContext::new(TaskKind::UnitTest, DownloadBehavior::Error);
+        let key = Key::from_i128(100);
+        let first_layer = vec![
+            (key, Lsn(0x20), 3),
+            (key, Lsn(0x40), 11),
+            (key.add(2), Lsn(0x4f), 7),
+        ];
+        let second_layer = vec![
+            // This exact key/LSN tie must retain selected-layer order, matching the stable
+            // materialized sort that L0 compaction used previously.
+            (key, Lsn(0x40), 19),
+            (key, Lsn(0x50), 5),
+            (key.add(1), Lsn(0x60), 5),
+            (key.add(2), Lsn(0x70), 13),
+        ];
+
+        let mut expected = first_layer
+            .iter()
+            .chain(&second_layer)
+            .copied()
+            .collect::<Vec<_>>();
+        expected.sort_by_key(|entry| (entry.0, entry.1));
+
+        let mut merged = IndexMergeIterator::from_iterators(vec![
+            make_index_cursor(&first_layer, &ctx)?,
+            make_index_cursor(&second_layer, &ctx)?,
+        ])
+        .await?;
+        let mut actual = Vec::new();
+        while let Some(entry) = merged.next().await? {
+            actual.push(entry);
+        }
+        assert_eq!(actual, expected);
+
+        let mut materialized = IndexMergeIterator::from_entries(&expected);
+        let mut materialized_actual = Vec::new();
+        while let Some(entry) = materialized.next().await? {
+            materialized_actual.push(entry);
+        }
+        assert_eq!(materialized_actual, expected);
+
+        // A target equal to the first entry's size prevents coalescing the following versions
+        // of this key. This exercises the duplicate-key output boundary used by L0 compaction.
+        let target_file_size = expected[0].2;
+        let mut expected_coalesced: Vec<(Key, Lsn, u64)> = Vec::new();
+        for current in expected.iter().copied() {
+            if let Some(previous) = expected_coalesced.last_mut()
+                && previous.0 == current.0
+                && previous.2 < target_file_size
+            {
+                previous.2 += current.2;
+            } else {
+                expected_coalesced.push(current);
+            }
+        }
+
+        let mut coalesced = CoalescedIndexMergeIterator::new(
+            IndexMergeIterator::from_iterators(vec![
+                make_index_cursor(&first_layer, &ctx)?,
+                make_index_cursor(&second_layer, &ctx)?,
+            ])
+            .await?,
+            target_file_size,
+        );
+        let mut actual_coalesced = Vec::new();
+        while let Some(entry) = coalesced.next().await? {
+            actual_coalesced.push(entry);
+        }
+        assert_eq!(actual_coalesced, expected_coalesced);
+
+        let mut output_plan = Vec::new();
+        for entry in expected.iter().copied() {
+            assert!(append_coalesced_output_metadata(
+                &mut output_plan,
+                entry,
+                target_file_size,
+                expected.len(),
+            ));
+        }
+        assert_eq!(output_plan, expected_coalesced);
+
+        // The plan is already coalesced, so the normal consumer leaves it unchanged.
+        let mut planned_coalesced = CoalescedIndexMergeIterator::new(
+            IndexMergeIterator::from_entries(&output_plan),
+            target_file_size,
+        );
+        let mut planned_actual = Vec::new();
+        while let Some(entry) = planned_coalesced.next().await? {
+            planned_actual.push(entry);
+        }
+        assert_eq!(planned_actual, expected_coalesced);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn randomized_index_merge_matches_materialized_sort() -> anyhow::Result<()> {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let ctx = RequestContext::new(TaskKind::UnitTest, DownloadBehavior::Error);
+        let mut rng = StdRng::seed_from_u64(0x1D3E_3C63);
+
+        for case_index in 0..128 {
+            let layer_count = rng.random_range(1..=8);
+            let mut layers = Vec::with_capacity(layer_count);
+            for _ in 0..layer_count {
+                let entry_count = rng.random_range(1..=64);
+                let mut entries: Vec<IndexMetadataEntry> = (0..entry_count)
+                    .map(|_| {
+                        (
+                            Key::from_i128(rng.random_range(0..=15)),
+                            Lsn(rng.random_range(1..=16)),
+                            rng.random_range(1..=128),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                entries.sort_by_key(|entry| (entry.0, entry.1));
+                entries.dedup_by_key(|entry| (entry.0, entry.1));
+                if entries.is_empty() {
+                    entries.push((Key::from_i128(0), Lsn(1), 1));
+                }
+                layers.push(entries);
+            }
+
+            // This is the former implementation's stable extension followed by sort. Small key
+            // and LSN domains deliberately create ties across layers and duplicate-key runs.
+            let mut expected = layers.iter().flatten().copied().collect::<Vec<_>>();
+            expected.sort_by_key(|entry| (entry.0, entry.1));
+
+            let cursors = layers
+                .iter()
+                .map(|entries| make_index_cursor(entries, &ctx))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            let mut merged = IndexMergeIterator::from_iterators(cursors).await?;
+            let mut actual = Vec::with_capacity(expected.len());
+            while let Some(entry) = merged.next().await? {
+                actual.push(entry);
+            }
+            assert_eq!(
+                actual, expected,
+                "merged order mismatch in case {case_index}"
+            );
+
+            // Include exact entry sizes as targets so both sides exercise the strict `< target`
+            // coalescing boundary, in addition to targets on either side of it.
+            let mut target_sizes = vec![1, 2, 8, 32, 128];
+            target_sizes.extend(expected.iter().map(|entry| entry.2));
+            target_sizes.sort_unstable();
+            target_sizes.dedup();
+            for target_file_size in target_sizes {
+                let mut expected_coalesced: Vec<IndexMetadataEntry> = Vec::new();
+                for current in expected.iter().copied() {
+                    if let Some(previous) = expected_coalesced.last_mut()
+                        && previous.0 == current.0
+                        && previous.2 < target_file_size
+                    {
+                        previous.2 += current.2;
+                    } else {
+                        expected_coalesced.push(current);
+                    }
+                }
+
+                let cursors = layers
+                    .iter()
+                    .map(|entries| make_index_cursor(entries, &ctx))
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                let inner = IndexMergeIterator::from_iterators(cursors).await?;
+                let mut coalesced = CoalescedIndexMergeIterator::new(inner, target_file_size);
+                let mut actual_coalesced = Vec::new();
+                while let Some(entry) = coalesced.next().await? {
+                    actual_coalesced.push(entry);
+                }
+                assert_eq!(
+                    actual_coalesced, expected_coalesced,
+                    "coalescing mismatch in case {case_index}, target {target_file_size}"
+                );
+            }
+        }
+
+        Ok(())
     }
 
     #[tokio::test]
@@ -4772,12 +5531,29 @@ mod tests {
         // than size alone, can separate them. It is smaller than the C version history, which
         // requires LSN-sliced output layers for that one key.
         let target_file_size = 640;
-        assert_eq!(
-            timeline
-                .compact_level0(target_file_size, true, None, &ctx)
-                .await?,
-            CompactionOutcome::Done
-        );
+        // This boundary-visible override makes the assertions below run through the same
+        // phase-1 streaming branch that production selects for a large index.
+        let compaction_ctx = ctx.with_scope_timeline(&timeline);
+        let phase1 = timeline
+            .compact_level0_phase1(
+                CompactLevel0Phase1StatsBuilder {
+                    version: Some(2),
+                    tenant_id: Some(timeline.tenant_shard_id),
+                    timeline_id: Some(timeline.timeline_id),
+                    metadata_traversal_override: Some(IndexMetadataTraversal::Streaming),
+                    ..Default::default()
+                },
+                target_file_size,
+                true,
+                None,
+                &compaction_ctx,
+            )
+            .await?;
+        assert_eq!(phase1.metadata_traversal, IndexMetadataTraversal::Streaming);
+        assert_eq!(phase1.outcome, CompactionOutcome::Done);
+        timeline
+            .finish_compact_batch(&phase1.new_layers, &[], &phase1.deltas_to_compact)
+            .await?;
         // force_set_disk_consistent_lsn changes the in-memory test state only. Publish matching
         // metadata so reloading exercises the compacted layer map rather than discarding these
         // intentionally test-created layers as future files.

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -5777,6 +5777,7 @@ mod tests {
             .compaction_iteration(&cancel, &compaction_ctx)
             .await?;
         let elapsed_micros = started.elapsed().as_micros();
+        let compaction_allocation_bytes = allocation_bytes();
 
         assert_eq!(outcome, CompactionOutcome::Done);
         let layer_manager = timeline.layers.read(LayerManagerLockHolder::Testing).await;
@@ -5815,7 +5816,7 @@ mod tests {
         );
         println!(
             "l0_compaction_metadata_calibration_allocation_bytes={}",
-            allocation_bytes()
+            compaction_allocation_bytes
         );
         Ok(())
     }

--- a/pageserver/src/tenant/timeline/compaction.rs
+++ b/pageserver/src/tenant/timeline/compaction.rs
@@ -2041,6 +2041,7 @@ impl Timeline {
         stats.compaction_prerequisites_micros = stats.read_lock_acquisition_micros.till_now();
 
         // TODO: replace with streaming k-merge
+        let index_metadata_started = tokio::time::Instant::now();
         let all_keys = {
             let mut all_keys = Vec::new();
             for l in deltas_to_compact.iter() {
@@ -2059,8 +2060,16 @@ impl Timeline {
             all_keys.sort_by_key(|DeltaEntry { key, lsn, .. }| (*key, *lsn));
             all_keys
         };
-
-        stats.read_lock_held_key_sort_micros = stats.compaction_prerequisites_micros.till_now();
+        let index_metadata_finished = tokio::time::Instant::now();
+        let index_metadata_elapsed = index_metadata_finished - index_metadata_started;
+        stats.read_lock_held_key_sort_micros = DurationRecorder::Recorded(
+            RecordedDuration(index_metadata_elapsed),
+            index_metadata_finished,
+        );
+        stats.read_lock_held_index_metadata_micros = DurationRecorder::Recorded(
+            RecordedDuration(index_metadata_elapsed),
+            index_metadata_finished,
+        );
 
         // Determine N largest holes where N is number of compacted layers. The vec is sorted by key range start.
         //
@@ -2486,6 +2495,7 @@ struct CompactLevel0Phase1StatsBuilder {
     timeline_id: Option<TimelineId>,
     read_lock_acquisition_micros: DurationRecorder,
     read_lock_held_key_sort_micros: DurationRecorder,
+    read_lock_held_index_metadata_micros: DurationRecorder,
     compaction_prerequisites_micros: DurationRecorder,
     read_lock_held_compute_holes_micros: DurationRecorder,
     read_lock_drop_micros: DurationRecorder,
@@ -2502,6 +2512,7 @@ struct CompactLevel0Phase1Stats {
     timeline_id: TimelineId,
     read_lock_acquisition_micros: RecordedDuration,
     read_lock_held_key_sort_micros: RecordedDuration,
+    read_lock_held_index_metadata_micros: RecordedDuration,
     compaction_prerequisites_micros: RecordedDuration,
     read_lock_held_compute_holes_micros: RecordedDuration,
     read_lock_drop_micros: RecordedDuration,
@@ -2531,6 +2542,10 @@ impl TryFrom<CompactLevel0Phase1StatsBuilder> for CompactLevel0Phase1Stats {
                 .read_lock_held_key_sort_micros
                 .into_recorded()
                 .ok_or_else(|| anyhow!("read_lock_held_key_sort_micros not set"))?,
+            read_lock_held_index_metadata_micros: value
+                .read_lock_held_index_metadata_micros
+                .into_recorded()
+                .ok_or_else(|| anyhow!("read_lock_held_index_metadata_micros not set"))?,
             compaction_prerequisites_micros: value
                 .compaction_prerequisites_micros
                 .into_recorded()


### PR DESCRIPTION
## Problem

L0 compaction materializes the index entries from every selected delta layer, then sorts the combined metadata before writing output. Large batches therefore retain the full index metadata while selecting holes and output boundaries.

## Summary of changes

Large metadata batches now use ordered per-layer cursors and a bounded k-way merge. Output sizing consumes that stream and keeps only per-key totals and duplicate-LSN split points, spilling oversized plans instead of retaining every entry.

Small batches and broad, high-fanout overlapping batches keep the materialized path. The existing key-sort metric keeps its original meaning, while cursor traversal is reported separately. Tests cover cursor ordering and coalescing, target-size boundaries, holes, duplicate-LSN splits, output descriptors, values, restart, and streaming selection.

**Workload:** `10-layer by one-million-entry threshold-triggered L0 compaction`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `l0_compaction_10x1m_peak_rss_kib` | 1006058 | 356266 | 64.6% lower |

**Workload:** `10-layer by one-million-entry reverse-disjoint threshold-triggered L0 compaction, three-run median`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `l0_compaction_10x1m_reverse_peak_rss_kib` | 1047086 | 517714 | 50.6% lower |
| `l0_compaction_10x1m_reverse_index_metadata_micros` | 1020177 | 861711 | 15.5% lower |
Checks: 1 passed.

---

Generated by [Perfloop](https://app.perfloop.ai). Human sponsor: [Tomás Senart](https://github.com/tsenart). [Measurements and checks](https://app.perfloop.ai/t/oss/case_bn7ej53pyt).